### PR TITLE
Improve efficiency for CSV conversion

### DIFF
--- a/tools/convert/converter.cpp
+++ b/tools/convert/converter.cpp
@@ -59,6 +59,12 @@ void converter_base::wait()
     _worker.join();
 }
 
+void converter_base::flush()
+{
+	
+}
+
+
 std::string converter_base::get_statistics()
 {
     std::stringstream result;

--- a/tools/convert/converter.hpp
+++ b/tools/convert/converter.hpp
@@ -48,7 +48,9 @@ namespace rs2 {
 
                 virtual std::string get_statistics();
 
-                void wait();
+                virtual void wait();
+
+                virtual void flush();
             };
 
         }

--- a/tools/convert/converters/converter-csv.hpp
+++ b/tools/convert/converters/converter-csv.hpp
@@ -58,16 +58,16 @@ namespace rs2 {
                 rs2_stream _streamType;
                 std::string _filePath;
                 std::map<std::pair<rs2_stream, int>, std::vector<motion_pose_frame_record>> _imu_pose_collection;
-                bool _sub_workers_joined;
-                std::mutex _m;
-                std::condition_variable _cv;
-
 
             public:
 
                 converter_csv(const std::string& filePath, rs2_stream streamType = rs2_stream::RS2_STREAM_ANY);
 
                 void convert(rs2::frame& frame) override;
+
+                void wait() override { }
+
+                void flush() override;
                 
                 std::string name() const override
                 {

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -281,6 +281,13 @@ int main(int argc, char** argv) try
         }
     }
 
+
+    for_each(converters.begin(), converters.end(),
+        [](shared_ptr<rs2::tools::converter::converter_base>& converter) {
+            converter->flush();
+        });
+
+
     if( !switchTextOutput.isSet() )
         cout << endl;
 


### PR DESCRIPTION
This PR is to improve the efficiency of converting from a bag file to a CSV file.
previous implementation was re-writing the csv file every time a new IMU sample was received.  Generating a CSV files was taking hours before, now it takes seconds.

The main modification was to add a flush method to the converters.  That flush method is called once all the frames are read from the bag file.   Since the CSV converter was already accumulating the information of the IMU, I just moved the writing of the csv file in the flush method.


