### PR TITLE
Exclude D401 from pytest-hdr-long

### DIFF
--- a/unit-tests/live/d400/pytest-hdr-long.py
+++ b/unit-tests/live/d400/pytest-hdr-long.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device("D400*"),
+    pytest.mark.device_exclude("D401"),
     pytest.mark.context("nightly"),
 ]
 


### PR DESCRIPTION
Disabling pytest-hdr-long.py on D401 until RSDEV-8393 is resolved