### PR TITLE
enforce =std=c++14 for lambda capture initializers

### DIFF
--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -4,6 +4,19 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # View the makefile commands during build
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
+macro(use_cxx14)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
+    else()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    endif()
+  else()
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+endmacro(use_cxx14)
+use_cxx14()
+
 include(GNUInstallDirs)
 # include librealsense helper macros
 include(CMake/lrs_macros.cmake)


### PR DESCRIPTION
Fixes realsense-viewer.cpp:69:33: warning: lambda capture initializers only available with ‘-std=c++14’ or ‘-std=gnu++14’ [-Wc++14-extensions]
   69 |                 [&viewer_model, weak_device_models = std::weak_ptr< device_models_list >( device_models ), filename](

This is needed on C++17 compilers.