### PR TITLE
Add bits to sign built kernel modules

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -269,6 +269,23 @@ fi
 
 echo -e "\e[32mPatched kernels modules were created successfully\n\e[0m"
 
+
+## -- This code signs the modules so that users don't have to disable secure-boot.
+cd ../../../
+
+echo "Signing Modules"
+for file in `find ./ -name '*.ko'`
+do
+        echo $file 
+        sudo kmodsign sha512 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der $file
+done
+
+echo "Unsigned modules:"
+find ./ -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+
+## -- End of new code
+
+
 # Load the newly-built modules
 # As a precausion start with unloading the core uvcvideo:
 try_unload_module uvcvideo


### PR DESCRIPTION
Quality-of-life improvement, signs kernel modules after generation and before import, otherwise it fails with a cryptic error on systems with secure-boot configured.

Might need some error handling around making sure the user has an appropriate signing key, or maybe move it into a function in patch-utils, etc.