### PR TITLE
Cant build with message Could NOT find PythonInterp (missing: PYTHON_…

### DIFF
--- a/scripts/Docker/Dockerfile
+++ b/scripts/Docker/Dockerfile
@@ -41,6 +41,7 @@ RUN ln -s /usr/src/librealsense-$LIBRS_VERSION /usr/src/librealsense
 RUN cd /usr/src/librealsense \
     && mkdir build && cd build \
     && cmake \
+    -DPYTHON_EXECUTABLE=/usr/bin/python3 \
     -DCMAKE_C_FLAGS_RELEASE="${CMAKE_C_FLAGS_RELEASE} -s" \
     -DCMAKE_CXX_FLAGS_RELEASE="${CMAKE_CXX_FLAGS_RELEASE} -s" \
     -DCMAKE_INSTALL_PREFIX=/opt/librealsense \    


### PR DESCRIPTION
…EXECUTABLE) (Required is at least version "3.6")

<!--
    Pull requests should go to the development branch:
    https://github.com/IntelRealSense/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/IntelRealSense/librealsense/blob/master/CONTRIBUTING.md
-->
