### PR TITLE
Update GitHub Actions versions and replace EOL ROS2 iron with Kilted

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -43,12 +43,12 @@ jobs:
     steps:
 
       - name: setup ROS environment
-        uses: ros-tooling/setup-ros@87aeba050fd62d0ee5d5fdf4b6c9f847892ea864 #v0.7.13
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30 #v0.7.15
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - name: build librealsense ROS 2
-        uses: ros-tooling/action-ros-ci@1ff2c804b4c2383146d8cd8444dfda64ab4bf7ac #v0.4.3
+        uses: ros-tooling/action-ros-ci@9125cf1fa1f87e7830ed1c77f8b1885ee649b9a0 #v0.4.6
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           skip-tests: true

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         ros_distribution:
           - humble
-          - iron
+          - kilted
           - rolling
           - jazzy
 
@@ -26,9 +26,9 @@ jobs:
           - docker_image: ubuntu:jammy
             ros_distribution: humble
 
-          # Iron Irwini
-          - docker_image: ubuntu:jammy
-            ros_distribution: iron
+          # Kilted Kaiju
+          - docker_image: ubuntu:noble
+            ros_distribution: kilted
 
           # Rolling Ridley
           - docker_image: ubuntu:noble

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Install
       run: pip3 install pytest pytest-retry pytest-timeout pytest-repeat
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Enable Long Paths
       shell: powershell
@@ -82,7 +82,7 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Enable Long Paths
       shell: powershell
@@ -124,8 +124,8 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 #v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
        python-version: '3.9'
 
@@ -184,8 +184,8 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 #v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
        python-version: '3.9'
 
@@ -233,8 +233,8 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
        python-version: '3.9'
 
@@ -277,8 +277,8 @@ jobs:
     timeout-minutes: 60
       
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 #v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
        python-version: '3.9'
 
@@ -328,7 +328,7 @@ jobs:
     name: ${{ matrix.name }}_ST_Py_EX_CfU
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Install CMake 4
       if: matrix.os == 'ubuntu-24.04'
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Prebuild
       shell: bash
@@ -402,7 +402,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Prebuild
       shell: bash
@@ -455,7 +455,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Prebuild
       shell: bash
@@ -510,7 +510,7 @@ jobs:
     name: ${{ matrix.name }}_SH_Py_DDS_CI
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Install CMake 4
       if: matrix.os == 'ubuntu-24.04'
@@ -557,7 +557,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
     
     - name: Prebuild
       shell: bash
@@ -586,7 +586,7 @@ jobs:
     timeout-minutes: 60
     
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Prebuild
       run: |
@@ -613,7 +613,7 @@ jobs:
     runs-on: ubuntu-22.04   
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Check_API
       shell: bash
@@ -645,7 +645,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Prebuild
       shell: bash
@@ -676,7 +676,7 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Enable Long Paths
       shell: powershell

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Install 
         shell: bash
@@ -64,7 +64,7 @@ jobs:
             &&  echo "No diffs found in cppcheck_run.parsed.log"
 
       - name: Upload logs
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 #v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with: 
           name: cppcheck_log
           path: |
@@ -102,7 +102,7 @@ jobs:
     name: Valgrind Memory Leak Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       
       - name: Install Valgrind
         run: |
@@ -142,7 +142,7 @@ jobs:
         continue-on-error: true
       
       - name: Upload Valgrind log
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 #v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: valgrind-log
           path: build/valgrind-out.txt
@@ -159,7 +159,7 @@ jobs:
     name: ASAN Memory Leak Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
     
     - name: Install Dependencies
       run: |
@@ -198,7 +198,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload ASAN log
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
           name: asan-log
           path: build/asan-out.txt*
@@ -224,7 +224,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: "Install Dependencies"
         run: |
@@ -320,7 +320,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Build docs 
         run: |


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4.1.7 to v6.0.2 (node24)
- Update `actions/setup-python` from v5.2.0 to v6.2.0 (node24)
- Update `actions/upload-artifact` from v4.0.0 to v7.0.1 (node24)

Fixes most of the Node.js 20 deprecation warning on all CI workflows.