### PR TITLE
pytest-depth-unit: log SDK error on test failure

### DIFF
--- a/unit-tests/live/metadata/pytest-depth-unit.py
+++ b/unit-tests/live/metadata/pytest-depth-unit.py
@@ -33,5 +33,8 @@ def test_depth_units_metadata(test_device):
         check.is_true(ds.supports(rs.option.depth_units), "Depth sensor should support depth_units option")
         check.equal(ds.get_option(rs.option.depth_units), depth_units_from_metadata,
             f"Depth units option ({ds.get_option(rs.option.depth_units)}) should match metadata ({depth_units_from_metadata})")
+    except Exception as e:
+        log.error(f"test failed: {e}")
+        raise
     finally:
         pipeline.stop()


### PR DESCRIPTION
## Summary
- Add `except` clause in `test_depth_units_metadata` that logs the SDK exception message before re-raising.
- Without this, if `pipeline.start()` fails, the subsequent `pipeline.stop()` in `finally` raises its own exception which can obscure the root cause. The `log.error(...)` ensures the real SDK error lands in the per-test log file regardless.

## Test plan
- [x] Happy path: `pytest -v unit-tests/live/metadata/pytest-depth-unit.py` with D455 connected → PASSED
- [x] Forced failure (invalid stream config) → log shows `test failed: Couldn't resolve requests` and the original traceback is preserved; the follow-up `stop()` error is chained after, not masking the root cause.