### PR TITLE
RSUSB: Avoid some memory copies

### DIFF
--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -173,7 +173,7 @@ namespace librealsense
                 for(auto&& r : _requests)
                 {
                     r = _messenger->create_request(get_hid_endpoint());
-                    r->set_buffer(std::vector<uint8_t>(sizeof(REALSENSE_HID_REPORT)));
+                    r->set_buffer(std::move(std::vector<uint8_t>(sizeof(REALSENSE_HID_REPORT))));
                     r->set_callback(_request_callback);
                 }
 #endif

--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -1320,7 +1320,7 @@ namespace librealsense
             _device->submit_request(request);
         });
 
-        _interrupt_request = _device->interrupt_read_request(buffer, _interrupt_callback);
+        _interrupt_request = _device->interrupt_read_request(std::move(buffer), _interrupt_callback);
         _device->submit_request(_interrupt_request);
         return true;
     }
@@ -1381,7 +1381,7 @@ namespace librealsense
             _device->submit_request(request);
         });
 
-        _stream_request = _device->stream_read_request(buffer, _stream_callback);
+        _stream_request = _device->stream_read_request(std::move(buffer), _stream_callback);
         _device->submit_request(_stream_request);
         return true;
     }
@@ -2087,10 +2087,10 @@ namespace librealsense
         return e;
     }
 
-    platform::rs_usb_request tm2_device::stream_read_request(std::vector<uint8_t> & buffer, std::shared_ptr<platform::usb_request_callback> callback)
+    platform::rs_usb_request tm2_device::stream_read_request(std::vector<uint8_t> && buffer, std::shared_ptr<platform::usb_request_callback> callback)
     {
         auto request = usb_messenger->create_request(endpoint_bulk_in);
-        request->set_buffer(buffer);
+        request->set_buffer(std::move(buffer));
         request->set_callback(callback);
         return request;
     }
@@ -2110,10 +2110,10 @@ namespace librealsense
         return true;
     }
 
-    platform::rs_usb_request tm2_device::interrupt_read_request(std::vector<uint8_t> & buffer, std::shared_ptr<platform::usb_request_callback> callback)
+    platform::rs_usb_request tm2_device::interrupt_read_request(std::vector<uint8_t> && buffer, std::shared_ptr<platform::usb_request_callback> callback)
     {
         auto request = usb_messenger->create_request(endpoint_int_in);
-        request->set_buffer(buffer);
+        request->set_buffer(std::move(buffer));
         request->set_callback(callback);
         return request;
     }

--- a/src/tm2/tm-device.h
+++ b/src/tm2/tm-device.h
@@ -65,12 +65,12 @@ namespace librealsense
         std::mutex bulk_mutex;
         template<typename Request, typename Response> platform::usb_status bulk_request_response(const Request &request, Response &response, size_t max_response_size = 0, bool assert_success = true);
 
-        platform::rs_usb_request interrupt_read_request(std::vector<uint8_t> & buffer, std::shared_ptr<platform::usb_request_callback> callback);
+        platform::rs_usb_request interrupt_read_request(std::vector<uint8_t> && buffer, std::shared_ptr<platform::usb_request_callback> callback);
 
         std::mutex stream_mutex;
         platform::usb_status stream_write(const t265::bulk_message_request_header * request);
 
-        platform::rs_usb_request stream_read_request(std::vector<uint8_t> & buffer, std::shared_ptr<platform::usb_request_callback> callback);
+        platform::rs_usb_request stream_read_request(std::vector<uint8_t> && buffer, std::shared_ptr<platform::usb_request_callback> callback);
 
         void submit_request(platform::rs_usb_request request);
         bool cancel_request(platform::rs_usb_request request);

--- a/src/usb/usb-request.h
+++ b/src/usb/usb-request.h
@@ -30,6 +30,7 @@ namespace librealsense
             virtual void* get_native_request() const = 0;
             virtual const std::vector<uint8_t>& get_buffer() const = 0;
             virtual void set_buffer(std::vector<uint8_t>&& buffer) = 0;
+            virtual void swap_buffer(std::vector<uint8_t>* other_buffer) = 0;
 
         protected:
             virtual void set_native_buffer_length(int length) = 0;
@@ -52,6 +53,12 @@ namespace librealsense
             virtual void set_buffer(std::vector<uint8_t>&& buffer) override
             {
                 _buffer = std::move(buffer);
+                set_native_buffer(_buffer.data());
+                set_native_buffer_length( static_cast< int >( _buffer.size() ));
+            }
+            virtual void swap_buffer(std::vector<uint8_t>* other_buffer) override
+            {
+                std::swap(_buffer, *other_buffer);
                 set_native_buffer(_buffer.data());
                 set_native_buffer_length( static_cast< int >( _buffer.size() ));
             }

--- a/src/usb/usb-request.h
+++ b/src/usb/usb-request.h
@@ -29,7 +29,7 @@ namespace librealsense
             virtual void* get_client_data() const = 0;
             virtual void* get_native_request() const = 0;
             virtual const std::vector<uint8_t>& get_buffer() const = 0;
-            virtual void set_buffer(const std::vector<uint8_t>& buffer) = 0;
+            virtual void set_buffer(std::vector<uint8_t>&& buffer) = 0;
 
         protected:
             virtual void set_native_buffer_length(int length) = 0;
@@ -49,9 +49,9 @@ namespace librealsense
             virtual void set_client_data(void* data) override { _client_data = data; }
             virtual void* get_client_data() const override { return _client_data; }
             virtual const std::vector<uint8_t>& get_buffer() const override { return _buffer; }
-            virtual void set_buffer(const std::vector<uint8_t>& buffer) override
+            virtual void set_buffer(std::vector<uint8_t>&& buffer) override
             {
-                _buffer = buffer;
+                _buffer = std::move(buffer);
                 set_native_buffer(_buffer.data());
                 set_native_buffer_length( static_cast< int >( _buffer.size() ));
             }

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -678,7 +678,7 @@ namespace librealsense
                      });
 
             _interrupt_request = _messenger->create_request(iep);
-            _interrupt_request->set_buffer(std::vector<uint8_t>(INTERRUPT_BUFFER_SIZE));
+            _interrupt_request->set_buffer(std::move(std::vector<uint8_t>(INTERRUPT_BUFFER_SIZE)));
             _interrupt_request->set_callback(_interrupt_callback);
             auto sts = _messenger->submit_request(_interrupt_request);
             if (sts != RS2_USB_STATUS_SUCCESS)

--- a/src/uvc/uvc-streamer.cpp
+++ b/src/uvc/uvc-streamer.cpp
@@ -143,7 +143,7 @@ namespace librealsense
             for(auto&& r : _requests)
             {
                 r = _context.messenger->create_request(_read_endpoint);
-                r->set_buffer(std::vector<uint8_t>(_read_buff_length));
+                r->set_buffer(std::move(std::vector<uint8_t>(_read_buff_length)));
                 r->set_callback(_request_callback);
             }
         }

--- a/src/uvc/uvc-streamer.cpp
+++ b/src/uvc/uvc-streamer.cpp
@@ -128,7 +128,10 @@ namespace librealsense
                         {
                             _frame_arrived = true;
                             _watchdog->kick();
-                            memcpy(f->pixels.data(), r->get_buffer().data(), r->get_buffer().size());
+                            if (f->pixels.size() == r->get_buffer().size())
+                                r->swap_buffer(&f->pixels);
+                            else
+                                memcpy(f->pixels.data(), r->get_buffer().data(), r->get_buffer().size());
                             uvc_process_bulk_payload(std::move(f), r->get_actual_length(), _queue);
                         }
                     }


### PR DESCRIPTION
This PR proposes to avoid some memory copies in the RSUSB code that do not seem to be necessary:
* Use `std::move()` for `usb_request::set_buffer()`.
* Replace a memcpy of the frame data in uvc-streamer.cpp with a pointer swap.

Note that I could not test the changes to `src/tm2/tm-device.cpp`.