### PR TITLE
Unable to successfully play rosbag containing topics of type realsense_msgs/Notification

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -59,7 +59,6 @@ namespace librealsense
             }
             else
             {
-                res[i] = ' ';
                 first = true;
             }
         }


### PR DESCRIPTION
Hello.
We are developing a robot with D435i.
I have been concerned for some time that the rosbag recorded using realsense-viewer may not play back properly.

Therefore, this Pull Request proposes a fix to resolve the issue and successfully play rosbag.
I would like to discuss whether this fix is appropriate, as it may affect other parts of the system that are not related to ros.

### Environment I used
|        | Details                                  | 
| ------ | ---------------------------------------- | 
| Camera | D435i（Connected via USB2.0）            | 
| OS     | Ubuntu 18.04 LTS                         | 
| ROS    | Melodic                                  | 
| CPU    | Intel® Core™ i7-8665U CPU @ 1.90GHz × 8 | 

### Commands used（When recording rosbag）
```
realsense-viewer 
```

### Commands used（Playing back recorded rosbags causes errors）
```
roscore
rosbag play space_existence_topic_notification.bag
```

### Error log
```
ikebe@ikebe:~$ rosbag play space_existence_topic_notification.bag 
[ INFO] [1659491276.715054503]: Opening space_existence_topic_notification.bag

[FATAL] [1659491276.779427919]: Character [ ] at element [38] is not valid in Graph Resource Name [/device_0/sensor_1/notification/Frames Timeout].  Valid characters are a-z, A-Z, 0-9, / and _.
```

### Detailed explanation of this issue
ros does not consider names containing spaces.

Reference)
* http://wiki.ros.org/ja/Names
* [ ros/ros_comm/clients/roscpp/src/libros/names.cpp ](https://github.com/ros/ros_comm/blob/dd78ac8af128bb8eb992d6431bb9f994658ea6ab/clients/roscpp/src/libros/names.cpp#L56-L64)

Therefore, if you create a topic that contains spaces, it will fail when loaded.

However, topics of type realsense_msgs/Notification
All of them contain whitespace in the suffix.
I can solve this by using `rosbag filter` to remove the topic, but
However, we believe that it is difficult to parse realsense_msgs/Notification type topics without modification.

Therefore, we have proposed a modification to create topics without spaces.

## Reproduction method
### How to create a rosbag containing topics of type realsense_msgs/Notification
* Environment building
Build and install librealsense2 SDK
```
git clone https://github.com/IntelRealSense/librealsense
./scripts/setup_udev_rules.sh
cd librealsense
mkdir build && cd build
cmake .. -DBUILD_EXAMPLES=true
make -j8
sudo make install
sudo ldconfig
```

* Launching realsense-viewer
```
realsense-viewer
```

* Rosbag records（To have a topic of type realsense_msgs/Notification created, intentionally connect the PC to the D435i via USB 2.0.）

https://user-images.githubusercontent.com/40545422/182510951-dadb54d1-f4be-4d0b-884b-dfa3f28380f9.mp4

### Experiment
#### Error
* If you run the source in the master branch

https://user-images.githubusercontent.com/40545422/182512186-95c34c5d-f175-4fb0-bb36-e5e2ef4461af.mp4

#### If modified
* If the source in the master branch reflects this modification
In the modified source, rosbag can contain topics of type realsense_msgs/Notification that do not contain spaces.

https://user-images.githubusercontent.com/40545422/182512131-ee19bb12-7668-483d-9690-53a1098378bb.mp4
