### PR TITLE
Compiler warning cleanup

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -138,6 +138,7 @@ namespace librealsense
 
     rs2_format sensor_base::fourcc_to_rs2_format(uint32_t fourcc_format) const
     {
+#if (0)
         rs2_format f;
 
         if (_fourcc_to_rs2_format->end() == std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
@@ -151,11 +152,24 @@ namespace librealsense
         {
             f = RS2_FORMAT_ANY; // Format not found.
         }
+#else
+        rs2_format f = RS2_FORMAT_ANY;
+
+        std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
+            if (p.first == fourcc_format)
+            {
+                f = p.second;
+                return true;
+            }
+            return false;
+        });
+#endif
         return f;
     }
 
     rs2_stream sensor_base::fourcc_to_rs2_stream(uint32_t fourcc_format) const
     {
+#if (0)
         rs2_stream s;
 
         if (_fourcc_to_rs2_stream->end() == std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
@@ -169,6 +183,18 @@ namespace librealsense
         {
             s = RS2_STREAM_ANY; // Stream with selected format not found.
         }
+#else
+        rs2_stream s = RS2_STREAM_ANY;
+
+        std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
+            if (p.first == fourcc_format)
+            {
+                s = p.second;
+                return true;
+            }
+            return false;
+        });
+#endif
         return s;
     }
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -138,7 +138,6 @@ namespace librealsense
 
     rs2_format sensor_base::fourcc_to_rs2_format(uint32_t fourcc_format) const
     {
-#if (0)
         rs2_format f;
 
         if (_fourcc_to_rs2_format->end() == std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
@@ -152,24 +151,11 @@ namespace librealsense
         {
             f = RS2_FORMAT_ANY; // Format not found.
         }
-#else
-        rs2_format f = RS2_FORMAT_ANY;
-
-        std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
-            if (p.first == fourcc_format)
-            {
-                f = p.second;
-                return true;
-            }
-            return false;
-        });
-#endif
         return f;
     }
 
     rs2_stream sensor_base::fourcc_to_rs2_stream(uint32_t fourcc_format) const
     {
-#if (0)
         rs2_stream s;
 
         if (_fourcc_to_rs2_stream->end() == std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
@@ -183,18 +169,6 @@ namespace librealsense
         {
             s = RS2_STREAM_ANY; // Stream with selected format not found.
         }
-#else
-        rs2_stream s = RS2_STREAM_ANY;
-
-        std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
-            if (p.first == fourcc_format)
-            {
-                s = p.second;
-                return true;
-            }
-            return false;
-        });
-#endif
         return s;
     }
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -138,33 +138,37 @@ namespace librealsense
 
     rs2_format sensor_base::fourcc_to_rs2_format(uint32_t fourcc_format) const
     {
-        rs2_format f = RS2_FORMAT_ANY;
+        rs2_format f;
 
-        std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
+        if (_fourcc_to_rs2_format->end() == std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
             if (p.first == fourcc_format)
             {
                 f = p.second;
                 return true;
             }
             return false;
-        });
-
+        }))
+        {
+            f = RS2_FORMAT_ANY; // Format not found.
+        }
         return f;
     }
 
     rs2_stream sensor_base::fourcc_to_rs2_stream(uint32_t fourcc_format) const
     {
-        rs2_stream s = RS2_STREAM_ANY;
+        rs2_stream s;
 
-        std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
+        if (_fourcc_to_rs2_stream->end() == std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
             if (p.first == fourcc_format)
             {
                 s = p.second;
                 return true;
             }
             return false;
-        });
-
+        }))
+        {
+            s = RS2_STREAM_ANY; // Stream with selected format not found.
+        }
         return s;
     }
 
@@ -262,7 +266,7 @@ namespace librealsense
             last_timestamp,
             last_frame_number,
             false,
-            fo.frame_size);
+            static_cast<uint32_t>(fo.frame_size));
         fr->additional_data = additional_data;
 
         // update additional data
@@ -1253,9 +1257,9 @@ namespace librealsense
         stream_profiles best_match_requests;
         std::shared_ptr<processing_block_factory> best_match_processing_block_factory;
 
-        int max_satisfied_req = 0;
-        int best_source_size = 0;
-        int satisfied_count = 0;
+        size_t max_satisfied_req = 0;
+        size_t best_source_size = 0;
+        size_t satisfied_count = 0;
 
         for (auto&& pbf : _pb_factories)
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -117,11 +117,7 @@ namespace librealsense
         friend class software_device;
         stream_profiles _profiles;
         std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
-#if (0)
         uint64_t _unique_id;
-#else
-        int _unique_id;
-#endif
         class stereo_extension : public depth_stereo_sensor
         {
         public:

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -117,7 +117,7 @@ namespace librealsense
         friend class software_device;
         stream_profiles _profiles;
         std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
-        int _unique_id;
+        uint64_t _unique_id;
 
         class stereo_extension : public depth_stereo_sensor
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -117,8 +117,11 @@ namespace librealsense
         friend class software_device;
         stream_profiles _profiles;
         std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
+#if (0)
         uint64_t _unique_id;
-
+#else
+        int _unique_id;
+#endif
         class stereo_extension : public depth_stereo_sensor
         {
         public:


### PR DESCRIPTION
This is a very minor update (mostly for testing my process of CI and unit testing under Windows) that cleans up the MSVC compiler warnings in two files.
sensor.cpp fixes a nodiscard warning on find_if(), also casting and size_t changes.
software-device.h changes _unique_id to a uint64_t. This is the return type of the function that fills in this value.

This PR is a portion of Issue6738 improvements. This passes CI on my Windows machine..