### PR TITLE
Fix: OpenGL based point cloud is empty if depth mapping texture is not provided

### DIFF
--- a/src/gl/pointcloud-gl.h
+++ b/src/gl/pointcloud-gl.h
@@ -31,6 +31,9 @@ namespace librealsense
                 const rs2_intrinsics &other_intrinsics,
                 const rs2_extrinsics& extr,
                 float2* pixels_ptr) override;
+            void get_gl_points(rs2::points& output,
+                const unsigned int width,
+                const unsigned int height);
             rs2::points allocate_points(
                 const rs2::frame_source& source, 
                 const rs2::frame& f) override;
@@ -39,6 +42,7 @@ namespace librealsense
 
             std::shared_ptr<rs2::visualizer_2d> _projection_renderer;
             std::shared_ptr<rs2::visualizer_2d> _occu_renderer;
+            std::shared_ptr<rs2::visualizer_2d> _point_cloud_processor;
 
             rs2::depth_frame _depth_data;
             float _depth_scale;


### PR DESCRIPTION
See: https://github.com/IntelRealSense/realsense-ros/issues/3206 When called through realsense-ros package, depth mapping texture is not provided, thus point cloud is not generated. A new shader is generated to handle the case.

