### PR TITLE
Add thread naming and thread-start callback for all library threads

### DIFF
--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -271,6 +271,21 @@ typedef enum rs2_embedded_filter_type
 } rs2_embedded_filter_type;
 const char* rs2_embedded_filter_type_to_string(rs2_embedded_filter_type embedded_filter);
 
+/** \brief Category of a library-created thread, for use with the thread-start callback. */
+typedef enum rs2_thread_category
+{
+    RS2_THREAD_CATEGORY_USB_IO,              /**< USB I/O threads: libusb events, UVC stream/device dispatch, WinUSB endpoints */
+    RS2_THREAD_CATEGORY_VIDEO_CAPTURE,       /**< Video capture threads: V4L2 capture loop */
+    RS2_THREAD_CATEGORY_SENSOR_IO,           /**< Sensor I/O threads: HID data reads, interrupt processing, timestamp sync */
+    RS2_THREAD_CATEGORY_FRAME_PROCESSING,    /**< Frame processing threads: UVC frame publishing */
+    RS2_THREAD_CATEGORY_DEVICE_MONITORING,   /**< Device monitoring threads: udev/polling/DDS device watchers, error polling, thermal monitoring */
+    RS2_THREAD_CATEGORY_DISPATCH,            /**< Dispatch threads: pipeline dispatch, notification dispatch */
+    RS2_THREAD_CATEGORY_NETWORK,             /**< Network threads: DDS communication, network adapter monitoring */
+    RS2_THREAD_CATEGORY_UTILITY,             /**< Utility threads: delayed initialization, firmware logging, power management */
+    RS2_THREAD_CATEGORY_COUNT                /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
+} rs2_thread_category;
+const char * rs2_thread_category_to_string(rs2_thread_category category);
+
 typedef struct rs2_device_info rs2_device_info;
 typedef struct rs2_device rs2_device;
 typedef struct rs2_error rs2_error;
@@ -311,6 +326,7 @@ typedef struct rs2_firmware_log_message rs2_firmware_log_message;
 typedef struct rs2_firmware_log_parsed_message rs2_firmware_log_parsed_message;
 typedef struct rs2_firmware_log_parser rs2_firmware_log_parser;
 typedef struct rs2_terminal_parser rs2_terminal_parser;
+typedef struct rs2_thread_start_callback rs2_thread_start_callback;
 typedef void (*rs2_log_callback_ptr)(rs2_log_severity, rs2_log_message const *, void * arg);
 typedef void (*rs2_notification_callback_ptr)(rs2_notification*, void*);
 typedef void (*rs2_software_device_destruction_callback_ptr)(void*);
@@ -319,6 +335,7 @@ typedef void (*rs2_frame_callback_ptr)(rs2_frame*, void*);
 typedef void (*rs2_frame_processor_callback_ptr)(rs2_frame*, rs2_source*, void*);
 typedef void (*rs2_update_progress_callback_ptr)(const float, void*);
 typedef void (*rs2_options_changed_callback_ptr)(const rs2_options_list *);
+typedef void (*rs2_thread_start_callback_ptr)(rs2_thread_category category, const char * name, void * arg);
 
 typedef double      rs2_time_t;     /**< Timestamp format. units are milliseconds */
 typedef long long   rs2_metadata_type; /**< Metadata attribute type is defined as 64 bit signed integer*/

--- a/include/librealsense2/hpp/rs_types.hpp
+++ b/include/librealsense2/hpp/rs_types.hpp
@@ -110,6 +110,14 @@ struct rs2_options_changed_callback
 };
 typedef std::shared_ptr< rs2_options_changed_callback > rs2_options_changed_callback_sptr;
 
+struct rs2_thread_start_callback
+{
+    virtual void                            on_thread_start( rs2_thread_category category, const char * name ) noexcept = 0;
+    virtual void                            release() = 0;
+    virtual                                 ~rs2_thread_start_callback() {}
+};
+typedef std::shared_ptr< rs2_thread_start_callback > rs2_thread_start_callback_sptr;
+
 namespace rs2
 {
     class error : public std::runtime_error

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -97,6 +97,25 @@ void rs2_log_to_callback_cpp( rs2_log_severity min_severity, rs2_log_callback * 
 
 void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr callback, void * arg, rs2_error** error );
 
+/**
+* Register a callback that is invoked at the start of every library-created thread.
+* The callback runs inside the new thread before any work begins, so the user can call
+* platform-specific APIs (e.g., pthread_setpriority, SetThreadPriority) to adjust the thread priority.
+* Only one callback can be registered at a time; registering a new one replaces the previous.
+* \param[in] callback         Callback function pointer
+* \param[in] arg              User data passed to the callback
+* \param[out] error           if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_set_thread_start_callback( rs2_thread_start_callback_ptr callback, void * arg, rs2_error ** error );
+
+/**
+* Register a callback that is invoked at the start of every library-created thread (C++ interface).
+* The callback runs inside the new thread before any work begins.
+* \param[in] callback         Callback object implementing rs2_thread_start_callback interface
+* \param[out] error           if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_set_thread_start_callback_cpp( rs2_thread_start_callback * callback, rs2_error ** error );
+
 void rs2_reset_logger( rs2_error ** error);
 
 /**

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -160,6 +160,50 @@ namespace rs2
         rs2_log(severity, message, &e);
         error::handle(e);
     }
+
+    /*
+        Wrapper around any callback function that is given to set_thread_start_callback.
+    */
+    class thread_start_callback : public rs2_thread_start_callback
+    {
+    public:
+        typedef std::function< void( rs2_thread_category, const char * ) > callback_fn;
+
+    private:
+        callback_fn _on_thread_start;
+
+    public:
+        explicit thread_start_callback( callback_fn && on_thread_start )
+            : _on_thread_start( std::move( on_thread_start ) )
+        {
+        }
+
+        void on_thread_start( rs2_thread_category category, const char * name ) noexcept override
+        {
+            _on_thread_start( category, name );
+        }
+
+        void release() override { delete this; }
+    };
+
+    /*
+        Register a callback to be invoked at the start of every library-created thread.
+        The callback runs inside the new thread, so the user can call platform APIs to
+        adjust thread priority.
+
+        Example:
+            rs2::set_thread_start_callback(
+                []( rs2_thread_category category, const char * name )
+                {
+                    // Adjust thread priority based on category...
+                });
+    */
+    inline void set_thread_start_callback( thread_start_callback::callback_fn callback )
+    {
+        rs2_error * e = nullptr;
+        rs2_set_thread_start_callback_cpp( new thread_start_callback( std::move( callback ) ), &e );
+        error::handle( e );
+    }
 }
 
 inline std::ostream & operator << (std::ostream & o, rs2_stream stream) { return o << rs2_stream_to_string(stream); }
@@ -180,5 +224,6 @@ inline std::ostream & operator << (std::ostream & o, rs2_sensor_mode mode) { ret
 inline std::ostream & operator << (std::ostream & o, rs2_calibration_type mode) { return o << rs2_calibration_type_to_string(mode); }
 inline std::ostream & operator << (std::ostream & o, rs2_calibration_status mode) { return o << rs2_calibration_status_to_string(mode); }
 inline std::ostream & operator << (std::ostream & o, rs2_eth_link_priority priority) { return o << rs2_eth_link_priority_to_string(priority); }
+inline std::ostream & operator << (std::ostream & o, rs2_thread_category category) { return o << rs2_thread_category_to_string(category); }
 
 #endif // LIBREALSENSE_RS2_HPP

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -55,6 +55,7 @@ auto_exposure_mechanism::auto_exposure_mechanism(option& gain_option, option& ex
       _skip_frames(auto_exposure_state.skip_frames)
 {
     _exposure_thread = std::make_shared<std::thread>(
+        rsutils::concurrency::create_thread( rsutils::concurrency::thread_category_frame_processing, "auto-expos",
                 [this]()
     {
         while (_keep_alive)
@@ -127,7 +128,7 @@ auto_exposure_mechanism::auto_exposure_mechanism(option& gain_option, option& ex
                 LOG_ERROR("Unknown error during Auto-Exposure loop!");
             }
         }
-    });
+    }));
 }
 
 auto_exposure_mechanism::~auto_exposure_mechanism()

--- a/src/android/fw-logger/rs-fw-logger.cpp
+++ b/src/android/fw-logger/rs-fw-logger.cpp
@@ -9,6 +9,8 @@
 #include <chrono>
 #include <fstream>
 
+#include <rsutils/concurrency/thread-utils.h>
+
 #include "../../../tools/fw-logger/fw-logs-parser.h"
 #include "../../../include/librealsense2/hpp/rs_context.hpp"
 
@@ -120,7 +122,9 @@ void android_fw_logger::read_log_loop()
 android_fw_logger::android_fw_logger(std::string xml_path, int sample_rate) : _xml_path(xml_path), _sample_rate(sample_rate)
 {
     log("StartReadingFwLogs");
-    _thread = std::thread(&android_fw_logger::read_log_loop, this);
+    _thread = rsutils::concurrency::create_thread(
+        rsutils::concurrency::thread_category_utility, "fw-logger",
+        [this]() { read_log_loop(); });
 }
 
 android_fw_logger::~android_fw_logger()

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -85,6 +85,7 @@ RS2_ENUM_HELPERS( rs2_point_cloud_label, POINT_CLOUD_LABEL )
 RS2_ENUM_HELPERS( rs2_calib_location, CALIB_LOCATION )
 RS2_ENUM_HELPERS( rs2_embedded_filter_type, EMBEDDED_FILTER_TYPE )
 RS2_ENUM_HELPERS( rs2_gyro_sensitivity, GYRO_SENSITIVITY )
+RS2_ENUM_HELPERS( rs2_thread_category, THREAD_CATEGORY )
 
 
 }  // namespace librealsense

--- a/src/core/notification.cpp
+++ b/src/core/notification.cpp
@@ -24,7 +24,7 @@ notification::notification( rs2_notification_category category,
 
 
 notifications_processor::notifications_processor()
-    : _dispatcher( 10 )
+    : _dispatcher( 10, rsutils::concurrency::thread_category_dispatch, "notif-d" )
 {
 }
 

--- a/src/core/options-watcher.cpp
+++ b/src/core/options-watcher.cpp
@@ -69,7 +69,9 @@ void options_watcher::start()
 {
     if( ! _updater.joinable() ) // If not already started
     {
-        _updater = std::thread( [this]() {
+        _updater = rsutils::concurrency::create_thread(
+            rsutils::concurrency::thread_category_device_monitoring, "opt-watcher",
+            [this]() {
             update_options();
             thread_loop();
         } );

--- a/src/ds/d400/d400-mipi-device.cpp
+++ b/src/ds/d400/d400-mipi-device.cpp
@@ -3,6 +3,7 @@
 
 #include "context.h"
 #include "d400-mipi-device.h"
+#include <rsutils/concurrency/thread-utils.h>
 
 namespace librealsense
 {
@@ -31,7 +32,9 @@ namespace librealsense
         auto non_const_device_info = std::const_pointer_cast<librealsense::device_info>(dev_info);
         std::vector< std::shared_ptr< device_info > > devices{ non_const_device_info };
         auto ctx = std::weak_ptr< context >(dev_info->get_context());
-        std::thread fake_notification(
+        rsutils::concurrency::create_thread(
+            rsutils::concurrency::thread_category_device_monitoring,
+            "mipi-reconn",
             [ctx, devs = std::move(devices)]()
             {
                 try
@@ -50,7 +53,6 @@ namespace librealsense
                     LOG_ERROR(e.what());
                     return;
                 }
-            });
-        fake_notification.detach();
+            }).detach();
     }
 }

--- a/src/ds/ds-thermal-monitor.cpp
+++ b/src/ds/ds-thermal-monitor.cpp
@@ -12,7 +12,7 @@ namespace librealsense
         _monitor([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            }),
+            }, rsutils::concurrency::thread_category_device_monitoring, "thermal-mon"),
         _poll_intervals_ms(2000), // Temperature check routine to be invoked every 2 sec
         _thermal_threshold_deg(2.f),
         _temp_base(0.f),

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -20,7 +20,8 @@ namespace librealsense
         _decoder(decoder)
     {
         _active_object = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
-            {  polling(cancellable_timer);  });
+            {  polling(cancellable_timer);  },
+            rsutils::concurrency::thread_category_device_monitoring, "err-poll");
     }
 
     polling_error_handler::~polling_error_handler()

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -177,7 +177,7 @@ namespace librealsense
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            })
+            }, rsutils::concurrency::thread_category_sensor_io, "time-sync")
     {
         //LOG_DEBUG("start new time_diff_keeper ");
     }

--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -57,7 +57,7 @@ namespace librealsense
 
         rs_hid_device::rs_hid_device(rs_usb_device usb_device)
             : _usb_device(usb_device),
-              _action_dispatcher(10)
+              _action_dispatcher(10, rsutils::concurrency::thread_category_usb_io, "hid-dev-d")
         {
             _id_to_sensor[REPORT_ID_GYROMETER_3D] = gyro;
             _id_to_sensor[REPORT_ID_ACCELEROMETER_3D] = accel;
@@ -150,7 +150,7 @@ namespace librealsense
                 _handle_interrupts_thread = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
                 {
                     handle_interrupt();
-                });
+                }, rsutils::concurrency::thread_category_sensor_io, "hid-intr");
 
                 _handle_interrupts_thread->start();
 

--- a/src/libusb/context-libusb.cpp
+++ b/src/libusb/context-libusb.cpp
@@ -89,7 +89,9 @@ namespace librealsense
                     _event_handler.join();
                     _kill_handler_thread = 0;
                 }
-                _event_handler = std::thread([this]() {
+                _event_handler = rsutils::concurrency::create_thread(
+                    rsutils::concurrency::thread_category_usb_io, "libusb-evts",
+                    [this]() {
                     while (!_kill_handler_thread)
                         libusb_handle_events_completed(_ctx, &_kill_handler_thread);
                 });

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -255,7 +255,9 @@ namespace librealsense
 
             _callback = sensor_callback;
             _is_capturing = true;
-            _hid_thread = std::unique_ptr<std::thread>(new std::thread([this, read_device_path_str](){
+            _hid_thread = std::unique_ptr<std::thread>(new std::thread(rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_sensor_io, "hid-custom",
+                [this, read_device_path_str](){
                 const uint32_t channel_size = 24; // TODO: why 24?
                 std::vector<uint8_t> raw_data(channel_size * hid_buf_len);
 
@@ -326,7 +328,7 @@ namespace librealsense
                         LOG_WARNING("hid_custom_sensor: Frames didn't arrived within 5 seconds");
                     }
                 } while(this->_is_capturing);
-            }));
+            })));
         }
 
         void hid_custom_sensor::stop_capture()
@@ -463,7 +465,7 @@ namespace librealsense
               _sampling_frequency_name(""),
               _callback(nullptr),
               _is_capturing(false),
-              _pm_dispatcher(16)    // queue for async power management commands
+              _pm_dispatcher(16, rsutils::concurrency::thread_category_sensor_io, "hid-pm-d")    // queue for async power management commands
         {
             init(frequency, sensitivity);
         }
@@ -536,7 +538,9 @@ namespace librealsense
 
             _callback = sensor_callback;
             _is_capturing = true;
-            _hid_thread = std::unique_ptr<std::thread>(new std::thread([this](){
+            _hid_thread = std::unique_ptr<std::thread>(new std::thread(rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_sensor_io, "hid-iio-cap",
+                [this](){
                 const uint32_t channel_size = get_channel_size();
                 size_t raw_data_size = channel_size*hid_buf_len;
 
@@ -642,7 +646,7 @@ namespace librealsense
                         std::this_thread::sleep_for(std::chrono::milliseconds(2));
                     }
                 } while(this->_is_capturing);
-            }));
+            })));
         }
 
         void iio_hid_sensor::stop_capture()
@@ -818,7 +822,9 @@ namespace librealsense
             // The patch will rectify this behaviour
             std::string current_trigger = _sensor_name + "-dev" + _iio_device_path.back();
             std::string path = _iio_device_path + "/trigger/current_trigger";
-            _pm_thread = std::unique_ptr<std::thread>(new std::thread([path,current_trigger](){
+            _pm_thread = std::unique_ptr<std::thread>(new std::thread(rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_utility, "hid-pm-init",
+                [path,current_trigger](){
                 bool retry =true;
                 while (retry) {
                     try {
@@ -830,7 +836,7 @@ namespace librealsense
                     catch(...){} // Device disconnect
                     retry = false;
                 }
-            }));
+            })));
             _pm_thread->detach();
 
             // read all available input of the iio_device

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1599,7 +1599,9 @@ namespace librealsense
                 streamon();
 
                 _is_capturing = true;
-                _thread = std::unique_ptr<std::thread>(new std::thread([this](){ capture_loop(); }));
+                _thread = std::unique_ptr<std::thread>(new std::thread(rsutils::concurrency::create_thread(
+                    rsutils::concurrency::thread_category_video_capture, "v4l2-cap",
+                    [this](){ capture_loop(); })));
 
                 // Starting the video/metadata syncer
                 _video_md_syncer.start();

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -137,7 +137,7 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
             }
             _changed = false;
         }
-    } )
+    }, rsutils::concurrency::thread_category_device_monitoring, "udev-dev-w" )
 {
     _udev_ctx = udev_new();
     if( ! _udev_ctx )

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -35,7 +35,8 @@ std::shared_ptr< device_interface > playback_device_info::create_device()
 
 playback_device::playback_device( std::shared_ptr< const device_info > const & dev_info,
                                   std::shared_ptr< device_serializer::reader > const & serializer )
-    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max() ); } )
+    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max(),
+          rsutils::concurrency::thread_category_utility, "playback-rd" ); } )
     , m_device_info( dev_info )
     , m_is_started( false )
     , m_is_paused( false )

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -95,7 +95,10 @@ void playback_sensor::open(const stream_profiles& requests)
 
         m_dispatchers.emplace( std::make_pair(
             profile->get_unique_id(),
-            std::make_shared< dispatcher >( _default_queue_size, on_drop_callback ) ) );
+            std::make_shared< dispatcher >( _default_queue_size,
+                rsutils::concurrency::thread_category_dispatch,
+                "play-s" + std::to_string( profile->get_unique_id() ),
+                on_drop_callback ) ) );
 
         m_dispatchers[profile->get_unique_id()]->start();
 

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -13,7 +13,8 @@ using namespace librealsense;
 
 librealsense::record_device::record_device(std::shared_ptr<librealsense::device_interface> device,
                                       std::shared_ptr<librealsense::device_serializer::writer> serializer):
-    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max());}),
+    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max(),
+        rsutils::concurrency::thread_category_utility, "record-wr");}),
     m_is_recording(true),
     m_record_total_pause_duration(0)
 {

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -213,7 +213,9 @@ namespace librealsense
                 _last = backend_device_group( _backend->query_uvc_devices(),
                                               _backend->query_usb_devices(),
                                               _backend->query_hid_devices() );
-                _thread = std::thread([this]() { run(); });
+                _thread = rsutils::concurrency::create_thread(
+                    rsutils::concurrency::thread_category_device_monitoring, "win-dev-mon",
+                    [this]() { run(); });
             }
 
             void stop() override

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -22,7 +22,7 @@ namespace librealsense
     {
         pipeline::pipeline(std::shared_ptr<librealsense::context> ctx) :
             _ctx(ctx),
-            _dispatcher(10),
+            _dispatcher(10, rsutils::concurrency::thread_category_dispatch, "pipeline-d"),
             _hub( device_hub::make( ctx, RS2_PRODUCT_LINE_ANY_INTEL )),
             _synced_streams({ RS2_STREAM_COLOR, RS2_STREAM_DEPTH, RS2_STREAM_INFRARED, RS2_STREAM_FISHEYE })
         {}

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -11,6 +11,7 @@
 #include <src/metadata-parser.h>
 
 #include <rsutils/type/fourcc.h>
+#include <rsutils/concurrency/thread-utils.h>
 using rsutils::type::fourcc;
 
 
@@ -149,7 +150,9 @@ platform_camera::platform_camera( std::shared_ptr< const device_info > const & d
                                  make_uvc_header_parser( &platform::uvc_header::timestamp ) );
 
     // Create a thread to call initialize after a delay
-    _init_thread = std::thread([this]() {
+    _init_thread = rsutils::concurrency::create_thread(
+        rsutils::concurrency::thread_category_utility, "platcam-init",
+        [this]() {
         std::this_thread::sleep_for(std::chrono::seconds(2)); // Delay for 2 seconds
         this->initialize();
     });

--- a/src/polling-device-watcher.h
+++ b/src/polling-device-watcher.h
@@ -19,7 +19,8 @@ class polling_device_watcher : public librealsense::platform::device_watcher
 public:
     polling_device_watcher( const platform::backend * backend_ref )
         : _backend( backend_ref )
-        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); } )
+        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); },
+                          rsutils::concurrency::thread_category_device_monitoring, "poll-dev-w" )
         , _devices_data()
     {
         _devices_data = { _backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices() };

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -493,3 +493,7 @@ EXPORTS
     rs2_get_embedded_filter_type
     rs2_is_embedded_filter_extendable_to
     rs2_embedded_filter_type_to_string
+
+    rs2_thread_category_to_string
+    rs2_set_thread_start_callback
+    rs2_set_thread_start_callback_cpp

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -11,6 +11,7 @@
 #include "core/debug.h"
 #include "core/motion.h"
 #include "core/extension.h"
+#include <rsutils/concurrency/thread-utils.h>
 #include "media/playback/playback-device-info.h"
 #include "media/record/record_device.h"
 #include <media/ros/ros_writer.h>
@@ -1902,6 +1903,77 @@ void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr on
     );
 }
 HANDLE_EXCEPTIONS_AND_RETURN( , min_severity, on_log, arg )
+
+// librealsense wrapper around a C function for thread-start callback
+class on_thread_start_callback : public rs2_thread_start_callback
+{
+    rs2_thread_start_callback_ptr _on_thread_start;
+    void * _user_arg;
+
+public:
+    on_thread_start_callback( rs2_thread_start_callback_ptr on_thread_start, void * user_arg )
+        : _on_thread_start( on_thread_start )
+        , _user_arg( user_arg )
+    {
+    }
+
+    void on_thread_start( rs2_thread_category category, const char * name ) noexcept override
+    {
+        if( _on_thread_start )
+        {
+            try
+            {
+                _on_thread_start( category, name, _user_arg );
+            }
+            catch( ... )
+            {
+                std::cerr << "Exception in thread-start callback!" << std::endl;
+            }
+        }
+    }
+    void release() override { delete this; }
+};
+
+// Compile-time verification that rsutils::concurrency::thread_category values match rs2_thread_category.
+// These two enums must stay in sync — rsutils owns the internal definition (no dependency on public API),
+// and rs2_thread_category is the public C API mirror.
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_usb_io )            == static_cast< int >( RS2_THREAD_CATEGORY_USB_IO ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_video_capture )     == static_cast< int >( RS2_THREAD_CATEGORY_VIDEO_CAPTURE ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_sensor_io )         == static_cast< int >( RS2_THREAD_CATEGORY_SENSOR_IO ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_frame_processing )  == static_cast< int >( RS2_THREAD_CATEGORY_FRAME_PROCESSING ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_device_monitoring ) == static_cast< int >( RS2_THREAD_CATEGORY_DEVICE_MONITORING ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_dispatch )          == static_cast< int >( RS2_THREAD_CATEGORY_DISPATCH ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_network )           == static_cast< int >( RS2_THREAD_CATEGORY_NETWORK ) );
+static_assert( static_cast< int >( rsutils::concurrency::thread_category_utility )           == static_cast< int >( RS2_THREAD_CATEGORY_UTILITY ) );
+
+void rs2_set_thread_start_callback( rs2_thread_start_callback_ptr callback, void * arg, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( callback );
+    // Wrap the C function pointer + user data into a C++ callback object, then delegate to the _cpp version
+    rs2_thread_start_callback_sptr cb_ptr{ new on_thread_start_callback( callback, arg ) };
+    rsutils::concurrency::set_thread_start_callback(
+        [cb = std::move( cb_ptr )]( rsutils::concurrency::thread_category category, std::string const & name )
+        {
+            cb->on_thread_start( static_cast< rs2_thread_category >( category ), name.c_str() );
+        } );
+}
+HANDLE_EXCEPTIONS_AND_RETURN( , callback, arg )
+
+void rs2_set_thread_start_callback_cpp( rs2_thread_start_callback * callback, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( callback );
+    rs2_thread_start_callback_sptr cb_ptr{ callback,
+                                           []( rs2_thread_start_callback * p )
+                                           {
+                                               p->release();
+                                           } };
+    rsutils::concurrency::set_thread_start_callback(
+        [cb = std::move( cb_ptr )]( rsutils::concurrency::thread_category category, std::string const & name )
+        {
+            cb->on_thread_start( static_cast< rs2_thread_category >( category ), name.c_str() );
+        } );
+}
+HANDLE_EXCEPTIONS_AND_RETURN( , callback )
 
 
 unsigned rs2_get_log_message_line_number( rs2_log_message const* msg, rs2_error** error ) BEGIN_API_CALL

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -593,6 +593,26 @@ const char * get_string( rs2_eth_link_priority value )
 #undef CASE
 }
 
+const char * get_string( rs2_thread_category value )
+{
+#define CASE( X ) STRCASE( THREAD_CATEGORY, X )
+    switch( value )
+    {
+    CASE( USB_IO )
+    CASE( VIDEO_CAPTURE )
+    CASE( SENSOR_IO )
+    CASE( FRAME_PROCESSING )
+    CASE( DEVICE_MONITORING )
+    CASE( DISPATCH )
+    CASE( NETWORK )
+    CASE( UTILITY )
+    default:
+        assert( ! is_valid( value ) );
+        return UNKNOWN_VALUE;
+    }
+#undef CASE
+}
+
 std::string const & get_string( rs2_option const option )
 {
     if( options_registry::is_option_registered( option ) )
@@ -1026,3 +1046,4 @@ const char * rs2_calib_location_to_string(rs2_calib_location calib_location) { r
 const char * rs2_embedded_filter_type_to_string(rs2_embedded_filter_type embedded_filter_type) { return librealsense::get_string(embedded_filter_type); }
 const char * rs2_gyro_sensitivity_to_string( rs2_gyro_sensitivity mode ){return librealsense::get_string( mode );}
 const char * rs2_eth_link_priority_to_string( rs2_eth_link_priority priority ){return librealsense::get_string( priority );}
+const char * rs2_thread_category_to_string( rs2_thread_category category ) { return librealsense::get_string( category ); }

--- a/src/usbhost/device-usbhost.cpp
+++ b/src/usbhost/device-usbhost.cpp
@@ -100,13 +100,16 @@ namespace librealsense
                     auto type = e->get_type();
                     if(type == RS2_USB_ENDPOINT_INTERRUPT || type == RS2_USB_ENDPOINT_BULK)
                     {
-                        _dispatchers[e->get_address()] = std::make_shared<dispatcher>(10);
+                        _dispatchers[e->get_address()] = std::make_shared<dispatcher>(10,
+                            rsutils::concurrency::thread_category_usb_io,
+                            "usbh-ep" + std::to_string(e->get_address()));
                         auto d = _dispatchers.at(e->get_address());
                         d->start();
                     }
                 }
             }
-            _dispatcher = std::make_shared<dispatcher>(10);
+            _dispatcher = std::make_shared<dispatcher>(10,
+                rsutils::concurrency::thread_category_usb_io, "usbh-ctrl");
             _dispatcher->start();
         }
 

--- a/src/uvc-sensor.h
+++ b/src/uvc-sensor.h
@@ -5,6 +5,7 @@
 
 #include "sensor.h"
 #include "platform/uvc-device.h"
+#include <rsutils/concurrency/thread-utils.h>
 
 
 namespace librealsense {
@@ -48,13 +49,14 @@ public:
     {
         acquire_power();
         std::weak_ptr< uvc_sensor > weak = std::dynamic_pointer_cast< uvc_sensor >( shared_from_this() );
-        std::thread release_power_thread( [weak, timeout]()
+        rsutils::concurrency::create_thread(
+            rsutils::concurrency::thread_category_utility, "uvc-pwr-rel",
+            [weak, timeout]()
         {
             std::this_thread::sleep_for( timeout );
             if( auto strong = weak.lock() )
                 strong->release_power();
-        } );
-        release_power_thread.detach();
+        } ).detach();
     }
 
 protected:

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -82,7 +82,7 @@ namespace librealsense
         rs_uvc_device::rs_uvc_device(const rs_usb_device& usb_device, const uvc_device_info &info, uint8_t usb_request_count) :
                 _usb_device(usb_device),
                 _info(info),
-                _action_dispatcher(10),
+                _action_dispatcher(10, rsutils::concurrency::thread_category_usb_io, "uvc-dev-d"),
                 _usb_request_count(usb_request_count)
         {
             _parser = std::make_shared<uvc_parser>(usb_device, info);

--- a/src/uvc/uvc-streamer.cpp
+++ b/src/uvc/uvc-streamer.cpp
@@ -16,7 +16,7 @@ namespace librealsense
     namespace platform
     {
         uvc_streamer::uvc_streamer(uvc_streamer_context context) :
-            _context(context), _action_dispatcher(10)
+            _context(context), _action_dispatcher(10, rsutils::concurrency::thread_category_usb_io, "uvc-strm-d")
         {
             auto inf = context.usb_device->get_interface(context.control->bInterfaceNumber);
             if (inf == nullptr)
@@ -93,7 +93,7 @@ namespace librealsense
                     if(_publish_frames && running())
                         _context.user_cb(_context.profile, fp->fo, []() mutable {});
                 }
-            });
+            }, rsutils::concurrency::thread_category_frame_processing, "uvc-pub-fr");
 
             _watchdog = std::make_shared<watchdog>([this]()
              {
@@ -106,7 +106,7 @@ namespace librealsense
                        _context.messenger->reset_endpoint(_read_endpoint, ENDPOINT_RESET_MILLISECONDS_TIMEOUT);
                        _frame_arrived = false;
                    });
-             }, _watchdog_timeout);
+             }, _watchdog_timeout, rsutils::concurrency::thread_category_usb_io, "uvc-wdog");
 
             _watchdog->start();
 

--- a/src/winusb/messenger-winusb.cpp
+++ b/src/winusb/messenger-winusb.cpp
@@ -176,7 +176,8 @@ namespace librealsense
             std::lock_guard<std::mutex> lk(_mutex);
             if (_dispatchers.find(endpoint) == _dispatchers.end())
             {
-                _dispatchers[endpoint] = std::make_shared<dispatcher>(10);
+                std::string name = std::string("winusb-ep") + std::to_string(endpoint);
+                _dispatchers[endpoint] = std::make_shared<dispatcher>(10, rsutils::concurrency::thread_category_usb_io, name);
                 _dispatchers[endpoint]->start();
             }
             return _dispatchers.at(endpoint);

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -17,6 +17,7 @@
 
 #include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/string/slice.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/json.h>
 
 using rsutils::string::slice;
@@ -58,7 +59,8 @@ public:
             } );
         _writer->run();
 
-        _th = std::thread(
+        _th = rsutils::concurrency::create_thread(
+            rsutils::concurrency::thread_category_network, "dds-bcast",
             [this]()
             {
                 LOG_DEBUG( _writer->topic()->get_participant()->name() << ": broadcaster thread running" );
@@ -161,7 +163,8 @@ void dds_device_broadcaster::broadcast() const
         // If a broadcast callback is asked for, we wait for acks and call it on the first broadcast (and never again)
         if( _on_ack )
         {
-            std::thread(
+            rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_network, "dds-bcast-ak",
                 [on_ack = std::move( _on_ack ),
                  weak_broadcaster = std::weak_ptr< const dds_device_broadcaster >( shared_from_this() )]
                 {
@@ -176,8 +179,7 @@ void dds_device_broadcaster::broadcast() const
                         }
                         catch( ... ) {}
                     }
-                } )
-                .detach();
+                } ).detach();
         }
     }
     catch( std::exception const & e )

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -39,7 +39,7 @@ dds_device_server::dds_device_server( std::shared_ptr< dds_participant > const &
     : _publisher( std::make_shared< dds_publisher >( participant ) )
     , _subscriber( std::make_shared< dds_subscriber >( participant ) )
     , _topic_root( topic_root )
-    , _control_dispatcher( QUEUE_MAX_SIZE )
+    , _control_dispatcher( QUEUE_MAX_SIZE, rsutils::concurrency::thread_category_network, "dds-ctrl-d" )
 {
     LOG_DEBUG( "[" << debug_name() << "] device server created" );
     _control_dispatcher.start();

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -10,6 +10,7 @@
 #include <realdds/topics/flexible-msg.h>
 #include <realdds/topics/device-info-msg.h>
 
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/json.h>
 using rsutils::json;
 
@@ -86,9 +87,10 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                                 ->on_discovery_restored( device_info );
                             if( _on_device_added )
                             {
-                                std::thread( [device = device.alive, on_device_added = _on_device_added]()
-                                             { on_device_added( device ); } )
-                                    .detach();
+                                rsutils::concurrency::create_thread(
+                                    rsutils::concurrency::thread_category_device_monitoring, "dds-dev-add",
+                                    [device = device.alive, on_device_added = _on_device_added]()
+                                             { on_device_added( device ); } ).detach();
                             }
                             continue;
                         }
@@ -115,11 +117,11 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                 // NOTE: device removals are handled via the writer-removed notification; see on_subscription_matched() below
                 if( _on_device_added )
                 {
-                    std::thread(
+                    rsutils::concurrency::create_thread(
+                        rsutils::concurrency::thread_category_device_monitoring, "dds-dev-new",
                         [new_device, on_device_added = _on_device_added]() {  //
                             on_device_added( new_device );
-                        } )
-                        .detach();
+                        } ).detach();
                 }
             }
         } );
@@ -204,7 +206,8 @@ void dds_device_watcher::device_discovery_lost( device_liveliness & device, std:
         static_cast< dds_discovery_sink * >( disconnected_device.get() )->on_discovery_lost();
 
         // rest must happen outside the mutex
-        std::thread(
+        rsutils::concurrency::create_thread(
+            rsutils::concurrency::thread_category_device_monitoring, "dds-dev-rm",
             [disconnected_device, on_device_removed = _on_device_removed]
             {
                 if( on_device_removed )
@@ -214,8 +217,7 @@ void dds_device_watcher::device_discovery_lost( device_liveliness & device, std:
                 // will cause some sort of invalid state in DDS. The thread will get killed and we won't get
                 // any notification of the remote participant getting removed... and the process will even
                 // hang on exit.
-            } )
-            .detach();
+            } ).detach();
     }
 }
 

--- a/third-party/realdds/src/dds-network-adapter-watcher.cpp
+++ b/third-party/realdds/src/dds-network-adapter-watcher.cpp
@@ -4,6 +4,7 @@
 #include <realdds/dds-network-adapter-watcher.h>
 #include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/signal.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/time/stopwatch.h>
 
@@ -44,7 +45,8 @@ public:
                 _time_since_update.reset();
                 if( ! _th.joinable() )
                 {
-                    _th = std::thread(
+                    _th = rsutils::concurrency::create_thread(
+                        rsutils::concurrency::thread_category_network, "dds-ip-wait",
                         [this, weak = std::weak_ptr< rsutils::os::network_adapter_watcher >( _adapter_watcher )]
                         {
                             LOG_DEBUG( "waiting for IP changes" );

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -61,7 +61,8 @@ dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher
                       _new_instant_notification = false;
                   }
               }
-          } )
+          },
+          rsutils::concurrency::thread_category_network, "dds-notif" )
 {
     auto topic = topics::flexible_msg::create_topic( publisher->get_participant(), topic_name.c_str() );
     _writer = std::make_shared< dds_topic_writer >( topic, publisher );

--- a/third-party/realdds/src/dds-topic-reader-thread.cpp
+++ b/third-party/realdds/src/dds-topic-reader-thread.cpp
@@ -6,6 +6,8 @@
 #include <realdds/dds-subscriber.h>
 #include <realdds/dds-utilities.h>
 
+#include <rsutils/concurrency/thread-utils.h>
+
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
@@ -44,7 +46,8 @@ void dds_topic_reader_thread::run( qos const & rqos )
     _reader = DDS_API_CALL( _subscriber->get()->create_datareader( _topic->get(), rqos ) );
     _stopped = std::make_shared< eprosima::fastdds::dds::GuardCondition >();
     
-    _th = std::thread(
+    _th = rsutils::concurrency::create_thread(
+        rsutils::concurrency::thread_category_network, "dds-reader",
         [this,
          weak = std::weak_ptr< dds_topic_reader >( shared_from_this() ),  // detect lifetime
          name = _topic->get()->get_name(),

--- a/third-party/rsutils/include/rsutils/concurrency/concurrency.h
+++ b/third-party/rsutils/include/rsutils/concurrency/concurrency.h
@@ -9,6 +9,8 @@
 #include <atomic>
 #include <functional>
 #include <cassert>
+#include <string>
+#include <rsutils/concurrency/thread-utils.h>
 
 const int QUEUE_MAX_SIZE = 10;
 // Simplest implementation of a blocking concurrent queue for thread messaging
@@ -314,12 +316,20 @@ public:
     // and we're non-blocking. The on_drop_callback allows caputring of these instances, if we
     // want...
     //
+    // The thread_category and thread_name parameters are used for OS-level thread naming and
+    // the user-registerable thread-start callback. The thread name will be prefixed with "rs:".
+    //
     dispatcher( unsigned int queue_capacity,
+                rsutils::concurrency::thread_category thread_category,
+                std::string const & thread_name,
                 std::function< void( action ) > on_drop_callback = nullptr );
 
     ~dispatcher();
 
     bool empty() const { return _queue.empty(); }
+
+    std::string const & get_thread_name() const { return _thread_name; }
+    rsutils::concurrency::thread_category get_thread_category() const { return _thread_category; }
 
     // Main invocation of an action: this will be called from any thread, and basically just queues
     // up the actions for our dispatching thread to handle them.
@@ -400,14 +410,17 @@ private:
     std::mutex _blocking_invoke_mutex;
 
     std::atomic<bool> _is_alive;
+
+    rsutils::concurrency::thread_category _thread_category;
+    std::string _thread_name;
 };
 
 template<class T = std::function<void(dispatcher::cancellable_timer)>>
 class active_object
 {
 public:
-    active_object(T operation)
-        : _operation(std::move(operation)), _dispatcher(1), _stopped(true)
+    active_object(T operation, rsutils::concurrency::thread_category thread_category, std::string const & thread_name)
+        : _operation(std::move(operation)), _dispatcher(1, thread_category, thread_name), _stopped(true)
     {
     }
 
@@ -457,7 +470,8 @@ private:
 class watchdog
 {
 public:
-    watchdog(std::function<void()> operation, uint64_t timeout_ms) :
+    watchdog(std::function<void()> operation, uint64_t timeout_ms,
+             rsutils::concurrency::thread_category thread_category, std::string const & thread_name) :
             _timeout_ms(timeout_ms), _operation(std::move(operation))
     {
         _watcher = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
@@ -469,7 +483,7 @@ public:
                 std::lock_guard<std::mutex> lk(_m);
                 _kicked = false;
             }
-        });
+        }, thread_category, thread_name);
     }
 
     ~watchdog()

--- a/third-party/rsutils/include/rsutils/concurrency/delayed.h
+++ b/third-party/rsutils/include/rsutils/concurrency/delayed.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <rsutils/concurrency/event.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/time/timer.h>
 #include <functional>
 #include <thread>
@@ -67,7 +68,8 @@ public:
         {
             if( _th.joinable() )
                 _th.join();
-            _th = std::thread(
+            _th = rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_utility, "delayed",
                 [this]
                 {
                     while( ! _done.wait( _timer.time_left() ) )  // i.e., timeout occurred

--- a/third-party/rsutils/include/rsutils/concurrency/thread-utils.h
+++ b/third-party/rsutils/include/rsutils/concurrency/thread-utils.h
@@ -1,0 +1,59 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <thread>
+
+
+namespace rsutils {
+namespace concurrency {
+
+
+// Thread categories for classifying the purpose of threads created by the library.
+// Values must match rs2_thread_category in the public C API.
+enum thread_category
+{
+    thread_category_usb_io            = 0,
+    thread_category_video_capture     = 1,
+    thread_category_sensor_io         = 2,
+    thread_category_frame_processing  = 3,
+    thread_category_device_monitoring = 4,
+    thread_category_dispatch          = 5,
+    thread_category_network           = 6,
+    thread_category_utility           = 7,
+};
+
+
+// Type for the user-provided thread-start callback.
+// Called from within the new thread before any work begins.
+// Parameters: category (thread_category enum), name (thread name string).
+using thread_start_callback_fn = std::function< void( thread_category category, std::string const & name ) >;
+
+
+// Register a global callback that is invoked at the start of every library-created thread.
+// The callback runs inside the new thread, so the user can call platform-specific APIs
+// (e.g., pthread_setpriority, SetThreadPriority) to adjust thread priority.
+// Pass an empty function (or nullptr-equivalent) to clear the callback.
+void set_thread_start_callback( thread_start_callback_fn callback );
+
+
+// Set the current thread's OS-level name. The name is prefixed with "rs:" automatically.
+// On Linux, the name is truncated to 15 characters (pthread_setname_np limit).
+// On Windows, SetThreadDescription is used (no length limit).
+// On macOS, pthread_setname_np is used (no length limit).
+void set_current_thread_name( std::string const & name );
+
+
+// Create a new std::thread with proper naming and callback invocation.
+// The thread body will:
+//   1. Set the OS thread name to "rs:<name>" (truncated to 15 chars on Linux)
+//   2. Invoke the registered thread-start callback (if any)
+//   3. Run the user-provided function
+std::thread create_thread( thread_category category, std::string const & name, std::function< void() > fn );
+
+
+}  // namespace concurrency
+}  // namespace rsutils

--- a/third-party/rsutils/src/dispatcher.cpp
+++ b/third-party/rsutils/src/dispatcher.cpp
@@ -2,45 +2,51 @@
 // Copyright(c) 2021 RealSense, Inc. All Rights Reserved.
 
 #include <rsutils/concurrency/concurrency.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/time/waiting-on.h>
 
-dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_drop_callback )
+dispatcher::dispatcher( unsigned int cap, rsutils::concurrency::thread_category thread_category,
+                        std::string const & thread_name,
+                        std::function< void( action ) > on_drop_callback )
     : _queue( cap, on_drop_callback )
     , _was_stopped( true )
     , _is_alive( true )
+    , _thread_category( thread_category )
+    , _thread_name( thread_name )
 {
     // We keep a running thread that takes stuff off our queue and dispatches them
-    _thread = std::thread([&]()
-    {
-        int timeout_ms = 5000;
-        while( _is_alive )
+    _thread = rsutils::concurrency::create_thread( _thread_category, _thread_name,
+        [this]()
         {
-            if( _wait_for_start( timeout_ms ) )
+            int timeout_ms = 5000;
+            while( _is_alive )
             {
-                std::function< void(cancellable_timer) > item;
-                if (_queue.dequeue(&item, timeout_ms))
+                if( _wait_for_start( timeout_ms ) )
                 {
-                    cancellable_timer time(this);
+                    std::function< void(cancellable_timer) > item;
+                    if (_queue.dequeue(&item, timeout_ms))
+                    {
+                        cancellable_timer time(this);
 
-                    try
-                    {
-                        // While we're dispatching the item, we cannot stop!
-                        std::lock_guard< std::mutex > lock(_dispatch_mutex);
-                        item(time);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        LOG_ERROR("Dispatcher [" << this << "] exception caught: " << e.what());
-                    }
-                    catch (...)
-                    {
-                        LOG_ERROR("Dispatcher [" << this << "] unknown exception caught!");
+                        try
+                        {
+                            // While we're dispatching the item, we cannot stop!
+                            std::lock_guard< std::mutex > lock(_dispatch_mutex);
+                            item(time);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            LOG_ERROR("Dispatcher [" << _thread_name << "] exception caught: " << e.what());
+                        }
+                        catch (...)
+                        {
+                            LOG_ERROR("Dispatcher [" << _thread_name << "] unknown exception caught!");
+                        }
                     }
                 }
             }
-        }
-    });
+        } );
 }
 
 

--- a/third-party/rsutils/src/network-adapter-watcher.cpp
+++ b/third-party/rsutils/src/network-adapter-watcher.cpp
@@ -4,6 +4,7 @@
 #include <rsutils/os/network-adapter-watcher.h>
 #include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/signal.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 
 #if ! defined( __APPLE__ ) && ! defined( __ANDROID__ )
@@ -110,7 +111,8 @@ public:
         }
         else
         {
-            _th = std::thread(
+            _th = rsutils::concurrency::create_thread(
+                rsutils::concurrency::thread_category_network, "net-adp-mon",
                 [this]
                 {
                     // We're going to wait on the following handles:

--- a/third-party/rsutils/src/thread-utils.cpp
+++ b/third-party/rsutils/src/thread-utils.cpp
@@ -1,0 +1,92 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include <rsutils/concurrency/thread-utils.h>
+
+#include <atomic>
+#include <cstring>
+#include <mutex>
+
+#ifdef _WIN32
+#include <windows.h>
+#elif defined( __APPLE__ )
+#include <pthread.h>
+#else
+#include <pthread.h>
+#endif
+
+
+namespace rsutils {
+namespace concurrency {
+
+
+// Global callback storage, protected by a mutex for thread-safe registration
+static std::mutex s_callback_mutex;
+static thread_start_callback_fn s_thread_start_callback;
+
+
+void set_thread_start_callback( thread_start_callback_fn callback )
+{
+    std::lock_guard< std::mutex > lock( s_callback_mutex );
+    s_thread_start_callback = std::move( callback );
+}
+
+
+static thread_start_callback_fn get_thread_start_callback()
+{
+    std::lock_guard< std::mutex > lock( s_callback_mutex );
+    return s_thread_start_callback;
+}
+
+
+void set_current_thread_name( std::string const & name )
+{
+    if( name.empty() )
+        return;
+
+#ifdef _WIN32
+    // SetThreadDescription is available on Windows 10 1607+
+    // Convert narrow string to wide string
+    int len = static_cast< int >( name.size() );
+    int wlen = MultiByteToWideChar( CP_UTF8, 0, name.c_str(), len, nullptr, 0 );
+    if( wlen > 0 )
+    {
+        std::wstring wname( wlen, L'\0' );
+        MultiByteToWideChar( CP_UTF8, 0, name.c_str(), len, &wname[0], wlen );
+        SetThreadDescription( GetCurrentThread(), wname.c_str() );
+    }
+#elif defined( __APPLE__ )
+    // macOS: pthread_setname_np takes only the name (applies to current thread)
+    // No documented length limit, but 64 chars is typical
+    pthread_setname_np( name.c_str() );
+#else
+    // Linux: pthread_setname_np has a 16-byte limit (15 chars + null terminator)
+    char truncated[16];
+    std::strncpy( truncated, name.c_str(), 15 );
+    truncated[15] = '\0';
+    pthread_setname_np( pthread_self(), truncated );
+#endif
+}
+
+
+std::thread create_thread( thread_category category, std::string const & name, std::function< void() > fn )
+{
+    // Build the prefixed name outside the thread to avoid races on 'name' reference
+    std::string prefixed_name = "rs:" + ( name.empty() ? std::string( "unnamed" ) : name );
+
+    return std::thread(
+        [category, thread_name = std::move( prefixed_name ), thread_fn = std::move( fn )]()
+        {
+            set_current_thread_name( thread_name );
+
+            auto cb = get_thread_start_callback();
+            if( cb )
+                cb( category, thread_name );
+
+            thread_fn();
+        } );
+}
+
+
+}  // namespace concurrency
+}  // namespace rsutils

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -28,6 +28,7 @@
 #include <realdds/topics/ros2/parameter-events-msg.h>
 
 #include <rsutils/number/crc32.h>
+#include <rsutils/concurrency/thread-utils.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/json.h>
 #include <rsutils/string/hexarray.h>
@@ -637,7 +638,7 @@ lrs_device_controller::frame_to_streaming_server( rs2::frame const & f, rs2::str
 lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< realdds::dds_device_server > dds_device_server )
     : _rs_dev( dev )
     , _dds_device_server( dds_device_server )
-    , _control_dispatcher( QUEUE_MAX_SIZE )
+    , _control_dispatcher( QUEUE_MAX_SIZE, rsutils::concurrency::thread_category_network, "dds-ctrl-d" )
 {
     if( ! _dds_device_server )
         throw std::runtime_error( "Empty dds_device_server" );

--- a/unit-tests/rsutils/concurrency/test-dispatcher.cpp
+++ b/unit-tests/rsutils/concurrency/test-dispatcher.cpp
@@ -21,7 +21,7 @@ int fibo( int num )
 
 TEST_CASE( "dispatcher main flow" )
 {
-    dispatcher d(3);
+    dispatcher d(3, rsutils::concurrency::thread_category_utility, "test-disp");
     std::atomic_bool run = { false };
     auto func = [&](dispatcher::cancellable_timer c) 
     {
@@ -44,7 +44,7 @@ TEST_CASE( "dispatcher main flow" )
 
 TEST_CASE( "invoke and wait" )
 {
-    dispatcher d(2);
+    dispatcher d(2, rsutils::concurrency::thread_category_utility, "test-disp");
 
     std::atomic_bool run = { false };
     auto func = [&](dispatcher::cancellable_timer c)
@@ -67,7 +67,7 @@ TEST_CASE("verify stop() not consuming high CPU usage")
 
     for (int i = 0 ; i < 32; ++i)
     {
-        dispatchers.push_back(std::make_shared<dispatcher>(10));
+        dispatchers.push_back(std::make_shared<dispatcher>(10, rsutils::concurrency::thread_category_utility, "test-disp"));
     }
 
     for (auto &&dispatcher : dispatchers)
@@ -99,7 +99,7 @@ TEST_CASE("stop() notify flush to finish")
 {
     // On this test we check that if during a flush() another thread call stop(),
     // than the flush CV will be triggered to exit and not wait a full timeout
-    dispatcher dispatcher( 10 );
+    dispatcher dispatcher( 10, rsutils::concurrency::thread_category_utility, "test-disp" );
     dispatcher.start();
 
     stopwatch sw;

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/ThreadCategory.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/ThreadCategory.java
@@ -1,0 +1,17 @@
+package com.intel.realsense.librealsense;
+
+public enum ThreadCategory {
+    USB_IO(0),
+    VIDEO_CAPTURE(1),
+    SENSOR_IO(2),
+    FRAME_PROCESSING(3),
+    DEVICE_MONITORING(4),
+    DISPATCH(5),
+    NETWORK(6),
+    UTILITY(7);
+
+    private final int mValue;
+
+    private ThreadCategory(int value) { mValue = value; }
+    public int value() { return mValue; }
+}

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/CMakeLists.txt
@@ -16,4 +16,5 @@ target_sources(${LRS_DOTNET_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/Stream.cs"
         "${CMAKE_CURRENT_LIST_DIR}/TimestampDomain.cs"
         "${CMAKE_CURRENT_LIST_DIR}/CameraInfo.cs"
+        "${CMAKE_CURRENT_LIST_DIR}/ThreadCategory.cs"
 )

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/ThreadCategory.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/ThreadCategory.cs
@@ -1,0 +1,35 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 Intel Corporation. All Rights Reserved.
+
+namespace Intel.RealSense
+{
+    /// <summary>
+    /// Category of a library-created thread, for use with the thread-start callback
+    /// </summary>
+    public enum ThreadCategory
+    {
+        /// <summary> USB I/O threads </summary>
+        UsbIo = 0,
+
+        /// <summary> Video capture threads </summary>
+        VideoCapture = 1,
+
+        /// <summary> Sensor I/O threads </summary>
+        SensorIo = 2,
+
+        /// <summary> Frame processing threads </summary>
+        FrameProcessing = 3,
+
+        /// <summary> Device monitoring threads </summary>
+        DeviceMonitoring = 4,
+
+        /// <summary> Dispatch threads </summary>
+        Dispatch = 5,
+
+        /// <summary> Network threads </summary>
+        Network = 6,
+
+        /// <summary> Utility threads </summary>
+        Utility = 7,
+    }
+}

--- a/wrappers/matlab/thread_category.m
+++ b/wrappers/matlab/thread_category.m
@@ -1,0 +1,13 @@
+classdef thread_category < int64
+    enumeration
+        usb_io            (0)
+        video_capture     (1)
+        sensor_io         (2)
+        frame_processing  (3)
+        device_monitoring (4)
+        dispatch          (5)
+        network           (6)
+        utility           (7)
+        count             (8)
+    end
+end

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -23,6 +23,7 @@ void init_c_files(py::module &m) {
     // rs2_exception_type
     BIND_ENUM(m, rs2_distortion, RS2_DISTORTION_COUNT, "Distortion model: defines how pixel coordinates should be mapped to sensor coordinates.")
     BIND_ENUM(m, rs2_log_severity, RS2_LOG_SEVERITY_COUNT, "Severity of the librealsense logger.")
+    BIND_ENUM(m, rs2_thread_category, RS2_THREAD_CATEGORY_COUNT, "Category of a library-created thread, for use with the thread-start callback.")
     BIND_ENUM(m, rs2_extension, RS2_EXTENSION_COUNT, "Specifies advanced interfaces (capabilities) objects may implement.")
     BIND_ENUM(m, rs2_matchers, RS2_MATCHER_COUNT, "Specifies types of different matchers.")
     BIND_ENUM(m, rs2_camera_info, RS2_CAMERA_INFO_COUNT, "This information is mainly available for camera debug and troubleshooting and should not be used in applications.")

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseTypes.h
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseTypes.h
@@ -174,6 +174,20 @@ enum class ERealSenseDepthColormap : uint8
     Pattern,
 };
 
+// typedef enum rs2_thread_category
+UENUM(Blueprintable)
+enum class ERealSenseThreadCategory : uint8
+{
+    USB_IO                                     , /**< USB I/O threads */
+    VIDEO_CAPTURE                              , /**< Video capture threads */
+    SENSOR_IO                                  , /**< Sensor I/O threads */
+    FRAME_PROCESSING                           , /**< Frame processing threads */
+    DEVICE_MONITORING                          , /**< Device monitoring threads */
+    DISPATCH                                   , /**< Dispatch threads */
+    NETWORK                                    , /**< Network threads */
+    UTILITY                                    , /**< Utility threads */
+};
+
 USTRUCT(BlueprintType)
 struct FRealSenseStreamProfile
 {


### PR DESCRIPTION
All threads created by the library are now named with an "rs:" prefix and assigned an OS-level thread name (via pthread_setname_np / SetThreadDescription).

A global thread-start callback can be registered via rs2_set_thread_start_callback() which is invoked from within each new thread before any work begins, allowing the caller to set thread priorities or perform other per-thread setup.

Each thread is classified into one of eight categories (rs2_thread_category): usb_io, video_capture, sensor_io, frame_processing, device_monitoring, dispatch, network, utility.

Changes:
- New rsutils::concurrency::create_thread() helper with thread naming and callback
- dispatcher, active_object, watchdog now require thread_category and thread_name
- All ~50 thread creation sites migrated to create_thread or named constructors
- Public C API: rs2_thread_category enum, rs2_set_thread_start_callback()
- C++ API: rs2::set_thread_start_callback() convenience wrapper
- Wrapper enum parity: Python, C#, Java, MATLAB, Unreal Engine 4

<!--
    Pull requests should go to the development branch:
    https://github.com/realsenseai/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/realsenseai/librealsense/blob/master/CONTRIBUTING.md
-->
