### PR TITLE
Reduce Compiler Warnings (WinUsb_ReadPipe, std::codecvt, uint32_t for usb buffer)

### DIFF
--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -570,7 +570,7 @@ namespace rs2
             rs2_error* e = nullptr;
 
             std::shared_ptr<const rs2_raw_data_buffer> list(
-                rs2_terminal_parse_command(_terminal_parser.get(), command.c_str(), command.size(), &e),
+                rs2_terminal_parse_command(_terminal_parser.get(), command.c_str(), static_cast<unsigned int>(command.size()), &e),
                 rs2_delete_raw_data);
             error::handle(e);
 
@@ -590,8 +590,8 @@ namespace rs2
             rs2_error* e = nullptr;
 
             std::shared_ptr<const rs2_raw_data_buffer> list(
-                rs2_terminal_parse_response(_terminal_parser.get(), command.c_str(), command.size(),
-                (void*)response.data(), response.size(), &e),
+                rs2_terminal_parse_response(_terminal_parser.get(), command.c_str(), static_cast<unsigned int>(command.size()),
+                (void*)response.data(), static_cast<unsigned int>(response.size()), &e),
                 rs2_delete_raw_data);
             error::handle(e);
 

--- a/src/libusb/request-libusb.cpp
+++ b/src/libusb/request-libusb.cpp
@@ -59,17 +59,17 @@ namespace librealsense
             _active = state;
         }
 
-        int usb_request_libusb::get_native_buffer_length()
+        uint32_t usb_request_libusb::get_native_buffer_length()
         {
             return _transfer->length;
         }
 
-        void usb_request_libusb::set_native_buffer_length(int length)
+        void usb_request_libusb::set_native_buffer_length(uint32_t length)
         {
             _transfer->length = length;
         }
 
-        int usb_request_libusb::get_actual_length() const
+        uint32_t usb_request_libusb::get_actual_length() const
         {
             return _transfer->actual_length;
         }

--- a/src/libusb/request-libusb.h
+++ b/src/libusb/request-libusb.h
@@ -18,7 +18,7 @@ namespace librealsense
             usb_request_libusb(libusb_device_handle *dev_handle, rs_usb_endpoint endpoint);
             virtual ~usb_request_libusb();
             
-            virtual int get_actual_length() const override;
+            virtual uint32_t get_actual_length() const override;
             virtual void* get_native_request() const override;
 
             std::shared_ptr<usb_request> get_shared() const;
@@ -26,8 +26,8 @@ namespace librealsense
             void set_active(bool state);
 
         protected:
-            virtual void set_native_buffer_length(int length) override;
-            virtual int get_native_buffer_length() override;
+            virtual void set_native_buffer_length(uint32_t length) override;
+            virtual uint32_t get_native_buffer_length() override;
             virtual void set_native_buffer(uint8_t* buffer) override;
             virtual uint8_t* get_native_buffer() const override;
 

--- a/src/usb/usb-request.h
+++ b/src/usb/usb-request.h
@@ -22,7 +22,7 @@ namespace librealsense
         {
         public:
             virtual rs_usb_endpoint get_endpoint() const = 0;
-            virtual int get_actual_length() const = 0;
+            virtual uint32_t get_actual_length() const = 0;
             virtual void set_callback(rs_usb_request_callback callback) = 0;
             virtual rs_usb_request_callback get_callback() const = 0;
             virtual void set_client_data(void* data) = 0;
@@ -32,8 +32,8 @@ namespace librealsense
             virtual void set_buffer(const std::vector<uint8_t>& buffer) = 0;
 
         protected:
-            virtual void set_native_buffer_length(int length) = 0;
-            virtual int get_native_buffer_length() = 0;
+            virtual void set_native_buffer_length(uint32_t length) = 0;
+            virtual uint32_t get_native_buffer_length() = 0;
             virtual void set_native_buffer(uint8_t* buffer) = 0;
             virtual uint8_t* get_native_buffer() const = 0;
         };

--- a/src/winusb/enumerator-winusb.cpp
+++ b/src/winusb/enumerator-winusb.cpp
@@ -18,7 +18,8 @@
 #include <regex>
 #include <sstream>
 #include <mutex>
-
+#include <locale>
+#include <codecvt>
 #include <Cfgmgr32.h>
 #include <SetupAPI.h>
 
@@ -82,7 +83,10 @@ namespace librealsense
         {
             usb_device_info rv{};
             std::smatch matches;
-            std::string device_str(device_wstr.begin(), device_wstr.end());
+
+            using convert_type = std::codecvt_utf8<wchar_t>; // Avoid warnings about function template instantiation by using converter.
+            std::wstring_convert<convert_type, wchar_t> converter;
+            std::string device_str = converter.to_bytes(device_wstr); // Device string converted from wstring to string.
 
             std::regex regex_camera_interface("\\b(.*VID_)(.*)(&PID_)(.*)(&MI_)(.*)(#.*&)(.*)(&.*)(&.*)(.*#)(.*)", std::regex_constants::icase);
             std::regex regex_usb_interface("\\b(.*VID_)(.*)(&PID_)(.*)(#.*&)(.*)(&.*)(&.*)", std::regex_constants::icase);

--- a/src/winusb/messenger-winusb.cpp
+++ b/src/winusb/messenger-winusb.cpp
@@ -136,9 +136,9 @@ namespace librealsense
             auto h = _handle->get_interface_handle(in);
 
             auto buffer = const_cast<uint8_t*>(request->get_buffer().data());
-            int res = WinUsb_ReadPipe(h, epa, buffer, request->get_buffer().size(), &read_pipe_transfer_size, ovl);
-            if (0 != res)
-                return winusb_status_to_rs(res);
+
+            if (0 != WinUsb_ReadPipe(h, epa, buffer, static_cast<ULONG>(request->get_buffer().size()), &read_pipe_transfer_size, ovl))
+                return RS2_USB_STATUS_SUCCESS;
 
             auto lastError = GetLastError();
             if (lastError != ERROR_IO_PENDING)

--- a/src/winusb/request-winusb.cpp
+++ b/src/winusb/request-winusb.cpp
@@ -23,19 +23,19 @@ namespace librealsense
 
         }
 
-        int usb_request_winusb::get_actual_length() const
+        uint32_t usb_request_winusb::get_actual_length() const
         {
-            return _overlapped->InternalHigh;// _request->actual_length;
+            return static_cast<uint32_t>(_overlapped->InternalHigh); // InternalHigh is a ULONG_PTR which could be 64 bits.
         }
 
-        void usb_request_winusb::set_native_buffer_length(int length)
+        void usb_request_winusb::set_native_buffer_length(uint32_t length)
         {
 
         }
 
-        int usb_request_winusb::get_native_buffer_length()
+        uint32_t usb_request_winusb::get_native_buffer_length()
         {
-            return _buffer.size();
+            return static_cast<uint32_t>(_buffer.size());
         }
 
         void usb_request_winusb::set_native_buffer(uint8_t* buffer)

--- a/src/winusb/request-winusb.h
+++ b/src/winusb/request-winusb.h
@@ -48,12 +48,12 @@ namespace librealsense
             usb_request_winusb(rs_usb_device device, rs_usb_endpoint endpoint);
             virtual ~usb_request_winusb();
 
-            virtual int get_actual_length() const override;
+            virtual uint32_t get_actual_length() const override;
             virtual void* get_native_request() const override;
 
         protected:
-            virtual void set_native_buffer_length(int length) override;
-            virtual int get_native_buffer_length() override;
+            virtual void set_native_buffer_length(uint32_t length) override;
+            virtual uint32_t get_native_buffer_length() override;
             virtual void set_native_buffer(uint8_t* buffer) override;
             virtual uint8_t* get_native_buffer() const override;
 

--- a/unit-tests/unit-tests-post-processing-from-bag.cpp
+++ b/unit-tests/unit-tests-post-processing-from-bag.cpp
@@ -18,7 +18,6 @@
 
 typedef struct _sw_context
 {
-
     rs2::software_device sdev;
     std::map<std::string, std::shared_ptr<rs2::software_sensor>> sw_sensors;
     std::map<std::string, rs2::syncer> sw_syncers;

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -220,8 +220,8 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
             rs2::software_device dev; // Create software-only device
             auto depth_sensor = dev.add_sensor("Depth");
 
-            uint32_t width = test_cfg.input_res_x;
-            uint32_t height = test_cfg.input_res_y;
+            int width = static_cast<int>(test_cfg.input_res_x);
+            int height = static_cast<int>(test_cfg.input_res_y);
             int depth_bpp = 2; //16bit unsigned
             int frame_number = 1;
             rs2_intrinsics depth_intrinsics = { width, height,

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -294,8 +294,8 @@ TEST_CASE("Post-Processing Filters metadata validation", "[software-device][post
             rs2::software_device dev; // Create software-only device
             auto depth_sensor = dev.add_sensor("Depth");
 
-            uint32_t width = test_cfg.input_res_x;
-            uint32_t height = test_cfg.input_res_y;
+            int width = test_cfg.input_res_x;
+            int height = test_cfg.input_res_y;
             int depth_bpp = 2; //16bit unsigned
             int frame_number = 1;
             rs2_intrinsics depth_intrinsics = { width, height,

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -220,8 +220,8 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
             rs2::software_device dev; // Create software-only device
             auto depth_sensor = dev.add_sensor("Depth");
 
-            int width = test_cfg.input_res_x;
-            int height = test_cfg.input_res_y;
+            uint32_t width = test_cfg.input_res_x;
+            uint32_t height = test_cfg.input_res_y;
             int depth_bpp = 2; //16bit unsigned
             int frame_number = 1;
             rs2_intrinsics depth_intrinsics = { width, height,
@@ -294,8 +294,8 @@ TEST_CASE("Post-Processing Filters metadata validation", "[software-device][post
             rs2::software_device dev; // Create software-only device
             auto depth_sensor = dev.add_sensor("Depth");
 
-            int width = test_cfg.input_res_x;
-            int height = test_cfg.input_res_y;
+            uint32_t width = test_cfg.input_res_x;
+            uint32_t height = test_cfg.input_res_y;
             int depth_bpp = 2; //16bit unsigned
             int frame_number = 1;
             rs2_intrinsics depth_intrinsics = { width, height,
@@ -313,10 +313,10 @@ TEST_CASE("Post-Processing Filters metadata validation", "[software-device][post
             depth_sensor.start(sync);
 
             size_t frames = (test_cfg.frames_sequence_size > 1) ? test_cfg.frames_sequence_size : 1;
-            for (auto i = 0; i < frames; i++)
+            for (auto i = 0U; i < frames; i++)
             {
                 //set next frames metadata
-                for (auto i = 0; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
+                for (auto i = 0U; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
                     depth_sensor.set_metadata((rs2_frame_metadata_value)i, rand());
 
                 // Inject input frame


### PR DESCRIPTION
Use uint32_t for get_native_buffer_length(), set_native_buffer_length(uint32_t length),get_actual_length().

Use std::codecvt_utf8 to avoid warnings about function template.
WinUsb_ReadPipe() succeeds when it returns non-zero. No reason to punt to winusb_status_to_rs() on non-zero return just return RS2_USB_STATUS_SUCCESS.

This reduces the development branch realsense2 MSVC warnings/info from 35/15 to 31/9.