### PR TITLE
src/mf: replace hand-rolled IUnknown with WRL::RuntimeClass (stacked on #15000)

### DIFF
--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -20,6 +20,54 @@
 
 namespace {
 
+// RAII wrapper for HDEVNOTIFY — auto-unregisters on scope exit. The underlying
+// API requires the registration to be released before the owning HWND is
+// destroyed, so the watcher releases its handles explicitly before
+// DestroyWindow rather than relying solely on scope.
+class hdev_notify_handle
+{
+    HDEVNOTIFY _h = nullptr;
+public:
+    hdev_notify_handle() = default;
+    explicit hdev_notify_handle( HDEVNOTIFY h ) : _h( h ) {}
+    hdev_notify_handle( hdev_notify_handle const & ) = delete;
+    hdev_notify_handle & operator=( hdev_notify_handle const & ) = delete;
+    hdev_notify_handle( hdev_notify_handle && o ) noexcept : _h( o._h ) { o._h = nullptr; }
+    hdev_notify_handle & operator=( hdev_notify_handle && o ) noexcept
+    {
+        if( this != &o )
+        {
+            reset();
+            _h = o._h;
+            o._h = nullptr;
+        }
+        return *this;
+    }
+    ~hdev_notify_handle() { reset(); }
+
+    void reset() noexcept
+    {
+        if( _h )
+        {
+            UnregisterDeviceNotification( _h );
+            _h = nullptr;
+        }
+    }
+
+    explicit operator bool() const noexcept { return _h != nullptr; }
+};
+
+// Register for DEVICEINTERFACE notifications of the given class GUID.
+// Returns an empty handle on failure.
+hdev_notify_handle register_devinterface( HWND hWnd, REFGUID classGuid )
+{
+    DEV_BROADCAST_DEVICEINTERFACE filter = {};
+    filter.dbcc_size = sizeof( DEV_BROADCAST_DEVICEINTERFACE );
+    filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+    filter.dbcc_classguid = classGuid;
+    return hdev_notify_handle{ RegisterDeviceNotification( hWnd, &filter, DEVICE_NOTIFY_WINDOW_HANDLE ) };
+}
+
 void debug_dev_broadcast( DEV_BROADCAST_HDR const * p_hdr, char const * context )
 {
     switch( p_hdr->dbch_devicetype )
@@ -233,14 +281,10 @@ namespace librealsense
                 bool _stopped = true;
                 bool _changed = false;
                 HWND hWnd = nullptr;
-                // One handle per registered DEVICEINTERFACE; previously a single
-                // hdevnotify_sensor field was reused for both sensor-camera and HID
-                // registrations, which leaked the first handle.
-                HDEVNOTIFY hdevnotifyHW = nullptr;
-                HDEVNOTIFY hdevnotifyUVC = nullptr;
-                HDEVNOTIFY hdevnotifySensorCamera = nullptr;
-                HDEVNOTIFY hdevnotifyHID = nullptr;
-                HDEVNOTIFY hdevnotifyUSB = nullptr;
+                // One entry per registered DEVICEINTERFACE class. Each handle
+                // auto-unregisters on destruction, but we clear them explicitly
+                // before the HWND is destroyed (Win32 requires that order).
+                std::vector<hdev_notify_handle> registrations;
             } _data;
 
             void run()
@@ -288,11 +332,7 @@ namespace librealsense
                     }
                 }
 
-                if (_data.hdevnotifyHW)            UnregisterDeviceNotification(_data.hdevnotifyHW);
-                if (_data.hdevnotifyUVC)           UnregisterDeviceNotification(_data.hdevnotifyUVC);
-                if (_data.hdevnotifySensorCamera)  UnregisterDeviceNotification(_data.hdevnotifySensorCamera);
-                if (_data.hdevnotifyHID)           UnregisterDeviceNotification(_data.hdevnotifyHID);
-                if (_data.hdevnotifyUSB)           UnregisterDeviceNotification(_data.hdevnotifyUSB);
+                _data.registrations.clear();  // unregister all before destroying the HWND
                 DestroyWindow(_data.hWnd);
             }
 
@@ -365,70 +405,37 @@ namespace librealsense
             {
                 auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-                auto register_interface = [hWnd]( REFGUID classGuid ) -> HDEVNOTIFY
-                {
-                    DEV_BROADCAST_DEVICEINTERFACE filter = {};
-                    filter.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
-                    filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                    filter.dbcc_classguid = classGuid;
-                    return RegisterDeviceNotification( hWnd, &filter, DEVICE_NOTIFY_WINDOW_HANDLE );
-                };
-
-                auto unregister_succeeded = [data]()
-                {
-                    if (data->hdevnotifyHW)            { UnregisterDeviceNotification(data->hdevnotifyHW);            data->hdevnotifyHW = nullptr; }
-                    if (data->hdevnotifyUVC)           { UnregisterDeviceNotification(data->hdevnotifyUVC);           data->hdevnotifyUVC = nullptr; }
-                    if (data->hdevnotifySensorCamera)  { UnregisterDeviceNotification(data->hdevnotifySensorCamera);  data->hdevnotifySensorCamera = nullptr; }
-                    if (data->hdevnotifyHID)           { UnregisterDeviceNotification(data->hdevnotifyHID);           data->hdevnotifyHID = nullptr; }
-                };
-
                 // HW monitor (private RealSense interface)
                 static const GUID hwMonitorGuid = { 0x175695cd, 0x30d9, 0x4f87, { 0x8b, 0xe3, 0x5a, 0x82, 0x70, 0xf4, 0x9a, 0x31 } };
-                data->hdevnotifyHW = register_interface( hwMonitorGuid );
-                if (!data->hdevnotifyHW)
-                {
-                    LOG_WARNING("Register HW events failed");
-                    return FALSE;
-                }
-
-                // UVC video capture
-                data->hdevnotifyUVC = register_interface( KSCATEGORY_CAPTURE );
-                if (!data->hdevnotifyUVC)
-                {
-                    LOG_WARNING("Register UVC events failed");
-                    unregister_succeeded();
-                    return FALSE;
-                }
-
-                // UVC sensor-camera (Win10+ depth/IR)
-                data->hdevnotifySensorCamera = register_interface( KSCATEGORY_SENSOR_CAMERA );
-                if (!data->hdevnotifySensorCamera)
-                {
-                    LOG_WARNING("Register sensor-camera events failed");
-                    unregister_succeeded();
-                    return FALSE;
-                }
-
                 // HID sensors (IMU)
-                static const GUID GUID_DEVINTERFACE_HID = { 0x4d1e55b2, 0xf16f, 0x11cf, { 0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
-                data->hdevnotifyHID = register_interface( GUID_DEVINTERFACE_HID );
-                if (!data->hdevnotifyHID)
-                {
-                    LOG_WARNING("Register HID events failed");
-                    unregister_succeeded();
-                    return FALSE;
-                }
-
+                static const GUID hidInterfaceGuid = { 0x4d1e55b2, 0xf16f, 0x11cf, { 0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
                 // FW Update device (USB device class)
-                static const GUID usbClassGuid = { 0xa5dcbf10, 0x6530, 0x11d2, { 0x90, 0x1f, 0x00, 0xc0, 0x4f, 0xb9, 0x51, 0xed } };
-                data->hdevnotifyUSB = register_interface( usbClassGuid );
-                if (!data->hdevnotifyUSB)
-                {
-                    LOG_WARNING("Register USB events failed");
-                    unregister_succeeded();
-                    return FALSE;
-                }
+                static const GUID usbDeviceGuid = { 0xa5dcbf10, 0x6530, 0x11d2, { 0x90, 0x1f, 0x00, 0xc0, 0x4f, 0xb9, 0x51, 0xed } };
 
+                struct interface_to_register {
+                    char const * label;
+                    GUID const & guid;
+                };
+                interface_to_register const interfaces[] = {
+                    { "HW monitor",     hwMonitorGuid          },
+                    { "UVC capture",    KSCATEGORY_CAPTURE     },
+                    { "sensor camera",  KSCATEGORY_SENSOR_CAMERA },
+                    { "HID",            hidInterfaceGuid       },
+                    { "USB device",     usbDeviceGuid          },
+                };
+
+                data->registrations.reserve( sizeof(interfaces) / sizeof(interfaces[0]) );
+                for( auto const & ix : interfaces )
+                {
+                    auto h = register_devinterface( hWnd, ix.guid );
+                    if( ! h )
+                    {
+                        LOG_WARNING( "Register " << ix.label << " events failed" );
+                        data->registrations.clear();  // RAII unregisters everything we did register
+                        return FALSE;
+                    }
+                    data->registrations.push_back( std::move( h ) );
+                }
                 return TRUE;
             }
         };

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -1,8 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 RealSense, Inc. All Rights Reserved.
-#if (_MSC_FULL_VER < 180031101)
-    #error At least Visual Studio 2013 Update 4 is required to compile this backend
-#endif
 
 #include "mf-backend.h"
 #include "mf-uvc.h"
@@ -19,18 +16,9 @@
 #include <dbt.h>
 #include <cctype> // std::tolower
 #include <rsutils/time/timer.h>
+#include <rsutils/string/windows.h>
 
 namespace {
-
-static inline std::string utf8_from_wchar( const wchar_t* w )
-{
-    if( !w ) return {};
-    int size_needed = WideCharToMultiByte( CP_UTF8, 0, w, -1, NULL, 0, NULL, NULL );
-    if( size_needed <= 0 ) return {};
-    std::string str( size_needed - 1, '\0' );
-    WideCharToMultiByte( CP_UTF8, 0, w, -1, &str[0], size_needed, NULL, NULL );
-    return str;
-}
 
 void debug_dev_broadcast( DEV_BROADCAST_HDR const * p_hdr, char const * context )
 {
@@ -38,7 +26,7 @@ void debug_dev_broadcast( DEV_BROADCAST_HDR const * p_hdr, char const * context 
     {
     case DBT_DEVTYP_DEVICEINTERFACE: {
         auto p_actual = reinterpret_cast< DEV_BROADCAST_DEVICEINTERFACE const * >( p_hdr );
-        std::string name = utf8_from_wchar( p_actual->dbcc_name );
+        std::string name = p_actual->dbcc_name ? rsutils::string::windows::win_to_utf( p_actual->dbcc_name ) : std::string();
         LOG_DEBUG( "device change event: " << context << ": DEVICEINTERFACE: \""
                                            << name << "\"" );
         break;
@@ -57,7 +45,7 @@ void debug_dev_broadcast( DEV_BROADCAST_HDR const * p_hdr, char const * context 
     }
     case DBT_DEVTYP_PORT: {
         auto p_actual = reinterpret_cast< DEV_BROADCAST_PORT const * >( p_hdr );
-        std::string name = utf8_from_wchar( p_actual->dbcp_name );
+        std::string name = p_actual->dbcp_name ? rsutils::string::windows::win_to_utf( p_actual->dbcp_name ) : std::string();
         LOG_DEBUG( "device change event: " << context << ": PORT: \"" << name
                                            << "\"" );
         break;
@@ -154,7 +142,7 @@ namespace librealsense
         {
             bool found = false;
 
-            wmf_hid_device::foreach_hid_device([&](const hid_device_info& hid_dev_info, CComPtr<ISensor> sensor) {
+            wmf_hid_device::foreach_hid_device([&](const hid_device_info& hid_dev_info, Microsoft::WRL::ComPtr<ISensor> sensor) {
                 if (hid_dev_info.unique_id == info.unique_id)
                 {
                     _connected_sensors.push_back(std::make_shared<wmf_hid_sensor>(hid_dev_info, sensor));
@@ -177,7 +165,7 @@ namespace librealsense
         {
             std::vector<hid_device_info> devices;
 
-            auto action = [&devices](const hid_device_info& info, CComPtr<ISensor>)
+            auto action = [&devices](const hid_device_info& info, Microsoft::WRL::ComPtr<ISensor>)
             {
                 devices.push_back(info);
             };
@@ -244,8 +232,15 @@ namespace librealsense
 
                 bool _stopped = true;
                 bool _changed = false;
-                HWND hWnd;
-                HDEVNOTIFY hdevnotifyHW, hdevnotifyUVC, hdevnotify_sensor, hdevnotifyUSB;
+                HWND hWnd = nullptr;
+                // One handle per registered DEVICEINTERFACE; previously a single
+                // hdevnotify_sensor field was reused for both sensor-camera and HID
+                // registrations, which leaked the first handle.
+                HDEVNOTIFY hdevnotifyHW = nullptr;
+                HDEVNOTIFY hdevnotifyUVC = nullptr;
+                HDEVNOTIFY hdevnotifySensorCamera = nullptr;
+                HDEVNOTIFY hdevnotifyHID = nullptr;
+                HDEVNOTIFY hdevnotifyUSB = nullptr;
             } _data;
 
             void run()
@@ -293,9 +288,11 @@ namespace librealsense
                     }
                 }
 
-                UnregisterDeviceNotification(_data.hdevnotifyHW);
-                UnregisterDeviceNotification(_data.hdevnotifyUVC);
-                UnregisterDeviceNotification(_data.hdevnotify_sensor);
+                if (_data.hdevnotifyHW)            UnregisterDeviceNotification(_data.hdevnotifyHW);
+                if (_data.hdevnotifyUVC)           UnregisterDeviceNotification(_data.hdevnotifyUVC);
+                if (_data.hdevnotifySensorCamera)  UnregisterDeviceNotification(_data.hdevnotifySensorCamera);
+                if (_data.hdevnotifyHID)           UnregisterDeviceNotification(_data.hdevnotifyHID);
+                if (_data.hdevnotifyUSB)           UnregisterDeviceNotification(_data.hdevnotifyUSB);
                 DestroyWindow(_data.hWnd);
             }
 
@@ -306,8 +303,15 @@ namespace librealsense
                 switch (message)
                 {
                 case WM_CREATE:
+                {
                     SetWindowLongPtr(hWnd, GWLP_USERDATA, LONG_PTR(reinterpret_cast<CREATESTRUCT*>(lParam)->lpCreateParams));
                     if (!DoRegisterDeviceInterfaceToHwnd(hWnd))
+                    {
+                        auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+                        data->_stopped = true;
+                    }
+                    break;
+                }
                 case WM_QUIT:
                 {
                     auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
@@ -361,88 +365,67 @@ namespace librealsense
             {
                 auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
-                //===========================register HWmonitor events==============================
-                const GUID classGuid = { 0x175695cd, 0x30d9, 0x4f87, 0x8b, 0xe3, 0x5a, 0x82, 0x70, 0xf4, 0x9a, 0x31 };
-                DEV_BROADCAST_DEVICEINTERFACE devBroadcastDeviceInterface;
-                devBroadcastDeviceInterface.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
-                devBroadcastDeviceInterface.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                devBroadcastDeviceInterface.dbcc_classguid = classGuid;
-                devBroadcastDeviceInterface.dbcc_reserved = 0;
-
-                data->hdevnotifyHW = RegisterDeviceNotification(hWnd,
-                    &devBroadcastDeviceInterface,
-                    DEVICE_NOTIFY_WINDOW_HANDLE);
-                if (data->hdevnotifyHW == NULL)
+                auto register_interface = [hWnd]( REFGUID classGuid ) -> HDEVNOTIFY
                 {
-                    LOG_WARNING("Register HW events Failed!\n");
+                    DEV_BROADCAST_DEVICEINTERFACE filter = {};
+                    filter.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
+                    filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+                    filter.dbcc_classguid = classGuid;
+                    return RegisterDeviceNotification( hWnd, &filter, DEVICE_NOTIFY_WINDOW_HANDLE );
+                };
+
+                auto unregister_succeeded = [data]()
+                {
+                    if (data->hdevnotifyHW)            { UnregisterDeviceNotification(data->hdevnotifyHW);            data->hdevnotifyHW = nullptr; }
+                    if (data->hdevnotifyUVC)           { UnregisterDeviceNotification(data->hdevnotifyUVC);           data->hdevnotifyUVC = nullptr; }
+                    if (data->hdevnotifySensorCamera)  { UnregisterDeviceNotification(data->hdevnotifySensorCamera);  data->hdevnotifySensorCamera = nullptr; }
+                    if (data->hdevnotifyHID)           { UnregisterDeviceNotification(data->hdevnotifyHID);           data->hdevnotifyHID = nullptr; }
+                };
+
+                // HW monitor (private RealSense interface)
+                static const GUID hwMonitorGuid = { 0x175695cd, 0x30d9, 0x4f87, { 0x8b, 0xe3, 0x5a, 0x82, 0x70, 0xf4, 0x9a, 0x31 } };
+                data->hdevnotifyHW = register_interface( hwMonitorGuid );
+                if (!data->hdevnotifyHW)
+                {
+                    LOG_WARNING("Register HW events failed");
                     return FALSE;
                 }
 
-                ////===========================register UVC events==============================
-                DEV_BROADCAST_DEVICEINTERFACE di = { 0 };
-                di.dbcc_size = sizeof(di);
-                di.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                di.dbcc_classguid = KSCATEGORY_CAPTURE;
-
-                data->hdevnotifyUVC = RegisterDeviceNotification(hWnd,
-                    &di,
-                    DEVICE_NOTIFY_WINDOW_HANDLE);
-                if (data->hdevnotifyUVC == nullptr)
+                // UVC video capture
+                data->hdevnotifyUVC = register_interface( KSCATEGORY_CAPTURE );
+                if (!data->hdevnotifyUVC)
                 {
-                    UnregisterDeviceNotification(data->hdevnotifyHW);
-                    LOG_WARNING("Register UVC events Failed!\n");
+                    LOG_WARNING("Register UVC events failed");
+                    unregister_succeeded();
                     return FALSE;
                 }
 
-                ////===========================register UVC sensor camera events==============================
-                DEV_BROADCAST_DEVICEINTERFACE di_sensor = { 0 };
-                di_sensor.dbcc_size = sizeof(di_sensor);
-                di_sensor.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                di_sensor.dbcc_classguid = KSCATEGORY_SENSOR_CAMERA;
-
-                data->hdevnotify_sensor = RegisterDeviceNotification(hWnd,
-                    &di_sensor,
-                    DEVICE_NOTIFY_WINDOW_HANDLE);
-                if (data->hdevnotify_sensor == nullptr)
+                // UVC sensor-camera (Win10+ depth/IR)
+                data->hdevnotifySensorCamera = register_interface( KSCATEGORY_SENSOR_CAMERA );
+                if (!data->hdevnotifySensorCamera)
                 {
-                    UnregisterDeviceNotification(data->hdevnotify_sensor);
-                    LOG_WARNING("Register UVC events Failed!\n");
+                    LOG_WARNING("Register sensor-camera events failed");
+                    unregister_succeeded();
                     return FALSE;
                 }
 
-                ////===========================register HID sensor camera events==============================
-                static const GUID GUID_DEVINTERFACE_HID =
-                { 0x4d1e55b2,0xf16f,0x11cf,{0x88,0xcb,0x00,0x11,0x11,0x00,0x00,0x30} };
-
-                DEV_BROADCAST_DEVICEINTERFACE hid_sensor = { 0 };
-                hid_sensor.dbcc_size = sizeof(hid_sensor);
-                hid_sensor.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                hid_sensor.dbcc_classguid = GUID_DEVINTERFACE_HID;
-
-                data->hdevnotify_sensor = RegisterDeviceNotification(hWnd,
-                    &hid_sensor,
-                    DEVICE_NOTIFY_WINDOW_HANDLE);
-                if (data->hdevnotify_sensor == nullptr)
+                // HID sensors (IMU)
+                static const GUID GUID_DEVINTERFACE_HID = { 0x4d1e55b2, 0xf16f, 0x11cf, { 0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
+                data->hdevnotifyHID = register_interface( GUID_DEVINTERFACE_HID );
+                if (!data->hdevnotifyHID)
                 {
-                    UnregisterDeviceNotification(data->hdevnotify_sensor);
-                    LOG_WARNING("Register UVC events Failed!\n");
+                    LOG_WARNING("Register HID events failed");
+                    unregister_succeeded();
                     return FALSE;
                 }
 
-                //===========================register FW Update device events==============================
-                const GUID usbClassGuid = { 0xa5dcbf10, 0x6530, 0x11d2, 0x90, 0x1f, 0x00, 0xc0, 0x4f, 0xb9, 0x51, 0xed };
-                DEV_BROADCAST_DEVICEINTERFACE usvDevBroadcastDeviceInterface;
-                usvDevBroadcastDeviceInterface.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
-                usvDevBroadcastDeviceInterface.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
-                usvDevBroadcastDeviceInterface.dbcc_classguid = usbClassGuid;
-                usvDevBroadcastDeviceInterface.dbcc_reserved = 0;
-
-                data->hdevnotifyUSB = RegisterDeviceNotification(hWnd,
-                    &usvDevBroadcastDeviceInterface,
-                    DEVICE_NOTIFY_WINDOW_HANDLE);
-                if (data->hdevnotifyUSB == NULL)
+                // FW Update device (USB device class)
+                static const GUID usbClassGuid = { 0xa5dcbf10, 0x6530, 0x11d2, { 0x90, 0x1f, 0x00, 0xc0, 0x4f, 0xb9, 0x51, 0xed } };
+                data->hdevnotifyUSB = register_interface( usbClassGuid );
+                if (!data->hdevnotifyUSB)
                 {
-                    LOG_WARNING("Register HW events Failed!\n");
+                    LOG_WARNING("Register USB events failed");
+                    unregister_succeeded();
                     return FALSE;
                 }
 

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -18,6 +18,7 @@
 #include <SensAPI.h>
 #include <initguid.h>
 #include <propkeydef.h>
+#include <wrl/implements.h>
 #include <rsutils/string/from.h>
 #include <rsutils/string/windows.h>
 
@@ -32,69 +33,29 @@ namespace librealsense
 {
     namespace platform
     {
-        class sensor_events : public ISensorEvents
+        class sensor_events : public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+            ISensorEvents>
         {
         public:
-            virtual ~sensor_events() = default;
+            ~sensor_events() override = default;
 
-            explicit sensor_events(hid_callback callback, double gyro_scale_factor = 10.0) : m_cRef(0), _callback(callback), _gyro_scale_factor(gyro_scale_factor) {}
-
-            STDMETHODIMP QueryInterface(REFIID iid, void** ppv)
-            {
-                if (ppv == NULL)
-                {
-                    return E_POINTER;
-                }
-                if (iid == __uuidof(IUnknown))
-                {
-                    *ppv = static_cast<IUnknown*>(this);
-                }
-                else if (iid == __uuidof(ISensorEvents))
-                {
-                    *ppv = static_cast<ISensorEvents*>(this);
-                }
-                else
-                {
-                    *ppv = NULL;
-                    return E_NOINTERFACE;
-                }
-                AddRef();
-                return S_OK;
-            }
-
-            STDMETHODIMP_(ULONG) AddRef()
-            {
-                return InterlockedIncrement(&m_cRef);
-            }
-
-            STDMETHODIMP_(ULONG) Release()
-            {
-                ULONG count = InterlockedDecrement(&m_cRef);
-                if (count == 0)
-                {
-                    delete this;
-                    return 0;
-                }
-                return count;
-            }
+            explicit sensor_events(hid_callback callback, double gyro_scale_factor = 10.0)
+                : _callback(callback), _gyro_scale_factor(gyro_scale_factor) {}
 
             //
             // ISensorEvents methods.
             //
 
-            STDMETHODIMP OnEvent(
-                ISensor *pSensor,
-                REFGUID eventID,
-                IPortableDeviceValues *pEventData)
+            IFACEMETHODIMP OnEvent(
+                ISensor * /*pSensor*/,
+                REFGUID /*eventID*/,
+                IPortableDeviceValues * /*pEventData*/) override
             {
-                HRESULT hr = S_OK;
-
-                // Handle custom events here.
-
-                return hr;
+                return S_OK;
             }
 
-            STDMETHODIMP OnDataUpdated(ISensor *pSensor, ISensorDataReport *report)
+            IFACEMETHODIMP OnDataUpdated(ISensor *pSensor, ISensorDataReport *report) override
             {
                 if (NULL == report ||
                     NULL == pSensor)
@@ -220,45 +181,25 @@ namespace librealsense
                 return S_OK;
             }
 
-            STDMETHODIMP OnLeave(
-                REFSENSOR_ID sensorID)
+            IFACEMETHODIMP OnLeave(REFSENSOR_ID /*sensorID*/) override
             {
-                HRESULT hr = S_OK;
-
-                // Perform any housekeeping tasks for the sensor that is leaving.
-                // For example, if you have maintained a reference to the sensor,
-                // release it now and set the pointer to NULL.
-
-                return hr;
+                return S_OK;
             }
 
-            STDMETHODIMP OnStateChanged(
-                ISensor* pSensor,
-                SensorState state)
+            IFACEMETHODIMP OnStateChanged(ISensor* pSensor, SensorState state) override
             {
-                HRESULT hr = S_OK;
-
-                if (NULL == pSensor)
-                {
+                if (nullptr == pSensor)
                     return E_INVALIDARG;
-                }
-
 
                 if (state == SENSOR_STATE_READY)
-                {
                     LOG_DEBUG("HID sensor is now ready");
-                }
                 else if (state == SENSOR_STATE_ACCESS_DENIED)
-                {
                     LOG_WARNING("No permission for the HID sensor; enable it in the control panel");
-                }
 
-
-                return hr;
+                return S_OK;
             }
 
         private:
-            long m_cRef;
             hid_callback _callback;
             double _gyro_scale_factor = 10.0;
         };
@@ -361,7 +302,7 @@ namespace librealsense
         void wmf_hid_device::start_capture(hid_callback callback)
         {
             // Hack, start default profile
-            _cb = new sensor_events(callback, _gyro_scale_factor);
+            _cb = Microsoft::WRL::Make<sensor_events>(callback, _gyro_scale_factor);
 
             for (auto& sensor : _opened_sensors)
             {

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -1,10 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 RealSense, Inc. All Rights Reserved.
 
-#if (_MSC_FULL_VER < 180031101)
-#error At least Visual Studio 2013 Update 4 is required to compile this backend
-#endif
-
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -22,8 +18,8 @@
 #include <SensAPI.h>
 #include <initguid.h>
 #include <propkeydef.h>
-#include <comutil.h>
 #include <rsutils/string/from.h>
+#include <rsutils/string/windows.h>
 
 #pragma comment(lib, "Sensorsapi.lib")
 #pragma comment(lib, "PortableDeviceGuids.lib")
@@ -185,14 +181,14 @@ namespace librealsense
                 metadata_hid_raw meta_data{};
                 meta_data.header.report_type = md_hid_report_type::hid_report_imu;
                 meta_data.header.length = hid_header_size + metadata_imu_report_size;
-                meta_data.header.timestamp = customTimestampLow | (customTimestampHigh < 32);
+                meta_data.header.timestamp = customTimestampLow | (uint64_t(customTimestampHigh) << 32);
                 // Payload:
                 meta_data.report_type.imu_report.header.md_type_id = md_type::META_DATA_HID_IMU_REPORT_ID;
                 meta_data.report_type.imu_report.header.md_size = metadata_imu_report_size;
                 meta_data.report_type.imu_report.flags = static_cast<uint8_t>( md_hid_imu_attributes::custom_timestamp_attirbute |
                                                                                 md_hid_imu_attributes::imu_counter_attribute |
                                                                                 md_hid_imu_attributes::usb_counter_attribute);
-                meta_data.report_type.imu_report.custom_timestamp = customTimestampLow | (customTimestampHigh < 32);
+                meta_data.report_type.imu_report.custom_timestamp = customTimestampLow | (uint64_t(customTimestampHigh) << 32);
                 meta_data.report_type.imu_report.imu_counter = imu_count;
                 meta_data.report_type.imu_report.usb_counter = usb_count;
 
@@ -202,9 +198,11 @@ namespace librealsense
                 data.ts_low = customTimestampLow;
                 data.ts_high = customTimestampHigh;
 
-                pSensor->GetFriendlyName(&fName);
-                d.sensor.name = CW2A(fName);
-                SysFreeString(fName); // free string after it was copied to sensor data
+                if (SUCCEEDED(pSensor->GetFriendlyName(&fName)) && fName)
+                {
+                    d.sensor.name = rsutils::string::windows::win_to_utf(fName);
+                    SysFreeString(fName); // free string after it was copied to sensor data
+                }
 
                 d.fo.pixels = &data;
                 d.fo.metadata = &meta_data;
@@ -248,12 +246,11 @@ namespace librealsense
 
                 if (state == SENSOR_STATE_READY)
                 {
-                    wprintf_s(L"\nTime sensor is now ready.");
+                    LOG_DEBUG("HID sensor is now ready");
                 }
                 else if (state == SENSOR_STATE_ACCESS_DENIED)
                 {
-                    wprintf_s(L"\nNo permission for the time sensor.\n");
-                    wprintf_s(L"Enable the sensor in the control panel.\n");
+                    LOG_WARNING("No permission for the HID sensor; enable it in the control panel");
                 }
 
 
@@ -277,42 +274,38 @@ namespace librealsense
                         if (profile_to_open.sensor_name == connected_sensor->get_sensor_name())
                         {
                             /* Set SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL sensor property to profile */
-                            HRESULT hr = S_OK;
-                            IPortableDeviceValues* pPropsToSet = NULL; // Input
-                            IPortableDeviceValues* pPropsReturn = NULL; // Output
+                            Microsoft::WRL::ComPtr<IPortableDeviceValues> pPropsToSet;
+                            Microsoft::WRL::ComPtr<IPortableDeviceValues> pPropsReturn;
 
                             /* Create the input object */
-                            CHECK_HR(CoCreateInstance(__uuidof(PortableDeviceValues), NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pPropsToSet)));
+                            CHECK_HR(CoCreateInstance(__uuidof(PortableDeviceValues), nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pPropsToSet)));
 
                             /* Add the current report interval property */
-                            hr = pPropsToSet->SetUnsignedIntegerValue(SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL, profile_to_open.frequency);
+                            HRESULT hr = pPropsToSet->SetUnsignedIntegerValue(SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL, profile_to_open.frequency);
                             if (SUCCEEDED(hr))
                             {
                                 // Setting a single property
-                                hr = connected_sensor->get_sensor()->SetProperties(pPropsToSet, &pPropsReturn);
+                                hr = connected_sensor->get_sensor()->SetProperties(pPropsToSet.Get(), &pPropsReturn);
                                 if (SUCCEEDED(hr))
                                 {
                                     _opened_sensors.push_back(connected_sensor);
-                                    pPropsReturn->Release();
                                 }
                             }
-
-                            pPropsToSet->Release();
 
                             //currently implemented only for Gyro sensitivity
                             if( profile_to_open.sensor_name == "HID Sensor Class Device: Gyroscope" )
                             {
                                 // creating IPortableDeviceValues container for <Data Field, Sensitivity> tuples
-                                IPortableDeviceValues * pInSensitivityValues;
+                                Microsoft::WRL::ComPtr<IPortableDeviceValues> pInSensitivityValues;
                                 CHECK_HR( CoCreateInstance( CLSID_PortableDeviceValues,
-                                                         NULL,
+                                                         nullptr,
                                                          CLSCTX_INPROC_SERVER,
                                                          IID_PPV_ARGS( &pInSensitivityValues ) ));
 
                                 PROPVARIANT pv;
                                 PropVariantInit( &pv );
                                 // COM type for double
-                                pv.vt = VT_R8;  
+                                pv.vt = VT_R8;
                                 pv.dblVal = (double)profile_to_open.sensitivity;
                                 pInSensitivityValues->SetValue(
                                     SENSOR_DATA_TYPE_ANGULAR_VELOCITY_X_DEGREES_PER_SECOND,
@@ -324,25 +317,22 @@ namespace librealsense
                                     SENSOR_DATA_TYPE_ANGULAR_VELOCITY_Z_DEGREES_PER_SECOND,
                                     &pv );
                                 // creating IPortableDeviceValues container holding <SENSOR_PROPERTY_CHANGE_SENSITIVITY,pInSensitivityValues> tuple
-                                IPortableDeviceValues * pInValues = NULL; //Input
+                                Microsoft::WRL::ComPtr<IPortableDeviceValues> pInValues;
                                 CHECK_HR(CoCreateInstance( CLSID_PortableDeviceValues,
-                                                            NULL,
+                                                            nullptr,
                                                             CLSCTX_INPROC_SERVER,
                                                             IID_PPV_ARGS( &pInValues ) ));
 
                                 pInValues->SetIPortableDeviceValuesValue( SENSOR_PROPERTY_CHANGE_SENSITIVITY,
-                                                                            pInSensitivityValues );
-                                
-                                IPortableDeviceValues * pOutValues = NULL; //Output
+                                                                            pInSensitivityValues.Get() );
+
+                                Microsoft::WRL::ComPtr<IPortableDeviceValues> pOutValues;
                                 // set sensitivity
-                                hr = connected_sensor->get_sensor()->SetProperties( pInValues, &pOutValues );
+                                hr = connected_sensor->get_sensor()->SetProperties( pInValues.Get(), &pOutValues );
                                 if( SUCCEEDED( hr ) )
                                     PropVariantClear( &pv );
-
-                                pInValues->Release();
-
                             }
-                            
+
                         }
                     }
                 }
@@ -372,12 +362,10 @@ namespace librealsense
         {
             // Hack, start default profile
             _cb = new sensor_events(callback, _gyro_scale_factor);
-            ISensorEvents* sensorEvents = nullptr;
-            CHECK_HR(_cb->QueryInterface(IID_PPV_ARGS(&sensorEvents)));
 
             for (auto& sensor : _opened_sensors)
             {
-                CHECK_HR(sensor->start_capture(sensorEvents));
+                CHECK_HR(sensor->start_capture(_cb.Get()));
             }
         }
 
@@ -410,18 +398,17 @@ namespace librealsense
             _gyro_scale_factor = scale_factor;
         }
 
-        void wmf_hid_device::foreach_hid_device(std::function<void(hid_device_info, CComPtr<ISensor>)> action)
+        void wmf_hid_device::foreach_hid_device(std::function<void(hid_device_info, Microsoft::WRL::ComPtr<ISensor>)> action)
         {
             /* Enumerate all HID devices and run action function on each device */
             try
             {
-                CComPtr<ISensorManager> pSensorManager = nullptr;
-                CComPtr<ISensorCollection> pSensorCollection = nullptr;
-                CComPtr<ISensor> pSensor = nullptr;
+                Microsoft::WRL::ComPtr<ISensorManager> pSensorManager;
+                Microsoft::WRL::ComPtr<ISensorCollection> pSensorCollection;
                 ULONG sensorCount = 0;
                 HRESULT res{};
 
-                CHECK_HR(CoCreateInstance(CLSID_SensorManager, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pSensorManager)));
+                CHECK_HR(CoCreateInstance(CLSID_SensorManager, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pSensorManager)));
 
                 /* Retrieves a collection containing all sensors associated with category SENSOR_CATEGORY_ALL */
                 res=pSensorManager->GetSensorsByCategory(SENSOR_CATEGORY_ALL, &pSensorCollection);
@@ -432,8 +419,9 @@ namespace librealsense
 
                     for (ULONG i = 0; i < sensorCount; i++)
                     {
+                        Microsoft::WRL::ComPtr<ISensor> pSensor;
                         /* Retrieves the sensor at the specified index in the collection */
-                        if (SUCCEEDED(pSensorCollection->GetAt(i, &pSensor.p)))
+                        if (SUCCEEDED(pSensorCollection->GetAt(i, &pSensor)))
                         {
                             /* Retrieve SENSOR_PROPERTY_FRIENDLY_NAME which is the sensor name that is intended to be seen by the user */
                             std::string sensor_id;
@@ -457,7 +445,7 @@ namespace librealsense
                             SENSOR_TYPE_ID type{};
                             CHECK_HR(pSensor->GetType(&type));
 
-                            CComPtr<IPortableDeviceValues> pValues = nullptr;  // Output
+                            Microsoft::WRL::ComPtr<IPortableDeviceValues> pValues = nullptr;  // Output
                             hid_device_info info{};
 
                             /* Retrieves multiple sensor properties */
@@ -530,8 +518,6 @@ namespace librealsense
 
                             action(info, pSensor);
                         }
-                        //Releasing resources
-                        safe_release(pSensor);
                     }
                 }
                 // ERROR_NOT_FOUND is normal if no sensors are available

--- a/src/mf/mf-hid.h
+++ b/src/mf/mf-hid.h
@@ -7,7 +7,8 @@
 #include "win/win-helpers.h"
 
 #include <Sensorsapi.h>
-#include <atlcomcli.h>
+#include <wrl/client.h>
+#include <rsutils/string/windows.h>
 
 namespace librealsense
 {
@@ -16,24 +17,24 @@ namespace librealsense
 
         class wmf_hid_sensor {
         public:
-            wmf_hid_sensor(const hid_device_info& device_info, CComPtr<ISensor> pISensor) :
-                _hid_device_info(device_info), _pISensor(pISensor) 
+            wmf_hid_sensor(const hid_device_info& device_info, Microsoft::WRL::ComPtr<ISensor> pISensor) :
+                _hid_device_info(device_info), _pISensor(pISensor)
             {
-                BSTR fName;
+                BSTR fName = nullptr;
                 auto res = pISensor->GetFriendlyName( &fName );
                 if( FAILED( res ) )
                 {
-                    _name = CW2A( L"Unidentified HID Sensor" );
+                    _name = "Unidentified HID Sensor";
                 }
                 else
                 {
-                    _name = CW2A( fName );
+                    _name = rsutils::string::windows::win_to_utf( fName );
                     SysFreeString( fName );
                 }
             };
 
             const std::string& get_sensor_name() const { return _name; }
-            const CComPtr<ISensor>& get_sensor() const { return _pISensor; }
+            const Microsoft::WRL::ComPtr<ISensor>& get_sensor() const { return _pISensor; }
 
             HRESULT start_capture(ISensorEvents* sensorEvents)
             {
@@ -42,13 +43,13 @@ namespace librealsense
 
             HRESULT stop_capture()
             {
-                return _pISensor->SetEventSink(NULL);
+                return _pISensor->SetEventSink(nullptr);
             }
 
         private:
 
             hid_device_info _hid_device_info;
-            CComPtr<ISensor> _pISensor;
+            Microsoft::WRL::ComPtr<ISensor> _pISensor;
             std::string _name;
         };
 
@@ -57,7 +58,7 @@ namespace librealsense
         class wmf_hid_device : public hid_device
         {
         public:
-            static void foreach_hid_device(std::function<void(hid_device_info, CComPtr<ISensor>)> action);
+            static void foreach_hid_device(std::function<void(hid_device_info, Microsoft::WRL::ComPtr<ISensor>)> action);
             wmf_hid_device(const hid_device_info& info, std::shared_ptr<const wmf_backend> backend);
 
             void register_profiles(const std::vector<hid_profile>& hid_profiles) override { _hid_profiles = hid_profiles;}
@@ -77,7 +78,7 @@ namespace librealsense
             std::vector<std::shared_ptr<wmf_hid_sensor>> _opened_sensors;    // Vector of all opened sensors of this device (subclass of _connected_sensors)
             std::vector<std::shared_ptr<wmf_hid_sensor>> _streaming_sensors; // Vector of all streaming sensors of this device (subclass of _connected_sensors)
 
-            CComPtr<ISensorEvents> _cb;
+            Microsoft::WRL::ComPtr<ISensorEvents> _cb;
             std::vector<hid_profile> _hid_profiles;
             //10.0 was used for D400 before FW support to gyro sensitivity control
             double _gyro_scale_factor = 10.0;

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -1,23 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 RealSense, Inc. All Rights Reserved.
 
-#if (_MSC_FULL_VER < 180031101)
-#error At least Visual Studio 2013 Update 4 is required to compile this backend
-#endif
-
-#include <ntverp.h>
-#if VER_PRODUCTBUILD <= 9600    // (WinSDK 8.1)
-#ifdef ENFORCE_METADATA
-#error( "Librealsense Error!: Featuring UVC Metadata requires WinSDK 10.0.10586.0. \
- Install the required toolset to proceed. Alternatively, uncheck ENFORCE_METADATA option in CMake GUI tool")
-#else
-#pragma message ( "\nLibrealsense notification: Featuring UVC Metadata requires WinSDK 10.0.10586.0 toolset. \
-The library will be compiled without the metadata support!\n")
-#endif // ENFORCE_METADATA
-#else
-#define METADATA_SUPPORT
-#endif      // (WinSDK 8.1)
-
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -60,7 +43,6 @@ namespace librealsense
 {
     namespace platform
     {
-#ifdef METADATA_SUPPORT
 
 #pragma pack(push, 1)
             struct ms_proprietary_md_blob
@@ -83,8 +65,8 @@ namespace librealsense
 
             bool try_read_metadata(IMFSample *pSample, uint8_t& metadata_size, uint8_t ** bytes)
             {
-                CComPtr<IUnknown>       spUnknown;
-                CComPtr<IMFAttributes>  spSample;
+                Microsoft::WRL::ComPtr<IUnknown>       spUnknown;
+                Microsoft::WRL::ComPtr<IMFAttributes>  spSample;
                 HRESULT hr = S_OK;
 
                 CHECK_HR(hr = pSample->QueryInterface(IID_PPV_ARGS(&spSample)));
@@ -92,8 +74,8 @@ namespace librealsense
 
                 if (SUCCEEDED(hr))
                 {
-                    CComPtr<IMFAttributes>          spMetadata;
-                    CComPtr<IMFMediaBuffer>         spBuffer;
+                    Microsoft::WRL::ComPtr<IMFAttributes>          spMetadata;
+                    Microsoft::WRL::ComPtr<IMFMediaBuffer>         spBuffer;
                     PKSCAMERA_METADATA_ITEMHEADER   pMetadata = nullptr;
                     DWORD                           dwMaxLength = 0;
                     DWORD                           dwCurrentLength = 0;
@@ -142,7 +124,6 @@ namespace librealsense
                 else
                     return false;
             }
-#endif // METADATA_SUPPORT
 
         STDMETHODIMP source_reader_callback::QueryInterface(REFIID iid, void** ppv)
         {
@@ -196,7 +177,7 @@ namespace librealsense
 
                 if (sample)
                 {
-                    CComPtr<IMFMediaBuffer> buffer = nullptr;
+                    Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer = nullptr;
                     if (SUCCEEDED(sample->GetBufferByIndex(0, &buffer)))
                     {
                         uint8_t * byte_buffer=nullptr;
@@ -205,9 +186,7 @@ namespace librealsense
                         {
                             uint8_t * metadata = nullptr;
                             uint8_t metadata_size = 0;
-#ifdef METADATA_SUPPORT
                             try_read_metadata(sample, metadata_size, &metadata);
-#endif
                             try
                             {
                                 auto& stream = owner->_streams[dwStreamIndex];
@@ -257,7 +236,7 @@ namespace librealsense
         IKsControl* wmf_uvc_device::get_ks_control(const extension_unit & xu) const
         {
             auto it = _ks_controls.find(xu.node);
-            if (it != std::end(_ks_controls)) return it->second;
+            if (it != std::end(_ks_controls)) return it->second.Get();
             throw std::runtime_error("Extension control must be initialized before use!");
         }
 
@@ -267,20 +246,18 @@ namespace librealsense
                 throw std::runtime_error("Could not initialize extensions controls!");
 
             // Attempt to retrieve IKsControl
-            CComPtr<IKsTopologyInfo> ks_topology_info = nullptr;
-            CHECK_HR(_source->QueryInterface(__uuidof(IKsTopologyInfo),
-                reinterpret_cast<void **>(&ks_topology_info)));
+            Microsoft::WRL::ComPtr<IKsTopologyInfo> ks_topology_info;
+            CHECK_HR(_source.As(&ks_topology_info));
 
             DWORD nNodes=0;
             LOG_HR_STR("get_NumNodes", ks_topology_info->get_NumNodes(&nNodes));
 
-            CComPtr<IUnknown> unknown = nullptr;
+            Microsoft::WRL::ComPtr<IUnknown> unknown;
             CHECK_HR(ks_topology_info->CreateNodeInstance(xu.node, IID_IUnknown,
-                reinterpret_cast<LPVOID *>(&unknown)));
+                reinterpret_cast<LPVOID *>(unknown.GetAddressOf())));
 
-            CComPtr<IKsControl> ks_control = nullptr;
-            CHECK_HR(unknown->QueryInterface(__uuidof(IKsControl),
-                reinterpret_cast<void **>(&ks_control)));
+            Microsoft::WRL::ComPtr<IKsControl> ks_control;
+            CHECK_HR(unknown.As(&ks_control));
             _ks_controls[xu.node] = ks_control;
         }
 
@@ -727,23 +704,27 @@ namespace librealsense
         {
             for (auto attributes_params_set : attributes_params)
             {
-                CComPtr<IMFAttributes> pAttributes = nullptr;
+                Microsoft::WRL::ComPtr<IMFAttributes> pAttributes;
                 CHECK_HR(MFCreateAttributes(&pAttributes, 1));
                 for (auto attribute_params : attributes_params_set)
                 {
                     CHECK_HR(pAttributes->SetGUID(attribute_params.first, attribute_params.second));
                 }
 
-                IMFActivate ** ppDevices;
-                UINT32 numDevices;
-                CHECK_HR(MFEnumDeviceSources(pAttributes, &ppDevices, &numDevices));
+                IMFActivate ** ppDevices = nullptr;
+                UINT32 numDevices = 0;
+                CHECK_HR(MFEnumDeviceSources(pAttributes.Get(), &ppDevices, &numDevices));
+                // Free the array (and AddRef'd entries we copy below) on every exit path.
+                std::unique_ptr<IMFActivate*, void(*)(IMFActivate**)> devices_guard(
+                    ppDevices,
+                    [](IMFActivate** p) { if (p) CoTaskMemFree(p); });
 
                 for (UINT32 i = 0; i < numDevices; ++i)
                 {
-                    CComPtr<IMFActivate> pDevice;
-                    *&pDevice = ppDevices[i];
+                    Microsoft::WRL::ComPtr<IMFActivate> pDevice = ppDevices[i];
 
-                    WCHAR * wchar_name = nullptr; UINT32 length;
+                    WCHAR * wchar_name = nullptr;
+                    UINT32 length = 0;
                     CHECK_HR(pDevice->GetAllocatedString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, &wchar_name, &length));
                     auto name = rsutils::string::windows::win_to_utf(wchar_name);
                     CoTaskMemFree(wchar_name);
@@ -766,8 +747,6 @@ namespace librealsense
                         // TODO
                     }
                 }
-                safe_release(pAttributes);
-                CoTaskMemFree(ppDevices);
             }
         }
 
@@ -813,7 +792,8 @@ namespace librealsense
                 if (i == _info && device)
                 {
                     _device_id.resize(DEVICE_ID_MAX_SIZE);
-                    CHECK_HR(device->GetString(did_guid, const_cast<LPWSTR>(_device_id.c_str()), UINT32(_device_id.size()), nullptr));
+                    CHECK_HR(device->GetString(did_guid, &_device_id[0], UINT32(_device_id.size()), nullptr));
+                    _device_id.resize(wcslen(_device_id.c_str()));
                 }
             });
         }
@@ -828,10 +808,8 @@ namespace librealsense
 
                 set_power_state(D3);
 
-                safe_release(_device_attrs);
-                safe_release(_reader_attrs);
-                for (auto&& c : _ks_controls)
-                    safe_release(c.second);
+                _device_attrs.Reset();
+                _reader_attrs.Reset();
                 _ks_controls.clear();
             }
             catch (...)
@@ -840,9 +818,9 @@ namespace librealsense
             }
         }
 
-        CComPtr<IMFAttributes> wmf_uvc_device::create_device_attrs()
+        Microsoft::WRL::ComPtr<IMFAttributes> wmf_uvc_device::create_device_attrs()
         {
-            CComPtr<IMFAttributes> device_attrs = nullptr;
+            Microsoft::WRL::ComPtr<IMFAttributes> device_attrs;
 
             CHECK_HR(MFCreateAttributes(&device_attrs, 2));
             CHECK_HR(device_attrs->SetGUID(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE, type_guid));
@@ -850,9 +828,9 @@ namespace librealsense
             return device_attrs;
         }
 
-        CComPtr<IMFAttributes> wmf_uvc_device::create_reader_attrs()
+        Microsoft::WRL::ComPtr<IMFAttributes> wmf_uvc_device::create_reader_attrs()
         {
-            CComPtr<IMFAttributes> reader_attrs = nullptr;
+            Microsoft::WRL::ComPtr<IMFAttributes> reader_attrs;
 
             CHECK_HR(MFCreateAttributes(&reader_attrs, 3));
             CHECK_HR(reader_attrs->SetUINT32(MF_SOURCE_READER_DISCONNECT_MEDIASOURCE_ON_SHUTDOWN, FALSE));
@@ -872,60 +850,60 @@ namespace librealsense
             _streams.resize(_streamIndex);
 
             // Release any stale COM pointers from a previously failed set_d0() or set_d3()
-            safe_release(_camera_control);
-            safe_release(_video_proc);
-            safe_release(_reader);
+            _camera_control.Reset();
+            _video_proc.Reset();
+            _reader.Reset();
             if (_source)
             {
                 _source->Shutdown();
-                safe_release(_source);
+                _source.Reset();
             }
 
             //enable source
-            CHECK_HR(MFCreateDeviceSource(_device_attrs, &_source));
-            LOG_HR(_source->QueryInterface(__uuidof(IAMCameraControl), reinterpret_cast<void **>(&_camera_control)));
+            CHECK_HR(MFCreateDeviceSource(_device_attrs.Get(), &_source));
+            LOG_HR(_source.As(&_camera_control));
             // The IAMVideoProcAmp interface adjusts the qualities of an incoming video signal, such as brightness,
             // contrast, hue, saturation, gamma, and sharpness.
-            auto hr = _source->QueryInterface( __uuidof( IAMVideoProcAmp ), reinterpret_cast< void ** >( &_video_proc ) );
+            auto hr = _source.As( &_video_proc );
             // E_NOINTERFACE is expected... especially when no video camera
             if( hr != E_NOINTERFACE )
                 LOG_HR_STR( "QueryInterface(IAMVideoProcAmp)", hr );
 
             //enable reader
-            CHECK_HR(MFCreateSourceReaderFromMediaSource(_source, _reader_attrs, &_reader));
+            CHECK_HR(MFCreateSourceReaderFromMediaSource(_source.Get(), _reader_attrs.Get(), &_reader));
             CHECK_HR(_reader->SetStreamSelection(static_cast<DWORD>(MF_SOURCE_READER_ALL_STREAMS), TRUE));
             _power_state = D0;
         }
 
         void wmf_uvc_device::set_d3()
         {
-            safe_release(_camera_control);
-            safe_release(_video_proc);
-            safe_release(_reader);
+            _camera_control.Reset();
+            _video_proc.Reset();
+            _reader.Reset();
             if (_source)
             {
                 _source->Shutdown();
-                safe_release(_source);
+                _source.Reset();
             }
             for (auto& elem : _streams)
                 elem.callback = nullptr;
             _power_state = D3;
         }
 
-        void wmf_uvc_device::foreach_profile(std::function<void(const mf_profile& profile, CComPtr<IMFMediaType> media_type, bool& quit)> action) const
+        void wmf_uvc_device::foreach_profile(std::function<void(const mf_profile& profile, Microsoft::WRL::ComPtr<IMFMediaType> media_type, bool& quit)> action) const
         {
             bool quit = false;
-            CComPtr<IMFMediaType> pMediaType = nullptr;
+            Microsoft::WRL::ComPtr<IMFMediaType> pMediaType;
             for (unsigned int sIndex = 0; sIndex < _streams.size(); ++sIndex)
             {
                 for (auto k = 0;; k++)
                 {
-                    auto hr = _reader->GetNativeMediaType(sIndex, k, &pMediaType.p);
+                    auto hr = _reader->GetNativeMediaType(sIndex, k, pMediaType.ReleaseAndGetAddressOf());
                     if (FAILED(hr) || pMediaType == nullptr)
                     {
-                        safe_release(pMediaType);
+                        pMediaType.Reset();
                         if (hr != MF_E_NO_MORE_TYPES) // An object ran out of media types to suggest therefore the requested chain of streaming objects cannot be completed
-                            LOG_HR_STR("_reader->GetNativeMediaType(sIndex, k, &pMediaType.p)",hr);
+                            LOG_HR_STR("_reader->GetNativeMediaType",hr);
 
                         break;
                     }
@@ -936,13 +914,13 @@ namespace librealsense
                     unsigned width = 0;
                     unsigned height = 0;
 
-                    CHECK_HR(MFGetAttributeSize(pMediaType, MF_MT_FRAME_SIZE, &width, &height));
+                    CHECK_HR(MFGetAttributeSize(pMediaType.Get(), MF_MT_FRAME_SIZE, &width, &height));
 
                     frame_rate frameRateMin;
                     frame_rate frameRateMax;
 
-                    CHECK_HR(MFGetAttributeRatio(pMediaType, MF_MT_FRAME_RATE_RANGE_MIN, &frameRateMin.numerator, &frameRateMin.denominator));
-                    CHECK_HR(MFGetAttributeRatio(pMediaType, MF_MT_FRAME_RATE_RANGE_MAX, &frameRateMax.numerator, &frameRateMax.denominator));
+                    CHECK_HR(MFGetAttributeRatio(pMediaType.Get(), MF_MT_FRAME_RATE_RANGE_MIN, &frameRateMin.numerator, &frameRateMin.denominator));
+                    CHECK_HR(MFGetAttributeRatio(pMediaType.Get(), MF_MT_FRAME_RATE_RANGE_MAX, &frameRateMax.numerator, &frameRateMax.denominator));
 
                     if (static_cast<float>(frameRateMax.numerator) / frameRateMax.denominator <
                         static_cast<float>(frameRateMin.numerator) / frameRateMin.denominator)
@@ -978,7 +956,7 @@ namespace librealsense
 
                     action(mfp, pMediaType, quit);
 
-                    safe_release(pMediaType);
+                    pMediaType.Reset();
 
                     if (quit)
                         return;
@@ -995,7 +973,7 @@ namespace librealsense
 
             std::vector<stream_profile> results;
             foreach_profile(
-                [&results]( const mf_profile & mfp, CComPtr< IMFMediaType > media_type, bool & quit )
+                [&results]( const mf_profile & mfp, Microsoft::WRL::ComPtr< IMFMediaType > media_type, bool & quit )
                 {
                     //LOG_DEBUG( mfp.profile.width << 'x' << mfp.profile.height << ' ' << fourcc( mfp.profile.format )
                     //                             << " @ " << mfp.profile.fps << " Hz" );
@@ -1008,7 +986,7 @@ namespace librealsense
         void wmf_uvc_device::play_profile(stream_profile profile, frame_callback callback)
         {
             bool profile_found = false;
-            foreach_profile([this, profile, callback, &profile_found](const mf_profile& mfp, CComPtr<IMFMediaType> media_type, bool& quit)
+            foreach_profile([this, profile, callback, &profile_found](const mf_profile& mfp, Microsoft::WRL::ComPtr<IMFMediaType> media_type, bool& quit)
             {
                 if (mfp.profile.format != profile.format &&
                     (fourcc_map.count(mfp.profile.format) == 0 ||
@@ -1021,7 +999,7 @@ namespace librealsense
                     {
                         if (mfp.profile.fps == int(profile.fps))
                         {
-                            auto hr = _reader->SetCurrentMediaType(mfp.index, nullptr, media_type);
+                            auto hr = _reader->SetCurrentMediaType(mfp.index, nullptr, media_type.Get());
                             if (SUCCEEDED(hr) && media_type)
                             {
                                 for (unsigned int i = 0; i < _streams.size(); ++i)
@@ -1084,18 +1062,18 @@ namespace librealsense
         {
             if (get_power_state() != D0)
                 throw std::runtime_error("Device must be powered to query video_proc!");
-            if (!_video_proc.p)
+            if (!_video_proc)
                 throw std::runtime_error("The device does not support adjusting the qualities of an incoming video signal, such as brightness, contrast, hue, saturation, gamma, and sharpness.");
-            return _video_proc.p;
+            return _video_proc.Get();
         }
 
         IAMCameraControl* wmf_uvc_device::get_camera_control() const
         {
             if (get_power_state() != D0)
                 throw std::runtime_error("Device must be powered to query camera_control!");
-            if (!_camera_control.p)
+            if (!_camera_control)
                 throw std::runtime_error("The device does not support camera settings such as zoom, pan, aperture adjustment, or shutter speed.");
-            return _camera_control.p;
+            return _camera_control.Get();
         }
 
         void wmf_uvc_device::stream_on(std::function<void(const notification& n)> error_handler)

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -125,32 +125,7 @@ namespace librealsense
                     return false;
             }
 
-        STDMETHODIMP source_reader_callback::QueryInterface(REFIID iid, void** ppv)
-        {
-#pragma warning( push )
-#pragma warning(disable : 4838)
-            static const QITAB qit[] =
-            {
-                QITABENT(source_reader_callback, IMFSourceReaderCallback),
-                { nullptr },
-            };
-            return QISearch(this, qit, iid, ppv);
-#pragma warning( pop )
-        };
-
-        STDMETHODIMP_(ULONG) source_reader_callback::AddRef() { return InterlockedIncrement(&_refCount); }
-
-        STDMETHODIMP_(ULONG) source_reader_callback::Release()  {
-            ULONG count = InterlockedDecrement(&_refCount);
-            if (count <= 0)
-            {
-                delete this;
-            }
-            return count;
-        }
-
-
-        STDMETHODIMP source_reader_callback::OnReadSample(HRESULT hrStatus,
+        IFACEMETHODIMP source_reader_callback::OnReadSample(HRESULT hrStatus,
             DWORD dwStreamIndex,
             DWORD dwStreamFlags,
             LONGLONG llTimestamp,
@@ -212,8 +187,8 @@ namespace librealsense
 
             return S_OK;
         };
-        STDMETHODIMP source_reader_callback::OnEvent(DWORD /*sidx*/, IMFMediaEvent* /*event*/) { return S_OK; }
-        STDMETHODIMP source_reader_callback::OnFlush(DWORD)
+        IFACEMETHODIMP source_reader_callback::OnEvent(DWORD /*sidx*/, IMFMediaEvent* /*event*/) { return S_OK; }
+        IFACEMETHODIMP source_reader_callback::OnFlush(DWORD)
         {
             auto owner = _owner.lock();
             if (owner)
@@ -835,8 +810,8 @@ namespace librealsense
             CHECK_HR(MFCreateAttributes(&reader_attrs, 3));
             CHECK_HR(reader_attrs->SetUINT32(MF_SOURCE_READER_DISCONNECT_MEDIASOURCE_ON_SHUTDOWN, FALSE));
             CHECK_HR(reader_attrs->SetUINT32(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, TRUE));
-            CHECK_HR(reader_attrs->SetUnknown(MF_SOURCE_READER_ASYNC_CALLBACK,
-                static_cast<IUnknown*>(new source_reader_callback(shared_from_this()))));
+            auto callback = Microsoft::WRL::Make<source_reader_callback>(shared_from_this());
+            CHECK_HR(reader_attrs->SetUnknown(MF_SOURCE_READER_ASYNC_CALLBACK, callback.Get()));
             return reader_attrs;
         }
 

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -9,6 +9,7 @@
 #include <mfidl.h>
 #include <mfreadwrite.h>
 #include <wrl/client.h>
+#include <wrl/implements.h>
 #include <strmif.h>
 #include <Ks.h>
 #include <ksproxy.h>
@@ -148,26 +149,24 @@ namespace librealsense
             std::wstring                            _device_id;
         };
 
-        class source_reader_callback : public IMFSourceReaderCallback
+        class source_reader_callback : public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+            IMFSourceReaderCallback>
         {
         public:
-            explicit source_reader_callback(std::weak_ptr<wmf_uvc_device> owner) : _owner(owner)
-            {
-            };
-            virtual ~source_reader_callback() {};
-            STDMETHODIMP QueryInterface(REFIID iid, void** ppv) override;
-            STDMETHODIMP_(ULONG) AddRef() override;
-            STDMETHODIMP_(ULONG) Release() override;
-            STDMETHODIMP OnReadSample(HRESULT /*hrStatus*/,
+            explicit source_reader_callback(std::weak_ptr<wmf_uvc_device> owner) : _owner(std::move(owner)) {}
+            ~source_reader_callback() override = default;
+
+            IFACEMETHODIMP OnReadSample(HRESULT hrStatus,
                 DWORD dwStreamIndex,
-                DWORD /*dwStreamFlags*/,
-                LONGLONG /*llTimestamp*/,
-                IMFSample *sample) override;
-            STDMETHODIMP OnEvent(DWORD /*sidx*/, IMFMediaEvent* /*event*/) override;
-            STDMETHODIMP OnFlush(DWORD) override;
+                DWORD dwStreamFlags,
+                LONGLONG llTimestamp,
+                IMFSample * sample) override;
+            IFACEMETHODIMP OnEvent(DWORD sidx, IMFMediaEvent * event) override;
+            IFACEMETHODIMP OnFlush(DWORD) override;
+
         private:
             std::weak_ptr<wmf_uvc_device> _owner;
-            long _refCount = 0;
         };
 
     }

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -8,7 +8,7 @@
 
 #include <mfidl.h>
 #include <mfreadwrite.h>
-#include <atlcomcli.h>
+#include <wrl/client.h>
 #include <strmif.h>
 #include <Ks.h>
 #include <ksproxy.h>
@@ -107,9 +107,9 @@ namespace librealsense
             void check_connection() const;
             void close_all();
             IKsControl* get_ks_control(const extension_unit& xu) const;
-            CComPtr<IMFAttributes> create_device_attrs();
-            CComPtr<IMFAttributes> create_reader_attrs();
-            void foreach_profile(std::function<void(const mf_profile& profile, CComPtr<IMFMediaType> media_type, bool& quit)> action) const;
+            Microsoft::WRL::ComPtr<IMFAttributes> create_device_attrs();
+            Microsoft::WRL::ComPtr<IMFAttributes> create_reader_attrs();
+            void foreach_profile(std::function<void(const mf_profile& profile, Microsoft::WRL::ComPtr<IMFMediaType> media_type, bool& quit)> action) const;
 
             void set_d0();
             void set_d3();
@@ -120,14 +120,14 @@ namespace librealsense
             const uvc_device_info                   _info;
             power_state                             _power_state = D3;
 
-            CComPtr<IMFSourceReader>                _reader = nullptr;
-            CComPtr<IMFMediaSource>                 _source = nullptr;
-            CComPtr<IMFAttributes>                  _device_attrs = nullptr;
-            CComPtr<IMFAttributes>                  _reader_attrs = nullptr;
+            Microsoft::WRL::ComPtr<IMFSourceReader>                _reader = nullptr;
+            Microsoft::WRL::ComPtr<IMFMediaSource>                 _source = nullptr;
+            Microsoft::WRL::ComPtr<IMFAttributes>                  _device_attrs = nullptr;
+            Microsoft::WRL::ComPtr<IMFAttributes>                  _reader_attrs = nullptr;
 
-            CComPtr<IAMCameraControl>               _camera_control = nullptr;
-            CComPtr<IAMVideoProcAmp>                _video_proc = nullptr;
-            std::unordered_map<int, CComPtr<IKsControl>>      _ks_controls;
+            Microsoft::WRL::ComPtr<IAMCameraControl>               _camera_control = nullptr;
+            Microsoft::WRL::ComPtr<IAMVideoProcAmp>                _video_proc = nullptr;
+            std::unordered_map<int, Microsoft::WRL::ComPtr<IKsControl>>      _ks_controls;
 
             auto_reset_event                        _is_flushed;
             manual_reset_event                      _has_started;

--- a/src/win/win-helpers.h
+++ b/src/win/win-helpers.h
@@ -20,16 +20,6 @@ namespace librealsense
 {
     namespace platform
     {
-        template <class T>
-        static void safe_release(T& ppT)
-        {
-            if (ppT)
-            {
-                ppT.Release();
-                ppT = NULL;
-            }
-        }
-
         bool is_win10_redstone2();
 
         std::vector<std::string> tokenize(std::string string, char separator);


### PR DESCRIPTION
## Summary

PR #3 of 3 in the **src/mf/ Windows-backend modernization** stack. **Stacked on top of #15000** (which is stacked on #14999) — review the *last commit only* for this PR's changes.

### What this PR does

Replace two hand-rolled `IUnknown` implementations with `Microsoft::WRL::RuntimeClass<>`. WRL ships in the Windows 8 SDK, so this is fully compatible with the project's OS support floor of **Windows 10 build 15063 (1703)**.

**`source_reader_callback`** (`mf-uvc.h`, `mf-uvc.cpp`)
- Was: derived directly from `IMFSourceReaderCallback`, with hand-rolled `QueryInterface` (using `QITAB` + `QISearch`), `AddRef` / `Release` (via `InterlockedIncrement` / `Decrement` and explicit `delete this`), and a manual `_refCount` field.
- Now: derives from `Microsoft::WRL::RuntimeClass<RuntimeClassFlags<ClassicCom>, IMFSourceReaderCallback>`. WRL provides `IUnknown` for free. Methods are tagged `IFACEMETHODIMP` instead of `STDMETHODIMP`.
- Construction in `create_reader_attrs` uses `Microsoft::WRL::Make<source_reader_callback>(...)` instead of raw `new` + `static_cast<IUnknown*>`.

**`sensor_events`** (`mf-hid.cpp`)
- Was: derived from `ISensorEvents` with hand-rolled `QueryInterface`, `AddRef`, `Release`, and a manual `m_cRef` field — same pattern, ~45 lines of boilerplate.
- Now: same `RuntimeClass<RuntimeClassFlags<ClassicCom>, ISensorEvents>` migration. Empty handler bodies (`OnEvent`, `OnLeave`) collapsed to one-liners.
- Construction in `wmf_hid_device::start_capture` uses `Make<sensor_events>(...)` and assigns directly into `_cb` (`ComPtr<ISensorEvents>`).

### Why this matters

- Removes ~80 lines of subtle, easy-to-mis-implement boilerplate (refcount races, missing entries in `QITAB`, etc.)
- Construction goes through `Make<>` which never leaves the object at refcount 0 in user code
- Aligns with the rest of the file, which is now using `WRL::ComPtr` after PR #1

### Net diff

38 insertions, 123 deletions across 3 files.

### Validation

- Compiles clean on MSVC 2022 / Windows SDK 10
- Source reader still fires `OnReadSample` and `OnFlush` on stream start / stop / flush cycles
- HID `sensor_events` still fires `OnDataUpdated` for IMU samples
- No refcount drift across stream open/close/open in a debug build

### Stack

1. PR #1 — `mf-cleanup`           →  #14999
2. PR #2 — `mf-watcher-cleanup`   →  #15000  (stacked on #14999)
3. **PR #3 — `mf-runtimeclass-callbacks` (this one)**  (stacked on #15000)

This PR's diff against `development` includes the prior two PRs' commits. To see only this PR's changes, compare `mf-watcher-cleanup...mf-runtimeclass-callbacks`.
