### PR TITLE
rest-api wrapper test: forward pyrealsense2 path to subprocess via PYTHONPATH

### DIFF
--- a/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
+++ b/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
@@ -30,7 +30,8 @@ def test_rest_api_wrapper(module_device_setup):
     env = os.environ.copy()
     pyrs_dir = repo.find_pyrs_dir()
     if pyrs_dir:
-        env["PYTHONPATH"] = pyrs_dir + os.pathsep + env.get("PYTHONPATH", "")
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = pyrs_dir + os.pathsep + existing if existing else pyrs_dir
     p = subprocess.run(
         [sys.executable, "-m", "pytest", rest_api_test],
         stdout=subprocess.PIPE,

--- a/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
+++ b/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
@@ -24,6 +24,13 @@ pytestmark = [
 
 def test_rest_api_wrapper(module_device_setup):
     rest_api_test = os.path.join(repo.root, "wrappers", "rest-api", "tests", "test_api_service.py")
+    # The subprocess starts a fresh interpreter, so the parent's sys.path
+    # injection of the locally-built pyrealsense2 (unit-tests/conftest.py)
+    # is not inherited. Forward it via PYTHONPATH.
+    env = os.environ.copy()
+    pyrs_dir = repo.find_pyrs_dir()
+    if pyrs_dir:
+        env["PYTHONPATH"] = pyrs_dir + os.pathsep + env.get("PYTHONPATH", "")
     p = subprocess.run(
         [sys.executable, "-m", "pytest", rest_api_test],
         stdout=subprocess.PIPE,
@@ -31,6 +38,7 @@ def test_rest_api_wrapper(module_device_setup):
         universal_newlines=True,
         timeout=10,
         check=False,
+        env=env,
     )
     if p.returncode != 0:
         log.error("Subprocess failed (rc=%s):\n%s", p.returncode, p.stdout)


### PR DESCRIPTION
## Summary
- `unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py` runs the rest-api tests in a fresh `python -m pytest` subprocess. The parent pytest can `import pyrealsense2` because `unit-tests/conftest.py` injects the locally-built `.so` directory into `sys.path` at runtime — but that's an in-process tweak the child interpreter doesn't see.
- Previously this worked in CI because the Jenkins pipeline did a system-wide `pip install pyrealsense2`. After that step was removed, the subprocess fails at collection with `ModuleNotFoundError: No module named 'pyrealsense2'` (e.g. [LRS_linux_compile_lib_ci #11119](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/11119/console)).
- Fix: forward `repo.find_pyrs_dir()` to the subprocess via `PYTHONPATH`, prepended so it wins over anything else.

## Test plan
- [ ] libci green on the rest-api wrapper test