### PR TITLE
live/hw-reset: add advanced-mode toggle test

### DIFF
--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -4,6 +4,7 @@
 import pytest
 import pyrealsense2 as rs
 from rspy.timer import Timer
+from rspy.snippets import is_dds_dev
 import time
 import logging
 log = logging.getLogger(__name__)
@@ -16,7 +17,8 @@ pytestmark = [
     pytest.mark.device_each("D500*"),
 ]
 
-TOGGLE_WAIT_TIME = 30  # [sec] max wait for device to reconnect after advanced mode toggle
+TOGGLE_WAIT_TIME     = 30  # [sec] max wait for device to reconnect after advanced mode toggle
+TOGGLE_WAIT_TIME_DDS = 60  # [sec] DDS devices enumerate slower after advanced mode toggle
 
 dev = None
 target_sn = None   # cached before toggle — the removed dev handle cannot be queried safely
@@ -34,9 +36,9 @@ def device_changed( info ):
             continue
 
 
-def _wait_for_reconnect():
-    """Wait up to TOGGLE_WAIT_TIME seconds for the device to reappear. Returns True if it did."""
-    t = Timer( TOGGLE_WAIT_TIME )
+def _wait_for_reconnect( timeout ):
+    """Wait up to *timeout* seconds for the device to reappear. Returns True if it did."""
+    t = Timer( timeout )
     t.start()
     while not t.has_expired():
         if device_added:
@@ -60,9 +62,11 @@ def test_advanced_mode_toggle( test_device ):
 
     ctx.set_devices_changed_callback( device_changed )
 
+    wait_time = TOGGLE_WAIT_TIME_DDS if is_dds_dev( dev ) else TOGGLE_WAIT_TIME
     initial_state = am_dev.is_enabled()
     toggled_state = not initial_state
-    log.info( "Device: %s | Initial advanced mode: %s", name, "ON" if initial_state else "OFF" )
+    log.info( "Device: %s | Initial advanced mode: %s | Reconnect timeout: %d sec",
+              name, "ON" if initial_state else "OFF", wait_time )
 
     # --- Toggle to opposite state ---
     # Clear the flag before toggling so a fast reconnect cannot be missed
@@ -70,10 +74,10 @@ def test_advanced_mode_toggle( test_device ):
     log.info( "Toggling advanced mode to %s", "ON" if toggled_state else "OFF" )
     am_dev.toggle_advanced_mode( toggled_state )
 
-    log.info( "Waiting up to %d sec for device to reconnect after toggle...", TOGGLE_WAIT_TIME )
+    log.info( "Waiting up to %d sec for device to reconnect after toggle...", wait_time )
     try:
-        assert _wait_for_reconnect(), \
-            f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
+        assert _wait_for_reconnect( wait_time ), \
+            f"Device did not reconnect within {wait_time} sec after toggling advanced mode"
 
         toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
         assert toggled_enabled == toggled_state, \
@@ -88,9 +92,9 @@ def test_advanced_mode_toggle( test_device ):
                 device_added = False
                 rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
 
-                log.info( "Waiting up to %d sec for device to reconnect after restore...", TOGGLE_WAIT_TIME )
-                if not _wait_for_reconnect():
-                    log.warning( "Device did not reconnect within %d sec after restoring advanced mode", TOGGLE_WAIT_TIME )
+                log.info( "Waiting up to %d sec for device to reconnect after restore...", wait_time )
+                if not _wait_for_reconnect( wait_time ):
+                    log.warning( "Device did not reconnect within %d sec after restoring advanced mode", wait_time )
                 else:
                     restored_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
                     if restored_enabled != initial_state:

--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -13,9 +13,12 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D400*"),
+    pytest.mark.context("nightly"),
+    pytest.mark.timeout(360),
 ]
 
-TOGGLE_WAIT_TIME = 30  # [sec] max wait for device to reconnect after advanced mode toggle
+TOGGLE_WAIT_TIME  = 30  # [sec] max wait for device to reconnect after advanced mode toggle
+TOGGLE_ITERATIONS =  3  # number of ON→OFF→ON cycles
 
 dev = None
 target_sn = None   # cached before toggle — the removed dev handle cannot be queried safely
@@ -61,23 +64,42 @@ def test_advanced_mode_toggle( test_device ):
 
     initial_state = am_dev.is_enabled()
     toggled_state = not initial_state
-    log.info( "Device: %s | Initial advanced mode: %s", name, "ON" if initial_state else "OFF" )
+    log.info( "Device: %s | Initial advanced mode: %s | Iterations: %d",
+              name, "ON" if initial_state else "OFF", TOGGLE_ITERATIONS )
 
-    # --- Toggle to opposite state ---
-    # Clear the flag before toggling so a fast reconnect cannot be missed
-    device_added = False
-    log.info( "Toggling advanced mode to %s", "ON" if toggled_state else "OFF" )
-    am_dev.toggle_advanced_mode( toggled_state )
-
-    log.info( "Waiting up to %d sec for device to reconnect after toggle...", TOGGLE_WAIT_TIME )
     try:
-        assert _wait_for_reconnect( TOGGLE_WAIT_TIME ), \
-            f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
+        for i in range( 1, TOGGLE_ITERATIONS + 1 ):
+            log.info( "[%d/%d] Toggling advanced mode to %s",
+                      i, TOGGLE_ITERATIONS, "ON" if toggled_state else "OFF" )
+            device_added = False
+            am_dev.toggle_advanced_mode( toggled_state )
 
-        toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
-        assert toggled_enabled == toggled_state, \
-            f"Expected advanced mode {'ON' if toggled_state else 'OFF'} after toggle but got {'ON' if toggled_enabled else 'OFF'}"
-        log.info( "Device reconnected; advanced mode is %s", "ON" if toggled_state else "OFF" )
+            log.info( "[%d/%d] Waiting up to %d sec for device to reconnect...",
+                      i, TOGGLE_ITERATIONS, TOGGLE_WAIT_TIME )
+            assert _wait_for_reconnect( TOGGLE_WAIT_TIME ), \
+                f"[{i}/{TOGGLE_ITERATIONS}] Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
+
+            toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
+            assert toggled_enabled == toggled_state, \
+                f"[{i}/{TOGGLE_ITERATIONS}] Expected advanced mode {'ON' if toggled_state else 'OFF'} after toggle but got {'ON' if toggled_enabled else 'OFF'}"
+            log.info( "[%d/%d] Device reconnected; advanced mode is %s",
+                      i, TOGGLE_ITERATIONS, "ON" if toggled_state else "OFF" )
+
+            log.info( "[%d/%d] Toggling advanced mode back to %s",
+                      i, TOGGLE_ITERATIONS, "ON" if initial_state else "OFF" )
+            device_added = False
+            rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
+
+            log.info( "[%d/%d] Waiting up to %d sec for device to reconnect after restore...",
+                      i, TOGGLE_ITERATIONS, TOGGLE_WAIT_TIME )
+            assert _wait_for_reconnect( TOGGLE_WAIT_TIME ), \
+                f"[{i}/{TOGGLE_ITERATIONS}] Device did not reconnect within {TOGGLE_WAIT_TIME} sec after restoring advanced mode"
+
+            am_dev = rs.rs400_advanced_mode( dev )
+            restored_enabled = am_dev.is_enabled()
+            assert restored_enabled == initial_state, \
+                f"[{i}/{TOGGLE_ITERATIONS}] Expected advanced mode {'ON' if initial_state else 'OFF'} after restore but got {'ON' if restored_enabled else 'OFF'}"
+            log.info( "[%d/%d] Advanced mode restored to %s", i, TOGGLE_ITERATIONS, "ON" if initial_state else "OFF" )
 
     finally:
         # Best-effort restore initial state so later tests in the session are not affected
@@ -96,6 +118,6 @@ def test_advanced_mode_toggle( test_device ):
                         log.warning( "Advanced mode restore: expected %s but got %s",
                                      "ON" if initial_state else "OFF", "ON" if restored_enabled else "OFF" )
                     else:
-                        log.info( "Advanced mode restored to %s; test passed", "ON" if initial_state else "OFF" )
+                        log.info( "Advanced mode restored to %s", "ON" if initial_state else "OFF" )
         except Exception as e:
             log.warning( "Best-effort advanced mode restore failed for %s: %s", name, e )

--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.context("nightly"),
-    pytest.mark.timeout(360),
 ]
 
 TOGGLE_WAIT_TIME  = 30  # [sec] max wait for device to reconnect after advanced mode toggle

--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -36,8 +36,6 @@ def device_changed( info ):
 
 def _wait_for_reconnect():
     """Wait up to TOGGLE_WAIT_TIME seconds for the device to reappear. Returns True if it did."""
-    global device_added
-    device_added = False
     t = Timer( TOGGLE_WAIT_TIME )
     t.start()
     while not t.has_expired():
@@ -63,31 +61,42 @@ def test_advanced_mode_toggle( test_device ):
     ctx.set_devices_changed_callback( device_changed )
 
     initial_state = am_dev.is_enabled()
+    toggled_state = not initial_state
     log.info( "Device: %s | Initial advanced mode: %s", name, "ON" if initial_state else "OFF" )
 
     # --- Toggle to opposite state ---
-    toggled_state = not initial_state
+    # Clear the flag before toggling so a fast reconnect cannot be missed
+    device_added = False
     log.info( "Toggling advanced mode to %s", "ON" if toggled_state else "OFF" )
     am_dev.toggle_advanced_mode( toggled_state )
 
     log.info( "Waiting up to %d sec for device to reconnect after toggle...", TOGGLE_WAIT_TIME )
-    assert _wait_for_reconnect(), \
-        f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
+    try:
+        assert _wait_for_reconnect(), \
+            f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
 
-    toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
-    assert toggled_enabled == toggled_state, \
-        f"Expected advanced mode {'ON' if toggled_state else 'OFF'} after toggle but got {'ON' if toggled_enabled else 'OFF'}"
-    log.info( "Device reconnected; advanced mode is %s", "ON" if toggled_state else "OFF" )
+        toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
+        assert toggled_enabled == toggled_state, \
+            f"Expected advanced mode {'ON' if toggled_state else 'OFF'} after toggle but got {'ON' if toggled_enabled else 'OFF'}"
+        log.info( "Device reconnected; advanced mode is %s", "ON" if toggled_state else "OFF" )
 
-    # --- Toggle back to original state ---
-    log.info( "Toggling advanced mode back to %s", "ON" if initial_state else "OFF" )
-    rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
+    finally:
+        # Best-effort restore initial state so later tests in the session are not affected
+        try:
+            if dev and rs.rs400_advanced_mode( dev ).is_enabled() != initial_state:
+                log.info( "Restoring advanced mode to %s", "ON" if initial_state else "OFF" )
+                device_added = False
+                rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
 
-    log.info( "Waiting up to %d sec for device to reconnect after restore...", TOGGLE_WAIT_TIME )
-    assert _wait_for_reconnect(), \
-        f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after restoring advanced mode"
-
-    restored_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
-    assert restored_enabled == initial_state, \
-        f"Expected advanced mode {'ON' if initial_state else 'OFF'} after restore but got {'ON' if restored_enabled else 'OFF'}"
-    log.info( "Advanced mode restored to %s; test passed", "ON" if initial_state else "OFF" )
+                log.info( "Waiting up to %d sec for device to reconnect after restore...", TOGGLE_WAIT_TIME )
+                if not _wait_for_reconnect():
+                    log.warning( "Device did not reconnect within %d sec after restoring advanced mode", TOGGLE_WAIT_TIME )
+                else:
+                    restored_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
+                    if restored_enabled != initial_state:
+                        log.warning( "Advanced mode restore: expected %s but got %s",
+                                     "ON" if initial_state else "OFF", "ON" if restored_enabled else "OFF" )
+                    else:
+                        log.info( "Advanced mode restored to %s; test passed", "ON" if initial_state else "OFF" )
+        except Exception as e:
+            log.warning( "Best-effort advanced mode restore failed for %s: %s", name, e )

--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -1,0 +1,93 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import pytest
+import pyrealsense2 as rs
+from rspy.timer import Timer
+import time
+import logging
+log = logging.getLogger(__name__)
+
+# Verify that toggling advanced mode ON/OFF causes the device to reconnect
+# and that the state is correctly applied and reversible.
+
+pytestmark = [
+    pytest.mark.device_each("D400*"),
+    pytest.mark.device_each("D500*"),
+]
+
+TOGGLE_WAIT_TIME = 30  # [sec] max wait for device to reconnect after advanced mode toggle
+
+dev = None
+target_sn = None   # cached before toggle — the removed dev handle cannot be queried safely
+device_added = False
+
+
+def device_changed( info ):
+    global dev, device_added
+    for candidate in info.get_new_devices():
+        try:
+            if candidate.get_info( rs.camera_info.serial_number ) == target_sn:
+                dev = candidate   # update handle to the newly enumerated instance
+                device_added = True
+        except RuntimeError:
+            continue
+
+
+def _wait_for_reconnect():
+    """Wait up to TOGGLE_WAIT_TIME seconds for the device to reappear. Returns True if it did."""
+    global device_added
+    device_added = False
+    t = Timer( TOGGLE_WAIT_TIME )
+    t.start()
+    while not t.has_expired():
+        if device_added:
+            return True
+        time.sleep( 0.1 )
+    return False
+
+
+def test_advanced_mode_toggle( test_device ):
+    global dev, target_sn, device_added
+    device_added = False
+
+    dev, ctx = test_device
+    target_sn = dev.get_info( rs.camera_info.serial_number )
+    name = dev.get_info( rs.camera_info.name )
+
+    try:
+        am_dev = rs.rs400_advanced_mode( dev )
+    except Exception as e:
+        pytest.skip( f"Advanced mode not supported on {name}: {e}" )
+
+    ctx.set_devices_changed_callback( device_changed )
+
+    initial_state = am_dev.is_enabled()
+    log.info( "Device: %s | Initial advanced mode: %s", name, "ON" if initial_state else "OFF" )
+
+    # --- Toggle to opposite state ---
+    toggled_state = not initial_state
+    log.info( "Toggling advanced mode to %s", "ON" if toggled_state else "OFF" )
+    am_dev.toggle_advanced_mode( toggled_state )
+
+    log.info( "Waiting up to %d sec for device to reconnect after toggle...", TOGGLE_WAIT_TIME )
+    assert _wait_for_reconnect(), \
+        f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
+
+    toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
+    assert toggled_enabled == toggled_state, \
+        f"Expected advanced mode {'ON' if toggled_state else 'OFF'} after toggle but got {'ON' if toggled_enabled else 'OFF'}"
+    log.info( "Device reconnected; advanced mode is %s", "ON" if toggled_state else "OFF" )
+
+    # --- Toggle back to original state ---
+    log.info( "Toggling advanced mode back to %s", "ON" if initial_state else "OFF" )
+    rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
+
+    log.info( "Waiting up to %d sec for device to reconnect after restore...", TOGGLE_WAIT_TIME )
+    assert _wait_for_reconnect(), \
+        f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after restoring advanced mode"
+
+    restored_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
+    assert restored_enabled == initial_state, \
+        f"Expected advanced mode {'ON' if initial_state else 'OFF'} after restore but got {'ON' if restored_enabled else 'OFF'}"
+    log.info( "Advanced mode restored to %s; test passed", "ON" if initial_state else "OFF" )

--- a/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
+++ b/unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py
@@ -4,7 +4,6 @@
 import pytest
 import pyrealsense2 as rs
 from rspy.timer import Timer
-from rspy.snippets import is_dds_dev
 import time
 import logging
 log = logging.getLogger(__name__)
@@ -14,11 +13,9 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D400*"),
-    pytest.mark.device_each("D500*"),
 ]
 
-TOGGLE_WAIT_TIME     = 30  # [sec] max wait for device to reconnect after advanced mode toggle
-TOGGLE_WAIT_TIME_DDS = 60  # [sec] DDS devices enumerate slower after advanced mode toggle
+TOGGLE_WAIT_TIME = 30  # [sec] max wait for device to reconnect after advanced mode toggle
 
 dev = None
 target_sn = None   # cached before toggle — the removed dev handle cannot be queried safely
@@ -62,11 +59,9 @@ def test_advanced_mode_toggle( test_device ):
 
     ctx.set_devices_changed_callback( device_changed )
 
-    wait_time = TOGGLE_WAIT_TIME_DDS if is_dds_dev( dev ) else TOGGLE_WAIT_TIME
     initial_state = am_dev.is_enabled()
     toggled_state = not initial_state
-    log.info( "Device: %s | Initial advanced mode: %s | Reconnect timeout: %d sec",
-              name, "ON" if initial_state else "OFF", wait_time )
+    log.info( "Device: %s | Initial advanced mode: %s", name, "ON" if initial_state else "OFF" )
 
     # --- Toggle to opposite state ---
     # Clear the flag before toggling so a fast reconnect cannot be missed
@@ -74,10 +69,10 @@ def test_advanced_mode_toggle( test_device ):
     log.info( "Toggling advanced mode to %s", "ON" if toggled_state else "OFF" )
     am_dev.toggle_advanced_mode( toggled_state )
 
-    log.info( "Waiting up to %d sec for device to reconnect after toggle...", wait_time )
+    log.info( "Waiting up to %d sec for device to reconnect after toggle...", TOGGLE_WAIT_TIME )
     try:
-        assert _wait_for_reconnect( wait_time ), \
-            f"Device did not reconnect within {wait_time} sec after toggling advanced mode"
+        assert _wait_for_reconnect( TOGGLE_WAIT_TIME ), \
+            f"Device did not reconnect within {TOGGLE_WAIT_TIME} sec after toggling advanced mode"
 
         toggled_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
         assert toggled_enabled == toggled_state, \
@@ -92,9 +87,9 @@ def test_advanced_mode_toggle( test_device ):
                 device_added = False
                 rs.rs400_advanced_mode( dev ).toggle_advanced_mode( initial_state )
 
-                log.info( "Waiting up to %d sec for device to reconnect after restore...", wait_time )
-                if not _wait_for_reconnect( wait_time ):
-                    log.warning( "Device did not reconnect within %d sec after restoring advanced mode", wait_time )
+                log.info( "Waiting up to %d sec for device to reconnect after restore...", TOGGLE_WAIT_TIME )
+                if not _wait_for_reconnect( TOGGLE_WAIT_TIME ):
+                    log.warning( "Device did not reconnect within %d sec after restoring advanced mode", TOGGLE_WAIT_TIME )
                 else:
                     restored_enabled = rs.rs400_advanced_mode( dev ).is_enabled()
                     if restored_enabled != initial_state:


### PR DESCRIPTION
Tracked by: RSDSO-20602

## Summary

Adds `unit-tests/live/hw-reset/pytest-advanced-mode-toggle.py`, a new live pytest test that verifies advanced mode can be toggled on D400 and D500 series devices and that the device successfully reconnects after each toggle.

**What the test does:**
- Runs once per connected D400* and D500* device (`@device_each`)
- Reads and logs the initial advanced-mode state (ON or OFF)
- Toggles advanced mode to the opposite state and waits up to 30 seconds for the device to reconnect
- Verifies the device is back and the new state is correctly applied
- Toggles back to the original state and waits up to 30 seconds for the device to reconnect again
- Verifies the device is back and the state is restored

Device reconnection is detected via `ctx.set_devices_changed_callback`, updating the device handle in the callback so the second toggle can be issued on the live instance. If the device does not reappear within 30 seconds either time, the test fails.

## Test plan
- [x] Ran locally against D405 -- passed in ~24 seconds

Nightly run succeeded:
https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/15221/
