### PR TITLE
rest-api: co-locate test + requirements under unit-tests/wrappers/rest-api/

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Install
-      run: pip3 install pytest pytest-retry pytest-timeout pytest-repeat pytest-check
+      run: pip3 install -r unit-tests/requirements.txt
 
     - name: Run infra tests
       run: cd unit-tests && python3 -m pytest infra-tests/ -v

--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -18,16 +18,4 @@ pytest-retry==1.7.0
 pytest-repeat==0.9.3
 pytest-check==2.8.0
 
-# REST API testing requirements (Only for Linux x86)
-fastapi==0.120.1;        sys_platform == "linux" and platform_machine == "x86_64"
-uvicorn==0.34.0;         sys_platform == "linux" and platform_machine == "x86_64"
-pydantic==2.10.6;        sys_platform == "linux" and platform_machine == "x86_64"
-aiortc==1.11.0;          sys_platform == "linux" and platform_machine == "x86_64"
-python-socketio==5.13.0; sys_platform == "linux" and platform_machine == "x86_64"
-pytest==8.3.5;           sys_platform == "linux" and platform_machine == "x86_64"
-pytest-asyncio==0.26.0;  sys_platform == "linux" and platform_machine == "x86_64"
-typeguard==4.4.4;        sys_platform == "linux" and platform_machine == "x86_64"
-jinja2==3.1.6;           sys_platform == "linux" and platform_machine == "x86_64"
-pyyaml==6.0.2;           sys_platform == "linux" and platform_machine == "x86_64"
-lark==1.2.2;             sys_platform == "linux" and platform_machine == "x86_64"
-httpx==0.28.1;           sys_platform == "linux" and platform_machine == "x86_64"
+# REST API deps live in wrappers/rest-api/ (requirements.txt + requirements-test.txt)

--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -18,4 +18,4 @@ pytest-retry==1.7.0
 pytest-repeat==0.9.3
 pytest-check==2.8.0
 
-# REST API deps live in wrappers/rest-api/ (requirements.txt + requirements-test.txt)
+# REST API deps: wrappers/rest-api/requirements.txt + unit-tests/wrappers/rest-api/requirements.txt

--- a/unit-tests/wrappers/rest-api/requirements.txt
+++ b/unit-tests/wrappers/rest-api/requirements.txt
@@ -1,9 +1,9 @@
 # Test-only extras for wrappers/rest-api/tests/ (on top of wrappers/rest-api/requirements.txt)
 # Usage: pip install -r wrappers/rest-api/requirements.txt -r unit-tests/wrappers/rest-api/requirements.txt
-pytest==8.3.5
-pytest-asyncio==0.26.0
-typeguard==4.4.4
-jinja2==3.1.6
-pyyaml==6.0.2
-lark==1.2.2
-httpx==0.28.1
+pytest==8.3.5;          platform_machine != "aarch64"
+pytest-asyncio==0.26.0; platform_machine != "aarch64"
+typeguard==4.4.4;       platform_machine != "aarch64"
+jinja2==3.1.6;          platform_machine != "aarch64"
+pyyaml==6.0.2;          platform_machine != "aarch64"
+lark==1.2.2;            platform_machine != "aarch64"
+httpx==0.28.1;          platform_machine != "aarch64"

--- a/unit-tests/wrappers/rest-api/requirements.txt
+++ b/unit-tests/wrappers/rest-api/requirements.txt
@@ -1,0 +1,9 @@
+# Test-only extras for wrappers/rest-api/tests/ (on top of wrappers/rest-api/requirements.txt)
+# Usage: pip install -r wrappers/rest-api/requirements.txt -r unit-tests/wrappers/rest-api/requirements.txt
+pytest==8.3.5
+pytest-asyncio==0.26.0
+typeguard==4.4.4
+jinja2==3.1.6
+pyyaml==6.0.2
+lark==1.2.2
+httpx==0.28.1

--- a/unit-tests/wrappers/rest-api/test-rest-api-wrapper.py
+++ b/unit-tests/wrappers/rest-api/test-rest-api-wrapper.py
@@ -1,6 +1,7 @@
 #test:device D455
 #test:donotrun:!linux
 
+import os
 import pyrealsense2 as rs
 from rspy import log, repo, test
 from rspy.stopwatch import Stopwatch
@@ -10,7 +11,8 @@ from rspy.stopwatch import Stopwatch
 test.start( "Run test-rest-api-wrapper test" )
 import subprocess, sys
 run_time_stopwatch = Stopwatch()
-p = subprocess.run( [sys.executable, "-m", "pytest", "./wrappers/rest-api/tests/test_api_service.py"],
+rest_api_test = os.path.join( repo.root, "wrappers", "rest-api", "tests", "test_api_service.py" )
+p = subprocess.run( [sys.executable, "-m", "pytest", rest_api_test],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,

--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -79,13 +79,7 @@ It simplifies remote control and data streaming from RealSense devices by handli
 
 ## Testing
 
-1. **To enable testing add the following to the requirements.txt**
+1. **Install the test extras:**
     ```bash
-    pytest==8.3.5
-    pytest-asyncio==0.26.0
-    typeguard==4.4.4
-    jinja2==3.1.6
-    pyyaml==6.0.2
-    lark==1.2.2
-    httpx==0.28.1
+    pip3 install -r requirements.txt -r requirements-test.txt
     ```

--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -79,7 +79,7 @@ It simplifies remote control and data streaming from RealSense devices by handli
 
 ## Testing
 
-1. **Install the test extras:**
+1. **Install the test extras (from the repository root):**
     ```bash
-    pip3 install -r requirements.txt -r ../../unit-tests/wrappers/rest-api/requirements.txt
+    pip3 install -r wrappers/rest-api/requirements.txt -r unit-tests/wrappers/rest-api/requirements.txt
     ```

--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -81,5 +81,5 @@ It simplifies remote control and data streaming from RealSense devices by handli
 
 1. **Install the test extras:**
     ```bash
-    pip3 install -r requirements.txt -r requirements-test.txt
+    pip3 install -r requirements.txt -r ../../unit-tests/wrappers/rest-api/requirements.txt
     ```

--- a/wrappers/rest-api/requirements-test.txt
+++ b/wrappers/rest-api/requirements-test.txt
@@ -1,0 +1,9 @@
+# Extras required to run wrappers/rest-api/tests/
+# Usage: pip install -r requirements.txt -r requirements-test.txt
+pytest==8.3.5
+pytest-asyncio==0.26.0
+typeguard==4.4.4
+jinja2==3.1.6
+pyyaml==6.0.2
+lark==1.2.2
+httpx==0.28.1

--- a/wrappers/rest-api/requirements-test.txt
+++ b/wrappers/rest-api/requirements-test.txt
@@ -1,9 +1,0 @@
-# Extras required to run wrappers/rest-api/tests/
-# Usage: pip install -r requirements.txt -r requirements-test.txt
-pytest==8.3.5
-pytest-asyncio==0.26.0
-typeguard==4.4.4
-jinja2==3.1.6
-pyyaml==6.0.2
-lark==1.2.2
-httpx==0.28.1

--- a/wrappers/rest-api/requirements.txt
+++ b/wrappers/rest-api/requirements.txt
@@ -1,8 +1,8 @@
-fastapi==0.120.1
-uvicorn==0.34.0
-pydantic==2.10.6
-pyrealsense2==2.56.4.9191
-aiortc==1.11.0
-opencv-python==4.11.0.86
-numpy==2.2.4
-python-socketio==5.13.0
+fastapi==0.120.1;        platform_machine != "aarch64"
+uvicorn==0.34.0;         platform_machine != "aarch64"
+pydantic==2.10.6;        platform_machine != "aarch64"
+pyrealsense2==2.56.4.9191; platform_machine != "aarch64"
+aiortc==1.11.0;          platform_machine != "aarch64"
+opencv-python==4.11.0.86; platform_machine != "aarch64"
+numpy==2.2.4;            platform_machine != "aarch64"
+python-socketio==5.13.0; platform_machine != "aarch64"


### PR DESCRIPTION
## Summary
- Split the REST API testing block out of `unit-tests/requirements.txt` (it pulled in `aiortc`/`av`, which needs system ffmpeg dev libs and broke `pip install` on stock GHA runners and on a fresh dev machine).
- Created `unit-tests/wrappers/rest-api/requirements.txt` holding only the REST test extras (pytest-asyncio, typeguard, jinja2, pyyaml, lark, httpx); the REST **runtime** deps stay in `wrappers/rest-api/requirements.txt`.
- Moved `test-rest-api-wrapper.py` from `unit-tests/live/wrappers/` to `unit-tests/wrappers/rest-api/` (next to its requirements) and switched the internal subprocess path from a CWD-relative `"./wrappers/..."` to `repo.root`-based, so the test works regardless of invocation directory.
- Switched the `Infra_Tests` GHA step to `pip3 install -r unit-tests/requirements.txt` so the workflow stays aligned with the pinned plugin set.
- Updated `wrappers/rest-api/README.md` Testing section to point at the new test-requirements path.

## Test plan
- [x] `unit-tests/infra-tests/` — 80/80 local pass
- [x] `run-unit-tests.py --list-tests --debug` discovers the moved test as `test-wrappers-rest-api-rest-api-wrapper` (correctly skipped on Windows per `#test:donotrun:!linux`)
- [x] CI Infra_Tests green after `aiortc` block is gone
- [x] REST machine CI still picks up `test-wrappers-rest-api-rest-api-wrapper`
Goes with librealsense-deploy/pull/96