### PR TITLE
OpenNI2 Stream Mirroring Compatibility Hack

### DIFF
--- a/wrappers/openni2/src/Rs2StreamProps.cpp
+++ b/wrappers/openni2/src/Rs2StreamProps.cpp
@@ -108,6 +108,13 @@ OniStatus Rs2Stream::setProperty(int propertyId, const void* data, int dataSize)
 			}
 			break;
 		}
+		
+		case ONI_STREAM_PROPERTY_MIRRORING:
+		{
+			// Doesn't do anything, but prevents certain 3D scanning applications from crashing.
+			return ONI_STATUS_OK;
+			break;
+		}
 
 		default:
 		{
@@ -402,11 +409,11 @@ OniBool Rs2Stream::isPropertySupported(int propertyId)
 		case ONI_STREAM_PROPERTY_MAX_VALUE:				// int
 		case ONI_STREAM_PROPERTY_MIN_VALUE:				// int
 		case ONI_STREAM_PROPERTY_STRIDE:				// int
-		case ONI_STREAM_PROPERTY_MIRRORING:				// OniBool
 			return true;
 
 		
 		case ONI_STREAM_PROPERTY_NUMBER_OF_FRAMES:		// int
+		case ONI_STREAM_PROPERTY_MIRRORING:				// OniBool
 			return false;
 
 		case ONI_STREAM_PROPERTY_AUTO_WHITE_BALANCE:	// OniBool


### PR DESCRIPTION
See Issue #12363 reported last week. Thanks to @MartyG-RealSense for extra info.

All these comments apply to the file `/wrappers/openni2/src/Rs2StreamProps.cpp`

Where I started looking at this, librealsense does not support stream mirroring, and the `getProperty(ONI_STREAM_PROPERTY_MIRRORING)` always returns `false`. 

OpenNI2 Viewer will crash if `isPropertySupported(ONI_STREAM_PROPERTY_MIRRORING)` returns `true`, but then when attempting to set the property it recieves `ONI_STATUS_NOT_SUPPORTED`. This was the behavior before my change.

Some Closed-source OpenNI2 Scanning apps call `setProperty(ONI_STREAM_PROPERTY_MIRRORING)` without checking if its supported first. By returning OK, we can allow these programs (Skanect, ReconstructMe, probably others) to function normally.

The downside is that some OpenNI2 developer may attempt to mirror the video (without checking if the property is supported), the wrapper will return OK, and the video will not be mirrored. This may not be intuitive. However, if they then check `getProperty(ONI_STREAM_PROPERTY_MIRRORING)` they will still receive `false`, so this is consistent.