### PR TITLE
patches script for jetson - replacing uvcvideo in its relevant place

### DIFF
--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -224,8 +224,7 @@ fi
 #Building modules_prepare, which:
 #1. Prepares kernel headers for building external modules
 #2. Generates Module.symvers if it doesn’t already exist.
-LOCALVERSION='-tegra'
-make ARCH=arm64 prepare modules_prepare LOCALVERSION='' -j$(($(nproc)-1))
+make ARCH=arm64 prepare modules_prepare LOCALVERSION='-tegra' -j$(($(nproc)-1))
 
 echo -e "\e[32mCompiling uvcvideo kernel module\e[0m"
 #sudo -s make -j -C $KBASE M=$KBASE/drivers/media/usb/uvc/ modules

--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -291,7 +291,7 @@ sudo depmod
 # when using our jetson drivers instructions
 UVCVIDEO_PATH=$(modinfo -F filename uvcvideo)
 if [[ -z "$UVCVIDEO_PATH" ]]; then
-    UVCVIDEO_PATH='/lib/modules/$(uname -r)/updates'
+    UVCVIDEO_PATH="/lib/modules/$(uname -r)/updates"
     echo -e "\e[33mCould not find the uvcvideo kernel module.\nIt will be loaded into updates folder: $UVCVIDEO_PATH.\e[0m"
 fi
 

--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -293,7 +293,7 @@ sudo depmod
 # when using our jetson drivers instructions
 UVCVIDEO_PATH=$(modinfo -F filename uvcvideo)
 if [[ -z "$UVCVIDEO_PATH" ]]; then
-    UVCVIDEO_PATH="/lib/modules/$(uname -r)/updates"
+    UVCVIDEO_PATH="/lib/modules/$(uname -r)/updates/uvcvideo.ko"
     echo -e "\e[33mCould not find the uvcvideo kernel module.\nIt will be loaded into updates folder: $UVCVIDEO_PATH.\e[0m"
 fi
 

--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -224,7 +224,9 @@ fi
 #Building modules_prepare, which:
 #1. Prepares kernel headers for building external modules
 #2. Generates Module.symvers if it doesn’t already exist.
-make ARCH=arm64 prepare modules_prepare LOCALVERSION='-tegra' -j$(($(nproc)-1))
+# Extract the local version suffix from the running kernel (e.g., "-tegra" or "")
+KERNEL_LOCALVERSION="$(uname -r | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?//')"
+make ARCH=arm64 prepare modules_prepare LOCALVERSION="${KERNEL_LOCALVERSION}" -j$(($(nproc)-1))
 
 echo -e "\e[32mCompiling uvcvideo kernel module\e[0m"
 #sudo -s make -j -C $KBASE M=$KBASE/drivers/media/usb/uvc/ modules

--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -224,6 +224,7 @@ fi
 #Building modules_prepare, which:
 #1. Prepares kernel headers for building external modules
 #2. Generates Module.symvers if it doesn’t already exist.
+LOCALVERSION='-tegra'
 make ARCH=arm64 prepare modules_prepare LOCALVERSION='' -j$(($(nproc)-1))
 
 echo -e "\e[32mCompiling uvcvideo kernel module\e[0m"
@@ -291,8 +292,8 @@ sudo depmod
 # when using our jetson drivers instructions
 UVCVIDEO_PATH=$(modinfo -F filename uvcvideo)
 if [[ -z "$UVCVIDEO_PATH" ]]; then
-    echo -e "\e[31mError: Could not find the uvcvideo kernel module. Please ensure it is available before running this script.\e[0m"
-    exit 1
+    UVCVIDEO_PATH='/lib/modules/$(uname -r)/updates'
+    echo -e "\e[33mCould not find the uvcvideo kernel module.\nIt will be loaded into updates folder: $UVCVIDEO_PATH.\e[0m"
 fi
 
 echo -e "\e[32mInsert the modified kernel modules\e[0m"

--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -290,6 +290,10 @@ sudo depmod
 # special attention to uvcvideo because it is one of the files that is set to /lib/modules/`uname -r`/updates/ folder
 # when using our jetson drivers instructions
 UVCVIDEO_PATH=$(modinfo -F filename uvcvideo)
+if [[ -z "$UVCVIDEO_PATH" ]]; then
+    echo -e "\e[31mError: Could not find the uvcvideo kernel module. Please ensure it is available before running this script.\e[0m"
+    exit 1
+fi
 
 echo -e "\e[32mInsert the modified kernel modules\e[0m"
 if version_lt "$PATCHES_REV" "6.0"; then


### PR DESCRIPTION
Without this PR, uvcvideo module that is compiled during the script is copied to:
/lib/modules/$(uname -r)/kernel/drivers/media/usb/uvc/

And when using our scripts for jetson d4xx drivers, the uvcvideo is copied to:
/lib/modules/$(uname -r)/updates
(ref: https://github.com/IntelRealSense/realsense_mipi_platform_driver/blob/838616396a43d4f5c9118c6ad23fc3a9ea015872/README_JP5.md?plain=1#L131)

When the OS sees that the module is in this folder, it does not consider the module in the "standard" folder.

So the script now checks first where is the uvcvideo module used by the system, and then copies the compiled module in the right place.
