### PR TITLE
Loosen spike rate threshold for test-depth-ae-toggle.py

### DIFF
--- a/unit-tests/live/d400/test-depth-ae-toggle.py
+++ b/unit-tests/live/d400/test-depth-ae-toggle.py
@@ -31,7 +31,8 @@ import time
 
 # Configuration: acceptable spike rate percentage
 # A "spike" is a gap exceeding 110% of expected frame time
-MAX_ACCEPTABLE_SPIKE_RATE_PERCENT = float(4.0)      # Maximum acceptable percentage of frames with timing spikes
+# Loosened to 10% for robustness in live tests since we cannot control host load/environment
+MAX_ACCEPTABLE_SPIKE_RATE_PERCENT = float(10.0)     # Maximum acceptable percentage of frames with timing spikes
 
 # Configuration: test iterations
 NUM_MANUAL_TO_AE_ITERATIONS = 20                    # Number of manual->AE toggle iterations in third test


### PR DESCRIPTION
Loosen spike rate from 4% to 10% since we testing if the camera continues to stream while toggling AE (if was crashing before the FW fix)
