### PR TITLE
Rename overloaded parameters in python opencv example for clarity

### DIFF
--- a/wrappers/python/examples/opencv_pointcloud_viewer.py
+++ b/wrappers/python/examples/opencv_pointcloud_viewer.py
@@ -77,7 +77,7 @@ pipeline.start(config)
 profile = pipeline.get_active_profile()
 depth_profile = rs.video_stream_profile(profile.get_stream(rs.stream.depth))
 depth_intrinsics = depth_profile.get_intrinsics()
-w, h = depth_intrinsics.width, depth_intrinsics.height
+w_original, h_original = depth_intrinsics.width, depth_intrinsics.height
 
 # Processing blocks
 pc = rs.pointcloud()
@@ -133,7 +133,7 @@ def mouse_cb(event, x, y, flags, param):
 
 
 cv2.namedWindow(state.WIN_NAME, cv2.WINDOW_AUTOSIZE)
-cv2.resizeWindow(state.WIN_NAME, w, h)
+cv2.resizeWindow(state.WIN_NAME, w_original, h_original)
 cv2.setMouseCallback(state.WIN_NAME, mouse_cb)
 
 
@@ -261,7 +261,7 @@ def pointcloud(out, verts, texcoords, color, painter=True):
     out[i[m], j[m]] = color[u[m], v[m]]
 
 
-out = np.empty((h, w, 3), dtype=np.uint8)
+out = np.empty((h_original, w_original, 3), dtype=np.uint8)
 
 while True:
     # Grab camera data


### PR DESCRIPTION
In trying replicate the functionality in this example I spent several hours on understanding the consequences of the width and height parameters throughout the code. I believe this implementation to be clearer. 

This is my first open source merge request. I read the contribution guidelines. If this is not the correct place I apologize and would like to submit it correctly. Thank you for your work.