### PR TITLE
Enable Depth and RGB on Intel IPU6/IPU7 Upstream

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -3182,7 +3182,13 @@ namespace librealsense
             // Extract the control group from the underlying control query
             v4l2_ext_controls ctrls_block { control.id&0xffff0000, 1, 0, 0, 0, &control};
 
-            if (xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block) < 0)
+            int rc = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+
+            if (rc < 0)
             {
                 if (errno == EIO || errno == EAGAIN) // TODO: Log?
                     return false;
@@ -3207,7 +3213,13 @@ namespace librealsense
 
             // Extract the control group from the underlying control query
             v4l2_ext_controls ctrls_block{ control.id & 0xffff0000, 1, 0, 0, 0, &control };
-            if (xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block) < 0)
+            int rc = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+
+            if (rc < 0)
             {
                 if (errno == EIO || errno == EAGAIN) // TODO: Log?
                     return false;
@@ -3334,7 +3346,12 @@ namespace librealsense
 
             struct v4l2_query_ext_ctrl query = {};
             query.id = get_cid(option);
-            if (xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query) < 0)
+            int rc = xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            if (rc < 0)
             {
                 // Some controls (exposure, auto exposure, auto hue) do not seem to work on V4L2
                 // Instead of throwing an error, return an empty range. This will cause this control to be omitted on our UI sample.

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -51,6 +51,7 @@
 #include <linux/media.h>
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
+#include <linux/v4l2-subdev.h>
 #include <regex>
 #include <list>
 
@@ -321,6 +322,15 @@ namespace librealsense
         buffer::buffer(int fd, v4l2_buf_type type, bool use_memory_map, uint32_t index)
             : _type(type), _use_memory_map(use_memory_map), _index(index)
         {
+            // Get and store the negotiated format
+            v4l2_format g_fmt = {};
+            g_fmt.type = _type;
+            if (xioctl(fd, VIDIOC_G_FMT, &g_fmt) < 0)
+            {
+                throw linux_backend_exception("xioctl(VIDIOC_G_FMT) failed");
+            }
+            _stride = g_fmt.fmt.pix.bytesperline;
+
             v4l2_buffer buf = {};
             struct v4l2_plane planes[VIDEO_MAX_PLANES] = {};
             buf.type = _type;
@@ -343,6 +353,7 @@ namespace librealsense
                 _offset = buf.m.planes[0].m.mem_offset;
                 md_extra = 0;
             }
+
             _length = _original_length + md_extra;
 
             if (use_memory_map)
@@ -1017,6 +1028,20 @@ namespace librealsense
             if (fd < 0)
                 throw linux_backend_exception("Mipi device PID could not be found");
 
+            // On Intel IPU6/IPU7 upstream pipelines controls are not propagated
+            // from the capture (video) node to the actual subdev, so the GVD
+            // ioctl below has to be issued on the subdev. Derive the subdev node
+            // path from the video node path:
+            //    /dev/video-rs-depth-0 -> /dev/video-rs-depth-sd-0
+            int sub_fd = -1;
+            {
+                std::string sub_path = dev_name;
+                auto pos = sub_path.rfind('-');
+                if (pos != std::string::npos)
+                    sub_path.insert(pos, "-sd");
+                sub_fd = open(sub_path.c_str(), O_RDWR);
+            }
+
             uint8_t gvd[276];
             struct v4l2_ext_control ctrl;
 
@@ -1036,7 +1061,10 @@ namespace librealsense
             bool opcode_ok = false;
             while (!opcode_ok && retries--)
             {
-                if (xioctl(fd, VIDIOC_G_EXT_CTRLS, &ext) == 0)
+                int rc = xioctl(fd, VIDIOC_G_EXT_CTRLS, &ext);
+                if (rc != 0 && sub_fd >= 0)
+                    rc = xioctl(sub_fd, VIDIOC_G_EXT_CTRLS, &ext);
+                if (rc == 0)
                 {
                     auto opcode = gvd[0];
                     if (opcode != 0x10)
@@ -1077,6 +1105,8 @@ namespace librealsense
                 std::this_thread::sleep_for( std::chrono::milliseconds(100));
             }
 
+            if (sub_fd >= 0)
+                ::close(sub_fd);
             ::close(fd);
 
             return device_pid;
@@ -1287,15 +1317,16 @@ namespace librealsense
                     int vfd = -1;
                     std::string device_path = "video-rs-" + vs + "-" + std::to_string(i);
                     std::string device_md_path = "video-rs-" + vs + "-md-" + std::to_string(i);
+                    std::string subdevice_path = "video-rs-" + vs + "-sd-" + std::to_string(i);
                     std::string video_path = "/dev/" + device_path;
                     std::string video_md_path = "/dev/" + device_md_path;
+                    std::string subdev_path = "/dev/" + subdevice_path;
                     std::string dfu_device_path = "/dev/d4xx-dfu-" + std::to_string(i);
                     uvc_device_info info{};
 
                     // Get Video node
                     // Check if file on video_path is exists
                     vfd = open(video_path.c_str(), O_RDONLY | O_NONBLOCK);
-
                     if (vfd < 0) // file does not exists, continue to the next one
                         continue;
                     else
@@ -1310,9 +1341,16 @@ namespace librealsense
                         continue;
                     }
 
+                    // Get Sub Device Node
+                    vfd = open(subdev_path.c_str(), O_RDONLY | O_NONBLOCK);
+                    if (vfd >= 0)
+                    {
+                        ::close(vfd); // file exists, close file and continue to assign it
+                        info.subdev_name = subdev_path;
+                    }
+
                     // Get DFU node for MIPI camera
                     vfd = open(dfu_device_path.c_str(), O_RDONLY | O_NONBLOCK);
-
                     if (vfd >= 0) {
                         ::close(vfd); // file exists, close file and continue to assign it
                         info.dfu_device_path = dfu_device_path;
@@ -1544,7 +1582,9 @@ namespace librealsense
 
         v4l_uvc_device::v4l_uvc_device(const uvc_device_info& info, bool use_memory_map)
             : _name(info.id), 
+              _subdev_name(info.subdev_name),
               _device_path(info.device_path),
+              _subdevice_path(info.subdevice_path),
               _device_usb_spec(info.conn_spec),
               _info(info),
               _is_capturing(false),
@@ -1579,62 +1619,89 @@ namespace librealsense
                 v4l2_fmtdesc pixel_format = {};
                 pixel_format.type = _dev.buf_type;
 
-                while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
+                if (_sub_fd > 0)
                 {
-                    v4l2_frmsizeenum frame_size = {};
-                    frame_size.pixel_format = pixel_format.pixelformat;
-
-                    uint32_t fourcc = (const big_endian<int> &)pixel_format.pixelformat;
-
-                    if (pixel_format.pixelformat == 0)
+                    v4l2_subdev_mbus_code_enum pixel_format_subdev = {};
+                    pixel_format_subdev.index = 0;
+                    pixel_format_subdev.pad = 0;
+                    while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
                     {
-                        // Microsoft Depth GUIDs for R400 series are not yet recognized
-                        // by the Linux kernel, but they do not require a patch, since there
-                        // are "backup" Z16 and Y8 formats in place
-                        static const std::set<std::string> pending_formats = {
-                            "00000050-0000-0010-8000-00aa003",
-                            "00000032-0000-0010-8000-00aa003",
-                        };
+                        uint32_t temp_fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+                        uint32_t fourcc = (const big_endian<int> &)temp_fourcc;
+                        ++pixel_format_subdev.index;
+                    }
+                }
+                else {
+                    while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
+                    {
+                        v4l2_frmsizeenum frame_size = {};
+                        frame_size.pixel_format = pixel_format.pixelformat;
 
-                        if (std::find(pending_formats.begin(),
-                                      pending_formats.end(),
-                                      (const char*)pixel_format.description) ==
-                            pending_formats.end())
+                        uint32_t fourcc = (const big_endian<int> &)pixel_format.pixelformat;
+
+                        if (pixel_format.pixelformat == 0)
                         {
-                            const std::string s(rsutils::string::from() << "!" << pixel_format.description);
-                            std::regex rgx("!([0-9a-f]+)-.*");
-                            std::smatch match;
+                            // Microsoft Depth GUIDs for R400 series are not yet recognized
+                            // by the Linux kernel, but they do not require a patch, since there
+                            // are "backup" Z16 and Y8 formats in place
+                            static const std::set<std::string> pending_formats = {
+                                "00000050-0000-0010-8000-00aa003",
+                                "00000032-0000-0010-8000-00aa003",
+                            };
 
-                            if (std::regex_search(s.begin(), s.end(), match, rgx))
+                            if (std::find(pending_formats.begin(),
+                                        pending_formats.end(),
+                                        (const char*)pixel_format.description) ==
+                                pending_formats.end())
                             {
-                                std::stringstream ss;
-                                ss <<  match[1];
-                                int id;
-                                ss >> std::hex >> id;
-                                fourcc = (const big_endian<int> &)id;
+                                const std::string s(rsutils::string::from() << "!" << pixel_format.description);
+                                std::regex rgx("!([0-9a-f]+)-.*");
+                                std::smatch match;
 
-                                if (fourcc == profile.format)
+                                if (std::regex_search(s.begin(), s.end(), match, rgx))
                                 {
-                                    throw linux_backend_exception(rsutils::string::from() << "The requested pixel format '"  << fourcc_to_string(id)
-                                                                  << "' is not natively supported by the running Linux kernel and likely requires a patch");
+                                    std::stringstream ss;
+                                    ss <<  match[1];
+                                    int id;
+                                    ss >> std::hex >> id;
+                                    fourcc = (const big_endian<int> &)id;
+
+                                    if (fourcc == profile.format)
+                                    {
+                                        throw linux_backend_exception(rsutils::string::from() << "The requested pixel format '"  << fourcc_to_string(id)
+                                                                    << "' is not natively supported by the running Linux kernel and likely requires a patch");
+                                    }
                                 }
                             }
                         }
+                        ++pixel_format.index;
                     }
-                    ++pixel_format.index;
                 }
-
                 set_format(profile);
 
                 v4l2_streamparm parm = {};
                 parm.type = _dev.buf_type;
-                if(xioctl(_fd, VIDIOC_G_PARM, &parm) < 0)
-                    throw linux_backend_exception("xioctl(VIDIOC_G_PARM) failed");
 
-                parm.parm.capture.timeperframe.numerator = 1;
-                parm.parm.capture.timeperframe.denominator = profile.fps;
-                if(xioctl(_fd, VIDIOC_S_PARM, &parm) < 0)
-                    throw linux_backend_exception("xioctl(VIDIOC_S_PARM) failed");
+                v4l2_subdev_frame_interval frame_interval = {};
+                frame_interval.pad = 0;
+
+                if(xioctl(_fd, VIDIOC_G_PARM, &parm) < 0) {
+                    if(xioctl(_sub_fd, VIDIOC_SUBDEV_G_FRAME_INTERVAL, &frame_interval) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_G_PARM) and xioctl(VIDIOC_SUBDEV_G_FRAME_INTERVAL) failed");
+
+                    frame_interval.interval.numerator = 1;
+                    frame_interval.interval.denominator = profile.fps;
+
+                    if(xioctl(_sub_fd, VIDIOC_SUBDEV_S_FRAME_INTERVAL, &frame_interval) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_SUBDEV_S_FRAME_INTERVAL) failed");
+
+                } else {
+                    parm.parm.capture.timeperframe.numerator = 1;
+                    parm.parm.capture.timeperframe.denominator = profile.fps;
+
+                    if(xioctl(_fd, VIDIOC_S_PARM, &parm) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_S_PARM) failed");
+                }
 
                 // Init memory mapped IO
                 negotiate_kernel_buffers(static_cast<size_t>(buffers));
@@ -1880,7 +1947,6 @@ namespace librealsense
                             }
                             auto buffer = _buffers[buf.index];
                             buf_mgr.handle_buffer(e_video_buf, _fd, buf, buffer);
-
                             if (_is_started)
                             {
                                 if(buf.bytesused == 0)
@@ -1890,7 +1956,7 @@ namespace librealsense
                                 }
 
                                 // Drop partial and overflow frames (assumes D4XX metadata only)
-                                bool partial_frame = (!compressed_format && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE));
+                                bool partial_frame = (!compressed_format && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE - buffer->get_stride()));
                                 bool overflow_frame = (buf.bytesused ==  buffer->get_length_frame_only() + MAX_META_DATA_SIZE);
                                 if (_dev.buf_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
                                     /* metadata size is one line of profile, temporary disable validation */
@@ -2360,15 +2426,122 @@ namespace librealsense
 
             return range;
         }
+        uint32_t v4l_uvc_device::mbus_code_to_fourcc(uint32_t mbus_code) const
+        {
+            // Common media bus code to fourcc mappings
+            switch (mbus_code) {
+                // RGB formats
+                case MEDIA_BUS_FMT_RGB888_1X24:
+                    return V4L2_PIX_FMT_RGB24;
+                case MEDIA_BUS_FMT_BGR888_1X24:
+                    return V4L2_PIX_FMT_BGR24;
+                // YUV formats
+                case MEDIA_BUS_FMT_YUYV8_2X8:
+                case MEDIA_BUS_FMT_YUYV8_1X16:
+                    //return V4L2_PIX_FMT_YUYV;
+                    return 0x59555956;
+                case MEDIA_BUS_FMT_UYVY8_2X8:
+                case MEDIA_BUS_FMT_UYVY8_1X16:
+                    return V4L2_PIX_FMT_UYVY;
+                case MEDIA_BUS_FMT_VYUY8_1X16:
+                    return V4L2_PIX_FMT_VYUY;
+                // RAW/Bayer formats
+                case MEDIA_BUS_FMT_SBGGR8_1X8:
+                    return V4L2_PIX_FMT_SBGGR8;
+                case MEDIA_BUS_FMT_SGBRG8_1X8:
+                    return V4L2_PIX_FMT_SGBRG8;
+                case MEDIA_BUS_FMT_SGRBG8_1X8:
+                    return V4L2_PIX_FMT_SGRBG8;
+                case MEDIA_BUS_FMT_SRGGB8_1X8:
+                    return V4L2_PIX_FMT_SRGGB8;
+                case MEDIA_BUS_FMT_SBGGR10_1X10:
+                    return V4L2_PIX_FMT_SBGGR10;
+                case MEDIA_BUS_FMT_SGBRG10_1X10:
+                    return V4L2_PIX_FMT_SGBRG10;
+                case MEDIA_BUS_FMT_SGRBG10_1X10:
+                    return V4L2_PIX_FMT_SGRBG10;
+                case MEDIA_BUS_FMT_SRGGB10_1X10:
+                    return V4L2_PIX_FMT_SRGGB10;
+                // Grayscale formats
+                case MEDIA_BUS_FMT_Y8_1X8:
+                    return V4L2_PIX_FMT_GREY;
+                case MEDIA_BUS_FMT_Y10_1X10:
+                    return V4L2_PIX_FMT_Y10;
+                case MEDIA_BUS_FMT_Y12_1X12:
+                    return V4L2_PIX_FMT_Y12;
 
+                // RealSense specific formats (if they exist)
+                case MEDIA_BUS_FMT_FIXED:
+                    return 0x5A313620; // 'Z16 ' in little-endian
+
+                default:
+                    return 0; // Unknown format
+            }
+        }
         std::vector<stream_profile> v4l_uvc_device::get_profiles() const
         {
             std::vector<stream_profile> results;
-
             // Retrieve the caps one by one, first get pixel format, then sizes, then
             // frame rates. See http://linuxtv.org/downloads/v4l-dvb-apis for reference.
+
+            if (_sub_fd > 0) {
+                std::vector<uint32_t> supported_mbus_codes;
+                // Get video node supported formats
+                std::set<uint32_t> video_fourccs;
+                v4l2_fmtdesc pixel_format = {};
+                pixel_format.type = _dev.buf_type;
+                pixel_format.index = 0;
+                while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0) {
+                   video_fourccs.insert(pixel_format.pixelformat);
+                    ++pixel_format.index;
+                }
+
+                v4l2_subdev_mbus_code_enum pixel_format_subdev = {};
+                pixel_format_subdev.pad = 0;
+                pixel_format_subdev.index = 0;
+
+                while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
+                {
+                    uint32_t fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+
+                    v4l2_subdev_frame_size_enum frame_size = {};
+                    frame_size.pad = 0;
+                    frame_size.code = pixel_format_subdev.code;
+                    frame_size.index = 0;
+                    while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_FRAME_SIZE, &frame_size) == 0)
+                    {
+                        v4l2_subdev_frame_interval_enum frame_interval = {};
+                        frame_interval.pad = 0;
+                        frame_interval.code = pixel_format_subdev.code;
+                        frame_interval.width = frame_size.max_width;
+                        frame_interval.height = frame_size.max_height;
+                        frame_interval.index = 0;
+
+                        while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_FRAME_INTERVAL, &frame_interval) == 0)
+                        {
+                            auto fps =
+                                static_cast<float>(frame_interval.interval.denominator) /
+                                static_cast<float>(frame_interval.interval.numerator);
+
+                            stream_profile p{};
+
+                            p.format = fourcc;
+                            p.width = frame_size.max_width;
+                            p.height = frame_size.max_height;
+                            p.fps = fps;
+                            results.push_back(p);
+                            ++frame_interval.index;
+                        }
+                        ++frame_size.index;
+                    }
+                    ++pixel_format_subdev.index;
+                }
+                return results;
+            }
+
             v4l2_fmtdesc pixel_format = {};
             pixel_format.type = _dev.buf_type;
+
             while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
             {
                 v4l2_frmsizeenum frame_size = {};
@@ -2553,6 +2726,11 @@ namespace librealsense
             _fd = open(_name.c_str(), O_RDWR | O_NONBLOCK, 0);
             if(_fd < 0)
                 throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot open '" << _name);
+
+            _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
+            if(_sub_fd < 0)
+                printf("%s: Failed to open %s\n", __FUNCTION__, _subdev_name.c_str());
+                //throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot open subdev '" << _subdev_name);
 
             if (pipe(_stop_pipe_fd) < 0)
                 throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot create pipe!");
@@ -2895,7 +3073,6 @@ namespace librealsense
                     meta.height     = 1;
                     memcpy(fmt.fmt.raw_data, &meta, sizeof(meta));
                 }
-
                 if(xioctl(_md_fd, VIDIOC_S_FMT, &fmt) >= 0)
                 {
                     LOG_INFO("Metadata node was successfully configured to " << fourcc_to_string(request) << " format" <<", fd " << std::dec <<_md_fd);
@@ -3065,12 +3242,16 @@ namespace librealsense
             int retVal = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             if (retVal < 0)
             {
-                if (errno == EIO || errno == EAGAIN) // TODO: Log?
-                    return false;
+                retVal = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+                if (retVal < 0)
+                {
+                    if (errno == EIO || errno == EAGAIN) // TODO: Log?
+                        return false;
 
-                throw linux_backend_exception(rsutils::string::from()
-                                              << "xioctl(VIDIOC_S_EXT_CTRLS) failed on control "
-                                              << static_cast< int >( control ) << ", errno=" << errno );
+                    throw linux_backend_exception(rsutils::string::from()
+                                                  << "xioctl(VIDIOC_S_EXT_CTRLS) failed on control "
+                                                  << static_cast< int >( control ) << ", errno=" << errno );
+                }
             }
             return true;
         }
@@ -3090,8 +3271,12 @@ namespace librealsense
                 int ret = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ext);
                 if (ret < 0)
                 {
-                    // exception is thrown if the ioctl fails twice
-                    continue;
+                    ret = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ext);
+                    if (ret < 0)
+                    {
+                        // exception is thrown if the ioctl fails twice
+                        continue;
+                    }
                 }
 
                 if (control == RS_ENABLE_AUTO_EXPOSURE)
@@ -3116,8 +3301,9 @@ namespace librealsense
             v4l2_query_ext_ctrl xctrl_query{};
             xctrl_query.id = xu_to_cid(xu,control);
 
-            if(0 > ioctl(_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query)){
-                throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
+            if(0 > ioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &xctrl_query)){
+                if (0 > ioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &xctrl_query))
+                    throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
             }
 
             if ((xctrl_query.elems !=1 ) ||

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2740,7 +2740,7 @@ namespace librealsense
 
             _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
             if(_sub_fd < 0)
-                LOG_WARNING( __FUNCTION__ << ": Failed to open subdev '" << _subdev_name
+                LOG_DEBUG( __FUNCTION__ << ": Failed to open subdev '" << _subdev_name
                             << "' (non-fatal, subdev controls will be unavailable)" );
             // sub_fd is only fatal for Intel IPU6/IPU7 upstream. Avoid throw here for other platforms.
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1037,9 +1037,13 @@ namespace librealsense
             {
                 std::string sub_path = dev_name;
                 auto pos = sub_path.rfind('-');
-                if (pos != std::string::npos)
+                if (pos != std::string::npos) {
                     sub_path.insert(pos, "-sd");
-                sub_fd = open(sub_path.c_str(), O_RDWR);
+                    sub_fd = open(sub_path.c_str(), O_RDWR);
+                } else {
+                    LOG_WARNING("Could not derive subdev path from " << dev_name);
+                    sub_fd = -1;
+                }
             }
 
             uint8_t gvd[276];
@@ -1619,13 +1623,15 @@ namespace librealsense
                 v4l2_fmtdesc pixel_format = {};
                 pixel_format.type = _dev.buf_type;
 
-                if (_sub_fd > 0)
+                if (_sub_fd >= 0)
                 {
                     v4l2_subdev_mbus_code_enum pixel_format_subdev = {};
                     pixel_format_subdev.index = 0;
                     pixel_format_subdev.pad = 0;
                     while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
                     {
+                        // subdev only returns mbus code. Convert it to fourcc using mbus_code_to_fourcc, but system only returns little-endian.
+                        // results is expecting big_endian, so convert it again into big_endian.
                         uint32_t temp_fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
                         uint32_t fourcc = (const big_endian<int> &)temp_fourcc;
                         ++pixel_format_subdev.index;
@@ -1686,7 +1692,9 @@ namespace librealsense
                 frame_interval.pad = 0;
 
                 if(xioctl(_fd, VIDIOC_G_PARM, &parm) < 0) {
-                    if(xioctl(_sub_fd, VIDIOC_SUBDEV_G_FRAME_INTERVAL, &frame_interval) < 0)
+                    if (_sub_fd < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_G_PARM) failed and no subdev to query frame interval");
+                    else if(xioctl(_sub_fd, VIDIOC_SUBDEV_G_FRAME_INTERVAL, &frame_interval) < 0)
                         throw linux_backend_exception("xioctl(VIDIOC_G_PARM) and xioctl(VIDIOC_SUBDEV_G_FRAME_INTERVAL) failed");
 
                     frame_interval.interval.numerator = 1;
@@ -1956,6 +1964,9 @@ namespace librealsense
                                 }
 
                                 // Drop partial and overflow frames (assumes D4XX metadata only)
+                                // For Intel IPU6/IPU7 upstream driver, there is extra padding when the buffer is first queued into the driver in order to meet IPU ISYS and DMA alignment requirements. 
+                                // This caused the actual byteused is always one stride shorter than the queued buffer.
+                                // Without this relaxation, the frame will always be marked as 99% frame, even though the actual video payload is fully present.
                                 bool partial_frame = (!compressed_format && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE - buffer->get_stride()));
                                 bool overflow_frame = (buf.bytesused ==  buffer->get_length_frame_only() + MAX_META_DATA_SIZE);
                                 if (_dev.buf_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
@@ -2438,8 +2449,7 @@ namespace librealsense
                 // YUV formats
                 case MEDIA_BUS_FMT_YUYV8_2X8:
                 case MEDIA_BUS_FMT_YUYV8_1X16:
-                    //return V4L2_PIX_FMT_YUYV;
-                    return 0x59555956;
+                    return V4L2_PIX_FMT_YUYV;
                 case MEDIA_BUS_FMT_UYVY8_2X8:
                 case MEDIA_BUS_FMT_UYVY8_1X16:
                     return V4L2_PIX_FMT_UYVY;
@@ -2472,7 +2482,7 @@ namespace librealsense
 
                 // RealSense specific formats (if they exist)
                 case MEDIA_BUS_FMT_FIXED:
-                    return 0x5A313620; // 'Z16 ' in little-endian
+                    return V4L2_PIX_FMT_Z16;
 
                 default:
                     return 0; // Unknown format
@@ -2484,15 +2494,13 @@ namespace librealsense
             // Retrieve the caps one by one, first get pixel format, then sizes, then
             // frame rates. See http://linuxtv.org/downloads/v4l-dvb-apis for reference.
 
-            if (_sub_fd > 0) {
+            if (_sub_fd >= 0) {
                 std::vector<uint32_t> supported_mbus_codes;
                 // Get video node supported formats
-                std::set<uint32_t> video_fourccs;
                 v4l2_fmtdesc pixel_format = {};
                 pixel_format.type = _dev.buf_type;
                 pixel_format.index = 0;
                 while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0) {
-                   video_fourccs.insert(pixel_format.pixelformat);
                     ++pixel_format.index;
                 }
 
@@ -2502,7 +2510,10 @@ namespace librealsense
 
                 while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
                 {
-                    uint32_t fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+                    // subdev only returns mbus code. Convert it to fourcc using mbus_code_to_fourcc, but system only returns little-endian.
+                    // results is expecting big_endian, so convert it again into big_endian.
+                    uint32_t temp_fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+                    uint32_t fourcc = (const big_endian<int> &)temp_fourcc;
 
                     v4l2_subdev_frame_size_enum frame_size = {};
                     frame_size.pad = 0;
@@ -2729,8 +2740,9 @@ namespace librealsense
 
             _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
             if(_sub_fd < 0)
-                printf("%s: Failed to open %s\n", __FUNCTION__, _subdev_name.c_str());
-                //throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot open subdev '" << _subdev_name);
+                LOG_WARNING( __FUNCTION__ << ": Failed to open subdev '" << _subdev_name
+                            << "' (non-fatal, subdev controls will be unavailable)" );
+            // sub_fd is only fatal for Intel IPU6/IPU7 upstream. Avoid throw here for other platforms.
 
             if (pipe(_stop_pipe_fd) < 0)
                 throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot create pipe!");
@@ -3185,8 +3197,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_G_EXT_CTRLS) failed and no subdev to get ext_ctrls from");
                 rc = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+            }
 
             if (rc < 0)
             {
@@ -3216,8 +3231,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_S_EXT_CTRLS) failed and no subdev to set ext_ctrls");
                 rc = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+            }
 
             if (rc < 0)
             {
@@ -3254,6 +3272,9 @@ namespace librealsense
             int retVal = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             if (retVal < 0)
             {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_S_EXT_CTRLS) failed and no subdev to set ext_ctrls");
+
                 retVal = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
                 if (retVal < 0)
                 {
@@ -3283,6 +3304,11 @@ namespace librealsense
                 int ret = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ext);
                 if (ret < 0)
                 {
+                    if (_sub_fd < 0) {
+                        LOG_WARNING("xioctl(VIDIOC_G_EXT_CTRLS) failed and no subdev to get ext_ctrls from");
+                        continue;
+                    }
+
                     ret = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ext);
                     if (ret < 0)
                     {
@@ -3314,6 +3340,10 @@ namespace librealsense
             xctrl_query.id = xu_to_cid(xu,control);
 
             if(0 > ioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &xctrl_query)){
+                if (_sub_fd < 0)
+                    throw linux_backend_exception(rsutils::string::from() <<
+                        "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno << " and no subdev to query ext_ctrls from");
+
                 if (0 > ioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &xctrl_query))
                     throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
             }
@@ -3349,8 +3379,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_QUERY_EXT_CTRL) failed and no subdev to query ext_ctrls from");
                 rc = xioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            }
             if (rc < 0)
             {
                 // Some controls (exposure, auto exposure, auto hue) do not seem to work on V4L2

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -467,7 +467,7 @@ namespace librealsense
             std::vector<int>  _fds;             // list the file descriptors to be monitored during frames polling
             buffers_mgr     _buf_dispatch;      // Holder for partial (MD only) frames that shall be preserved between 'select' calls when polling v4l buffers
             int _fd = 0;
-            int _sub_fd = 0;
+            int _sub_fd = -1;
             frame_drop_monitor _frame_drop_monitor;           // used to check the frames drops kpi
             v4l2_video_md_syncer _video_md_syncer;
             bool _are_device_capabilities_assigned;

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -109,6 +109,7 @@ namespace librealsense
             void close_fd();
 
             std::string _device_path;
+            std::string _subdevice_path;
             uint32_t _timeout;
             int _fildes;
             std::atomic< int > _lock_counter;
@@ -132,6 +133,7 @@ namespace librealsense
 
             uint32_t get_full_length() const { return _length; }
             uint32_t get_length_frame_only() const { return _original_length; }
+            uint32_t get_stride() const { return _stride; }
 
             uint8_t* get_frame_start() const { return _start; }
 
@@ -142,6 +144,7 @@ namespace librealsense
             uint8_t* _start;
             uint32_t _length;
             uint32_t _original_length;
+            uint32_t _stride;
             uint32_t _offset;
             bool _use_memory_map;
             uint32_t _index;
@@ -366,6 +369,7 @@ namespace librealsense
 
             control_range get_pu_range(rs2_option option) const override;
 
+            uint32_t mbus_code_to_fourcc(uint32_t mbus_code) const;
             std::vector<stream_profile> get_profiles() const override;
 
             void lock() const override;
@@ -438,7 +442,9 @@ namespace librealsense
 
             power_state _state = D3;
             std::string _name = "";
+            std::string _subdev_name = "";
             std::string _device_path = "";
+            std::string _subdevice_path = "";
             usb_spec _device_usb_spec = usb_undefined;
             uvc_device_info _info;
 
@@ -461,6 +467,7 @@ namespace librealsense
             std::vector<int>  _fds;             // list the file descriptors to be monitored during frames polling
             buffers_mgr     _buf_dispatch;      // Holder for partial (MD only) frames that shall be preserved between 'select' calls when polling v4l buffers
             int _fd = 0;
+            int _sub_fd = 0;
             frame_drop_monitor _frame_drop_monitor;           // used to check the frames drops kpi
             v4l2_video_md_syncer _video_md_syncer;
             bool _are_device_capabilities_assigned;

--- a/src/platform/uvc-device-info.h
+++ b/src/platform/uvc-device-info.h
@@ -20,6 +20,8 @@ struct uvc_device_info
     uint16_t mi = 0;
     std::string unique_id;
     std::string device_path;
+    std::string subdev_name;
+    std::string subdevice_path;
     std::string dfu_device_path; // for mipi multiple cameras
     std::string serial;
     usb_spec conn_spec = usb_undefined;


### PR DESCRIPTION
Get control from actual subdev instead of propagate from capture node. Include stride in frame calculation.

Validated rs-depth, rs-color, rs-distance, rs-multicam.
