### PR TITLE
unit-tests - fw-update - fixing filename to fw version method

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -40,6 +40,7 @@ def extract_version_from_filename(file_path):
     Extracts the version string from a filename like:
     FlashGeneratedImage_Image5_16_7_0.bin -> 5.16.7
     FlashGeneratedImage_RELEASE_DS5_5_16_3_1.bin -> 5.16.3.1
+    d555e_20251107_7_56_19919_4144.img -> 7.56.19919.4144
 
     Args:
         file_path (str): Full path to the file.
@@ -52,18 +53,26 @@ def extract_version_from_filename(file_path):
         return None
 
     filename = os.path.basename(file_path)
-    match = re.search(r'_(\d+)_(\d+)_(\d+)_(\d+).(bin|img)', filename)
-    if match:
-        groups = match.groups()[:-1] # exclude the file extension
-        if groups[3] == '0':
-            version_str = ".".join(groups[:3])
-        else:
-            version_str = ".".join(groups)
-        return rsutils.version(version_str)
-    else:
-        log.i(f"Version not found in filename: {filename}")
 
-    return None
+    # Match *last* 4 numeric groups before .img/.bin
+    # following matching patterns for cases:
+    # FlashGeneratedImage_Image5_16_7_0.bin -> 5.16.7
+    # FlashGeneratedImage_RELEASE_DS5_5_16_3_1.bin -> 5.16.3.1
+    match = re.search(r'(\d+)_(\d+)_(\d+)_(\d+)\.(bin|img)$', filename)
+    if not match:
+        # Match patterns like d555e_20251107_7_56_19919_4144.img -> 7.56.19919.4144
+        match = re.search(r'_(\d+)_(\d+)_(\d+)_(\d+).(bin|img)', filename)
+        if not match:
+            log.i(f"Version not found in filename: {filename}")
+            return None
+
+    a, b, c, d, _ = match.groups()
+
+    # Drop the last part only if it equals "0"
+    if d == "0":
+        return rsutils.version(f"{a}.{b}.{c}")
+    else:
+        return rsutils.version(f"{a}.{b}.{c}.{d}")
 
 
 def get_update_counter(device):
@@ -241,9 +250,19 @@ subprocess.run( cmd )   # may throw
 # make sure update worked
 time.sleep(3) # MIPI devices do not re-enumerate so we need to give them some time to restart
 device, ctx = test.find_first_device_or_exit()
+fw_version_str = device.get_info( rs.camera_info.firmware_version )
+log.d('fw_version_str = ' , fw_version_str)
+log.d('rsutils.version( fw_version_str ) = ' , rsutils.version( fw_version_str ) )
+log.d('rsutils.version( device.get_info( rs.camera_info.firmware_version )) = ' , 
+      rsutils.version( device.get_info( rs.camera_info.firmware_version )) )
+log.d('device is:', device)
 current_fw_version = rsutils.version( device.get_info( rs.camera_info.firmware_version ))
 
 expected_fw_version = custom_fw_version if custom_fw_path else bundled_fw_version
+log.d('expected_fw_version = ' , expected_fw_version)
+log.d('custom_fw_path = ' , custom_fw_path)
+log.d('custom_fw_version = ' , custom_fw_version)
+log.d('bundled_fw_version = ', bundled_fw_version)
 test.check_equal(current_fw_version, expected_fw_version)
 new_update_counter = get_update_counter( device )
 # According to FW: "update counter zeros if you load newer FW than (ever) before"

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -250,19 +250,9 @@ subprocess.run( cmd )   # may throw
 # make sure update worked
 time.sleep(3) # MIPI devices do not re-enumerate so we need to give them some time to restart
 device, ctx = test.find_first_device_or_exit()
-fw_version_str = device.get_info( rs.camera_info.firmware_version )
-log.d('fw_version_str = ' , fw_version_str)
-log.d('rsutils.version( fw_version_str ) = ' , rsutils.version( fw_version_str ) )
-log.d('rsutils.version( device.get_info( rs.camera_info.firmware_version )) = ' , 
-      rsutils.version( device.get_info( rs.camera_info.firmware_version )) )
-log.d('device is:', device)
 current_fw_version = rsutils.version( device.get_info( rs.camera_info.firmware_version ))
 
 expected_fw_version = custom_fw_version if custom_fw_path else bundled_fw_version
-log.d('expected_fw_version = ' , expected_fw_version)
-log.d('custom_fw_path = ' , custom_fw_path)
-log.d('custom_fw_version = ' , custom_fw_version)
-log.d('bundled_fw_version = ', bundled_fw_version)
 test.check_equal(current_fw_version, expected_fw_version)
 new_update_counter = get_update_counter( device )
 # According to FW: "update counter zeros if you load newer FW than (ever) before"


### PR DESCRIPTION
Without this PR, our ci fails when injecting custom fw