### PR TITLE
pytest-sync: drop redundant per-iteration hardware_reset (RSDSO-21449)

### DIFF
--- a/unit-tests/live/metadata/pytest-sync.py
+++ b/unit-tests/live/metadata/pytest-sync.py
@@ -155,9 +155,8 @@ def test_synchronized_frames(test_device):
     """Verify that timestamps of depth, infrared and color frames are consistent across configurations"""
     device, ctx = test_device
 
+    time.sleep(1)  # let device settle after hub power-cycle, before first pipeline.start
     for resolution, fps in CONFIGURATIONS:
         log.info(f"Timestamp Synchronization Test {resolution[0]}x{resolution[1]} @ {fps}fps")
-        device.hardware_reset()
-        time.sleep(5)
-        device = ctx.query_devices()[0]
         run_test(device, ctx, resolution, fps)
+        time.sleep(2)  # let hardware settle between configurations after pipeline.stop


### PR DESCRIPTION
## Summary

`unit-tests/live/metadata/pytest-sync.py::test_synchronized_frames` segfaulted in nightly [LRS_linux_compile_lib_ci #11175](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/11175/console), killing the whole pytest session. The Python main thread was sleeping in `time.sleep(5)` (line 161) immediately after `device.hardware_reset()` (line 160); the actual fault is in a librealsense backend thread.

The pytest hub-recycle in `module_device_setup` (`unit-tests/conftest.py:435-466`) had just power-cycled the port and re-enumerated the D455 milliseconds earlier — calling `hardware_reset()` on a freshly enumerated USB device triggers a race in the SDK backend.

## Changes

- Drop the per-iteration `device.hardware_reset()` from the loop in `test_synchronized_frames` — it was inherited verbatim from legacy `test-sync.py`, which predated the hub-recycle infrastructure. With pytest's `--hub-reset`, iter 0 already gets a freshly recycled device, and `pipeline.start/stop` isolates per-config state for iters 1-5.
- Add `time.sleep(1)` before the loop to let the device settle after the hub recycle (matches the convention in `pytest-stress.py:75` and `pytest-sanity.py:48`, both of which pass).
- Add `time.sleep(2)` between iterations to let hardware settle after `pipeline.stop()` before the next configuration starts.
- Kept the existing `time.sleep(5)` after `pipeline.start()` in `run_test()` unchanged.

## Reference

- Jira: [RSDSO-21449](https://rsjira.realsenseai.com/browse/RSDSO-21449) — SDK-side race between udev device-removed callback and in-flight USB transfer; tracked separately. This PR is the test-side mitigation; the SDK fix is a separate workstream.

## Test plan

- [x] Wait for libci CI to run; confirm `pytest-sync.py` no longer segfaults under `--context nightly --hub-reset`.
- [x] Confirm the test still exercises all six (resolution, fps) configurations.

Nightly build passing - https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/15315/