### PR TITLE
Fix building with pybind11 v3.0.2

### DIFF
--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -148,7 +148,7 @@ void init_frame(py::module &m) {
         .def_property_readonly("frame_number", &rs2::frame::get_frame_number, "The frame number. Identical to calling get_frame_number.")
         .def("get_data_size", &rs2::frame::get_data_size, "Retrieve data size from frame handle.")
         .def("get_data", get_frame_data, "Retrieve data from the frame handle.", py::keep_alive<0, 1>())
-        .def_property_readonly("data", get_frame_data, "Data from the frame handle. Identical to calling get_data.", py::keep_alive<0, 1>())
+        .def_property_readonly("data", py::cpp_function(get_frame_data, "Data from the frame handle. Identical to calling get_data.", py::keep_alive<0, 1>()))
         .def("get_profile", &rs2::frame::get_profile, "Retrieve stream profile from frame handle.")
         .def_property_readonly("profile", &rs2::frame::get_profile, "Stream profile from frame handle. Identical to calling get_profile.")
         .def("keep", &rs2::frame::keep, "Keep the frame, otherwise if no refernce to the frame, the frame will be released.")


### PR DESCRIPTION
pyrealsense2 fails to build with pybind11 v3.0.2

Build error log: https://cache.nixos.org/log/kcry0khph8g0crka6zzkznn8izfvsrq1-librealsense-2.56.3.drv

Cause: https://github.com/pybind/pybind11/pull/5533

I based this fix on https://github.com/NGSolve/netgen/commit/ceacae3844ed2f0c48c8b6a3a82904b16c594f41

I'm not very familiar with pybind11, please double check whether this fix is correct.

<!--
    Pull requests should go to the development branch:
    https://github.com/realsenseai/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/realsenseai/librealsense/blob/master/CONTRIBUTING.md
-->
