### PR TITLE
D400: Expose Y8I infrared stream

### DIFF
--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -667,6 +667,7 @@ namespace librealsense
 
         depth_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
 
+        depth_ep->register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Y8I, RS2_STREAM_INFRARED));
         depth_ep->register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 1));
         depth_ep->register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Z16, RS2_STREAM_DEPTH));
 


### PR DESCRIPTION
This PR proposes to expose the infrared streams of the D400 cameras in the interleaved `RS2_FORMAT_Y8I` format, which seems to be the original format provided by the D400 devices if one wants to stream the images of both infrared cameras as `RS2_FORMAT_Y8`. `RS2_FORMAT_Y8I` stores the images of both cameras in interleaved format, and normally librealsense de-interleaves these images when streaming both using the `y8i_to_y8y8` processing block. The use-case of using `RS2_FORMAT_Y8I` directly is if the images should simply be saved to disk as quickly as possible, while doing as little processing as possible to minimize the chance of frame drops, on a slow platform such as the Raspberry PI.