### PR TITLE
Fix libusb resource leak issues

### DIFF
--- a/src/libusb/handle-libusb.h
+++ b/src/libusb/handle-libusb.h
@@ -49,7 +49,7 @@ namespace librealsense
                     {
                         auto rs_sts =  libusb_status_to_rs(sts);
                         std::stringstream msg;
-                        msg << "failed to open usb interface: " << (int)interface->get_number() << ", error: " << usb_status_to_string.at(rs_sts);
+                        msg << "failed to open usb interface, error: " << usb_status_to_string.at(rs_sts);
                         LOG_ERROR(msg.str());
                         throw std::runtime_error(msg.str());
                     }

--- a/src/libusb/handle-libusb.h
+++ b/src/libusb/handle-libusb.h
@@ -91,7 +91,7 @@ namespace librealsense
                     } while (0);
                     
                     uninit(interface);
-                    throw std::runtime_error(to_string() << "Unable to claim interface " << failed_interface << ", error: " << usb_status_to_string.at(rs_sts));
+                    throw std::runtime_error(to_string() << "Unable to claim interface " << failed_interface << ", error: " << usb_status_to_string.at(status));
                 }
 
                 operator libusb_device_handle* () const

--- a/src/libusb/handle-libusb.h
+++ b/src/libusb/handle-libusb.h
@@ -133,7 +133,7 @@ namespace librealsense
             handle_libusb(std::shared_ptr<usb_context> context, libusb_device* device, std::shared_ptr<usb_interface_libusb> interface) :
                     _handle(device), _context(context)
             {
-                _handle.init(interface)
+                _handle.init(interface);
                 _context->start_event_handler();
             }
 

--- a/src/libusb/handle-libusb.h
+++ b/src/libusb/handle-libusb.h
@@ -123,7 +123,7 @@ namespace librealsense
                 {
                     for(auto&& i : interface->get_associated_interfaces())
                         libusb_release_interface(_handle, i->get_number());
-                    libusb_release_interface(interface->get_number());
+                    libusb_release_interface(_handle, interface->get_number());
                 }
                     
                 libusb_device_handle* _handle;


### PR DESCRIPTION
Issue 1: Interface claimed by `claim_interface_or_throw(interface->get_number());` not released 
Issue 2: Resource leak if exceptions thrown in handle_libusb::ctor() (dtor not getting called)