### PR TITLE
Fail fast when enable_only times out waiting for device enumeration

### DIFF
--- a/unit-tests/infra-tests/test_enable_only_timeout.py
+++ b/unit-tests/infra-tests/test_enable_only_timeout.py
@@ -2,13 +2,19 @@
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 """
-Tests that devices.enable_only() raises TimeoutError when the hub recycle
-fails to bring the requested serial back online (i.e. _wait_for returns False).
+Tests that devices.enable_only() raises when it cannot bring the requested
+serials online, instead of silently returning. Covers all three branches:
 
-Before this behavior existed, enable_only would silently swallow the timeout
-and the test fixture would proceed with a non-existent device, surfacing
-later as confusing IndexError / "list index out of range" failures inside
-the test body.
+- hub + recycle: TimeoutError when _wait_for times out
+- no-hub + no-recycle: TimeoutError when _wait_for times out
+- no-hub + recycle: RuntimeError when hw_reset fails (the False return
+  there can mean hardware_reset() raised, devices didn't disappear, or
+  devices didn't reappear — so "timeout" doesn't accurately describe it)
+
+Before this behavior existed, enable_only would silently swallow these
+failures and the test fixture would proceed with a non-existent device,
+surfacing later as confusing IndexError / "list index out of range"
+failures inside the test body.
 """
 
 import types

--- a/unit-tests/infra-tests/test_enable_only_timeout.py
+++ b/unit-tests/infra-tests/test_enable_only_timeout.py
@@ -1,0 +1,48 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests that devices.enable_only() raises TimeoutError when the hub recycle
+fails to bring the requested serial back online (i.e. _wait_for returns False).
+
+Before this behavior existed, enable_only would silently swallow the timeout
+and the test fixture would proceed with a non-existent device, surfacing
+later as confusing IndexError / "list index out of range" failures inside
+the test body.
+"""
+
+import types
+import pytest
+from unittest.mock import MagicMock
+
+import rspy.devices as dev
+
+
+@pytest.fixture
+def fake_hub_with_device(monkeypatch):
+    """Install a fake hub + one fake device on port 4 (D455-like)."""
+    fake_device = types.SimpleNamespace(port=4, serial_number='111')
+    monkeypatch.setattr(dev, '_device_by_sn', {'111': fake_device})
+    monkeypatch.setattr(dev, 'hub', MagicMock())
+    monkeypatch.setattr(dev, 'enabled', lambda: set())  # nothing enabled => skip the disable branch
+    monkeypatch.setattr(dev, 'time', types.SimpleNamespace(sleep=lambda _: None))
+    return fake_device
+
+
+def test_enable_only_raises_when_wait_for_times_out(monkeypatch, fake_hub_with_device):
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: False)
+    with pytest.raises(TimeoutError, match="did not enumerate"):
+        dev.enable_only(['111'], recycle=True, timeout=1)
+
+
+def test_enable_only_succeeds_when_wait_for_returns_true(monkeypatch, fake_hub_with_device):
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: True)
+    dev.enable_only(['111'], recycle=True, timeout=1)  # no exception
+
+
+def test_enable_only_no_hub_raises_when_wait_for_times_out(monkeypatch):
+    """Without a hub and without recycle, enable_only still waits for enumeration."""
+    monkeypatch.setattr(dev, 'hub', None)
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: False)
+    with pytest.raises(TimeoutError, match="did not enumerate"):
+        dev.enable_only(['111'], recycle=False, timeout=1)

--- a/unit-tests/infra-tests/test_enable_only_timeout.py
+++ b/unit-tests/infra-tests/test_enable_only_timeout.py
@@ -46,3 +46,16 @@ def test_enable_only_no_hub_raises_when_wait_for_times_out(monkeypatch):
     monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: False)
     with pytest.raises(TimeoutError, match="did not enumerate"):
         dev.enable_only(['111'], recycle=False, timeout=1)
+
+
+def test_enable_only_no_hub_recycle_raises_when_hw_reset_times_out(monkeypatch):
+    """No hub + recycle=True: enable_only delegates to hw_reset; timeout should raise."""
+    monkeypatch.setattr(dev, 'hub', None)
+    monkeypatch.setattr(dev, 'time', types.SimpleNamespace(sleep=lambda _: None))
+    monkeypatch.setattr(dev, '_device_by_sn', {
+        '111': types.SimpleNamespace(port=None, is_dds=False, handle=MagicMock())
+    })
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: False)
+    monkeypatch.setattr(dev, '_wait_until_removed', lambda *a, **kw: True)
+    with pytest.raises(TimeoutError, match="did not enumerate"):
+        dev.enable_only(['111'], recycle=True, timeout=1)

--- a/unit-tests/infra-tests/test_enable_only_timeout.py
+++ b/unit-tests/infra-tests/test_enable_only_timeout.py
@@ -48,8 +48,13 @@ def test_enable_only_no_hub_raises_when_wait_for_times_out(monkeypatch):
         dev.enable_only(['111'], recycle=False, timeout=1)
 
 
-def test_enable_only_no_hub_recycle_raises_when_hw_reset_times_out(monkeypatch):
-    """No hub + recycle=True: enable_only delegates to hw_reset; timeout should raise."""
+def test_enable_only_no_hub_recycle_raises_when_hw_reset_fails(monkeypatch):
+    """No hub + recycle=True: enable_only delegates to hw_reset; failure should raise.
+
+    hw_reset can return False for several reasons (hardware_reset() raised, devices
+    didn't disappear, devices didn't reappear) — so we raise RuntimeError, not
+    TimeoutError, since "timeout" doesn't accurately describe all of them.
+    """
     monkeypatch.setattr(dev, 'hub', None)
     monkeypatch.setattr(dev, 'time', types.SimpleNamespace(sleep=lambda _: None))
     monkeypatch.setattr(dev, '_device_by_sn', {
@@ -57,5 +62,5 @@ def test_enable_only_no_hub_recycle_raises_when_hw_reset_times_out(monkeypatch):
     })
     monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: False)
     monkeypatch.setattr(dev, '_wait_until_removed', lambda *a, **kw: True)
-    with pytest.raises(TimeoutError, match="did not enumerate"):
+    with pytest.raises(RuntimeError, match="hw_reset failed"):
         dev.enable_only(['111'], recycle=True, timeout=1)

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -634,7 +634,8 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         #
     elif recycle:
         #
-        hw_reset( serial_numbers )
+        if not hw_reset( serial_numbers, timeout = timeout ):
+            raise TimeoutError( f'devices did not enumerate within {timeout}s after hw_reset: {serial_numbers}' )
         #
     else:
         log.d( 'no hub; ports left as-is' )

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -629,7 +629,8 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
             else:
                 log.d( 'no hub ports to enable; leaving hub as-is' )
         #
-        _wait_for( serial_numbers, timeout = timeout )
+        if not _wait_for( serial_numbers, timeout = timeout ):
+            raise TimeoutError( f'devices did not enumerate within {timeout}s after hub enable: {serial_numbers}' )
         #
     elif recycle:
         #
@@ -638,7 +639,8 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
     else:
         log.d( 'no hub; ports left as-is' )
         # even without reset, enable_only should wait for the devices to be available again
-        _wait_for(serial_numbers, timeout=timeout)
+        if not _wait_for( serial_numbers, timeout = timeout ):
+            raise TimeoutError( f'devices did not enumerate within {timeout}s: {serial_numbers}' )
 
 
 def enable_all():

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -635,7 +635,7 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
     elif recycle:
         #
         if not hw_reset( serial_numbers, timeout = timeout ):
-            raise TimeoutError( f'devices did not enumerate within {timeout}s after hw_reset: {serial_numbers}' )
+            raise RuntimeError( f'hw_reset failed for: {serial_numbers}' )
         #
     else:
         log.d( 'no hub; ports left as-is' )

--- a/wrappers/rest-api/tests/test_api_service.py
+++ b/wrappers/rest-api/tests/test_api_service.py
@@ -614,7 +614,7 @@ class TestRealSenseAPIIntegration:
 
         # First get devices
         response = real_client.get("/api/devices")
-
+        assert response.status_code == 200, f"/api/devices returned {response.status_code}: {response.text}"
 
         devices = response.json()
         assert devices, "/api/devices returned no devices — hub/USB enumeration likely failed"
@@ -651,7 +651,7 @@ class TestRealSenseAPIIntegration:
 
         # First get devices
         response = real_client.get("/api/devices")
-
+        assert response.status_code == 200, f"/api/devices returned {response.status_code}: {response.text}"
 
         devices = response.json()
         assert devices, "/api/devices returned no devices — hub/USB enumeration likely failed"

--- a/wrappers/rest-api/tests/test_api_service.py
+++ b/wrappers/rest-api/tests/test_api_service.py
@@ -448,6 +448,7 @@ class TestRealSenseAPIIntegration:
 
         # Create a real RealSenseManager (not mocked)
         manager = RealSenseManager(sio)
+        assert manager.get_devices(), "RealSenseManager sees no devices — hub/USB enumeration likely failed"
         return manager
 
     def test_get_device_rs(self, real_rs_manager):
@@ -616,6 +617,7 @@ class TestRealSenseAPIIntegration:
 
 
         devices = response.json()
+        assert devices, "/api/devices returned no devices — hub/USB enumeration likely failed"
         device_id = devices[0]["device_id"]
 
         # Test sensors endpoint
@@ -652,6 +654,7 @@ class TestRealSenseAPIIntegration:
 
 
         devices = response.json()
+        assert devices, "/api/devices returned no devices — hub/USB enumeration likely failed"
 
         device_id = devices[0]["device_id"]
 


### PR DESCRIPTION
## Summary

When the Acroname hub recycle on a CI agent fails to bring a device back online, `enable_only` was silently returning instead of raising. The `module_device_setup` fixture would then yield a serial that wasn't actually present, surfacing later as confusing failures inside test bodies (e.g. `IndexError: list index out of range` on `devices[0]` in the rest-api wrapper).

This was masking a real DevOps issue on `vtglnx163.iil.intel.com`: across libci 15478 (Linux 11361) and 15479 (Linux 11362), every D455/D435 USB test errored after the hub recycle, while every D555 (DDS, no hub) test passed.

### Changes
- `unit-tests/py/rspy/devices.py` — `enable_only` raises `TimeoutError` when `_wait_for` returns False (both hub and no-hub paths). The conftest fixture and `run-unit-tests.py` already wrap the call in try/except, so the new exception turns into clean `pytest.fail(...)` / red test output instead of a misleading "Device enabled and ready" message followed by mystery failures downstream.
- `unit-tests/infra-tests/test_enable_only_timeout.py` — three new unit tests covering raise-on-timeout (hub path), raise-on-timeout (no-hub path), and the success path.
- `wrappers/rest-api/tests/test_api_service.py` — `real_rs_manager` fixture now asserts a device is present; the two endpoint-level tests assert `/api/devices` returned a non-empty list. Failures surface as one clear assertion message instead of 5 confusing `IndexError`s.

## Test plan
- [x] `pytest unit-tests/infra-tests/` — 111 passed (108 existing + 3 new)
- [x] libci run on this branch