### PR TITLE
Issue7638 firmware

### DIFF
--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -170,7 +170,7 @@ void rs2_write_calibration(const rs2_device* device, rs2_error** e);
 * \param[in]  callback      Optional callback for update progress notifications, the progress value is normailzed to 1
 * \param[out] error         If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, int fw_image_size, rs2_update_progress_callback* callback, rs2_error** error);
+void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, size_t fw_image_size, rs2_update_progress_callback* callback, rs2_error** error);
 
 /**
 * Update device to the provided firmware, the device must be extendable to RS2_EXTENSION_UPDATABLE.
@@ -182,7 +182,7 @@ void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, int
 * \param[in]  client_data   Optional client data for the callback
 * \param[out] error         If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_update_firmware(const rs2_device* device, const void* fw_image, int fw_image_size, rs2_update_progress_callback_ptr callback, void* client_data, rs2_error** error);
+void rs2_update_firmware(const rs2_device* device, const void* fw_image, size_t fw_image_size, rs2_update_progress_callback_ptr callback, void* client_data, rs2_error** error);
 
 /**
 * Create backup of camera flash memory. Such backup does not constitute valid firmware image, and cannot be

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -128,7 +128,7 @@ unsigned long long rs2_get_frame_number(const rs2_frame* frame, rs2_error** erro
 * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return               the size of the frame data
 */
-int rs2_get_frame_data_size(const rs2_frame* frame, rs2_error** error);
+size_t rs2_get_frame_data_size(const rs2_frame* frame, rs2_error** error);
 
 /**
 * retrieve data from frame handle

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -394,7 +394,7 @@ const unsigned char* rs2_fw_log_message_data(rs2_firmware_log_message* msg, rs2_
 * \param[out] error     If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return               size of the firmware log message data
 */
-int rs2_fw_log_message_size(rs2_firmware_log_message* msg, rs2_error** error);
+size_t rs2_fw_log_message_size(rs2_firmware_log_message* msg, rs2_error** error);
 
 
 /**

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
 /** \brief Category of the librealsense notification. */
 typedef enum rs2_notification_category{
     RS2_NOTIFICATION_CATEGORY_FRAMES_TIMEOUT,               /**< Frames didn't arrived within 5 seconds */

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -267,7 +267,7 @@ namespace rs2
         void update(const std::vector<uint8_t>& fw_image) const
         {
             rs2_error* e = nullptr;
-            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), (int)fw_image.size(), NULL, &e);
+            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), fw_image.size(), NULL, &e);
             error::handle(e);
         }
 
@@ -277,7 +277,7 @@ namespace rs2
         void update(const std::vector<uint8_t>& fw_image, T callback) const
         {
             rs2_error* e = nullptr;
-            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), int(fw_image.size()), new update_progress_callback<T>(std::move(callback)), &e);
+            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), fw_image.size(), new update_progress_callback<T>(std::move(callback)), &e);
             error::handle(e);
         }
     };

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -523,7 +523,7 @@ namespace rs2
         * retrieve data size from frame handle
         * \return               the number of bytes in frame
         */
-        const int get_data_size() const
+        const size_t get_data_size() const
         {
             rs2_error* e = nullptr;
             auto r = rs2_get_frame_data_size(frame_ref, &e);

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -60,11 +60,11 @@ namespace librealsense
         new_vertices.reserve(get_vertex_count());
         new_tex.reserve(get_vertex_count());
         assert(get_vertex_count());
-        for (size_t i = 0; i < get_vertex_count(); ++i)
+        for (int i = 0; i < get_vertex_count(); ++i)
             if (fabs(vertices[i].x) >= MIN_DISTANCE || fabs(vertices[i].y) >= MIN_DISTANCE ||
                 fabs(vertices[i].z) >= MIN_DISTANCE)
             {
-                index2reducedIndex[i] = new_vertices.size();
+                index2reducedIndex[i] = static_cast<int>(new_vertices.size());
                 new_vertices.push_back({ vertices[i].x,  -1*vertices[i].y, -1*vertices[i].z });
                 if (texture)
                 {
@@ -76,8 +76,8 @@ namespace librealsense
         const auto threshold = 0.05f;
         auto width = video_stream_profile->get_width();
         std::vector<std::tuple<int, int, int>> faces;
-        for (int x = 0; x < width - 1; ++x) {
-            for (int y = 0; y < video_stream_profile->get_height() - 1; ++y) {
+        for (auto x = 0U; x < width - 1; ++x) {
+            for (auto y = 0U; y < video_stream_profile->get_height() - 1; ++y) {
                 auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
                 if (vertices[a].z && vertices[b].z && vertices[c].z && vertices[d].z
                     && abs(vertices[a].z - vertices[b].z) < threshold && abs(vertices[a].z - vertices[c].z) < threshold
@@ -240,7 +240,7 @@ namespace librealsense
         return it->second->supports(*this);
     }
 
-    int frame::get_frame_data_size() const
+    size_t frame::get_frame_data_size() const
     {
         return data.size();
     }

--- a/src/archive.h
+++ b/src/archive.h
@@ -126,7 +126,7 @@ namespace librealsense
         virtual ~frame() { on_release.reset(); }
         rs2_metadata_type get_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const override;
         bool supports_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const override;
-        int get_frame_data_size() const override;
+        size_t get_frame_data_size() const override;
         const byte* get_frame_data() const override;
         rs2_time_t get_frame_timestamp() const override;
         rs2_timestamp_domain get_frame_timestamp_domain() const override;
@@ -232,7 +232,7 @@ namespace librealsense
         {
             return first()->supports_frame_metadata(frame_metadata);
         }
-        int get_frame_data_size() const override
+        size_t get_frame_data_size() const override
         {
             return first()->get_frame_data_size();
         }

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -83,7 +83,7 @@ namespace librealsense
     public:
         virtual rs2_metadata_type get_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const = 0;
         virtual bool supports_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const = 0;
-        virtual int get_frame_data_size() const = 0;
+        virtual size_t get_frame_data_size() const = 0;
         virtual const byte* get_frame_data() const = 0;
         virtual rs2_time_t get_frame_timestamp() const = 0;
         virtual rs2_timestamp_domain get_frame_timestamp_domain() const = 0;

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -190,15 +190,15 @@ namespace librealsense
 
     void update_flash_section(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, uint32_t offset, uint32_t size, update_progress_callback_ptr callback, float continue_from, float ratio)
     {
-        size_t sector_count = size / ds::FLASH_SECTOR_SIZE;
-        size_t first_sector = offset / ds::FLASH_SECTOR_SIZE;
+        uint32_t sector_count = size / ds::FLASH_SECTOR_SIZE;
+        uint32_t first_sector = offset / ds::FLASH_SECTOR_SIZE;
 
         if (sector_count * ds::FLASH_SECTOR_SIZE != size)
             sector_count++;
 
         sector_count += first_sector;
 
-        for (int sector_index = first_sector; sector_index < sector_count; sector_index++)
+        for (auto sector_index = first_sector; sector_index < sector_count; sector_index++)
         {
             command cmdFES(ds::FES);
             cmdFES.require_response = false;

--- a/src/ds5/ds5-fw-update-device.cpp
+++ b/src/ds5/ds5-fw-update-device.cpp
@@ -14,7 +14,7 @@ namespace librealsense
         _serial_number = parse_serial_number(_serial_number_buffer);
     }
 
-    void ds_update_device::update(const void* fw_image, int fw_image_size, update_progress_callback_ptr callback) const
+    void ds_update_device::update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr callback) const
     {
         update_device::update(fw_image, fw_image_size, callback);
     }

--- a/src/ds5/ds5-fw-update-device.h
+++ b/src/ds5/ds5-fw-update-device.h
@@ -13,7 +13,7 @@ namespace librealsense
         ds_update_device(std::shared_ptr<context> ctx, bool register_device_notifications, std::shared_ptr<platform::usb_device> usb_device);
         virtual ~ds_update_device() = default;
 
-        void update(const void* fw_image, int fw_image_size, update_progress_callback_ptr = nullptr) const override;
+        void update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr = nullptr) const override;
 
     protected:
         virtual const std::string& get_name() const override { return _name; }

--- a/src/fw-logs/fw-log-data.h
+++ b/src/fw-logs/fw-log-data.h
@@ -87,7 +87,7 @@ namespace librealsense
             uint32_t _p1;
             uint32_t _p2;
             uint32_t _p3;
-            uint64_t _timestamp;
+            uint32_t _timestamp;
             double _delta;
 
             uint32_t _thread_id;

--- a/src/fw-update/fw-update-device-interface.h
+++ b/src/fw-update/fw-update-device-interface.h
@@ -19,7 +19,7 @@ namespace librealsense
     class update_device_interface : public device_interface
     {
     public:
-        virtual void update(const void* fw_image, int fw_image_size, update_progress_callback_ptr = nullptr) const = 0;
+        virtual void update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr = nullptr) const = 0;
     protected:
         virtual const std::string& get_name() const = 0;
         virtual const std::string& get_product_line() const = 0;

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -136,26 +136,26 @@ namespace librealsense
 
     }
 
-    void update_device::update(const void* fw_image, int fw_image_size, update_progress_callback_ptr update_progress_callback) const
+    void update_device::update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr update_progress_callback) const
     {
         auto messenger = _usb_device->open(FW_UPDATE_INTERFACE_NUMBER);
 
         const size_t transfer_size = 1024;
 
         size_t remaining_bytes = fw_image_size;
-        uint16_t blocks_count = fw_image_size / transfer_size;
-        uint16_t block_number = 0;
+        const size_t blocks_count = fw_image_size / transfer_size;
+        int block_number = 0;
 
-        size_t offset = 0;
-        uint32_t transferred = 0;
+        uint32_t offset = 0U;
+        uint32_t transferred = 0U;
         int retries = 10;
 
         while (remaining_bytes > 0) 
         {
-            size_t chunk_size = std::min(transfer_size, remaining_bytes);
+            uint32_t chunk_size = static_cast<uint32_t>(std::min(transfer_size, remaining_bytes));
 
             auto curr_block = ((uint8_t*)fw_image + offset);
-            auto sts = messenger->control_transfer(0x21 /*DFU_DOWNLOAD_PACKET*/, RS2_DFU_DOWNLOAD, block_number, 0, curr_block, chunk_size, transferred, 5000);
+            auto sts = messenger->control_transfer(0x21 /*DFU_DOWNLOAD_PACKET*/, RS2_DFU_DOWNLOAD, block_number, 0, curr_block, chunk_size, transferred, 5000U);
             if (sts != platform::RS2_USB_STATUS_SUCCESS || !wait_for_state(messenger, RS2_DFU_STATE_DFU_DOWNLOAD_IDLE, 1000))
             {
                 auto state = get_dfu_state(messenger);

--- a/src/fw-update/fw-update-device.h
+++ b/src/fw-update/fw-update-device.h
@@ -100,7 +100,7 @@ namespace librealsense
         update_device(const std::shared_ptr<context>& ctx, bool register_device_notifications, std::shared_ptr<platform::usb_device> usb_device);
         virtual ~update_device();
 
-        virtual void update(const void* fw_image, int fw_image_size, update_progress_callback_ptr = nullptr) const override;
+        virtual void update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr = nullptr) const override;
         
         virtual sensor_interface& get_sensor(size_t i) override;
 

--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -95,13 +95,13 @@ namespace librealsense
         if (current_subpreset[offset] != CONTROL_ID_EXPOSURE)
             return false;
         offset += size_of_control_id;
-        float exposure_0 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float exposure_0 = static_cast<float>(*reinterpret_cast<const uint32_t*>(&(current_subpreset[offset])));
         offset += size_of_control_value;
 
         if (current_subpreset[offset] != CONTROL_ID_GAIN)
             return false;
         offset += size_of_control_id;
-        float gain_0 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float gain_0 = static_cast<float>(*reinterpret_cast<const uint32_t*>(&(current_subpreset[offset])));
         offset += size_of_control_value;
 
         offset += size_of_subpreset_item_header;
@@ -109,13 +109,13 @@ namespace librealsense
         if (current_subpreset[offset] != CONTROL_ID_EXPOSURE)
             return false;
         offset += size_of_control_id;
-        float exposure_1 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float exposure_1 = static_cast<float>(*reinterpret_cast<const uint32_t*>(&(current_subpreset[offset])));
         offset += size_of_control_value;
 
         if (current_subpreset[offset] != CONTROL_ID_GAIN)
             return false;
         offset += size_of_control_id;
-        float gain_1 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float gain_1 = static_cast<float>(*reinterpret_cast<const uint32_t*>(&(current_subpreset[offset])));
         offset += size_of_control_value;
 
         _hdr_sequence_params[0]._exposure = exposure_0;

--- a/src/hdr-config.h
+++ b/src/hdr-config.h
@@ -75,7 +75,7 @@ namespace librealsense
         int _id;
         size_t _sequence_size;
         std::vector<hdr_params> _hdr_sequence_params;
-        int _current_hdr_sequence_index;
+        size_t _current_hdr_sequence_index;
         mutable bool _is_enabled;
         bool _is_config_in_process;
         bool _has_config_changed;

--- a/src/ivcam/sr300-fw-update-device.cpp
+++ b/src/ivcam/sr300-fw-update-device.cpp
@@ -14,7 +14,7 @@ namespace librealsense
         _serial_number = parse_serial_number(_serial_number_buffer);
     }
 
-    void sr300_update_device::update(const void* fw_image, int fw_image_size, update_progress_callback_ptr callback) const
+    void sr300_update_device::update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr callback) const
     {
         update_device::update(fw_image, fw_image_size, callback);
 

--- a/src/ivcam/sr300-fw-update-device.h
+++ b/src/ivcam/sr300-fw-update-device.h
@@ -12,7 +12,7 @@ namespace librealsense
     public:
         sr300_update_device(std::shared_ptr<context> ctx, bool register_device_notifications, std::shared_ptr<platform::usb_device> usb_device);
         virtual ~sr300_update_device() = default;
-        virtual void update(const void* fw_image, int fw_image_size, update_progress_callback_ptr = nullptr) const override;
+        virtual void update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr = nullptr) const override;
 
     protected:
         virtual const std::string& get_name() const override { return _name; }

--- a/src/l500/l500-fw-update-device.cpp
+++ b/src/l500/l500-fw-update-device.cpp
@@ -14,7 +14,7 @@ namespace librealsense
         _serial_number = parse_serial_number(_serial_number_buffer);
     }
 
-    void l500_update_device::update(const void* fw_image, int fw_image_size, update_progress_callback_ptr callback) const
+    void l500_update_device::update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr callback) const
     {
         update_device::update(fw_image, fw_image_size, callback);
     }

--- a/src/l500/l500-fw-update-device.h
+++ b/src/l500/l500-fw-update-device.h
@@ -24,7 +24,7 @@ namespace librealsense
         l500_update_device(std::shared_ptr<context> ctx, bool register_device_notifications, std::shared_ptr<platform::usb_device> usb_device);
         virtual ~l500_update_device() = default;
 
-        void update(const void* fw_image, int fw_image_size, update_progress_callback_ptr = nullptr) const override;
+        void update(const void* fw_image, size_t fw_image_size, update_progress_callback_ptr = nullptr) const override;
 
     protected:
         virtual const std::string& get_name() const override { return _name; }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -920,7 +920,7 @@ rs2_sensor* rs2_get_frame_sensor(const rs2_frame* frame, rs2_error** error) BEGI
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, frame)
 
-int rs2_get_frame_data_size(const rs2_frame* frame_ref, rs2_error** error) BEGIN_API_CALL
+size_t rs2_get_frame_data_size(const rs2_frame* frame_ref, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame_ref);
     return ((frame_interface*)frame_ref)->get_frame_data_size();
@@ -2869,7 +2869,7 @@ int rs2_send_wheel_odometry(const rs2_sensor* sensor, char wo_sensor_id, unsigne
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, sensor, wo_sensor_id, frame_num, translational_velocity)
 
-void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, int fw_image_size, rs2_update_progress_callback* callback, rs2_error** error) BEGIN_API_CALL
+void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, size_t fw_image_size, rs2_update_progress_callback* callback, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
     VALIDATE_NOT_NULL(fw_image);
@@ -2886,7 +2886,7 @@ void rs2_update_firmware_cpp(const rs2_device* device, const void* fw_image, int
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, device, fw_image)
 
-void rs2_update_firmware(const rs2_device* device, const void* fw_image, int fw_image_size, rs2_update_progress_callback_ptr callback, void* client_data, rs2_error** error) BEGIN_API_CALL
+void rs2_update_firmware(const rs2_device* device, const void* fw_image, size_t fw_image_size, rs2_update_progress_callback_ptr callback, void* client_data, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
     VALIDATE_NOT_NULL(fw_image);
@@ -3194,7 +3194,7 @@ const unsigned char* rs2_fw_log_message_data(rs2_firmware_log_message* msg, rs2_
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, msg)
 
-int rs2_fw_log_message_size(rs2_firmware_log_message* msg, rs2_error** error)BEGIN_API_CALL
+size_t rs2_fw_log_message_size(rs2_firmware_log_message* msg, rs2_error** error)BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(msg);
     return msg->firmware_log_binary_data->logs_buffer.size();
@@ -3207,7 +3207,7 @@ rs2_log_severity rs2_fw_log_message_severity(const rs2_firmware_log_message* msg
 }
 HANDLE_EXCEPTIONS_AND_RETURN(RS2_LOG_SEVERITY_NONE, msg)
 
-unsigned int rs2_fw_log_message_timestamp(rs2_firmware_log_message* msg, rs2_error** error) BEGIN_API_CALL
+uint32_t rs2_fw_log_message_timestamp(rs2_firmware_log_message* msg, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(msg);
     return msg->firmware_log_binary_data->get_timestamp();

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -138,37 +138,33 @@ namespace librealsense
 
     rs2_format sensor_base::fourcc_to_rs2_format(uint32_t fourcc_format) const
     {
-        rs2_format f;
+        rs2_format f = RS2_FORMAT_ANY;
 
-        if (_fourcc_to_rs2_format->end() == std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
+        std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
             if (p.first == fourcc_format)
             {
                 f = p.second;
                 return true;
             }
             return false;
-        }))
-        {
-            f = RS2_FORMAT_ANY; // Format not found.
-        }
+        });
+
         return f;
     }
 
     rs2_stream sensor_base::fourcc_to_rs2_stream(uint32_t fourcc_format) const
     {
-        rs2_stream s;
+        rs2_stream s = RS2_STREAM_ANY;
 
-        if (_fourcc_to_rs2_stream->end() == std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
+        std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
             if (p.first == fourcc_format)
             {
                 s = p.second;
                 return true;
             }
             return false;
-        }))
-        {
-            s = RS2_STREAM_ANY; // Stream with selected format not found.
-        }
+        });
+
         return s;
     }
 
@@ -266,7 +262,7 @@ namespace librealsense
             last_timestamp,
             last_frame_number,
             false,
-            static_cast<uint32_t>(fo.frame_size));
+            fo.frame_size);
         fr->additional_data = additional_data;
 
         // update additional data
@@ -1257,9 +1253,9 @@ namespace librealsense
         stream_profiles best_match_requests;
         std::shared_ptr<processing_block_factory> best_match_processing_block_factory;
 
-        size_t max_satisfied_req = 0;
-        size_t best_source_size = 0;
-        size_t satisfied_count = 0;
+        int max_satisfied_req = 0;
+        int best_source_size = 0;
+        int satisfied_count = 0;
 
         for (auto&& pbf : _pb_factories)
         {

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -138,33 +138,37 @@ namespace librealsense
 
     rs2_format sensor_base::fourcc_to_rs2_format(uint32_t fourcc_format) const
     {
-        rs2_format f = RS2_FORMAT_ANY;
+        rs2_format f;
 
-        std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
+        if (_fourcc_to_rs2_format->end() == std::find_if(_fourcc_to_rs2_format->begin(), _fourcc_to_rs2_format->end(), [&fourcc_format, &f](const std::pair<uint32_t, rs2_format>& p) {
             if (p.first == fourcc_format)
             {
                 f = p.second;
                 return true;
             }
             return false;
-        });
-
+        }))
+        {
+            f = RS2_FORMAT_ANY; // Format not found.
+        }
         return f;
     }
 
     rs2_stream sensor_base::fourcc_to_rs2_stream(uint32_t fourcc_format) const
     {
-        rs2_stream s = RS2_STREAM_ANY;
+        rs2_stream s;
 
-        std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
+        if (_fourcc_to_rs2_stream->end() == std::find_if(_fourcc_to_rs2_stream->begin(), _fourcc_to_rs2_stream->end(), [&fourcc_format, &s](const std::pair<uint32_t, rs2_stream>& p) {
             if (p.first == fourcc_format)
             {
                 s = p.second;
                 return true;
             }
             return false;
-        });
-
+        }))
+        {
+            s = RS2_STREAM_ANY; // Stream with selected format not found.
+        }
         return s;
     }
 
@@ -262,7 +266,7 @@ namespace librealsense
             last_timestamp,
             last_frame_number,
             false,
-            fo.frame_size);
+            static_cast<uint32_t>(fo.frame_size));
         fr->additional_data = additional_data;
 
         // update additional data
@@ -1253,9 +1257,9 @@ namespace librealsense
         stream_profiles best_match_requests;
         std::shared_ptr<processing_block_factory> best_match_processing_block_factory;
 
-        int max_satisfied_req = 0;
-        int best_source_size = 0;
-        int satisfied_count = 0;
+        size_t max_satisfied_req = 0;
+        size_t best_source_size = 0;
+        size_t satisfied_count = 0;
 
         for (auto&& pbf : _pb_factories)
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -117,7 +117,7 @@ namespace librealsense
         friend class software_device;
         stream_profiles _profiles;
         std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
-        uint64_t _unique_id;
+        int _unique_id;
 
         class stereo_extension : public depth_stereo_sensor
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -117,7 +117,7 @@ namespace librealsense
         friend class software_device;
         stream_profiles _profiles;
         std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
-        int _unique_id;
+        uint64_t _unique_id;
 
         class stereo_extension : public depth_stereo_sensor
         {


### PR DESCRIPTION
This PR reduces compiler warnings (and subsequent casting).
firmware image size is changed to size_t in several functions. (image size should always be unsigned and using size_t matches the way std:vector.size is used with image size.
Same change applied to frame size and buffer size

Several for loop variables changed from "for (int i=0; " to "for (auto i=0U;". Using an explicit signed 0 makes sure the auto gets auto assigned correctly.

update_flash_section() already uses uint32_t for size (probably a valid hardware constraint). There's no reason to declare sector_count and sector_count to be anything other than uint32_t. 

I changed the fw log _timestamp to be a uint32_t instead of uint64_t. Searching the references it appeared that _timestamp was filled using a 32 bit value and only used as an int. 

These changes reduce the MSVC warning/info message of the development realsense2 build from 35/15 to 20/15.