### PR TITLE
Exclude D401 from fps-performance test

### DIFF
--- a/unit-tests/live/frames/pytest-fps-performance.py
+++ b/unit-tests/live/frames/pytest-fps-performance.py
@@ -31,6 +31,7 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.context("weekly"),
     pytest.mark.device("D400*"),
+    pytest.mark.device_exclude("D401")
 ]
 
 # Constants for device initialization and testing


### PR DESCRIPTION
Fails the weekly test. Will be handled in [RSDEV-6678]