### PR TITLE
Set the RPATH to be relative for install directory to be able to move it

### DIFF
--- a/CMake/install_config.cmake
+++ b/CMake/install_config.cmake
@@ -1,6 +1,10 @@
 # Set CMAKE_INSTALL_* if not defined
 set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${LRS_TARGET}")
 
+# Set a relative RPATH for installed libraries
+# to learn more about RPATH and cmake: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../include")
+
 add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 
 include(CMakePackageConfigHelpers)

--- a/CMake/install_config.cmake
+++ b/CMake/install_config.cmake
@@ -1,9 +1,12 @@
 # Set CMAKE_INSTALL_* if not defined
 set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${LRS_TARGET}")
 
-# Set a relative RPATH for installed libraries
-# to learn more about RPATH and cmake: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../include")
+if(UNIX)
+    # Set a relative RPATH for installed libraries
+    # to learn more about RPATH and cmake: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../include")
+endif()
+
 
 add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 


### PR DESCRIPTION
This PR is to set the RPATH of the libraries and executable in the install directory to be relative. 

**I do not know about the windows and iOS build systems. I tested this on Ubuntu 18.04 and Jetson Nano emulated environment.** please test it. thanks.

About the RPATH and CMAKE in Linux: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling

The story:
You can specify a `install` directory with cmake like 
```
cmake \
    -DCMAKE_INSTALL_PREFIX=~/librealsense_binary \
    -DPYTHON_INSTALL_DIR=~/librealsense_binary/python \
    -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") \
    ../
```
In this case without setting relative RPATH, you cannot move the install directory. If you move it to some other location in filesystem after the compilation, `ldd` cannot find required shared libraries. So you cannot import libraries or execute binaries.

With this PR, it should set a relative RPATH and make sure that everything works if you move the binary directories in your system.