### PR TITLE
Dispatcher deadlock workaround

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -129,6 +129,12 @@ namespace librealsense
 
         void add_software_device(std::shared_ptr<device_info> software_device);
 
+        void stop_device_watcher()
+        {
+            if (!_device_watcher->is_stopped())
+                _device_watcher->stop();
+        }
+
 #if WITH_TRACKING
         void unload_tracking_module();
 #endif

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -195,6 +195,7 @@ device::device(std::shared_ptr<context> ctx,
 
 device::~device()
 {
+    _context->stop_device_watcher();
     if (_device_changed_notifications)
     {
         _context->unregister_internal_device_callback(_callback_id);


### PR DESCRIPTION
Details on https://github.com/IntelRealSense/librealsense/issues/10482

Stopping _device_watcher before unregistering callbacks.
