### PR TITLE
hw_reset: always settle MIPI driver even if hardware_reset() fails

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -596,6 +596,10 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
                     re-enabling
     :param timeout: The maximum seconds to wait to make sure the devices are indeed online
     """
+    if recycle:
+        # let the driver/device settle before we disrupt it; helps the MIPI driver in particular
+        # recover cleanly when a preceding test left it in a bad state
+        time.sleep(1)
     if hub:
         #
         ports = [ get( sn ).port for sn in serial_numbers ]
@@ -721,7 +725,12 @@ def hw_reset( serial_numbers, timeout = MAX_ENUMERATION_TIME ):
     _wait_for(serial_numbers, timeout=timeout) # make sure devices are added before doing hw reset
     for sn in serial_numbers:
         dev = get( sn ).handle
-        dev.hardware_reset()
+        try:
+            dev.hardware_reset()
+        except Exception as e:
+            # swallow so one failing SN doesn't skip reset on the others and, more importantly,
+            # doesn't skip the post-reset settle that lets the driver re-enumerate
+            log.w( f'hardware_reset() failed for {sn}: {e}' )
     #
 
     if removable_devs_sns:


### PR DESCRIPTION
## Summary
- When a test leaves the MIPI driver in a bad state, a subsequent `dev.hardware_reset()` call can raise. The old `hw_reset()` unwound on that exception, skipping the 8-sec MIPI re-init sleep and the final `_wait_for()`, which left the driver half-broken and cascaded failures through every following test (see Jenkins [LRS_jetson_compile_pipeline #12661](https://rsjenkins.realsenseai.com/job/LRS_jetson_compile_pipeline/12661/consoleFull) — 1 real failure, 14 downstream `errno=121 Remote I/O error`).
- Wrap `dev.hardware_reset()` in try/except that logs via `log.w`, so the post-reset settle and `_wait_for()` always run.
- Add a 1-sec settle sleep at the top of `enable_only` when `recycle=True` — covers both hub-recycle and `hw_reset` paths, giving the driver a moment before we disrupt it.

## Test plan
- [x] Jenkins MIPI pipeline run on D401 passes through a forced `hardware_reset()` failure without poisoning subsequent tests
- [x] USB/hub path unaffected (1-sec delay is negligible)