### PR TITLE
Explicitly set OPENSSL_ROOT_DIR in libcurl build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,7 @@ matrix:
       sudo: required
       osx_image: xcode12.2
       script:
-        - export OPENSSL_ROOT_DIR=`brew --prefix openssl` # Used by libcurl for 'CHECK_FOR_UPDATES' capability
-        - cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true
+        - cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)
         - cmake --build . --config $LRS_BUILD_CONFIG -- -j4
         - ls
 

--- a/CMake/external_libcurl.cmake
+++ b/CMake/external_libcurl.cmake
@@ -11,7 +11,7 @@ if(CHECK_FOR_UPDATES)
     if (WIN32)
         set(CURL_FLAGS ${CURL_FLAGS} -DCMAKE_USE_SCHANNEL=ON )
     else()
-        set(CURL_FLAGS ${CURL_FLAGS} -DCMAKE_USE_OPENSSL=ON )
+        set(CURL_FLAGS ${CURL_FLAGS} -DCMAKE_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR})
     endif()
     
     ExternalProject_Add(

--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -9,7 +9,7 @@
 1. Install CommantLineTools `sudo xcode-select --install` or download XCode 6.0+ via the AppStore
 2. Install the Homebrew package manager via terminal - [link](http://brew.sh/)
 3. Install the following packages via brew:
-  * `brew install cmake libusb pkg-config`
+  * `brew install cmake libusb openssl pkg-config`
   * `brew cask install apenngrace/vulkan/vulkan-sdk`
 
 **Note** *librealsense* requires CMake version 3.8+ that can also be obtained via the [official CMake site](https://cmake.org/download/).  
@@ -18,7 +18,7 @@
 4. Generate XCode project:
   * `mkdir build && cd build`
   * `sudo xcode-select --reset`
-  * `cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false`
+  * `cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)`
 5. Build the Project
   * `make -j2`
 


### PR DESCRIPTION
When building the library on macOS, I need to set -DOPENSSL_ROOT_DIR in cmake like:
```
cmake ../ -DBUILD_PYTHON_BINDINGS=bool:true -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
```

However, OPENSSL_ROOT_DIR doesn't seem to propagate to the libcurl build, which results in an error when running `make`:
```
CMake Error at /Applications/CMake.app/Contents/share/cmake-3.20/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
  OPENSSL_INCLUDE_DIR)
```

Others seem to be experiencing this as well in https://github.com/IntelRealSense/librealsense/issues/8090#issuecomment-836892782. This fixes it by explicitly setting -DOPENSSL_ROOT_DIR in "external_libcurl.cmake"