### PR TITLE
Implement a CPU fallback for the GPU build

### DIFF
--- a/include/librealsense2/rsutil_gpu.h
+++ b/include/librealsense2/rsutil_gpu.h
@@ -1,0 +1,22 @@
+/* License: Apache 2.0. See LICENSE file in root directory.
+   Copyright(c) 2015 Intel Corporation. All Rights Reserved. */
+
+#ifndef LIBREALSENSE_RSUTIL2_GPU_H
+#define LIBREALSENSE_RSUTIL2_GPU_H
+
+#ifdef RS2_USE_CUDA
+# include <cuda_runtime.h>
+#endif
+namespace {
+  inline bool rs2_is_gpu_available()
+  {
+#ifdef RS2_USE_CUDA
+    static int gpuDeviceCount = -1;
+    if (gpuDeviceCount < 0) cudaGetDeviceCount(&gpuDeviceCount);
+    return (gpuDeviceCount > 0);
+#else
+    return false;
+#endif
+  }
+}
+#endif

--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -1,5 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+#include "../include/librealsense2/rsutil_gpu.h"
 
 #include "color-formats-converter.h"
 
@@ -56,8 +57,11 @@ namespace librealsense
         auto n = width * height;
         assert(n % 16 == 0); // All currently supported color resolutions are multiples of 16 pixels. Could easily extend support to other resolutions by copying final n<16 pixels into a zero-padded buffer and recursively calling self for final iteration.
 #ifdef RS2_USE_CUDA
-        rscuda::unpack_yuy2_cuda<FORMAT>(d, s, n);
-        return;
+        if (rs2_is_gpu_available())
+        {
+          rscuda::unpack_yuy2_cuda<FORMAT>(d, s, n);
+          return;
+        }
 #endif
 #if defined __SSSE3__ && ! defined ANDROID
         static bool do_avx = has_avx();

--- a/src/proc/depth-formats-converter.cpp
+++ b/src/proc/depth-formats-converter.cpp
@@ -1,5 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+#include "../include/librealsense2/rsutil_gpu.h"
 
 #include "depth-formats-converter.h"
 
@@ -17,11 +18,16 @@ namespace librealsense
         auto in = reinterpret_cast<const uint16_t*>(source);
         auto out_ir = reinterpret_cast<uint8_t *>(dest[1]);
 #ifdef RS2_USE_CUDA
-        rscuda::unpack_z16_y8_from_sr300_inzi_cuda(out_ir, in, count);
-        in += count;
-#else
-        for (int i = 0; i < count; ++i) *out_ir++ = *in++ >> 2;
+        if (rs2_is_gpu_available())
+        {
+          rscuda::unpack_z16_y8_from_sr300_inzi_cuda(out_ir, in, count);
+          in += count;
+        }
+        else
 #endif
+        {
+            for (int i = 0; i < count; ++i) *out_ir++ = *in++ >> 2;
+        }
         librealsense::copy(dest[0], in, count * 2);
     }
 
@@ -31,11 +37,16 @@ namespace librealsense
         auto in = reinterpret_cast<const uint16_t*>(source);
         auto out_ir = reinterpret_cast<uint16_t*>(dest[1]);
 #ifdef RS2_USE_CUDA
+        if (rs2_is_gpu_available())
+        {
         rscuda::unpack_z16_y16_from_sr300_inzi_cuda(out_ir, in, count);
         in += count;
-#else
-        for (int i = 0; i < count; ++i) *out_ir++ = *in++ << 6;
+        }
+        else
 #endif
+        {
+            for (int i = 0; i < count; ++i) *out_ir++ = *in++ << 6;
+        }
         librealsense::copy(dest[0], in, count * 2);
     }
 

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -2,6 +2,8 @@
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
 #include "../include/librealsense2/rs.hpp"
+#include "../include/librealsense2/rsutil.h"
+#include "../include/librealsense2/rsutil_gpu.h"
 #include "environment.h"
 #include "proc/occlusion-filter.h"
 #include "proc/pointcloud.h"
@@ -387,15 +389,17 @@ namespace librealsense
 
     std::shared_ptr<pointcloud> pointcloud::create()
     {
-        #ifdef RS2_USE_CUDA
-            return std::make_shared<librealsense::pointcloud_cuda>();
-        #else
-        #ifdef __SSSE3__
-            return std::make_shared<librealsense::pointcloud_sse>();
-        #else
-            return std::make_shared<librealsense::pointcloud>();
-        #endif
-        #endif
+#ifdef RS2_USE_CUDA
+      if (rs2_is_gpu_available())
+      {
+        return std::make_shared<librealsense::pointcloud_cuda>();
+      }
+#endif
+#ifdef __SSSE3__
+      return std::make_shared<librealsense::pointcloud_sse>();
+#else
+      return std::make_shared<librealsense::pointcloud>();
+#endif
     }
 
     bool pointcloud::run__occlusion_filter(const rs2_extrinsics& extr)

--- a/src/proc/processing-blocks-factory.cpp
+++ b/src/proc/processing-blocks-factory.cpp
@@ -1,6 +1,7 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
+#include "../include/librealsense2/rsutil_gpu.h"
 #include "processing-blocks-factory.h"
 
 #include "sse/sse-align.h"
@@ -10,24 +11,20 @@
 
 namespace librealsense
 {
+    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
+    {
 #ifdef RS2_USE_CUDA
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
+      if (rs2_is_gpu_available())
+      {
         return std::make_shared<librealsense::align_cuda>(align_to);
-    }
-#else
-#ifdef __SSSE3__
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
-        return std::make_shared<librealsense::align_sse>(align_to);
-    }
-#else // No optimizations
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
-        return std::make_shared<librealsense::align>(align_to);
-    }
-#endif // __SSSE3__
+      }
 #endif // RS2_USE_CUDA
+#ifdef __SSSE3__
+      return std::make_shared<librealsense::align_sse>(align_to);
+#else // No optimizations
+      return std::make_shared<librealsense::align>(align_to);
+#endif // __SSSE3__
+    }
 
     processing_block_factory::processing_block_factory(const std::vector<stream_profile>& from, const std::vector<stream_profile>& to, std::function<std::shared_ptr<processing_block>(void)> generate_func) :
         _source_info(from), _target_info(to), generate_processing_block(generate_func)

--- a/src/proc/y12i-to-y16y16.cpp
+++ b/src/proc/y12i-to-y16y16.cpp
@@ -1,5 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+#include "../include/librealsense2/rsutil_gpu.h"
 
 #include "y12i-to-y16y16.h"
 #include "stream.h"
@@ -10,17 +11,21 @@
 namespace librealsense
 {
     struct y12i_pixel { uint8_t rl : 8, rh : 4, ll : 4, lh : 8; int l() const { return lh << 4 | ll; } int r() const { return rh << 8 | rl; } };
-    void unpack_y16_y16_from_y12i_10(byte * const dest[], const byte * source, int width, int height, int actual_size)
+    static void unpack_y16_y16_from_y12i_10_CPU(byte * const dest[], const byte * source, int width, int height, int actual_size)
     {
         auto count = width * height;
-#ifdef RS2_USE_CUDA
-        rscuda::split_frame_y16_y16_from_y12i_cuda(dest, count, reinterpret_cast<const y12i_pixel *>(source));
-#else
         split_frame(dest, count, reinterpret_cast<const y12i_pixel*>(source),
             [](const y12i_pixel & p) -> uint16_t { return p.l() << 6 | p.l() >> 4; },  // We want to convert 10-bit data to 16-bit data
             [](const y12i_pixel & p) -> uint16_t { return p.r() << 6 | p.r() >> 4; }); // Multiply by 64 1/16 to efficiently approximate 65535/1023
-#endif
     }
+#ifdef RS2_USE_CUDA
+    static void unpack_y16_y16_from_y12i_10_GPU(byte * const dest[], const byte * source, int width, int height, int actual_size)
+    {
+        auto count = width * height;
+
+        rscuda::split_frame_y16_y16_from_y12i_cuda(dest, count, reinterpret_cast<const y12i_pixel *>(source));
+    }
+#endif
 
     y12i_to_y16y16::y12i_to_y16y16(int left_idx, int right_idx)
         : y12i_to_y16y16("Y12I to Y16L Y16R Transform", left_idx, right_idx) {}
@@ -28,7 +33,15 @@ namespace librealsense
     y12i_to_y16y16::y12i_to_y16y16(const char * name, int left_idx, int right_idx)
         : interleaved_functional_processing_block(name, RS2_FORMAT_Y12I, RS2_FORMAT_Y16, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME, 1,
                                                                          RS2_FORMAT_Y16, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME, 2)
-    {}
+        , unpack_y16_y16_from_y12i_10(unpack_y16_y16_from_y12i_10_CPU)
+    {
+#ifdef RS2_USE_CUDA
+      if (rs2_is_gpu_available())
+      {
+        unpack_y16_y16_from_y12i_10 = unpack_y16_y16_from_y12i_10_GPU;
+      }
+#endif
+    }
 
     void y12i_to_y16y16::process_function(byte * const dest[], const byte * source, int width, int height, int actual_size, int input_size)
     {

--- a/src/proc/y12i-to-y16y16.h
+++ b/src/proc/y12i-to-y16y16.h
@@ -17,5 +17,8 @@ namespace librealsense
     protected:
         y12i_to_y16y16(const char* name, int left_idx, int right_idx);
         void process_function(byte * const dest[], const byte * source, int width, int height, int actual_size, int input_size) override;
+
+    private:
+        void (*unpack_y16_y16_from_y12i_10)(byte * const dest[], const byte * source, int width, int height, int actual_size);
     };
 }

--- a/src/proc/y8i-to-y8y8.cpp
+++ b/src/proc/y8i-to-y8y8.cpp
@@ -1,5 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+#include "../include/librealsense2/rsutil_gpu.h"
 
 #include "y8i-to-y8y8.h"
 
@@ -12,25 +13,38 @@
 namespace librealsense
 {
     struct y8i_pixel { uint8_t l, r; };
-    void unpack_y8_y8_from_y8i(byte * const dest[], const byte * source, int width, int height, int actual_size)
+    static void unpack_y8_y8_from_y8i_CPU(byte * const dest[], const byte * source, int width, int height, int actual_size)
     {
         auto count = width * height;
-#ifdef RS2_USE_CUDA
-        rscuda::split_frame_y8_y8_from_y8i_cuda(dest, count, reinterpret_cast<const y8i_pixel *>(source));
-#else
         split_frame(dest, count, reinterpret_cast<const y8i_pixel*>(source),
             [](const y8i_pixel & p) -> uint8_t { return p.l; },
             [](const y8i_pixel & p) -> uint8_t { return p.r; });
-#endif
     }
 
-    y8i_to_y8y8::y8i_to_y8y8(int left_idx, int right_idx) :
-        y8i_to_y8y8("Y8i to Y8-Y8 Converter", left_idx, right_idx) {}
+#ifdef RS2_USE_CUDA
+    static void unpack_y8_y8_from_y8i_GPU(byte * const dest[], const byte * source, int width, int height, int actual_size)
+    {
+        auto count = width * height;
+        rscuda::split_frame_y8_y8_from_y8i_cuda(dest, count, reinterpret_cast<const y8i_pixel *>(source));
+    }
+#endif
+
+    y8i_to_y8y8::y8i_to_y8y8(int left_idx, int right_idx)
+        : y8i_to_y8y8("Y8i to Y8-Y8 Converter", left_idx, right_idx)
+    {}
 
     y8i_to_y8y8::y8i_to_y8y8(const char * name, int left_idx, int right_idx)
         : interleaved_functional_processing_block(name, RS2_FORMAT_Y8I, RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME, 1,
                                                                         RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME, 2)
-    {}
+        , unpack_y8_y8_from_y8i(unpack_y8_y8_from_y8i_CPU)
+    {
+#ifdef RS2_USE_CUDA
+      if (rs2_is_gpu_available())
+      {
+        unpack_y8_y8_from_y8i = unpack_y8_y8_from_y8i_GPU;
+      }
+#endif
+    }
 
     void y8i_to_y8y8::process_function(byte * const dest[], const byte * source, int width, int height, int actual_size, int input_size)
     {

--- a/src/proc/y8i-to-y8y8.h
+++ b/src/proc/y8i-to-y8y8.h
@@ -15,5 +15,8 @@ namespace librealsense
     protected:
         y8i_to_y8y8(const char* name, int left_idx, int right_idx);
         void process_function(byte * const dest[], const byte * source, int width, int height, int actual_size, int input_size) override;
+
+   private:
+        void (*unpack_y8_y8_from_y8i)(byte * const dest[], const byte * source, int width, int height, int actual_size);
     };
 }


### PR DESCRIPTION
If creating a CUDA context fails, fall back to the CPU implementation of the GPU methods in such a way that is transparent.

issue: #10085