### PR TITLE
Fix missing standard library includes for GCC 12/13 compatibility

### DIFF
--- a/src/librealsense-exception.h
+++ b/src/librealsense-exception.h
@@ -9,6 +9,7 @@
 
 #include <exception>
 #include <string>
+#include <cstring>
 
 
 namespace librealsense {

--- a/src/platform/platform-utils.cpp
+++ b/src/platform/platform-utils.cpp
@@ -6,6 +6,7 @@
 #include "uvc-device-info.h"
 #include "hid-device-info.h"
 #include <src/librealsense-exception.h>
+#include <algorithm>
 #include <rsutils/version.h>
 #include <fstream>
 

--- a/third-party/rsutils/src/control-c-handler.cpp
+++ b/third-party/rsutils/src/control-c-handler.cpp
@@ -6,6 +6,7 @@
 
 #include <signal.h>
 #include <atomic>
+#include <stdexcept>
 
 
 namespace rsutils {

--- a/third-party/rsutils/src/network-adapter-watcher.cpp
+++ b/third-party/rsutils/src/network-adapter-watcher.cpp
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <poll.h>
 #include <thread>
+#include <cstring>
 
 #endif
 #endif  // ! __APPLE__ && ! __ANDROID__

--- a/third-party/rsutils/src/special-folder.cpp
+++ b/third-party/rsutils/src/special-folder.cpp
@@ -18,6 +18,7 @@
 #include <pwd.h>
 
 #endif
+#include <stdexcept>
 
 
 namespace rsutils {


### PR DESCRIPTION
<!--
    Pull requests should go to the development branch:
    https://github.com/realsenseai/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/realsenseai/librealsense/blob/master/CONTRIBUTING.md
-->

# Description:

Several source files are missing standard library includes that are required by GCC 12 and GCC 13, causing build failures on recent Linux distributions (e.g., Debian Bookworm, Ubuntu 22.04+).

## Files fixed:

src/librealsense-exception.h — add <cstring> (required for memset/strerror)
src/platform/platform-utils.cpp — add <algorithm> (required for std::find)
third-party/rsutils/src/network-adapter-watcher.cpp — add <cstring>
third-party/rsutils/src/control-c-handler.cpp — add <stdexcept> (required for std::runtime_error)
third-party/rsutils/src/special-folder.cpp — add <stdexcept>
Tested on:

Linux arm64, GCC 12 (Debian Bookworm)
Linux x86_64, GCC 13 (Ubuntu 24.04)