### PR TITLE
fix some warnings

### DIFF
--- a/CMake/opengl_config.cmake
+++ b/CMake/opengl_config.cmake
@@ -1,2 +1,6 @@
 find_package(OpenGL REQUIRED)
 set(DEPENDENCIES realsense2 glfw ${OPENGL_LIBRARIES})
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_definitions(-DGL_SILENCE_DEPRECATION)
+endif()

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -1326,7 +1326,7 @@ namespace rs2
             update_state == RS2_CALIB_STATE_FL_INPUT ||
             update_state == RS2_CALIB_STATE_GET_TARE_GROUND_TRUTH ||
             update_state == RS2_CALIB_STATE_GET_TARE_GROUND_TRUTH_IN_PROCESS ||
-            update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS && (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_FL_CALIB || get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_UVMAPPING_CALIB))
+            (update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS && (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_FL_CALIB || get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_UVMAPPING_CALIB)))
             get_manager().turn_roi_on();
         else
             get_manager().turn_roi_off();

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -110,7 +110,7 @@ namespace rs2
             case FIRMWARE: return "FIRMWARE";
                 break;
             default:
-                LOG_ERROR("Unknown component type: " + component);
+                LOG_ERROR("Unknown component type: " + std::to_string(static_cast<int>(component)));
                 break;
             }
             return "";
@@ -126,7 +126,7 @@ namespace rs2
             case ESSENTIAL: return "ESSENTIAL";
                 break;
             default:
-                LOG_ERROR("Unknown policy type: " + policy);
+                LOG_ERROR("Unknown policy type: " + std::to_string(static_cast<int>(policy)));
                 break;
             }
             return "";

--- a/common/updates-model.cpp
+++ b/common/updates-model.cpp
@@ -216,13 +216,13 @@ bool updates_model::draw_software_section(const char * window_name, update_profi
                 if (!essential_found)
                 {
                     essential_found = essential_found || sw_update.name_for_display.find("ESSENTIAL") != std::string::npos;
-                    essential_sw_update_needed = essential_sw_update_needed || essential_found && (selected_profile.profile.software_version < sw_update.ver);
+                    essential_sw_update_needed = essential_sw_update_needed || (essential_found && (selected_profile.profile.software_version < sw_update.ver));
                 }
 
                 if (!recommended_found)
                 {
                     recommended_found = recommended_found || sw_update.name_for_display.find("RECOMMENDED") != std::string::npos;
-                    recommended_sw_update_needed = recommended_sw_update_needed || recommended_found && (selected_profile.profile.software_version < sw_update.ver);
+                    recommended_sw_update_needed = recommended_sw_update_needed || (recommended_found && (selected_profile.profile.software_version < sw_update.ver));
                 }
             }
 
@@ -477,13 +477,13 @@ bool updates_model::draw_firmware_section(std::shared_ptr<notifications_model> n
             if (!essential_found)
             {
                 essential_found = essential_found || fw_update.name_for_display.find("ESSENTIAL") != std::string::npos;
-                essential_fw_update_needed = essential_fw_update_needed || essential_found && (selected_profile.profile.firmware_version < fw_update.ver);
+                essential_fw_update_needed = essential_fw_update_needed || (essential_found && (selected_profile.profile.firmware_version < fw_update.ver));
             }
 
             if (!recommended_found)
             {
                 recommended_found = recommended_found || fw_update.name_for_display.find("RECOMMENDED") != std::string::npos;
-                recommended_fw_update_needed = recommended_fw_update_needed || recommended_found && (selected_profile.profile.firmware_version < fw_update.ver);
+                recommended_fw_update_needed = recommended_fw_update_needed || (recommended_found && (selected_profile.profile.firmware_version < fw_update.ver));
             }
         }
 

--- a/third-party/realsense-file/rosbag/console_bridge/include/console_bridge/console.h
+++ b/third-party/realsense-file/rosbag/console_bridge/include/console_bridge/console.h
@@ -75,17 +75,17 @@ static inline void CONSOLE_BRIDGE_DEPRECATED console_bridge_deprecated() {}
 
     \}
 */
-#define CONSOLE_BRIDGE_logError(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logError(...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logWarn(...)   \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN, __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logInform(fmt, ...) \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logInform(...) \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO, __VA_ARGS__)
 
-#define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#define CONSOLE_BRIDGE_logDebug(...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, __VA_ARGS__)
 
 //#define logError(fmt, ...)  \
 //  console_bridge::log_deprecated(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)


### PR DESCRIPTION
1. the warnings in console_bridge is fixed in upstream.
2. the OpenGL API is deprecated in macOS.
3. fix some warnings in librealsense.

Please double check the fix in common/on-chip-calib.cpp 