### PR TITLE
unit-tests: surgically shadow compiled pkgs from user-site (preserve paramiko/pykush)

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -32,6 +32,12 @@ if py_dir not in sys.path:
 # Consume --debug before any rspy imports (rspy.log also consumes it from sys.argv)
 _debug_requested = '--debug' in sys.argv
 
+# Make sure the freshly-built pyrealsense2/pyrealdds/pyrsutils win over any copy
+# pip may have left in the user site (~/.local/...). Must run before any rspy import
+# that may pull pyrealsense2 transitively.
+from rspy import python_path
+python_path.block_user_site_for({'pyrealsense2', 'pyrealdds', 'pyrsutils'})
+
 from rspy import devices, repo
 from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (

--- a/unit-tests/py/rspy/python_path.py
+++ b/unit-tests/py/rspy/python_path.py
@@ -1,0 +1,48 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Python import-path helpers for RealSense unit tests.
+
+The CMake build produces fresh pyrealsense2/pyrealdds/pyrsutils binaries which
+must take precedence over any copies that pip may have left in the user site
+(~/.local/lib/pythonX.Y/site-packages). The naive approach — stripping the
+whole user-site from sys.path — also hides paramiko/pykush etc. that tests
+legitimately consume from there.
+"""
+
+import os
+import sys
+from site import getusersitepackages
+
+from rspy import file
+
+
+def block_user_site_for( pkg_names ):
+    """
+    Make the listed top-level packages un-importable from the user site, leaving
+    everything else in user-site reachable. No-op if user-site doesn't currently
+    contain any of the named packages.
+
+    The freshly-built copies (in the CMake build directory, added later via
+    sys.path.insert) will be picked up instead.
+
+    :param pkg_names: iterable of top-level package names to block
+    """
+    user_site = getusersitepackages()
+    blocked = { pkg for pkg in pkg_names
+                if os.path.exists( os.path.join( user_site, pkg ) ) }
+    if not blocked:
+        return
+
+    import importlib.abc
+    import importlib.machinery
+
+    class _BlockUserSiteFinder( importlib.abc.MetaPathFinder ):
+        def find_spec( self, fullname, path, target=None ):
+            if fullname.split('.')[0] not in blocked:
+                return None
+            non_user = [ p for p in sys.path if not file.is_inside( p, user_site ) ]
+            return importlib.machinery.PathFinder.find_spec( fullname, non_user, target )
+
+    sys.meta_path.insert( 0, _BlockUserSiteFinder() )

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -9,26 +9,12 @@ import sys, os, subprocess, re, platform, getopt, time
 current_dir = os.path.dirname( os.path.abspath( __file__ ) )
 sys.path.append( os.path.join( current_dir, 'py' ))
 
-from rspy import log, file, repo, libci
+from rspy import log, file, repo, libci, python_path
 from rspy.signals import register_signal_handlers
 
-# Python's default list of paths to look for modules includes user-installed. We want
-# to avoid those to take only the pyrealsense2/pyrealdds/pyrsutils we actually compiled!
-#
-# Rather than rebuilding the whole sys.path, we instead remove only the user site-packages
-# directories that actually contain our compiled packages. This preserves other user-installed
-# packages (e.g. paramiko, pykush) that tests depend on.
-from site import getusersitepackages   # not the other stuff, like quit(), exit(), etc.!
-_user_site = getusersitepackages()
-_compiled_pkg_names = { 'pyrealsense2', 'pyrealdds', 'pyrsutils' }
-log.d( 'SYSPATH-PROBE user_site=', _user_site, 'exists?', os.path.isdir(_user_site) )
-log.d( 'SYSPATH-PROBE compiled-pkgs in user_site:',
-       { pkg: os.path.exists( os.path.join( _user_site, pkg ) ) for pkg in _compiled_pkg_names } )
-log.d( 'SYSPATH-PROBE PRE-filter sys.path:', sys.path )
-sys.path = [p for p in sys.path
-            if not file.is_inside( p, _user_site )
-            or not any( os.path.exists( os.path.join( p, pkg ) ) for pkg in _compiled_pkg_names )]
-log.d( 'SYSPATH-PROBE POST-filter sys.path:', sys.path )
+# Make sure the freshly-built pyrealsense2/pyrealdds/pyrsutils win over any copy
+# pip may have left in the user site (~/.local/...).
+python_path.block_user_site_for( { 'pyrealsense2', 'pyrealdds', 'pyrsutils' } )
 
 
 def usage():

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -21,12 +21,14 @@ from rspy.signals import register_signal_handlers
 from site import getusersitepackages   # not the other stuff, like quit(), exit(), etc.!
 _user_site = getusersitepackages()
 _compiled_pkg_names = { 'pyrealsense2', 'pyrealdds', 'pyrsutils' }
-#log.d( 'site packages=', _user_site )
-#log.d( 'sys.path=', sys.path )
+log.d( 'SYSPATH-PROBE user_site=', _user_site, 'exists?', os.path.isdir(_user_site) )
+log.d( 'SYSPATH-PROBE compiled-pkgs in user_site:',
+       { pkg: os.path.exists( os.path.join( _user_site, pkg ) ) for pkg in _compiled_pkg_names } )
+log.d( 'SYSPATH-PROBE PRE-filter sys.path:', sys.path )
 sys.path = [p for p in sys.path
             if not file.is_inside( p, _user_site )
             or not any( os.path.exists( os.path.join( p, pkg ) ) for pkg in _compiled_pkg_names )]
-#log.d( 'modified=', sys.path )
+log.d( 'SYSPATH-PROBE POST-filter sys.path:', sys.path )
 
 
 def usage():


### PR DESCRIPTION
## Summary
- The legacy `run-unit-tests.py` filter at lines 26-28 stripped the entire user-site directory from `sys.path` whenever it found `pyrealsense2`/`pyrealdds`/`pyrsutils` there. That side-effect also hid `paramiko`, `pykush`, and any other user-installed test deps — causing CI's legacy stage to log `no paramiko library is available` even though `pip install paramiko==3.5.1` had succeeded.
- Replaced with a surgical `importlib.abc.MetaPathFinder` in a new helper `rspy.python_path.block_user_site_for(pkg_names)`. The finder intercepts only the named packages and resolves them from `sys.path` minus user-site, so the freshly-built `.so` wins. Everything else in user-site stays reachable.
- Wired into `conftest.py` as well — defense-in-depth for pytest, in case any plugin or test pulls `pyrealsense2` transitively before `sys.path.insert(1, pyrs_dir)` runs.

## Test plan
- [ ] CI: `LRS_linux_compile_lib_ci` legacy stage on this branch logs `paramiko 3.5.1 loaded from /home/jenkins/.local/...` (previously logged `no paramiko library is available`).
- [ ] CI: pyrealsense2 still resolves to the freshly-built `.so` in `<build>/x86_64/static/Release/`, not the user-site copy. The existing `Using pyrealsense2 from:` log line confirms.
- [ ] Pytest stage continues to pass (no behavior change expected — the helper is a no-op when user-site has no compiled pkg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)