### PR TITLE
fix for cpuid has_avx feature

### DIFF
--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -37,8 +37,7 @@ void cpuid(int info[4], int info_type) {
 bool has_avx()
 {
     int info[4];
-    cpuid(info, 0);
-    cpuid(info, 0x80000000);
+    cpuid(info, 1);
     return (info[2] & ((int)1 << 28)) != 0;
 }
 


### PR DESCRIPTION
has_avx function seems to have incorrect usage of cpuid instruction for checking the AVX feature bit on Intel processors. Proposed fix by changing eax input to 01H (from 0x80000000 ).  Code correctly seeks the 28th bit from ECX to check AVX feature bit.