### PR TITLE
Include directory path in pytest log file names

### DIFF
--- a/.github/skills/pytest-infra.md
+++ b/.github/skills/pytest-infra.md
@@ -39,10 +39,11 @@ Both frameworks share the same device/hub infrastructure (`rspy/devices.py`, `rs
 ### Log file naming
 
 Python (`logging_setup.py:test_log_name()`):
-- `pytest-t2ff-pipeline.py::test_x[D455-SN]` → `pytest-t2ff-pipeline_D455-SN.log`
-- `pytest-t2ff-pipeline.py::test_x` → `pytest-t2ff-pipeline.log`
+- `live/frames/pytest-t2ff-pipeline.py::test_x[D455-SN]` → `pytest-live-frames-t2ff-pipeline_D455-SN.log`
+- `live/frames/pytest-t2ff-pipeline.py::test_x` → `pytest-live-frames-t2ff-pipeline.log`
+- `live/hw-reset/pytest-sanity.py::test_x[D455-SN]` → `pytest-live-hw-reset-sanity_D455-SN.log`
 
-The filename uses **file basename + device param from brackets only** — never the test function name.
+The filename uses **directory path (relative to unit-tests/) + file short name + device param from brackets** — mirroring the legacy `run-unit-tests.py` naming convention. Never includes the test function name.
 
 ### Jenkins report generation
 

--- a/unit-tests/infra-tests/test_log_naming.py
+++ b/unit-tests/infra-tests/test_log_naming.py
@@ -5,8 +5,10 @@
 Tests for rspy/pytest/logging_setup.py (test_log_name, _log_key).
 
 Verifies how per-test log filenames are derived:
-- With device param: pytest-depth.py::test[D455-111] → pytest-depth_D455-111.log
-- Without device param: pytest-depth.py::test_basic → pytest-depth.log
+- Directory components are included: live/frames/pytest-depth.py → pytest-live-frames-depth.log
+- With device param: pytest-depth.py::test[D455-111] → pytest-live-frames-depth_D455-111.log
+- Without device param: pytest-depth.py::test_basic → pytest-live-frames-depth.log
+- No parent dir: pytest-standalone.py::test → pytest-standalone.log
 - Special characters (<, >, etc.) are sanitized to underscores
 - _log_key extracts (fspath, device_id) for grouping tests into shared log files
 """
@@ -26,15 +28,35 @@ class TestLogNaming:
 
     def test_with_device_param(self):
         item = self._item("live/frames/pytest-depth.py", "test_x[D455-104623060005]")
-        assert derive_log_name(item) == "pytest-depth_D455-104623060005.log"
+        assert derive_log_name(item) == "pytest-live-frames-depth_D455-104623060005.log"
 
     def test_without_device_param(self):
         item = self._item("live/frames/pytest-depth.py", "test_depth_basic")
-        assert derive_log_name(item) == "pytest-depth.log"
+        assert derive_log_name(item) == "pytest-live-frames-depth.log"
 
     def test_special_chars_sanitized(self):
         item = self._item("live/frames/pytest-depth.py", "test_x[D455<special>]")
-        assert derive_log_name(item) == "pytest-depth_D455_special_.log"
+        assert derive_log_name(item) == "pytest-live-frames-depth_D455_special_.log"
+
+    def test_no_parent_dir(self):
+        """Test at root of unit-tests/ — no directory prefix added."""
+        item = self._item("pytest-standalone.py", "test_basic")
+        assert derive_log_name(item) == "pytest-standalone.log"
+
+    def test_single_parent_dir(self):
+        """Test one level deep — e.g. live/pytest-foo.py."""
+        item = self._item("live/pytest-foo.py", "test_bar")
+        assert derive_log_name(item) == "pytest-live-foo.log"
+
+    def test_deep_nesting(self):
+        """Test in hw-reset subdirectory."""
+        item = self._item("live/hw-reset/pytest-sanity.py", "test_x[D455-111]")
+        assert derive_log_name(item) == "pytest-live-hw-reset-sanity_D455-111.log"
+
+    def test_absolute_path_with_unit_tests(self):
+        """Absolute path — unit-tests/ marker is found and stripped."""
+        item = self._item("/home/user/librealsense/unit-tests/live/frames/pytest-depth.py", "test_x")
+        assert derive_log_name(item) == "pytest-live-frames-depth.log"
 
     def test_log_key_with_brackets(self):
         item = self._item("live/frames/pytest-depth.py", "test_x[D455-111]")

--- a/unit-tests/infra-tests/test_log_naming.py
+++ b/unit-tests/infra-tests/test_log_naming.py
@@ -6,8 +6,8 @@ Tests for rspy/pytest/logging_setup.py (test_log_name, _log_key).
 
 Verifies how per-test log filenames are derived:
 - Directory components are included: live/frames/pytest-depth.py → pytest-live-frames-depth.log
-- With device param: pytest-depth.py::test[D455-111] → pytest-live-frames-depth_D455-111.log
-- Without device param: pytest-depth.py::test_basic → pytest-live-frames-depth.log
+- With device param: live/frames/pytest-depth.py::test[D455-111] → pytest-live-frames-depth_D455-111.log
+- Without device param: live/frames/pytest-depth.py::test_basic → pytest-live-frames-depth.log
 - No parent dir: pytest-standalone.py::test → pytest-standalone.log
 - Special characters (<, >, etc.) are sanitized to underscores
 - _log_key extracts (fspath, device_id) for grouping tests into shared log files
@@ -57,6 +57,11 @@ class TestLogNaming:
         """Absolute path — unit-tests/ marker is found and stripped."""
         item = self._item("/home/user/librealsense/unit-tests/live/frames/pytest-depth.py", "test_x")
         assert derive_log_name(item) == "pytest-live-frames-depth.log"
+
+    def test_absolute_path_outside_tree(self):
+        """Absolute path without unit-tests/ — falls back to basename only."""
+        item = self._item("/tmp/other/pytest-depth.py", "test_x")
+        assert derive_log_name(item) == "pytest-depth.log"
 
     def test_log_key_with_brackets(self):
         item = self._item("live/frames/pytest-depth.py", "test_x[D455-111]")

--- a/unit-tests/live/frames/pytest-t2ff-pipeline.py
+++ b/unit-tests/live/frames/pytest-t2ff-pipeline.py
@@ -48,7 +48,6 @@ def time_to_first_frame(ctx, config):
 
 
 def test_pipeline_first_depth_frame_delay(pipeline_device):
-    assert False, "Deliberate failure to verify log file naming on Jenkins"
     dev, ctx = pipeline_device
     product_name = dev.get_info(rs.camera_info.name)
     max_delay = 1

--- a/unit-tests/live/frames/pytest-t2ff-pipeline.py
+++ b/unit-tests/live/frames/pytest-t2ff-pipeline.py
@@ -48,6 +48,7 @@ def time_to_first_frame(ctx, config):
 
 
 def test_pipeline_first_depth_frame_delay(pipeline_device):
+    assert False, "Deliberate failure to verify log file naming on Jenkins"
     dev, ctx = pipeline_device
     product_name = dev.get_info(rs.camera_info.name)
     max_delay = 1

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -239,14 +239,35 @@ def ensure_newline():
 
 
 def test_log_name(item):
-    """Derive log filename from file basename + device param (from brackets in item.name).
+    """Derive log filename from directory path + file basename + device param.
+
+    Mirrors the legacy run-unit-tests.py naming: directory components (relative to
+    unit-tests/) are joined with '-' and prepended to the file's short name.
 
     Examples:
-      'live/frames/pytest-t2ff-pipeline.py::test_x[D455-104623060005]' -> 'pytest-t2ff-pipeline_D455-104623060005.log'
-      'live/frames/pytest-t2ff-pipeline.py::test_x'                   -> 'pytest-t2ff-pipeline.log'
+      'live/frames/pytest-t2ff-pipeline.py::test_x[D455-104623060005]' -> 'pytest-live-frames-t2ff-pipeline_D455-104623060005.log'
+      'live/frames/pytest-t2ff-pipeline.py::test_x'                   -> 'pytest-live-frames-t2ff-pipeline.log'
+      'pytest-standalone.py::test_x'                                   -> 'pytest-standalone.log'
     """
-    file_path = item.fspath
-    basename = os.path.splitext(os.path.basename(str(file_path)))[0]
+    file_path = str(item.fspath)
+
+    # Resolve relative path within the unit-tests tree
+    normalized = file_path.replace(os.sep, '/')
+    marker = 'unit-tests/'
+    idx = normalized.rfind(marker)
+    if idx >= 0:
+        rel_path = normalized[idx + len(marker):]
+    else:
+        rel_path = normalized
+
+    dirname = os.path.dirname(rel_path)
+    basename = os.path.splitext(os.path.basename(rel_path))[0]
+
+    if dirname:
+        # Strip 'pytest-' prefix, prepend 'pytest-' + dir components joined by '-'
+        stripped = basename[7:] if basename.startswith('pytest-') else basename
+        dir_parts = dirname.replace('/', '-')
+        basename = f"pytest-{dir_parts}-{stripped}"
 
     match = re.search(r'\[(.+)\]', item.name)
     if match:

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -257,6 +257,10 @@ def test_log_name(item):
     idx = normalized.rfind(marker)
     if idx >= 0:
         rel_path = normalized[idx + len(marker):]
+    elif os.path.isabs(file_path) or normalized.startswith('/'):
+        # Absolute path outside the unit-tests tree — use basename only to avoid
+        # embedding host filesystem paths in the log filename.
+        rel_path = os.path.basename(normalized)
     else:
         rel_path = normalized
 

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -262,16 +262,18 @@ def test_log_name(item):
         # embedding host filesystem paths in the log filename.
         rel_path = os.path.basename(normalized)
     else:
+        # Relative path with no unit-tests/ marker — only hit by infra test
+        # mocks that pass paths like "live/frames/pytest-depth.py" directly.
         rel_path = normalized
 
     dirname = os.path.dirname(rel_path)
     basename = os.path.splitext(os.path.basename(rel_path))[0]
 
     if dirname:
-        # Strip 'pytest-' prefix, prepend 'pytest-' + dir components joined by '-'
-        stripped = basename[7:] if basename.startswith('pytest-') else basename
+        # conftest sets python_files=pytest-*.py, so basename always starts with 'pytest-'.
+        # Strip the prefix, then rebuild as 'pytest-{dirs}-{short_name}'.
         dir_parts = dirname.replace('/', '-')
-        basename = f"pytest-{dir_parts}-{stripped}"
+        basename = f"pytest-{dir_parts}-{basename[len('pytest-'):]}"
 
     match = re.search(r'\[(.+)\]', item.name)
     if match:


### PR DESCRIPTION
## Summary
- Pytest log file names now include directory components (relative to unit-tests/), matching the legacy `run-unit-tests.py` naming convention
- e.g. `live/frames/pytest-depth.py` produces `pytest-live-frames-depth.log` instead of `pytest-depth.log`
- Updated infra tests with new expectations + added coverage for edge cases (no parent dir, single dir, deep nesting, absolute paths)

## Test plan
- [x] All 84 infra tests pass locally
- [ ] 
<img width="754" height="196" alt="image" src="https://github.com/user-attachments/assets/ea287ca0-54bf-4b71-8217-e90a160a5f7e" />
