### PR TITLE
PLY vertices data should be on a single line per vertex

### DIFF
--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -242,23 +242,21 @@ namespace rs2
                     out << new_verts[i].x << " ";
                     out << new_verts[i].y << " ";
                     out << new_verts[i].z << " ";
-                    out << "\n";
-
+  
                     if (mesh && use_normals)
                     {
                         out << normals[i].x << " ";
                         out << normals[i].y << " ";
                         out << normals[i].z << " ";
-                        out << "\n";
-                    }
+                      }
 
                     if (use_texcoords)
                     {
                         out << unsigned(new_tex[i][0]) << " ";
                         out << unsigned(new_tex[i][1]) << " ";
                         out << unsigned(new_tex[i][2]) << " ";
-                        out << "\n";
                     }
+                    out << "\n";
                 }
                 if (mesh)
                 {


### PR DESCRIPTION
As shown in the PLY file format (http://gamma.cs.unc.edu/POWERPLANT/papers/ply.pdf) all the data for each vertex should be on a single line.
Adding a carriage return after each property makes the file unusable in some third party applications (see here : https://developer.blender.org/T88745)