### PR TITLE
build skill improved to use parrallel and specific projects

### DIFF
--- a/.github/skills/build.md
+++ b/.github/skills/build.md
@@ -47,15 +47,6 @@ cmake --build . --config Release --parallel --target realsense2
 
 # Build only the viewer
 cmake --build . --config Release --parallel --target realsense-viewer
-
-# Build only examples
-cmake --build . --config Release --parallel --target examples
-```
-
-### List Available Targets
-
-```powershell
-cmake --build . --target help
 ```
 
 ### Install
@@ -90,9 +81,6 @@ make realsense2
 
 # Build only the viewer
 make realsense-viewer
-
-# Build only examples
-make examples
 ```
 
 ### List Available Targets
@@ -135,9 +123,6 @@ make realsense2
 
 # Build only the viewer
 make realsense-viewer
-
-# Build only examples
-make examples
 ```
 
 ### List Available Targets
@@ -159,10 +144,8 @@ sudo make install
 |---|---|
 | `realsense2` | Core library only |
 | `realsense-viewer` | Viewer application |
-| `examples` | All examples |
 | `rs-enumerate-devices` | Device enumeration tool |
 | `rs-fw-update` | Firmware update tool |
-| `unit-tests` | Test executables |
 | `pyrealsense2` | Python bindings |
 
 ## Common CMake Build Flags

--- a/.github/skills/build.md
+++ b/.github/skills/build.md
@@ -20,48 +20,150 @@
 | **Raspberry Pi** | GCC (ARM) | See `doc/installation_raspbian.md` |
 | **Android** | NDK (r20b+) | Cross-compilation; see `doc/android.md` |
 
-## Basic Build (All Platforms)
-
-```bash
-mkdir build && cd build
-cmake ..
-cmake --build . --config Release
-```
-
 ## Windows Build (Visual Studio)
+
+### Full Build
 
 ```powershell
 mkdir build; cd build
 cmake .. -G "Visual Studio 17 2022" -A x64
-cmake --build . --config Release
+cmake --build . --config Release --parallel
 # Or open build/realsense2.sln in Visual Studio
 ```
 
-To install:
+**Note**: Always use `--parallel` flag on Windows for faster parallel builds.
+
+### Build Specific Target
+
+To build only a specific target:
 ```powershell
-cmake --build . --config Release --target install
+cmake --build . --config Release --parallel --target <target-name>
+```
+
+Examples:
+```powershell
+# Build only the core library
+cmake --build . --config Release --parallel --target realsense2
+
+# Build only the viewer
+cmake --build . --config Release --parallel --target realsense-viewer
+
+# Build only examples
+cmake --build . --config Release --parallel --target examples
+```
+
+### List Available Targets
+
+```powershell
+cmake --build . --target help
+```
+
+### Install
+
+```powershell
+cmake --build . --config Release --parallel --target install
 ```
 
 ## Linux Build
+
+### Full Build
 
 ```bash
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
+```
+
+### Build Specific Target
+
+To build only a specific target:
+```bash
+make <target-name>
+# Or with cmake:
+cmake --build . --target <target-name>
+```
+
+Examples:
+```bash
+# Build only the core library
+make realsense2
+
+# Build only the viewer
+make realsense-viewer
+
+# Build only examples
+make examples
+```
+
+### List Available Targets
+
+```bash
+make help
+```
+
+### Install
+
+```bash
 sudo make install
 ```
 
 ## macOS Build
 
+**Note**: macOS requires `FORCE_RSUSB_BACKEND=ON`.
+
+### Full Build
+
 ```bash
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DFORCE_RSUSB_BACKEND=ON
 make -j$(sysctl -n hw.ncpu)
+```
+
+### Build Specific Target
+
+To build only a specific target:
+```bash
+make <target-name>
+# Or with cmake:
+cmake --build . --target <target-name>
+```
+
+Examples:
+```bash
+# Build only the core library
+make realsense2
+
+# Build only the viewer
+make realsense-viewer
+
+# Build only examples
+make examples
+```
+
+### List Available Targets
+
+```bash
+make help
+```
+
+### Install
+
+```bash
 sudo make install
 ```
 
-Note: macOS requires `FORCE_RSUSB_BACKEND=ON`.
 
+## Common Target Reference
+
+| Target | Description |
+|---|---|
+| `realsense2` | Core library only |
+| `realsense-viewer` | Viewer application |
+| `examples` | All examples |
+| `rs-enumerate-devices` | Device enumeration tool |
+| `rs-fw-update` | Firmware update tool |
+| `unit-tests` | Test executables |
+| `pyrealsense2` | Python bindings |
 
 ## Common CMake Build Flags
 
@@ -97,6 +199,11 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DBUILD_PYTHON_BINDINGS=ON \
          -DBUILD_UNIT_TESTS=ON
 cmake --build . --config Release
+```
+
+**On Windows**, always add `--parallel`:
+```powershell
+cmake --build . --config Release --parallel
 ```
 
 ## Example: Build with DDS Support


### PR DESCRIPTION

**Update build.md: Consolidate platform-specific instructions and enable parallel builds on Windows**

**Summary**
Restructured [build.md](vscode-file://vscode-app/c:/Users/rbettan/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to provide more cohesive platform-specific build instructions and ensure Windows builds always use the --parallel flag for optimal performance.

**Changes**
**1. Merged build instructions by platform**

Consolidated "full build" and "specific target build" instructions into unified platform sections
Each platform section (Windows, Linux, macOS) now contains:
Full build instructions
Specific target build instructions with practical examples
How to list available targets
Installation commands

**2. Always enable parallel builds on Windows**

Added --parallel flag to all Windows cmake --build commands
Added explicit notes reminding users to use parallel builds on Windows
This applies to full builds, specific targets, and installation commands

**3. Improved documentation structure**

Removed redundant "Basic Build (All Platforms)" section
Removed separate "Building Specific Projects/Targets" section
Added "Common Target Reference" table for quick lookup
Users can now find all platform-specific information in one place

**Benefits**
Clearer navigation: Users find everything for their platform in a single section
Better performance: Windows builds now default to parallel compilation
More actionable: Concrete examples show how to build specific targets (viewer, core library, examples)
Less repetition: Eliminates jumping between multiple sections for related information

**Example improvements**
Before: Users had to read "Windows Build" section, then scroll to "Building Specific Projects/Targets" section
After: All Windows build scenarios (full, specific targets, install) are in one cohesive section