### PR TITLE
Fix UnboundLocalError in hub creators when import fails non-trivially

### DIFF
--- a/unit-tests/py/rspy/device_hub.py
+++ b/unit-tests/py/rspy/device_hub.py
@@ -200,25 +200,36 @@ def _create_acroname():
 def _create_ykush():
     try:
         from rspy import ykush
-        return ykush.Ykush()
     except ModuleNotFoundError:
+        return None  # package not installed
+    except BaseException as e:
+        log.w(f"ykush import failed: {e}")
         return None
+    try:
+        return ykush.Ykush()
     except ykush.NoneFoundError:
-        return None
-    except BaseException:
+        return None  # no hub connected
+    except BaseException as e:
+        log.w(f"ykush hub init failed: {e}")
         return None
 
 def _create_unifi():
     try:
         from rspy import unifi
-        return unifi.UniFiSwitch()
     except ModuleNotFoundError:
+        return None  # package not installed
+    except BaseException as e:
+        log.w(f"unifi import failed: {e}")
         return None
-    except EnvironmentError:
-        return None
+    try:
+        return unifi.UniFiSwitch()
     except unifi.NoneFoundError:
+        return None  # no hub connected
+    except EnvironmentError as e:
+        log.w(f"unifi hub init failed: {e}")
         return None
     except BaseException as e:
+        log.w(f"unifi hub init failed: {e}")
         return None
 
 def _create_combined_hubs(hub_list):

--- a/unit-tests/py/rspy/device_hub.py
+++ b/unit-tests/py/rspy/device_hub.py
@@ -188,12 +188,17 @@ def _find_active_hub():
 def _create_acroname():
     try:
         from rspy import acroname
-        return acroname.Acroname()
     except ModuleNotFoundError:
+        return None  # package not installed
+    except Exception as e:
+        log.w(f"acroname import failed: {e}")
         return None
+    try:
+        return acroname.Acroname()
     except acroname.NoneFoundError:
-        return None
-    except BaseException:
+        return None  # no hub connected
+    except Exception as e:
+        log.w(f"acroname hub init failed: {e}")
         return None
 
 
@@ -202,14 +207,14 @@ def _create_ykush():
         from rspy import ykush
     except ModuleNotFoundError:
         return None  # package not installed
-    except BaseException as e:
+    except Exception as e:
         log.w(f"ykush import failed: {e}")
         return None
     try:
         return ykush.Ykush()
     except ykush.NoneFoundError:
         return None  # no hub connected
-    except BaseException as e:
+    except Exception as e:
         log.w(f"ykush hub init failed: {e}")
         return None
 
@@ -218,17 +223,14 @@ def _create_unifi():
         from rspy import unifi
     except ModuleNotFoundError:
         return None  # package not installed
-    except BaseException as e:
+    except Exception as e:
         log.w(f"unifi import failed: {e}")
         return None
     try:
         return unifi.UniFiSwitch()
     except unifi.NoneFoundError:
         return None  # no hub connected
-    except EnvironmentError as e:
-        log.w(f"unifi hub init failed: {e}")
-        return None
-    except BaseException as e:
+    except Exception as e:
         log.w(f"unifi hub init failed: {e}")
         return None
 


### PR DESCRIPTION
## Summary

In \`unit-tests/py/rspy/device_hub.py\`, both \`_create_ykush()\` and \`_create_unifi()\` had a latent bug: the \`except <module>.NoneFoundError\` clause references the locally-imported module name. If the \`from rspy import <module>\` line raises any exception other than \`ModuleNotFoundError\`, that exception falls through to the \`except <module>.NoneFoundError\` clause — Python evaluates the unbound name and raises \`UnboundLocalError\`, masking the real error.

This was hit on Python 3.14 / Windows: paramiko 3.5.1's import-time \`importlib.metadata.version(\"paramiko\")\` triggers a \`TypeError\` due to a 3.14 stdlib regression. The TypeError propagates out of \`from rspy import unifi\`, hits \`except unifi.NoneFoundError:\`, and crashes pytest collection with \`UnboundLocalError\` instead of returning \`None\` like the function intends.

## Fix

Split the import from the construction:
- Import failure with \`ModuleNotFoundError\` → silent (package not installed).
- Import failure for any other reason → log a warning (unexpected — e.g. transitive dep broken).
- Construction \`NoneFoundError\` → silent (no hub connected, normal).
- Construction failure for any other reason → log a warning.

This matches the original intent (silently return None when the hub isn't usable) while no longer masking unexpected errors and no longer hitting \`UnboundLocalError\` when the import fails non-trivially.

## Test plan
- [x] Existing infra-tests still pass on the \`Infra_Tests\` GHA job (Ubuntu 22.04 + Python 3.10).
- [x] On Python 3.14 + Windows, \`cd unit-tests && python -m pytest infra-tests/ -v\` no longer crashes during collection (manually verified: paramiko TypeError is now caught and warned, \`_create_unifi\` returns None as intended).