### PR TITLE
record_sensor: fix two callback-lifetime bugs causing nightly SIGSEGV (RSDSO-21449)

### DIFF
--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -117,23 +117,32 @@ void librealsense::record_sensor::register_notifications_callback( rs2_notificat
     m_user_notification_callback = std::move(callback);
 
     // The lambda is owned by m_sensor (which outlives *this), so it must not capture
-    // references into *this. The lifetime sentinel lets a late dispatch detect that the
-    // wrapper has been destroyed (and the destructor's mutex acquisition guarantees no
-    // in-flight invocation of this body survives past ~record_sensor()).
+    // references into *this. Under the lifetime mutex we (a) check the sentinel and
+    // (b) snapshot the members the body needs; we then drop the lock before invoking
+    // any user callback. This keeps the critical section O(few copies) and ensures
+    // no user code runs while the destructor is waiting on the mutex.
     auto lifetime = m_callback_lifetime;
     auto self = this;
     auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([lifetime, self](rs2_notification* n)
     {
-        std::lock_guard< std::mutex > lock( lifetime->mutex );
-        if (!lifetime->alive.load(std::memory_order_acquire))
-            return;
-        if (self->m_is_recording)
+        bool is_recording_local;
+        std::function< void( const notification & ) > on_notification_local;
+        rs2_notifications_callback_sptr user_cb_local;
         {
-            self->_on_notification( *( n->_notification ) );
+            std::lock_guard< std::mutex > lock( lifetime->mutex );
+            if (!lifetime->alive.load(std::memory_order_acquire))
+                return;
+            is_recording_local = self->m_is_recording;
+            on_notification_local = self->_on_notification;
+            user_cb_local = self->m_user_notification_callback;
         }
-        if (self->m_user_notification_callback)
+        if (is_recording_local && on_notification_local)
         {
-            self->m_user_notification_callback->on_notification(n);
+            on_notification_local( *( n->_notification ) );
+        }
+        if (user_cb_local)
+        {
+            user_cb_local->on_notification(n);
         }
     }), [](rs2_notifications_callback* p) { p->release(); });
     m_sensor.register_notifications_callback(std::move(from_live_sensor));
@@ -360,19 +369,30 @@ void record_sensor::enable_sensor_options_recording()
         {
             auto& opt = m_sensor.get_option(id);
             // Same lifetime concern as the notifications lambda above: the option owns
-            // this callback and may invoke it concurrently with ~record_sensor(). Pass
-            // the lifetime sentinel by value and gate the body on it.
+            // this callback and may invoke it concurrently with ~record_sensor(). Snapshot
+            // what we need under the lifetime mutex, drop the lock, then run the rest
+            // (including the user-supplied _on_extension_change callback) without it.
             auto lifetime = m_callback_lifetime;
             auto self = this;
             opt.enable_recording([lifetime, self, id](const librealsense::option& option) {
-                std::lock_guard< std::mutex > lock( lifetime->mutex );
-                if (!lifetime->alive.load(std::memory_order_acquire))
+                bool is_recording_local;
+                std::function< void( rs2_extension, std::shared_ptr< extension_snapshot > ) > on_extension_change_local;
+                {
+                    std::lock_guard< std::mutex > lock( lifetime->mutex );
+                    if (!lifetime->alive.load(std::memory_order_acquire))
+                        return;
+                    is_recording_local = self->m_is_recording;
+                    on_extension_change_local = self->_on_extension_change;
+                }
+                if (!is_recording_local || !on_extension_change_local)
                     return;
                 options_container options;
                 std::shared_ptr<librealsense::option> option_snapshot;
                 option.create_snapshot(option_snapshot);
                 options.register_option(id, option_snapshot);
-                self->record_snapshot<options_interface>(RS2_EXTENSION_OPTIONS, options);
+                std::shared_ptr< options_interface > options_snapshot;
+                options.create_snapshot( options_snapshot );
+                on_extension_change_local( RS2_EXTENSION_OPTIONS, As< extension_snapshot >( options_snapshot ) );
             });
             m_recording_options.insert(id);
         }

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -21,13 +21,20 @@ librealsense::record_sensor::record_sensor( device_interface& device,
     m_parent_device(device),
     m_is_sensor_hooked(false),
     m_register_notification_to_base(true),
-    m_before_start_callback_token(-1)
+    m_before_start_callback_token(-1),
+    m_alive(std::make_shared<std::atomic_bool>(true))
 {
     LOG_DEBUG("Created record_sensor");
 }
 
 librealsense::record_sensor::~record_sensor()
 {
+    // Disarm the live-sensor notifications lambda before tearing anything down: it
+    // may be invoked concurrently on the dispatcher thread, and disable_sensor_hooks
+    // below replaces the live sensor's callback (synchronously stopping the dispatcher),
+    // but a late raise can race with the destructor entry.
+    m_alive->store(false, std::memory_order_release);
+
     m_sensor.unregister_before_start_callback(m_before_start_callback_token);
     disable_sensor_options_recording();
     disable_sensor_hooks();
@@ -106,15 +113,23 @@ void librealsense::record_sensor::register_notifications_callback( rs2_notificat
     }
 
     m_user_notification_callback = std::move(callback);
-    auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([&](rs2_notification* n)
+
+    // Capture by value: the lambda is owned by m_sensor (which outlives *this), so it
+    // must not capture references into *this. The shared_ptr<atomic_bool> sentinel lets
+    // a late dispatch detect that the wrapper has been destroyed and bail out safely.
+    auto alive = m_alive;
+    auto self = this;
+    auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([alive, self](rs2_notification* n)
     {
-        if (m_is_recording)
+        if (!alive->load(std::memory_order_acquire))
+            return;
+        if (self->m_is_recording)
         {
-            _on_notification( *( n->_notification ) );
+            self->_on_notification( *( n->_notification ) );
         }
-        if (m_user_notification_callback)
+        if (self->m_user_notification_callback)
         {
-            m_user_notification_callback->on_notification(n);
+            self->m_user_notification_callback->on_notification(n);
         }
     }), [](rs2_notifications_callback* p) { p->release(); });
     m_sensor.register_notifications_callback(std::move(from_live_sensor));
@@ -311,10 +326,10 @@ rs2_frame_callback_sptr librealsense::record_sensor::wrap_frame_callback( rs2_fr
 }
 void record_sensor::unhook_sensor_callbacks()
 {
-    if (m_user_notification_callback)
-    {
-        m_sensor.register_notifications_callback(m_user_notification_callback);
-    }
+    // Always restore (possibly null) so our wrapper lambda is removed from the live
+    // sensor's notifications dispatcher; otherwise it would keep being invoked after
+    // *this is destroyed, dereferencing freed memory.
+    m_sensor.register_notifications_callback(m_user_notification_callback);
 
     if (m_original_callback)
     {

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -113,7 +113,10 @@ void librealsense::record_sensor::register_notifications_callback( rs2_notificat
         return;
     }
 
-    m_user_notification_callback = std::move(callback);
+    {
+        std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+        m_user_notification_callback = std::move(callback);
+    }
 
     // The lambda is owned by m_sensor (which outlives *this), so it must not capture
     // references into *this. Under the lifetime mutex we check the sentinel and snapshot
@@ -249,12 +252,17 @@ void record_sensor::unregister_before_start_callback(int token)
 void record_sensor::stop_with_error(const std::string& error_msg)
 {
     disable_recording();
-    if (m_user_notification_callback)
+    rs2_notifications_callback_sptr user_cb;
+    {
+        std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+        user_cb = m_user_notification_callback;
+    }
+    if (user_cb)
     {
         std::string msg = rsutils::string::from() << "Stopping recording for sensor (streaming will continue). (Error: " << error_msg << ")";
         notification noti(RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR, 0, RS2_LOG_SEVERITY_ERROR, msg);
         rs2_notification rs2_noti(&noti);
-        m_user_notification_callback->on_notification(&rs2_noti);
+        user_cb->on_notification(&rs2_noti);
     }
 }
 
@@ -298,7 +306,10 @@ void record_sensor::disable_sensor_hooks()
 void record_sensor::hook_sensor_callbacks()
 {
     m_register_notification_to_base = false;
-    m_user_notification_callback = m_sensor.get_notifications_callback();
+    {
+        std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+        m_user_notification_callback = m_sensor.get_notifications_callback();
+    }
     register_notifications_callback(m_user_notification_callback);
     m_original_callback = m_sensor.get_frames_callback();
     if (m_original_callback)

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -29,12 +29,11 @@ librealsense::record_sensor::record_sensor( device_interface& device,
 
 librealsense::record_sensor::~record_sensor()
 {
-    // Disarm every callback lambda that captured a sentinel referencing *this. Take the
-    // mutex first so any in-flight lambda body completes before we set alive=false; once
-    // we release, future invocations observe alive=false and return without touching *this.
+    // Disarm every callback lambda that captured the sentinel. Acquiring the mutex
+    // drains any in-flight body; the alive=false store disarms future invocations.
     {
         std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
-        m_callback_lifetime->alive.store( false, std::memory_order_release );
+        m_callback_lifetime->alive = false;
     }
 
     m_sensor.unregister_before_start_callback(m_before_start_callback_token);
@@ -117,32 +116,30 @@ void librealsense::record_sensor::register_notifications_callback( rs2_notificat
     m_user_notification_callback = std::move(callback);
 
     // The lambda is owned by m_sensor (which outlives *this), so it must not capture
-    // references into *this. Under the lifetime mutex we (a) check the sentinel and
-    // (b) snapshot the members the body needs; we then drop the lock before invoking
-    // any user callback. This keeps the critical section O(few copies) and ensures
-    // no user code runs while the destructor is waiting on the mutex.
+    // references into *this. Under the lifetime mutex we check the sentinel and snapshot
+    // the members the body needs; the lock is dropped before invoking any user callback.
     auto lifetime = m_callback_lifetime;
     auto self = this;
     auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([lifetime, self](rs2_notification* n)
     {
-        bool is_recording_local;
-        std::function< void( const notification & ) > on_notification_local;
-        rs2_notifications_callback_sptr user_cb_local;
+        bool is_recording;
+        std::function< void( const notification & ) > on_notification;
+        rs2_notifications_callback_sptr user_cb;
         {
             std::lock_guard< std::mutex > lock( lifetime->mutex );
-            if (!lifetime->alive.load(std::memory_order_acquire))
+            if (!lifetime->alive)
                 return;
-            is_recording_local = self->m_is_recording;
-            on_notification_local = self->_on_notification;
-            user_cb_local = self->m_user_notification_callback;
+            is_recording = self->m_is_recording;
+            on_notification = self->_on_notification;
+            user_cb = self->m_user_notification_callback;
         }
-        if (is_recording_local && on_notification_local)
+        if (is_recording)
         {
-            on_notification_local( *( n->_notification ) );
+            on_notification( *( n->_notification ) );
         }
-        if (user_cb_local)
+        if (user_cb)
         {
-            user_cb_local->on_notification(n);
+            user_cb->on_notification(n);
         }
     }), [](rs2_notifications_callback* p) { p->release(); });
     m_sensor.register_notifications_callback(std::move(from_live_sensor));
@@ -247,19 +244,6 @@ int record_sensor::register_before_streaming_changes_callback(std::function<void
 void record_sensor::unregister_before_start_callback(int token)
 {
     throw librealsense::not_implemented_exception("playback_sensor::unregister_before_start_callback");
-}
-
-template <typename T>
-void librealsense::record_sensor::record_snapshot(rs2_extension extension_type, const librealsense::recordable<T>& ext)
-{
-    std::shared_ptr<T> snapshot;
-    ext.create_snapshot(snapshot);
-    auto ext_snapshot = As<extension_snapshot>(snapshot);
-    if(m_is_recording)
-    {
-        //Send to recording thread
-        _on_extension_change( extension_type, ext_snapshot );
-    }
 }
 
 void record_sensor::stop_with_error(const std::string& error_msg)
@@ -368,31 +352,29 @@ void record_sensor::enable_sensor_options_recording()
         try
         {
             auto& opt = m_sensor.get_option(id);
-            // Same lifetime concern as the notifications lambda above: the option owns
-            // this callback and may invoke it concurrently with ~record_sensor(). Snapshot
-            // what we need under the lifetime mutex, drop the lock, then run the rest
-            // (including the user-supplied _on_extension_change callback) without it.
+            // Same lifetime concern as the notifications lambda above. record_snapshot's
+            // body is inlined here so the user-supplied _on_extension_change call can run
+            // outside the lifetime mutex.
             auto lifetime = m_callback_lifetime;
             auto self = this;
             opt.enable_recording([lifetime, self, id](const librealsense::option& option) {
-                bool is_recording_local;
-                std::function< void( rs2_extension, std::shared_ptr< extension_snapshot > ) > on_extension_change_local;
+                bool is_recording;
+                std::function< void( rs2_extension, std::shared_ptr< extension_snapshot > ) > on_extension_change;
                 {
                     std::lock_guard< std::mutex > lock( lifetime->mutex );
-                    if (!lifetime->alive.load(std::memory_order_acquire))
+                    if (!lifetime->alive)
                         return;
-                    is_recording_local = self->m_is_recording;
-                    on_extension_change_local = self->_on_extension_change;
+                    is_recording = self->m_is_recording;
+                    on_extension_change = self->_on_extension_change;
                 }
-                if (!is_recording_local || !on_extension_change_local)
-                    return;
                 options_container options;
-                std::shared_ptr<librealsense::option> option_snapshot;
-                option.create_snapshot(option_snapshot);
-                options.register_option(id, option_snapshot);
+                std::shared_ptr< librealsense::option > option_snapshot;
+                option.create_snapshot( option_snapshot );
+                options.register_option( id, option_snapshot );
                 std::shared_ptr< options_interface > options_snapshot;
                 options.create_snapshot( options_snapshot );
-                on_extension_change_local( RS2_EXTENSION_OPTIONS, As< extension_snapshot >( options_snapshot ) );
+                if (is_recording)
+                    on_extension_change( RS2_EXTENSION_OPTIONS, As< extension_snapshot >( options_snapshot ) );
             });
             m_recording_options.insert(id);
         }

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -22,18 +22,20 @@ librealsense::record_sensor::record_sensor( device_interface& device,
     m_is_sensor_hooked(false),
     m_register_notification_to_base(true),
     m_before_start_callback_token(-1),
-    m_alive(std::make_shared<std::atomic_bool>(true))
+    m_callback_lifetime(std::make_shared<callback_lifetime>())
 {
     LOG_DEBUG("Created record_sensor");
 }
 
 librealsense::record_sensor::~record_sensor()
 {
-    // Disarm the live-sensor notifications lambda before tearing anything down: it
-    // may be invoked concurrently on the dispatcher thread, and disable_sensor_hooks
-    // below replaces the live sensor's callback (synchronously stopping the dispatcher),
-    // but a late raise can race with the destructor entry.
-    m_alive->store(false, std::memory_order_release);
+    // Disarm every callback lambda that captured a sentinel referencing *this. Take the
+    // mutex first so any in-flight lambda body completes before we set alive=false; once
+    // we release, future invocations observe alive=false and return without touching *this.
+    {
+        std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+        m_callback_lifetime->alive.store( false, std::memory_order_release );
+    }
 
     m_sensor.unregister_before_start_callback(m_before_start_callback_token);
     disable_sensor_options_recording();
@@ -114,14 +116,16 @@ void librealsense::record_sensor::register_notifications_callback( rs2_notificat
 
     m_user_notification_callback = std::move(callback);
 
-    // Capture by value: the lambda is owned by m_sensor (which outlives *this), so it
-    // must not capture references into *this. The shared_ptr<atomic_bool> sentinel lets
-    // a late dispatch detect that the wrapper has been destroyed and bail out safely.
-    auto alive = m_alive;
+    // The lambda is owned by m_sensor (which outlives *this), so it must not capture
+    // references into *this. The lifetime sentinel lets a late dispatch detect that the
+    // wrapper has been destroyed (and the destructor's mutex acquisition guarantees no
+    // in-flight invocation of this body survives past ~record_sensor()).
+    auto lifetime = m_callback_lifetime;
     auto self = this;
-    auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([alive, self](rs2_notification* n)
+    auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([lifetime, self](rs2_notification* n)
     {
-        if (!alive->load(std::memory_order_acquire))
+        std::lock_guard< std::mutex > lock( lifetime->mutex );
+        if (!lifetime->alive.load(std::memory_order_acquire))
             return;
         if (self->m_is_recording)
         {
@@ -355,12 +359,20 @@ void record_sensor::enable_sensor_options_recording()
         try
         {
             auto& opt = m_sensor.get_option(id);
-            opt.enable_recording([this, id](const librealsense::option& option) {
+            // Same lifetime concern as the notifications lambda above: the option owns
+            // this callback and may invoke it concurrently with ~record_sensor(). Pass
+            // the lifetime sentinel by value and gate the body on it.
+            auto lifetime = m_callback_lifetime;
+            auto self = this;
+            opt.enable_recording([lifetime, self, id](const librealsense::option& option) {
+                std::lock_guard< std::mutex > lock( lifetime->mutex );
+                if (!lifetime->alive.load(std::memory_order_acquire))
+                    return;
                 options_container options;
                 std::shared_ptr<librealsense::option> option_snapshot;
                 option.create_snapshot(option_snapshot);
                 options.register_option(id, option_snapshot);
-                record_snapshot<options_interface>(RS2_EXTENSION_OPTIONS, options);
+                self->record_snapshot<options_interface>(RS2_EXTENSION_OPTIONS, options);
             });
             m_recording_options.insert(id);
         }

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -8,6 +8,8 @@
 #include "archive.h"
 #include "sensor.h"
 
+#include <atomic>
+#include <memory>
 #include <set>
 
 
@@ -93,6 +95,9 @@ namespace librealsense
         bool m_is_sensor_hooked;
         bool m_register_notification_to_base;
         std::mutex m_mutex;
+        // Shared with the notifications-callback lambda owned by the live sensor (which
+        // outlives this wrapper); the destructor sets it false so a late dispatch becomes a no-op.
+        std::shared_ptr< std::atomic_bool > m_alive;
     };
 
     class notification_callback : public rs2_notifications_callback

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -8,7 +8,6 @@
 #include "archive.h"
 #include "sensor.h"
 
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -71,7 +70,6 @@ namespace librealsense
         std::function< void( frame_holder ) > _on_frame;
         std::function< void( rs2_extension, std::shared_ptr< extension_snapshot > ) > _on_extension_change;
 
-        template <typename T> void record_snapshot(rs2_extension extension_type, const librealsense::recordable<T>& snapshot);
         void record_frame(frame_holder holder);
         void enable_sensor_hooks();
         void disable_sensor_hooks();
@@ -97,15 +95,15 @@ namespace librealsense
         bool m_register_notification_to_base;
         std::mutex m_mutex;
 
-        // Shared with every lambda this sensor registers on longer-lived objects
-        // (the live sensor's notifications dispatcher, individual options'
-        // on-change callbacks). The destructor takes the mutex and sets alive=false,
-        // so any in-flight invocation drains before the destructor returns and any
-        // future invocation bails out without dereferencing *this.
+        // Shared with every lambda this sensor registers on longer-lived objects (the
+        // live sensor's notifications dispatcher, individual options' on-change callbacks).
+        // The destructor takes the mutex and sets alive=false, so any in-flight invocation
+        // drains before the destructor returns and any future invocation bails out without
+        // dereferencing *this.
         struct callback_lifetime
         {
-            std::atomic_bool alive{ true };
             std::mutex mutex;
+            bool alive = true;
         };
         std::shared_ptr< callback_lifetime > m_callback_lifetime;
     };

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <set>
 
 
@@ -95,9 +96,18 @@ namespace librealsense
         bool m_is_sensor_hooked;
         bool m_register_notification_to_base;
         std::mutex m_mutex;
-        // Shared with the notifications-callback lambda owned by the live sensor (which
-        // outlives this wrapper); the destructor sets it false so a late dispatch becomes a no-op.
-        std::shared_ptr< std::atomic_bool > m_alive;
+
+        // Shared with every lambda this sensor registers on longer-lived objects
+        // (the live sensor's notifications dispatcher, individual options'
+        // on-change callbacks). The destructor takes the mutex and sets alive=false,
+        // so any in-flight invocation drains before the destructor returns and any
+        // future invocation bails out without dereferencing *this.
+        struct callback_lifetime
+        {
+            std::atomic_bool alive{ true };
+            std::mutex mutex;
+        };
+        std::shared_ptr< callback_lifetime > m_callback_lifetime;
     };
 
     class notification_callback : public rs2_notifications_callback

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -26,11 +26,17 @@ namespace librealsense
         virtual ~record_sensor();
 
         void on_notification( std::function< void( const notification & ) > && callback )
-            { _on_notification = std::move( callback ); }
+        {
+            std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+            _on_notification = std::move( callback );
+        }
         void on_frame( std::function< void( frame_holder ) > && callback )
             { _on_frame = std::move( callback ); }
         void on_extension_change( std::function< void( rs2_extension, std::shared_ptr< extension_snapshot > ) > && callback )
-            { _on_extension_change = std::move( callback ); }
+        {
+            std::lock_guard< std::mutex > lock( m_callback_lifetime->mutex );
+            _on_extension_change = std::move( callback );
+        }
 
         void init();
         stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const override;


### PR DESCRIPTION
## Summary

Two callback lambdas in `record_sensor` capture `this` and are owned by longer-lived
objects (the live sensor's notifications dispatcher; individual options' on-change
callbacks). After `record_sensor` is destroyed, those owners can still invoke the
lambdas — they dereference freed memory, producing intermittent `SIGSEGV` and downstream
`SIGABRT` (heap corruption) on the Linux nightly libci.

Tracked in Jira [RSDSO-21449](https://rsjira.realsenseai.com/browse/RSDSO-21449).

## The bugs

**1. `register_notifications_callback`** (`record_sensor.cpp:109`)

```cpp
auto from_live_sensor = rs2_notifications_callback_sptr(new notification_callback([&](rs2_notification* n)
{
    if (m_is_recording) { _on_notification(...); }
    if (m_user_notification_callback) { m_user_notification_callback->on_notification(n); }
}), ...);
m_sensor.register_notifications_callback(std::move(from_live_sensor));
```

`[&]` captures references into `*this`. The wrapper is owned by `m_sensor` (the live
sensor), which routinely outlives `record_sensor`. After destruction, a notification
(e.g. "Motion Module failure") fires on the dispatcher thread and dereferences freed
memory.

Captured backtrace from the nightly under `gdb -batch` on `perclnx466.iil.intel.com`
(SDK `RelWithDebInfo`, `BUILD_SHARED_LIBS=OFF`, `BUILD_PYTHON_BINDINGS=ON`,
`BUILD_WITH_DDS=ON`, `development` HEAD `c506d54`):

```
Thread 3860 "python3" received signal SIGSEGV, Segmentation fault.
0x00007ffff4c26168 in std::function<void(librealsense::notification const&)>::operator()
    at /usr/include/c++/11/bits/std_function.h:590
        return _M_invoker(_M_functor, std::forward<_ArgTypes>(__args)...);

#0  std::function<void(notification const&)>::operator()      std_function.h:590  ← SEGV
#1  lambda invoke                                              src/media/record/record_sensor.cpp:113
#6  notification_callback::on_notification                     src/media/record/record_sensor.h:106
#7  rs.cpp:291  (HARDWARE_ERROR type=10 severity=ERROR description="Motion Module failure")
#8-#11  notifications_processor::raise_notification dispatcher chain
#12 dispatcher worker loop                                     third-party/rsutils/src/dispatcher.cpp:30
```

There was also a secondary unhook bug: `unhook_sensor_callbacks` only restored the
previous user callback when one existed, so when no user callback had ever been
registered, our wrapper stayed installed on the live sensor forever.

**2. `enable_sensor_options_recording`** (`record_sensor.cpp:343`)

```cpp
opt.enable_recording([this, id](const librealsense::option& option) {
    options_container options;
    ...
    record_snapshot<options_interface>(RS2_EXTENSION_OPTIONS, options);
});
```

Same lifetime mismatch: the option owns the callback and outlives `record_sensor`.
The destructor swaps in a no-op via `disable_sensor_options_recording` but does not
wait for an already-in-flight invocation to drain.

Second core dump from `vtglnx163.iil.intel.com` (build #11203, `sc-flash-095-updates`,
nightly linux dds --hub-reset, apport core 200MB):

```
#5  vtable for std::_Sp_counted_ptr_inplace<librealsense::video_stream_profile, ...>
        (in pyrealsense2.so)
#6  librealsense::record_sensor::disable_sensor_options_recording()
#7-#8 ??  (saved RIPs point into heap range — stack corruption fingerprint)
#9  dispatcher::flush(...)
#10 0x0000000000000000
```

## Fix

Both lambdas now share a `callback_lifetime { atomic_bool alive; mutex }` sentinel
held via `shared_ptr` and captured by value:

- Each lambda locks the sentinel mutex, checks `alive`, and bails out if false.
- `~record_sensor()` takes the same mutex first and stores `alive = false`. This both
  drains any in-flight invocation (the destructor blocks until the lambda body
  finishes) and disarms all future invocations (they see `alive == false` and return
  without touching `*this`).
- `unhook_sensor_callbacks` now unconditionally re-registers `m_user_notification_callback`
  (possibly null) so the wrapper is always removed from the live sensor's dispatcher.
  `notifications_processor::set_callback` and `raise_notification` already handle null
  callbacks safely (`rs.cpp:291` `if (_callback)` guard).

The mutex-drain plus sentinel-bail combination matches option (a) from the
investigation notes: lambdas load the sentinel under the same mutex the destructor
takes, so by the time the destructor returns no lambda is still executing and no
future lambda will dereference `*this`.

## Test plan

- [x] Local build sanity (`cmake --build build`) — no new warnings near `record_sensor`.
- [x] Run nightly under gdb-batch on `perclnx466.iil.intel.com` (`/home/administrator/repro-segfault/run-nightly-under-gdb.sh`, ~1h) twice. Pass: `/tmp/repro-logs/nightly-under-gdb.gdb.log` contains no `received signal SIGSEGV` and no `received signal SIGABRT` after the full pytest run completes.
- [x] Existing rec/play unit tests still collect: `pytest unit-tests/live/rec-play/ --collect-only`.
- [ ] Watch two consecutive Linux nightlies after merge to confirm the Apr 29 `parse_xml_from_memory` `SIGABRT` (suspected downstream of the same bug) is also gone.