### PR TITLE
pytest: fail fast if a required plugin from requirements.txt is missing

### DIFF
--- a/.github/skills/pytest-infra.md
+++ b/.github/skills/pytest-infra.md
@@ -24,11 +24,22 @@ Both frameworks share the same device/hub infrastructure (`rspy/devices.py`, `rs
 | `rspy/pytest/device_helpers.py` | Device parametrization (`@device_each`) |
 | `rspy/pytest/collection.py` | Test filtering (nightly, context gating, `--live`) |
 | `rspy/pytest/cli.py` | Legacy CLI flag consumption |
+| `rspy/pytest/plugins.py` | Required pytest plugin registry + availability check |
 | `rspy/devices.py` | Device discovery, port tracking, `enable_only()` |
 | `rspy/combined_hub.py` | Virtual port mapping across multiple hubs |
 | `rspy/device_hub.py` | Abstract hub interface |
 | `rspy/unifi.py` | UniFi PoE switch control via SSH |
 | `rspy/acroname.py` | Acroname USB hub control |
+
+### Adding a new pytest plugin requirement
+
+When adding a pytest plugin to `unit-tests/requirements.txt`, you **must** also register it in `rspy/pytest/plugins.py` under `REQUIRED_PYTEST_PLUGINS`. `conftest.py` calls `check_required_plugins()` at `pytest_configure` time and raises `pytest.UsageError` if any listed plugin is not importable.
+
+Why: a missing plugin silently disables its CLI options (e.g. if `pytest-repeat` is absent, `--repeat N` → `--count N` mapping becomes a no-op and tests run once with no error). The registry makes the dependency explicit and fails loudly.
+
+To add one:
+1. Pin the plugin in `unit-tests/requirements.txt`.
+2. Add a `'<module_name>': '<pip-package-name>'` entry to `REQUIRED_PYTEST_PLUGINS` in `rspy/pytest/plugins.py` (module name is the Python import name, typically with underscores; pip name uses hyphens).
 
 ### Hub port management
 

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
 
     - name: Install
-      run: pip3 install pytest pytest-retry pytest-timeout pytest-repeat
+      run: pip3 install -r unit-tests/requirements.txt
 
     - name: Run infra tests
       run: cd unit-tests && python3 -m pytest infra-tests/ -v

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
 
     - name: Install
-      run: pip3 install -r unit-tests/requirements.txt
+      run: pip3 install pytest pytest-retry pytest-timeout pytest-repeat pytest-check
 
     - name: Run infra tests
       run: cd unit-tests && python3 -m pytest infra-tests/ -v

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -41,6 +41,7 @@ from rspy.pytest.logging_setup import (
 from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
 from rspy.pytest.device_helpers import find_matching_devices, find_matching_devices_multi, resolve_device_each_serials
 from rspy.pytest.collection import filter_and_sort_items
+from rspy.pytest.plugins import check_required_plugins
 
 log = logging.getLogger('librealsense')
 
@@ -146,6 +147,7 @@ def pytest_configure(config):
     """Early setup: register markers, configure defaults, and query connected devices."""
     global context_list
 
+    check_required_plugins()
     apply_pending_flags(config)
 
     # --repeat N → pytest-repeat's --count N (only if --count wasn't explicitly set)

--- a/unit-tests/py/rspy/pytest/plugins.py
+++ b/unit-tests/py/rspy/pytest/plugins.py
@@ -1,0 +1,36 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""Required pytest plugin registry and availability check.
+
+Without this check a missing plugin silently disables its CLI options
+(e.g. --repeat maps to pytest-repeat's --count; if pytest-repeat is
+absent, the mapping becomes a no-op and tests run once instead of N
+times with no error). We fail fast in pytest_configure instead.
+
+When adding a new pytest plugin to unit-tests/requirements.txt, also
+add it to REQUIRED_PYTEST_PLUGINS below.
+"""
+
+import importlib.util
+import pytest
+
+
+REQUIRED_PYTEST_PLUGINS = {
+    # module name      : pip package name (for the install hint)
+    'pytest_timeout': 'pytest-timeout',
+    'pytest_retry':   'pytest-retry',
+    'pytest_repeat':  'pytest-repeat',
+    'pytest_check':   'pytest-check',
+}
+
+
+def check_required_plugins(plugins=None):
+    plugins = plugins if plugins is not None else REQUIRED_PYTEST_PLUGINS
+    missing = [pip_name for mod, pip_name in plugins.items()
+               if importlib.util.find_spec(mod) is None]
+    if missing:
+        raise pytest.UsageError(
+            f"Missing required pytest plugin(s): {', '.join(missing)}. "
+            f"Install via: pip install -r unit-tests/requirements.txt"
+        )


### PR DESCRIPTION
## Summary
- `--repeat` (and any other flag wired to an optional pytest plugin) silently became a no-op if the plugin wasn't installed — tests ran once with no error
- Added `rspy/pytest/plugins.py` with `REQUIRED_PYTEST_PLUGINS` registry and `check_required_plugins()`, called from `pytest_configure` to raise `pytest.UsageError` on any missing import
- Documented the two-step convention (pin in `requirements.txt` + register in the dict) in `.github/skills/pytest-infra.md`

## Test plan
- [x] `unit-tests/infra-tests/` — all 80 tests pass
- [x] Verify clear error message when a required plugin is uninstalled locally

<img width="1074" height="132" alt="image" src="https://github.com/user-attachments/assets/f2c330bd-2741-43fd-9cf4-4df4ab5cf5ca" />
