### PR TITLE
Fix Issue5736 index bug and specialization for template get_gvd_field<bool> 

### DIFF
--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -328,16 +328,43 @@ namespace librealsense
         static std::string get_module_serial_string(const std::vector<uint8_t>& buff, size_t index, size_t length = 6);
         bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
 
+        /**
+            \brief This function can be used to extract a field from a buffer.
+
+            Generic implementation to return any type field.
+            This function assumes big endian storage of values in the vector.
+
+            \param [in] data Pointer to the data buffer in which the field is stored.
+            \param [in] index Number of bytes into the buffer where the field starts.
+            \returns Field of arbitrary size
+        */
         template <typename T>
         T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
         {
             T rv = 0;
-            if (index + sizeof(T) >= data.size())
+            if (index + sizeof(T) > data.size())
                 throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
                     std::to_string(data.size()) + ", index: " + std::to_string(index));
             for (int i = 0; i < sizeof(T); i++)
-                rv += data[index + i] << (i * 8);
+                rv += data[index + i] << (i * CHAR_BIT);
             return rv;
+        }
+        /*
+            \brief get_gvd_field specialization which returns a bool field.
+
+            This specialization is required as bool is implementation specific and '+=' operation used in default template is not safe for bool.
+
+            \param [in] data Pointer to the data buffer in which the field is stored.
+            \param [in] index Number of bytes into the buffer where the field starts.
+            \returns bool field value.
+        */
+        template <>
+        bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+        {
+            if (index >= data.size())
+                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                    std::to_string(data.size()) + ", index: " + std::to_string(index));
+            return data[index];
         }
     };
 }

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -336,7 +336,7 @@ namespace librealsense
 
             \param [in] data Pointer to the data buffer in which the field is stored.
             \param [in] index Number of bytes into the buffer where the field starts.
-            \returns Field of arbitrary size
+            \returns Field of arbitrary type.
         */
         template <typename T>
         T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
@@ -345,26 +345,26 @@ namespace librealsense
             if (index + sizeof(T) > data.size())
                 throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
                     std::to_string(data.size()) + ", index: " + std::to_string(index));
-            for (int i = 0; i < sizeof(T); i++)
+            for (auto i = 0U; i < sizeof(T); i++)
                 rv += data[index + i] << (i * CHAR_BIT);
             return rv;
         }
-        /*
-            \brief get_gvd_field specialization which returns a bool field.
-
-            This specialization is required as bool is implementation specific and '+=' operation used in default template is not safe for bool.
-
-            \param [in] data Pointer to the data buffer in which the field is stored.
-            \param [in] index Number of bytes into the buffer where the field starts.
-            \returns bool field value.
-        */
-        template <>
-        bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
-        {
-            if (index >= data.size())
-                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
-                    std::to_string(data.size()) + ", index: " + std::to_string(index));
-            return data[index];
-        }
     };
+    /**
+        \brief get_gvd_field specialization which returns a bool field.
+
+        This specialization for bool is necessary as bool is implementation specific and MSVC warns '+=' operation used in default template is not safe for bool.
+
+        \param [in] data Pointer to the data buffer in which the bool field is stored.
+        \param [in] index Number of bytes into the buffer where the bool field starts.
+        \returns bool field value.
+    */
+    template <>
+    inline bool hw_monitor::get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+    {
+        if (index >= data.size())
+            throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                std::to_string(data.size()) + ", index: " + std::to_string(index));
+        return data[index];
+    }
 }


### PR DESCRIPTION
index bug, get_gvd_field() checks if the field exceeds the buffer. The <= check should be <. Without this change, reading the last field from the buffer will throw an exception.

The MSVC compiler warns about using += operator with type bool. To avoid this message, a template specialization is provided when returning a bool. My earlier pull request worked with the MSVC compiler, but the GCC compiler does not allow template specialization within the class. This pull moves the template specialization outside the class but keeps it in the header. This is consistent with both MSVC and GCC.

Beyond these improvements, it should be noted that the get_gvd_field template will only works with integer types and if size(T) > 1, it only works with integer types for big endian compilers.

The current librealsense code base only references get_gvd_field twice for checking the camera lock status. Since the lock status is not at the end of the buffer the index bug doesn't manifest itself. But cleaning up the compiler warning is a step towards a clean build.