### PR TITLE
Adding option for x64 linux to find libjpeg-turbo

### DIFF
--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -46,9 +46,13 @@ if(WIN32)
         PRIVATE ${CMAKE_BINARY_DIR}/libjpeg-turbo/lib/turbojpeg-static.lib
     )
 else()
+    set(LJ-T_DIR "lib")
+    if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+        set(LJ-T_DIR "lib64")
+    endif()
     target_link_libraries(${PROJECT_NAME}
         PRIVATE ${DEPENDENCIES}
-        PRIVATE ${CMAKE_BINARY_DIR}/libjpeg-turbo/lib/libturbojpeg.a
+        PRIVATE ${CMAKE_BINARY_DIR}/libjpeg-turbo/${LJ-T_DIR}/libturbojpeg.a
     )
 endif()
 


### PR DESCRIPTION
There is probably a cleaner way to do this, but I need to learn more about C languages.  

Essentially, the previous code when looking for `libturbojpeg.a` would look in the directory `lib` 
when it need to be looking at `lib64`
for 64 bit linux