### PR TITLE
Implement pre-computation of xy-map in the pointcloud base class

### DIFF
--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -22,15 +22,23 @@
 
 namespace librealsense
 {
-    template<class MAP_DEPTH> void deproject_depth(float * points, const rs2_intrinsics & intrin, const uint16_t * depth, MAP_DEPTH map_depth)
+    void pointcloud::preprocess()
     {
-        for (int y = 0; y < intrin.height; ++y)
+        _pre_compute_map_x.resize(_depth_intrinsics->width*_depth_intrinsics->height);
+        _pre_compute_map_y.resize(_depth_intrinsics->width*_depth_intrinsics->height);
+
+        for (int y = 0; y < _depth_intrinsics->height; ++y)
         {
-            for (int x = 0; x < intrin.width; ++x)
+            for (int x = 0; x < _depth_intrinsics->width; ++x)
             {
                 const float pixel[] = { (float)x, (float)y };
-                rs2_deproject_pixel_to_point(points, &intrin, pixel, map_depth(*depth++));
-                points += 3;
+                float point[3];
+
+                const rs2_intrinsics & intrin = *_depth_intrinsics;
+                rs2_deproject_pixel_to_point(point, &intrin, pixel, 1);
+
+                _pre_compute_map_x[y*_depth_intrinsics->width + x] = point[0];
+                _pre_compute_map_y[y*_depth_intrinsics->width + x] = point[1];
             }
         }
     }
@@ -38,9 +46,27 @@ namespace librealsense
     const float3 * pointcloud::depth_to_points(rs2::points output, 
         const rs2_intrinsics &depth_intrinsics, const rs2::depth_frame& depth_frame)
     {
+
         auto image = output.get_vertices();
         auto depth_scale = depth_frame.get_units();
-        deproject_depth((float*)image, depth_intrinsics, (const uint16_t*)depth_frame.get_data(), [depth_scale](uint16_t z) { return depth_scale * z; });
+
+        const uint16_t* depth = (const uint16_t*)depth_frame.get_data();
+        float* points = (float*)image;
+
+        for (int y = 0; y < depth_intrinsics.height; ++y)
+        {
+            for (int x = 0; x < depth_intrinsics.width; ++x)
+            {
+                float z = depth_scale * (*depth++);
+
+                points[0] = z * _pre_compute_map_x[y*depth_intrinsics.width + x];
+                points[1] = z * _pre_compute_map_y[y*depth_intrinsics.width + x];
+                points[2] = z;
+
+                points += 3;
+            }
+        }
+
         return (float3*)image;
     }
 

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -28,7 +28,7 @@ namespace librealsense
             const rs2_extrinsics& extr,
             float2* pixels_ptr);
         virtual rs2::points allocate_points(const rs2::frame_source& source, const rs2::frame& f);
-        virtual void preprocess() {}
+        virtual void preprocess();
         virtual bool run__occlusion_filter(const rs2_extrinsics& extr);
 
     protected:
@@ -57,5 +57,8 @@ namespace librealsense
 
         stream_filter _prev_stream_filter;
         std::shared_ptr< pointcloud > _registered_auto_calib_cb;
+
+        std::vector<float> _pre_compute_map_x;
+        std::vector<float> _pre_compute_map_y;
     };
 }

--- a/src/proc/sse/sse-pointcloud.cpp
+++ b/src/proc/sse/sse-pointcloud.cpp
@@ -22,37 +22,6 @@ namespace librealsense
 {
     pointcloud_sse::pointcloud_sse() : pointcloud("Pointcloud (SSE3)") {}
 
-    void pointcloud_sse::preprocess()
-    {
-        _pre_compute_map_x.resize(_depth_intrinsics->width*_depth_intrinsics->height);
-        _pre_compute_map_y.resize(_depth_intrinsics->width*_depth_intrinsics->height);
-
-        for (int h = 0; h < _depth_intrinsics->height; ++h)
-        {
-            for (int w = 0; w < _depth_intrinsics->width; ++w)
-            {
-                const float pixel[] = { (float)w, (float)h };
-
-                float x = (pixel[0] - _depth_intrinsics->ppx) / _depth_intrinsics->fx;
-                float y = (pixel[1] - _depth_intrinsics->ppy) / _depth_intrinsics->fy;
-
-
-                if (_depth_intrinsics->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
-                {
-                    float r2 = x * x + y * y;
-                    float f = 1 + _depth_intrinsics->coeffs[0] * r2 + _depth_intrinsics->coeffs[1] * r2*r2 + _depth_intrinsics->coeffs[4] * r2*r2*r2;
-                    float ux = x * f + 2 * _depth_intrinsics->coeffs[2] * x*y + _depth_intrinsics->coeffs[3] * (r2 + 2 * x*x);
-                    float uy = y * f + 2 * _depth_intrinsics->coeffs[3] * x*y + _depth_intrinsics->coeffs[2] * (r2 + 2 * y*y);
-                    x = ux;
-                    y = uy;
-                }
-
-                _pre_compute_map_x[h*_depth_intrinsics->width + w] = x;
-                _pre_compute_map_y[h*_depth_intrinsics->width + w] = y;
-            }
-        }
-    }
-
     const float3* pointcloud_sse::depth_to_points(rs2::points output,
             const rs2_intrinsics &depth_intrinsics, 
             const rs2::depth_frame& depth_frame)

--- a/src/proc/sse/sse-pointcloud.h
+++ b/src/proc/sse/sse-pointcloud.h
@@ -20,7 +20,6 @@ namespace librealsense
             float2 * pixels_ptr);
 
     private:
-        void preprocess() override;
         const float3 * depth_to_points(
             rs2::points output,
             const rs2_intrinsics &depth_intrinsics, 
@@ -33,10 +32,5 @@ namespace librealsense
             const rs2_intrinsics &other_intrinsics,
             const rs2_extrinsics& extr,
             float2* pixels_ptr) override;
-
-        std::vector<float> _pre_compute_map_x;
-        std::vector<float> _pre_compute_map_y;
-
-        void pre_compute_x_y_map();
     };
 }


### PR DESCRIPTION
Currently, platforms without SSE or GPU support suffer massive
performance hits when using pointcloud, because the xy-map is not
pre-computed when the intrinsics are first retrieved - this optimisation
is only implemented for pointcloud_sse.

This patch fixes this by implementing pointcloud::preprocess() for the
base class. pointcloud_sse::preprocess() is no longer necessary.

Also, this patch ensures that the pointcloud computation is the same
between SSE and non-SSE implementations, as they both now utilise
rs2_deproject_pixel_to_point(), which supports more distortion models
than pointcloud_sse::preprocess() did.

Testing on a Raspberry Pi 3+ Model B (using only CPU) with a RealSense
D455 camera with a 640x480 depth stream, this patch decreases the
per-frame pointcloud processing time from 55ms to 5ms (tenfold!)

_Note: It looks as though pointcloud_cuda also doesn't use a precompute map...? Is there any reason not to utilise one? preprocess() will be called again if the intrinsics change for any reason._