### PR TITLE
Enable stable tests for D401

### DIFF
--- a/unit-tests/live/frames/pytest-backend-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/pytest-backend-vs-frame-timestamp.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.device_exclude("D401"),
 ]
 
 FPS = 30
@@ -81,6 +80,10 @@ def test_depth_backend_vs_frame_timestamp(test_device):
 
 def test_color_backend_vs_frame_timestamp(test_device):
     dev, ctx = test_device
+    product_name = dev.get_info(rs.camera_info.name)
+
+    if any(model in product_name for model in ['D421', 'D401', 'D405']):
+        pytest.skip(f"Device {product_name} has no color sensor support")
 
     cs = dev.first_color_sensor()
     cp = next(p for p in cs.profiles

--- a/unit-tests/live/frames/pytest-backend-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/pytest-backend-vs-frame-timestamp.py
@@ -78,12 +78,12 @@ def test_depth_backend_vs_frame_timestamp(test_device):
         time.sleep(1)
 
 
+# D421/D401/D405 do not have a color sensor support.
+@pytest.mark.device_exclude("D421")
+@pytest.mark.device_exclude("D401")
+@pytest.mark.device_exclude("D405")
 def test_color_backend_vs_frame_timestamp(test_device):
     dev, ctx = test_device
-    product_name = dev.get_info(rs.camera_info.name)
-
-    if any(model in product_name for model in ['D421', 'D401', 'D405']):
-        pytest.skip(f"Device {product_name} has no color sensor support")
 
     cs = dev.first_color_sensor()
     cp = next(p for p in cs.profiles

--- a/unit-tests/live/frames/pytest-depth.py
+++ b/unit-tests/live/frames/pytest-depth.py
@@ -22,7 +22,6 @@ FRAMES_TO_CHECK = 30
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.device_exclude("D401"),
 ]
 
 
@@ -66,6 +65,9 @@ def test_depth_laser_on(test_device):
     dev, ctx = test_device
     product_name = dev.get_info(rs.camera_info.name)
 
+    if any(model in product_name for model in ['D405', 'D401']):
+        pytest.skip(f"Device {product_name} has no laser, the test requires ammendment to check fill rate with laser off")
+    
     tw.start_wrapper(dev)
     try:
         cfg = rs.config()

--- a/unit-tests/live/frames/pytest-depth.py
+++ b/unit-tests/live/frames/pytest-depth.py
@@ -64,9 +64,6 @@ def is_depth_fill_rate_enough(pipeline):
 def test_depth_laser_on(test_device):
     dev, ctx = test_device
     product_name = dev.get_info(rs.camera_info.name)
-
-    if any(model in product_name for model in ['D405', 'D401']):
-        pytest.skip(f"Device {product_name} has no laser, the test requires ammendment to check fill rate with laser off")
     
     tw.start_wrapper(dev)
     try:
@@ -79,11 +76,17 @@ def test_depth_laser_on(test_device):
             pipeline.wait_for_frames()
             time.sleep(2)
 
-            # Enable laser
+            # Enable laser when supported; otherwise continue with current emitter state.
             sensor = pipeline.get_active_profile().get_device().first_depth_sensor()
             if sensor.supports(rs.option.laser_power):
                 sensor.set_option(rs.option.laser_power, sensor.get_option_range(rs.option.laser_power).max)
-            sensor.set_option(rs.option.emitter_enabled, 1)
+            else:
+                log.info(f"Device {product_name} does not support laser power; running depth fill test without forcing laser power")
+
+            if sensor.supports(rs.option.emitter_enabled):
+                sensor.set_option(rs.option.emitter_enabled, 1)
+            else:
+                log.info(f"Device {product_name} does not support emitter control; running with default emitter state")
 
             log.info(f"Testing depth frame - laser ON - {product_name}")
 

--- a/unit-tests/live/frames/pytest-sensor-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/pytest-sensor-vs-frame-timestamp.py
@@ -78,12 +78,12 @@ def test_depth_sensor_vs_frame_timestamp(test_device):
     _run_sensor_ts_check(ds, dp, "Depth")
 
 
+# D421/D401/D405 do not have a color sensor support.
+@pytest.mark.device_exclude("D421")
+@pytest.mark.device_exclude("D401")
+@pytest.mark.device_exclude("D405")
 def test_color_sensor_vs_frame_timestamp(test_device):
     dev, ctx = test_device
-    product_name = dev.get_info(rs.camera_info.name)
-
-    if any(model in product_name for model in ['D421', 'D401', 'D405']):
-        pytest.skip(f"Device {product_name} has no color sensor support")
 
     cs = dev.first_color_sensor()
     cp = next(p for p in cs.profiles

--- a/unit-tests/live/frames/pytest-sensor-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/pytest-sensor-vs-frame-timestamp.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device("D400*"),
-    pytest.mark.device_exclude("D401"),
 ]
 
 FPS = 30
@@ -81,6 +80,10 @@ def test_depth_sensor_vs_frame_timestamp(test_device):
 
 def test_color_sensor_vs_frame_timestamp(test_device):
     dev, ctx = test_device
+    product_name = dev.get_info(rs.camera_info.name)
+
+    if any(model in product_name for model in ['D421', 'D401', 'D405']):
+        pytest.skip(f"Device {product_name} has no color sensor support")
 
     cs = dev.first_color_sensor()
     cp = next(p for p in cs.profiles

--- a/unit-tests/live/frames/pytest-t2ff-sensor.py
+++ b/unit-tests/live/frames/pytest-t2ff-sensor.py
@@ -113,14 +113,15 @@ def test_first_depth_frame_delay(sensor_device):
         time.sleep(1)
 
 
+# D421/D401/D405 do not have a color sensor support.
+@pytest.mark.device_exclude("D421")
+@pytest.mark.device_exclude("D401")
+@pytest.mark.device_exclude("D405")
 def test_first_color_frame_delay(sensor_device):
     dev, ctx = sensor_device
     product_name = dev.get_info(rs.camera_info.name)
     max_delay = 1
     os_name = platform.system()
-
-    if any(model in product_name for model in ['D421', 'D401', 'D405']):
-        pytest.skip(f"Device {product_name} has no color sensor support")
 
     log.info(f"Testing first color frame delay on {product_name} device - {os_name} OS")
 

--- a/unit-tests/live/frames/pytest-t2ff-sensor.py
+++ b/unit-tests/live/frames/pytest-t2ff-sensor.py
@@ -21,7 +21,6 @@ from rspy.snippets import is_dds_dev
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.device_exclude("D401"),
 ]
 
 
@@ -120,8 +119,8 @@ def test_first_color_frame_delay(sensor_device):
     max_delay = 1
     os_name = platform.system()
 
-    if any(model in product_name for model in ['D421', 'D405']):
-        pytest.skip(f"Device {product_name} has no color sensor")
+    if any(model in product_name for model in ['D421', 'D401', 'D405']):
+        pytest.skip(f"Device {product_name} has no color sensor support")
 
     log.info(f"Testing first color frame delay on {product_name} device - {os_name} OS")
 

--- a/unit-tests/live/metadata/pytest-alive.py
+++ b/unit-tests/live/metadata/pytest-alive.py
@@ -11,7 +11,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.device_exclude("D401"),
     pytest.mark.context("nightly"),
 ]
 

--- a/unit-tests/live/metadata/pytest-connection-type-found.py
+++ b/unit-tests/live/metadata/pytest-connection-type-found.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.device_exclude("D401"),
 ]
 
 
@@ -19,12 +18,12 @@ def test_connection_type_detected(test_device):
 
     assert dev.supports(rs.camera_info.connection_type), "Device should support connection_type info"
     connection_type = dev.get_info(rs.camera_info.connection_type)
-    camera_name = dev.get_info(rs.camera_info.name)
-    assert connection_type, f"Connection type should not be empty for {camera_name}"
+    product_name = dev.get_info(rs.camera_info.name)
+    assert connection_type, f"Connection type should not be empty for {product_name}"
 
-    if 'D457' in camera_name:
-        assert connection_type == "GMSL", f"D457 should have GMSL connection, got: {connection_type}"
-    elif 'D555' in camera_name:
-        assert connection_type == "DDS", f"D555 should have DDS connection, got: {connection_type}"
+    if any(model in product_name for model in ['D457', 'D401']):
+        assert connection_type == "GMSL", f"{product_name} should have GMSL connection, got: {connection_type}"
+    elif any(model in product_name for model in ['D555']):
+        assert connection_type == "DDS", f"{product_name} should have DDS connection, got: {connection_type}"
     else:
-        assert connection_type == "USB", f"{camera_name} should have USB connection, got: {connection_type}"
+        assert connection_type == "USB", f"{product_name} should have USB connection, got: {connection_type}"


### PR DESCRIPTION
* Enable stable tests for D401 (FW 5.17.3.6+)

The following tests require D401 RGB sensor support and still are excluded:
* test_pipeline_first_color_frame_delay
* test_first_color_frame_delay
* test-live-image-quality-basic-color
* test_color_sensor_vs_frame_timestamp
* test_color_backend_vs_frame_timestamp