### PR TITLE
viewer: eliminate UI freeze and slider snap-back on option change

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1973,7 +1973,7 @@ namespace rs2
                                             << "Setting " << opt_model.opt << " to " << new_val << " ("
                                             << labels[selected] << ")");
 
-                                        opt_model.set_option(opt_model.opt, static_cast<float>(new_val));
+                                        opt_model.set_option_async(opt_model.opt, static_cast<float>(new_val));
 
                                         // Only apply preset to GUI if set_option was succesful
                                         selected_file_preset = "";

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1973,7 +1973,7 @@ namespace rs2
                                             << "Setting " << opt_model.opt << " to " << new_val << " ("
                                             << labels[selected] << ")");
 
-                                        opt_model.set_option(opt_model.opt, static_cast<float>(new_val), error_message);
+                                        opt_model.set_option(opt_model.opt, static_cast<float>(new_val));
 
                                         // Only apply preset to GUI if set_option was succesful
                                         selected_file_preset = "";

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -133,13 +133,14 @@ namespace rs2
 
     void on_chip_calib_manager::set_laser_emitter_state( float value )
     {
-        // Use options_model::set_option to update GUI after change
-        std::string ignored_error_message{ "" };
-        auto it = _sub->options_metadata.find( RS2_OPTION_EMITTER_ENABLED );
-        if( it != _sub->options_metadata.end() )  // Option supported
+        // Calibration needs synchronous semantics: write, then read back to verify
+        // the FW actually applied the value. option_model::set_option is now async
+        // (its value_as_float() reads a local user-request cache, so the round-trip
+        // check would always pass) — go through the sensor endpoint directly here.
+        if( _sub->options_metadata.find( RS2_OPTION_EMITTER_ENABLED ) != _sub->options_metadata.end() )
         {
-            it->second.set_option( RS2_OPTION_EMITTER_ENABLED, value, ignored_error_message );
-            if( it->second.value_as_float() != value )
+            _sub->s->set_option( RS2_OPTION_EMITTER_ENABLED, value );
+            if( _sub->s->get_option( RS2_OPTION_EMITTER_ENABLED ) != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set laser " << ( value == off_value ? "off" : "on" ) );
         }
@@ -147,13 +148,11 @@ namespace rs2
 
     void on_chip_calib_manager::set_thermal_loop_state( float value )
     {
-        // Use options_model::set_option to update GUI after change
-        std::string ignored_error_message{ "" };
-        auto it = _sub->options_metadata.find( RS2_OPTION_THERMAL_COMPENSATION );
-        if( it != _sub->options_metadata.end() )  // Option supported
+        // See set_laser_emitter_state for why we bypass option_model here.
+        if( _sub->options_metadata.find( RS2_OPTION_THERMAL_COMPENSATION ) != _sub->options_metadata.end() )
         {
-            it->second.set_option( RS2_OPTION_THERMAL_COMPENSATION, value, ignored_error_message );
-            if( it->second.value_as_float() != value )
+            _sub->s->set_option( RS2_OPTION_THERMAL_COMPENSATION, value );
+            if( _sub->s->get_option( RS2_OPTION_THERMAL_COMPENSATION ) != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set thermal compensation " << ( value == off_value ? "off" : "on" ) );
         }

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -133,13 +133,16 @@ namespace rs2
 
     void on_chip_calib_manager::set_laser_emitter_state( float value )
     {
-        // Calibration needs synchronous semantics: write, then read back to verify
-        // the FW actually applied the value. option_model::set_option is now async
-        // (its value_as_float() reads a local user-request cache, so the round-trip
-        // check would always pass) — go through the sensor endpoint directly here.
-        if( _sub->options_metadata.find( RS2_OPTION_EMITTER_ENABLED ) != _sub->options_metadata.end() )
+        // Route the write through option_model::set_option_sync so it goes via the
+        // subdevice dispatcher — that way the FW write can't interleave with concurrent
+        // UI option writes on the same USB bus. The read-back verify uses the sensor
+        // endpoint directly (a single get_option is harmless to issue outside the
+        // dispatcher; if needed for stricter ordering, a second invoke_and_wait would
+        // do).
+        auto it = _sub->options_metadata.find( RS2_OPTION_EMITTER_ENABLED );
+        if( it != _sub->options_metadata.end() )
         {
-            _sub->s->set_option( RS2_OPTION_EMITTER_ENABLED, value );
+            it->second.set_option_sync( value );
             if( _sub->s->get_option( RS2_OPTION_EMITTER_ENABLED ) != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set laser " << ( value == off_value ? "off" : "on" ) );
@@ -148,10 +151,11 @@ namespace rs2
 
     void on_chip_calib_manager::set_thermal_loop_state( float value )
     {
-        // See set_laser_emitter_state for why we bypass option_model here.
-        if( _sub->options_metadata.find( RS2_OPTION_THERMAL_COMPENSATION ) != _sub->options_metadata.end() )
+        // See set_laser_emitter_state for why we route through option_model::set_option_sync.
+        auto it = _sub->options_metadata.find( RS2_OPTION_THERMAL_COMPENSATION );
+        if( it != _sub->options_metadata.end() )
         {
-            _sub->s->set_option( RS2_OPTION_THERMAL_COMPENSATION, value );
+            it->second.set_option_sync( value );
             if( _sub->s->get_option( RS2_OPTION_THERMAL_COMPENSATION ) != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set thermal compensation " << ( value == off_value ? "off" : "on" ) );

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -135,15 +135,14 @@ namespace rs2
     {
         // Route the write through option_model::set_option_sync so it goes via the
         // subdevice dispatcher — that way the FW write can't interleave with concurrent
-        // UI option writes on the same USB bus. The read-back verify uses the sensor
-        // endpoint directly (a single get_option is harmless to issue outside the
-        // dispatcher; if needed for stricter ordering, a second invoke_and_wait would
-        // do).
+        // UI option writes on the same USB bus. set_option_sync also refreshes the
+        // cached option_model::value before returning, so value_as_float() reads the
+        // post-write value here.
         auto it = _sub->options_metadata.find( RS2_OPTION_EMITTER_ENABLED );
         if( it != _sub->options_metadata.end() )
         {
             it->second.set_option_sync( value );
-            if( _sub->s->get_option( RS2_OPTION_EMITTER_ENABLED ) != value )
+            if( it->second.value_as_float() != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set laser " << ( value == off_value ? "off" : "on" ) );
         }
@@ -156,7 +155,7 @@ namespace rs2
         if( it != _sub->options_metadata.end() )
         {
             it->second.set_option_sync( value );
-            if( _sub->s->get_option( RS2_OPTION_THERMAL_COMPENSATION ) != value )
+            if( it->second.value_as_float() != value )
                 throw std::runtime_error( rsutils::string::from()
                                           << "Failed to set thermal compensation " << ( value == off_value ? "off" : "on" ) );
         }

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -43,79 +43,6 @@ namespace rs2
 
 using namespace rs2;
 
-option_async_setter::option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt, error_callback on_error )
-    : _endpoint( std::move( endpoint ) )
-    , _opt( opt )
-    , _on_error( std::move( on_error ) )
-{
-    _worker = std::thread( [this]() { run(); } );
-}
-
-option_async_setter::~option_async_setter()
-{
-    {
-        std::lock_guard< std::mutex > lock( _mtx );
-        _stop = true;
-    }
-    _cv.notify_all();
-    if( _worker.joinable() )
-        _worker.join();
-}
-
-void option_async_setter::post( float value )
-{
-    {
-        std::lock_guard< std::mutex > lock( _mtx );
-        _pending_value = value;
-        _has_pending = true;
-    }
-    _cv.notify_one();
-}
-
-void option_async_setter::run()
-{
-    while( true )
-    {
-        float value;
-        {
-            std::unique_lock< std::mutex > lock( _mtx );
-            _cv.wait( lock, [this]() { return _has_pending || _stop; } );
-            if( _stop && ! _has_pending )
-                return;
-            value = _pending_value;
-            _has_pending = false;
-        }
-        std::string err_msg;
-        try
-        {
-            _endpoint->set_option( _opt, value );
-        }
-        catch( const rs2::error & e )
-        {
-            // Surface the FW-side reason via the log so silent rejections/clamps are
-            // diagnosable. We also forward to the optional UI callback below so the
-            // notification panel can show the user why their slider snapped back.
-            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
-                                                 << " failed: " << e.what() );
-            err_msg = e.what();
-        }
-        catch( const std::exception & e )
-        {
-            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
-                                                 << " failed: " << e.what() );
-            err_msg = e.what();
-        }
-        catch( ... )
-        {
-            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
-                                                 << " failed with unknown exception" );
-            err_msg = "unknown error";
-        }
-        if( ! err_msg.empty() && _on_error )
-            _on_error( err_msg );
-    }
-}
-
 std::string option_model::adjust_description(const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace)
 {
     std::string adjusted_string(str_in);
@@ -749,47 +676,33 @@ bool option_model::slider_selected( rs2_option opt,
                                     notifications_model & model )
 {
     check_opt( opt, __func__ );
-    // Rate-limit FW writes to at most one per 200 ms while the slider is being
-    // dragged. The worker thread already coalesces post()s, but per-tick posts
-    // would still let the worker write every intermediate value when the FW
-    // round-trip is faster than the drag rate — flooding the bus with values the
-    // user never paused on. Within the throttle window we capture the latest
-    // value into unset_value; slider_unselected dispatches it on release so the
-    // user's final position always reaches the firmware.
+    // Dispatch every UI tick: the dispatcher action coalesces (per-option
+    // _latest_pending_value), and its try_sleep(200ms) enforces the FW-write
+    // floor that used to live in this function. set_option_async is O(atomic-CAS)
+    // when a job is already pending, so per-tick calls are cheap.
+    set_option_async( value );
+    if( invalidate_flag )
+        *invalidate_flag = true;
+    // Throttle the log line to ~5 Hz so the notifications panel stays readable
+    // during a drag. The actual FW writes are throttled independently by the
+    // dispatcher action's try_sleep(200ms).
     if( last_set_stopwatch.get_elapsed() >= std::chrono::milliseconds( 200 ) )
     {
         last_set_stopwatch.reset();
-        set_option_async( value );
-        have_unset_value = false;
-        if( invalidate_flag )
-            *invalidate_flag = true;
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value );
-    }
-    else
-    {
-        unset_value = value;
-        have_unset_value = true;
     }
     return true;
 }
+
 bool option_model::slider_unselected( rs2_option opt,
                                       float /*value*/,
                                       std::string & /*error_message*/,
-                                      notifications_model & model )
+                                      notifications_model & /*model*/ )
 {
     check_opt( opt, __func__ );
-    // Flush the most-recent value captured by slider_selected during the 200 ms
-    // throttle window so the user's final slider position always reaches FW.
-    if( have_unset_value )
-    {
-        last_set_stopwatch.reset();
-        set_option_async( unset_value );
-        have_unset_value = false;
-        if( invalidate_flag )
-            *invalidate_flag = true;
-        model.add_log( rsutils::string::from() << "Setting " << opt << " to " << unset_value );
-        return true;
-    }
+    // No-op. slider_selected dispatches on every tick (cheap, coalesced), so
+    // the user's final position is already in _latest_pending_value and will
+    // be picked up by the dispatcher's next action. No retry-on-release needed.
     return false;
 }
 
@@ -846,13 +759,12 @@ bool option_model::draw_option(bool update_read_only_options,
 void option_model::set_option(rs2_option opt, float req_value)
 {
     check_opt( opt, __func__ );
-    // All UI-thread option writes go through the async worker so the render loop is never
-    // blocked on the FW round-trip (set_option is ~200 ms on UVC; readback is another ~200 ms;
-    // and they serialize on the per-device USB lock against options_watcher's 1 s poll cycle).
-    // No 200 ms gate here: this entry point is reached from checkboxes / combos / edit-text
-    // submit — one click = one write, so there is nothing to throttle. The slider drag path
-    // (slider_selected) keeps an explicit 200 ms gate. We still reset last_set_stopwatch so
-    // a click immediately before a drag doesn't burn the slider's first throttle window.
+    // All UI-thread option writes go through the subdevice dispatcher so the render
+    // loop is never blocked on the FW round-trip (set_option is ~200 ms on UVC;
+    // readback is another ~200 ms; and they serialize on the per-device USB lock
+    // against options_watcher's 1 s poll cycle). The dispatcher's try_sleep(200ms)
+    // after each action enforces a uniform FW-write floor across all entry points
+    // (slider, checkbox, calibration) — no separate per-call rate-limit needed here.
     last_set_stopwatch.reset();
     set_option_async( req_value );
 }
@@ -867,31 +779,6 @@ void option_model::check_opt( rs2_option opt, char const * caller ) const
 
 void option_model::set_option_async( float value )
 {
-    if( ! _async_setter )
-    {
-        // Capture shared_ptrs (not `this`) so the callback is UAF-safe if option_model
-        // is destroyed while the worker is mid-FW-call. ~option_async_setter joins the
-        // worker before its own member fields are destroyed, but option_model's other
-        // members (including _async_state and _has_user_request) may already be gone
-        // by then if the worker called back via `this`.
-        auto state             = _async_state;
-        auto has_user_request  = _has_user_request;
-        _async_setter = std::make_shared< option_async_setter >( endpoint, opt,
-            [ state, has_user_request ]( std::string const & msg )
-            {
-                {
-                    std::lock_guard< std::mutex > lk( state->mutex );
-                    state->last_error = msg;
-                }
-                // FW rejected the write: drop the user-request mask immediately so
-                // the slider snaps back to the actual cached value within a frame
-                // rather than waiting for the 2 s timeout. The user sees the snap-back
-                // plus a notification (surfaced from draw_option below) explaining why.
-                has_user_request->store( false );
-            } );
-    }
-    _async_setter->post( value );
-
     // Mask the stale cached `value` with the user's just-requested value until the
     // FW echo refreshes it, so draw_slider doesn't snap back to the old value next
     // frame. Write _user_request_value and the stopwatch BEFORE flipping the atomic
@@ -901,10 +788,106 @@ void option_model::set_option_async( float value )
     _has_user_request->store( true );
     // Tell the parent subdevice_model to back off its per-frame option polling for a
     // bit, otherwise the UI thread will issue a sync get_option_value() that serializes
-    // on the per-device USB lock behind our worker's in-flight write (and behind any
+    // on the per-device USB lock behind the dispatcher's in-flight write (and behind any
     // concurrent options_watcher poll cycle), reintroducing the visible UI freeze.
     if( dev )
         dev->last_user_set_stopwatch.reset();
+
+    // Coalesce on the subdevice dispatcher: store the latest requested value, and
+    // only enqueue a new action if one isn't already queued. The action clears the
+    // pending flag BEFORE re-reading _latest_pending_value, so any post() that
+    // arrives during the in-flight FW call gets to enqueue a fresh action for that
+    // update. Result: between any two FW writes only the latest user value survives;
+    // a 60-Hz slider drag produces ~5 Hz of FW writes (paced by the action's
+    // try_sleep below), never queues stale values, and never blocks the UI thread.
+    _latest_pending_value->store( value );
+    if( _has_pending_job->exchange( true ) )
+        return;  // an action is already queued; it will pick up the latest value
+
+    if( ! dev )
+        return;
+    auto disp = dev->set_dispatcher();
+    if( ! disp )
+        return;
+
+    // Capture shared_ptrs by value (NOT `this`) so the action is UAF-safe if
+    // option_model is destroyed mid-FW-call. ~subdevice_model destroys the
+    // dispatcher first (declared last), which stops/joins the worker before any
+    // option_model is gone — but `endpoint` (sensor) outlives both via shared_ptr,
+    // and the atomics outlive the action via these captured shared_ptrs.
+    auto endpoint_copy    = endpoint;
+    auto opt_copy         = opt;
+    auto state            = _async_state;
+    auto has_user_request = _has_user_request;
+    auto pending          = _has_pending_job;
+    auto latest           = _latest_pending_value;
+
+    disp->invoke(
+        [ endpoint_copy, opt_copy, state, has_user_request, pending, latest ](
+            dispatcher::cancellable_timer c )
+        {
+            // Clear the "queued" flag FIRST so a concurrent post() during the FW
+            // call can enqueue a follow-up action; then read back the latest value.
+            pending->store( false );
+            float v = latest->load();
+            std::string err_msg;
+            try
+            {
+                endpoint_copy->set_option( opt_copy, v );
+            }
+            catch( const rs2::error & e )
+            {
+                LOG_WARNING( "async set_option opt=" << opt_copy << " value=" << v
+                                                     << " failed: " << e.what() );
+                err_msg = e.what();
+            }
+            catch( const std::exception & e )
+            {
+                LOG_WARNING( "async set_option opt=" << opt_copy << " value=" << v
+                                                     << " failed: " << e.what() );
+                err_msg = e.what();
+            }
+            catch( ... )
+            {
+                LOG_WARNING( "async set_option opt=" << opt_copy << " value=" << v
+                                                     << " failed with unknown exception" );
+                err_msg = "unknown error";
+            }
+            if( ! err_msg.empty() )
+            {
+                {
+                    std::lock_guard< std::mutex > lk( state->mutex );
+                    state->last_error = err_msg;
+                }
+                // FW rejected the write: drop the user-request mask immediately so
+                // the slider snaps back to the actual cached value within a frame
+                // rather than waiting for the 2 s timeout.
+                has_user_request->store( false );
+            }
+            // Protective floor — at least 200 ms between FW writes on this subdevice.
+            // Returns early if the dispatcher is shutting down (device disconnect).
+            c.try_sleep( std::chrono::milliseconds( 200 ) );
+        } );
+}
+
+void option_model::set_option_sync( float value )
+{
+    // Synchronous variant for callers that need to verify the write took effect
+    // (e.g., on_chip_calib_manager). Goes through the same dispatcher as async
+    // writes so it can't race with concurrent UI option writes on the USB bus.
+    // Blocks the calling thread until the action runs.
+    if( ! dev )
+        return;
+    auto disp = dev->set_dispatcher();
+    if( ! disp )
+        return;
+    disp->invoke_and_wait(
+        [ this, value ]( dispatcher::cancellable_timer c )
+        {
+            endpoint->set_option( opt, value );
+            c.try_sleep( std::chrono::milliseconds( 200 ) );
+        },
+        []() { return false; } );
 }
 
 void option_model::update_value( const rs2::option_value & updated_value, notifications_model & model )

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -256,6 +256,7 @@ void option_model::update_all_fields( std::string & error_message, notifications
             return;
 
         value = endpoint->get_option_value( opt );
+        _has_optimistic = false;
         supported = value->is_valid;
         if( supported )
         {
@@ -382,6 +383,11 @@ bool option_model::draw_combobox( notifications_model & model,
 
 float option_model::value_as_float() const
 {
+    // While the optimistic cache is fresh, prefer the user's just-committed value.
+    // Cap at 2s in case the FW echo never matches (rejected/clamped value).
+    if( _has_optimistic && _optimistic_stopwatch.get_elapsed_ms() < 2000 )
+        return _optimistic_value;
+
     switch( value->type )
     {
     case RS2_OPTION_TYPE_FLOAT:
@@ -808,6 +814,12 @@ void option_model::set_option_async( rs2_option opt, float value )
     if( ! _async_setter )
         _async_setter = std::make_shared< option_async_setter >( endpoint, opt );
     _async_setter->post( value );
+
+    // Mask the stale cached `value` with the user's choice until the FW echo
+    // refreshes it, so draw_slider doesn't snap back to the old value next frame.
+    _optimistic_value = value;
+    _has_optimistic = true;
+    _optimistic_stopwatch.reset();
     // Tell the parent subdevice_model to back off its per-frame option polling for a
     // bit, otherwise the UI thread will issue a sync get_option_value() that serializes
     // on the per-device USB lock behind our worker's in-flight write (and behind any
@@ -823,4 +835,5 @@ void option_model::update_value( const rs2::option_value & updated_value, notifi
         return;
 
     value = updated_value;
+    _has_optimistic = false;
 }

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -39,6 +39,61 @@ namespace rs2
 
 using namespace rs2;
 
+option_async_setter::option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt )
+    : _endpoint( std::move( endpoint ) )
+    , _opt( opt )
+{
+    _worker = std::thread( [this]() { run(); } );
+}
+
+option_async_setter::~option_async_setter()
+{
+    {
+        std::lock_guard< std::mutex > lock( _mtx );
+        _stop = true;
+    }
+    _cv.notify_all();
+    if( _worker.joinable() )
+        _worker.join();
+}
+
+void option_async_setter::post( float value )
+{
+    {
+        std::lock_guard< std::mutex > lock( _mtx );
+        _pending_value = value;
+        _has_pending = true;
+    }
+    _cv.notify_one();
+}
+
+void option_async_setter::run()
+{
+    while( true )
+    {
+        float value;
+        {
+            std::unique_lock< std::mutex > lock( _mtx );
+            _cv.wait( lock, [this]() { return _has_pending || _stop; } );
+            if( _stop && ! _has_pending )
+                return;
+            value = _pending_value;
+            _has_pending = false;
+        }
+        try
+        {
+            _endpoint->set_option( _opt, value );
+        }
+        catch( ... )
+        {
+            // Errors are intentionally swallowed: this runs off the UI thread and has no
+            // safe channel to surface a message synchronously. The next periodic refresh
+            // (option_model::update_all_fields) will read the device's actual value back,
+            // so the user sees the real applied state if the FW rejected/clamped the write.
+        }
+    }
+}
+
 std::string option_model::adjust_description(const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace)
 {
     std::string adjusted_string(str_in);
@@ -666,22 +721,22 @@ bool option_model::slider_selected( rs2_option opt,
                                     std::string & error_message,
                                     notifications_model & model )
 {
-    bool res = false;
-    auto option_was_set = set_option( opt, value, error_message, std::chrono::milliseconds( 200 ) );
-    if( option_was_set )
+    // Dispatch the write to a background thread so the UI/render loop keeps drawing
+    // frames while the FW round-trip is in flight. The worker coalesces — only the
+    // latest posted value gets applied between two FW writes, so dragging the slider
+    // never queues stale values.
+    set_option_async( opt, value );
+    have_unset_value = false;
+    if( invalidate_flag )
+        *invalidate_flag = true;
+
+    // Throttle the log to ~5 Hz to keep the notifications panel readable during drag.
+    if( last_set_stopwatch.get_elapsed() >= std::chrono::milliseconds( 200 ) )
     {
-        have_unset_value = false;
-        if (invalidate_flag)
-            *invalidate_flag = true;
+        last_set_stopwatch.reset();
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value );
-        res = true;
     }
-    else
-    {
-        have_unset_value = true;
-        unset_value = value;
-    }
-    return res;
+    return true;
 }
 bool option_model::slider_unselected( rs2_option opt,
                                       float value,
@@ -735,34 +790,30 @@ bool option_model::draw_option(bool update_read_only_options,
 
 bool option_model::set_option(rs2_option opt,
     float req_value,
-    std::string& error_message,
-    std::chrono::steady_clock::duration ignore_period)
+    std::string& /*error_message*/,
+    std::chrono::steady_clock::duration /*ignore_period*/)
 {
-    // Only set the value if `ignore_period` time past since last set_option() call for this option
-    if (last_set_stopwatch.get_elapsed() < ignore_period)
-        return false;
-
-    try
-    {
-        last_set_stopwatch.reset();
-        endpoint->set_option(opt, req_value);
-    }
-    catch (const error& e)
-    {
-        error_message = error_to_string(e);
-    }
-
-    // Only update the cached value once set_option is done! That way, if it doesn't change
-    // anything...
-    try
-    {
-        value = endpoint->get_option_value(opt);
-    }
-    catch (...)
-    {
-    }
-
+    // All UI-thread option writes go through the async worker so the render loop is never
+    // blocked on the FW round-trip (set_option is ~200 ms on UVC; readback is another ~200 ms;
+    // and they serialize on the per-device USB lock against options_watcher's 1 s poll cycle).
+    // Coalescing in option_async_setter replaces the previous ignore_period rate-limit, and
+    // the cached `value` is refreshed by options_watcher -> on_options_changed -> update_value.
+    last_set_stopwatch.reset();
+    set_option_async( opt, req_value );
     return true;
+}
+
+void option_model::set_option_async( rs2_option opt, float value )
+{
+    if( ! _async_setter )
+        _async_setter = std::make_shared< option_async_setter >( endpoint, opt );
+    _async_setter->post( value );
+    // Tell the parent subdevice_model to back off its per-frame option polling for a
+    // bit, otherwise the UI thread will issue a sync get_option_value() that serializes
+    // on the per-device USB lock behind our worker's in-flight write (and behind any
+    // concurrent options_watcher poll cycle), reintroducing the visible UI freeze.
+    if( dev )
+        dev->last_user_set_stopwatch.reset();
 }
 
 void option_model::update_value( const rs2::option_value & updated_value, notifications_model & model )

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -314,8 +314,6 @@ bool option_model::draw_combobox( notifications_model & model,
             model.add_log( rsutils::string::from()
                            << "Setting " << opt << " to " << tmp_value << " (" << labels[selected] << ")" );
             set_option_async( opt, tmp_value );
-            if( invalidate_flag )
-                *invalidate_flag = true;
             item_clicked = true;
         }
     }
@@ -538,8 +536,6 @@ bool option_model::draw_slider( notifications_model & model,
                 {
                     // run when the value is valid and the enter key is pressed to submit the new value
                     set_option_async(opt, new_value);
-                    if (invalidate_flag)
-                        *invalidate_flag = true;
                     model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
                 }
                 edit_mode = false;
@@ -660,8 +656,6 @@ bool option_model::draw_checkbox( notifications_model & model,
                                                << ( bool_value ? "ON" : "OFF" ) << ")" );
 
         set_option_async( opt, bool_value ? 1.f : 0.f );
-        if (invalidate_flag)
-            *invalidate_flag = true;
     }
     if( ImGui::IsItemHovered() && description )
     {
@@ -673,23 +667,14 @@ bool option_model::draw_checkbox( notifications_model & model,
 bool option_model::slider_selected( rs2_option opt,
                                     float value,
                                     std::string & /*error_message*/,
-                                    notifications_model & model )
+                                    notifications_model & /*model*/ )
 {
     // Dispatch every UI tick: the dispatcher action coalesces (per-option
     // _latest_pending_value), and its try_sleep enforces the FW-write floor.
     // set_option_async is O(atomic-CAS) when a job is already pending, so
-    // per-tick calls are cheap.
+    // per-tick calls are cheap. Invalidate + add_log fire later from draw_option
+    // once the worker reports an actual FW write completed.
     set_option_async( opt, value );
-    if( invalidate_flag )
-        *invalidate_flag = true;
-    // Throttle the log line to ~5 Hz so the notifications panel stays readable
-    // during a drag. The actual FW writes are throttled independently by the
-    // dispatcher action's try_sleep(200ms).
-    if( last_set_stopwatch.get_elapsed() >= std::chrono::milliseconds( 200 ) )
-    {
-        last_set_stopwatch.reset();
-        model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value );
-    }
     return true;
 }
 
@@ -709,21 +694,25 @@ bool option_model::draw_option(bool update_read_only_options,
     bool is_streaming,
     std::string& error_message, notifications_model& model)
 {
-    // Surface any pending async FW error (e.g., "exposure can't be changed while AE
-    // is enabled" on certain D4xx variants). The async worker stashes the message
-    // under _async_state->mutex; we swap it out here on the UI thread and write it
-    // to the error_message out-param. The caller chain eventually feeds that to
-    // viewer_model::popup_if_error which shows a centered modal — matching the
-    // pre-PR synchronous flow's error UX. The popup deduplicates by message and
-    // honors the user's "don't show this error again" preference, so we don't need
-    // to throttle here: a continuous failing slider drag gets one modal until
-    // dismissed, and dismissed-as-ignored errors fall back to the notifications
-    // panel automatically.
+    // Drain the async worker's cross-thread state on the UI thread:
+    //  - last_error: any FW write failure — surface as an error_message that
+    //    eventually drives viewer_model::popup_if_error (matching the pre-PR
+    //    synchronous flow's error UX; deduplicated by message and honoring the
+    //    user's "don't show this error again" preference).
+    //  - did_write / written_value: a FW write completed since the last drain.
+    //    Fire *invalidate_flag and add_log here so both are tied to the actual
+    //    FW write rather than to UI-thread dispatch — keeps cross-option re-polls
+    //    from reading stale values while a write is still queued.
     {
         std::string async_err;
+        bool did_write = false;
+        float written_value = 0.f;
         {
             std::lock_guard< std::mutex > lk( _async_state->mutex );
             async_err.swap( _async_state->last_error );
+            did_write = _async_state->did_write;
+            written_value = _async_state->written_value;
+            _async_state->did_write = false;
         }
         if( ! async_err.empty() )
         {
@@ -734,6 +723,12 @@ bool option_model::draw_option(bool update_read_only_options,
                               << ": " << async_err;
             }
             catch( ... ) {}
+        }
+        if( did_write )
+        {
+            if( invalidate_flag )
+                *invalidate_flag = true;
+            model.add_log( rsutils::string::from() << "Setting " << opt << " to " << written_value );
         }
     }
 
@@ -885,14 +880,21 @@ void option_model::set_option_async( rs2_option opt, float value )
                 // rather than waiting for the 2 s timeout.
                 has_user_request->store( false );
             }
-            // Bus-fairness floor between FW writes on this subdevice. The FW
-            // round-trip itself already rate-limits the bus; this small extra idle
-            // window (~20 Hz cap when FW is fast) keeps the video frame stream from
-            // starving during sustained option-write traffic. 200 ms was too long
-            // when one of the queued writes is for a slow option like exposure at
-            // high values — subsequent writes (e.g. gain) waited behind it.
-            // Returns early if the dispatcher is shutting down (device disconnect).
-            c.try_sleep( std::chrono::milliseconds( 50 ) );
+            else
+            {
+                // Record that a FW write completed so the UI thread can drive
+                // invalidate + add_log off the actual write, not off dispatch.
+                std::lock_guard< std::mutex > lk( state->mutex );
+                state->did_write     = true;
+                state->written_value = v;
+            }
+            // FW-write floor between actions on this subdevice. 200 ms matches the
+            // pre-PR `ignore_period` gate that used to live on the UI thread, so a
+            // 60 Hz slider drag produces ~5 Hz of FW writes — paced enough to keep
+            // the video frame stream from starving during sustained option traffic,
+            // and to give each invalidate + cross-option re-poll a real value to
+            // read back. Returns early if the dispatcher is shutting down.
+            c.try_sleep( std::chrono::milliseconds( 200 ) );
         } );
 }
 

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -745,48 +745,51 @@ bool option_model::draw_checkbox( notifications_model & model,
 
 bool option_model::slider_selected( rs2_option opt,
                                     float value,
-                                    std::string & error_message,
+                                    std::string & /*error_message*/,
                                     notifications_model & model )
 {
     check_opt( opt, __func__ );
-    // Dispatch the write to a background thread so the UI/render loop keeps drawing
-    // frames while the FW round-trip is in flight. The worker coalesces — only the
-    // latest posted value gets applied between two FW writes, so dragging the slider
-    // never queues stale values.
-    set_option_async( value );
-    have_unset_value = false;
-    if( invalidate_flag )
-        *invalidate_flag = true;
-
-    // Throttle the log to ~5 Hz to keep the notifications panel readable during drag.
+    // Rate-limit FW writes to at most one per 200 ms while the slider is being
+    // dragged. The worker thread already coalesces post()s, but per-tick posts
+    // would still let the worker write every intermediate value when the FW
+    // round-trip is faster than the drag rate — flooding the bus with values the
+    // user never paused on. Within the throttle window we capture the latest
+    // value into unset_value; slider_unselected dispatches it on release so the
+    // user's final position always reaches the firmware.
     if( last_set_stopwatch.get_elapsed() >= std::chrono::milliseconds( 200 ) )
     {
         last_set_stopwatch.reset();
+        set_option_async( value );
+        have_unset_value = false;
+        if( invalidate_flag )
+            *invalidate_flag = true;
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value );
+    }
+    else
+    {
+        unset_value = value;
+        have_unset_value = true;
     }
     return true;
 }
-bool option_model::slider_unselected( rs2_option /*opt*/,
+bool option_model::slider_unselected( rs2_option opt,
                                       float /*value*/,
                                       std::string & /*error_message*/,
-                                      notifications_model & /*model*/ )
+                                      notifications_model & model )
 {
-    // Intentionally a no-op. The pre-PR body retried a rate-limited write on slider
-    // release: when the synchronous set_option was throttled by `ignore_period` it
-    // returned false, slider_selected captured the value into `unset_value`, and
-    // slider_unselected re-attempted that write. That retry existed only because the
-    // rate-limiter could otherwise drop the user's final slider position.
-    //
-    // With async dispatch, no value is ever dropped: option_async_setter coalesces
-    // — between two FW writes it always delivers the latest posted value — so the
-    // user's release-position value (the last `slider_selected` call before release)
-    // is guaranteed to reach the firmware on the next worker iteration. There is no
-    // rate-limit to retry around. slider_selected accordingly clears
-    // `have_unset_value` unconditionally, so the old `if (have_unset_value) { ... }`
-    // body would be dead code anyway.
-    //
-    // The function is kept (as a no-op) so the slider_selected / slider_unselected
-    // pairing in draw_slider doesn't need to change.
+    check_opt( opt, __func__ );
+    // Flush the most-recent value captured by slider_selected during the 200 ms
+    // throttle window so the user's final slider position always reaches FW.
+    if( have_unset_value )
+    {
+        last_set_stopwatch.reset();
+        set_option_async( unset_value );
+        have_unset_value = false;
+        if( invalidate_flag )
+            *invalidate_flag = true;
+        model.add_log( rsutils::string::from() << "Setting " << opt << " to " << unset_value );
+        return true;
+    }
     return false;
 }
 
@@ -846,8 +849,10 @@ void option_model::set_option(rs2_option opt, float req_value)
     // All UI-thread option writes go through the async worker so the render loop is never
     // blocked on the FW round-trip (set_option is ~200 ms on UVC; readback is another ~200 ms;
     // and they serialize on the per-device USB lock against options_watcher's 1 s poll cycle).
-    // Coalescing in option_async_setter replaces the previous ignore_period rate-limit, and
-    // the cached `value` is refreshed by options_watcher -> on_options_changed -> update_value.
+    // No 200 ms gate here: this entry point is reached from checkboxes / combos / edit-text
+    // submit — one click = one write, so there is nothing to throttle. The slider drag path
+    // (slider_selected) keeps an explicit 200 ms gate. We still reset last_set_stopwatch so
+    // a click immediately before a drag doesn't burn the slider's first throttle window.
     last_set_stopwatch.reset();
     set_option_async( req_value );
 }

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -896,7 +896,7 @@ void option_model::set_option_async( rs2_option opt, float value )
         } );
 }
 
-void option_model::set_option_sync( float value )
+void option_model::set_option_sync( float req_value )
 {
     // Synchronous variant for callers that need to verify the write took effect
     // (e.g., on_chip_calib_manager). Goes through the same dispatcher as async
@@ -908,9 +908,20 @@ void option_model::set_option_sync( float value )
     if( ! disp )
         return;
     disp->invoke_and_wait(
-        [ this, value ]( dispatcher::cancellable_timer c )
+        [ this, req_value ]( dispatcher::cancellable_timer c )
         {
-            endpoint->set_option( opt, value );
+            endpoint->set_option( opt, req_value );
+            // Refresh the cached value under the dispatcher so callers that follow up
+            // with value_as_float() see what the FW actually accepted (which may clamp
+            // or reject the requested value). Mirrors the post-write readback that the
+            // synchronous set_option() does.
+            try
+            {
+                this->value = endpoint->get_option_value( opt );
+            }
+            catch( ... )
+            {
+            }
             c.try_sleep( std::chrono::milliseconds( 50 ) );
         },
         []() { return false; } );

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -10,6 +10,10 @@
 #include "subdevice-model.h"
 #include <os.h>
 
+#include <rsutils/easylogging/easyloggingpp.h>
+
+#include <stdexcept>
+
 namespace rs2
 {
     option_model create_option_model( option_value const & opt,
@@ -39,9 +43,10 @@ namespace rs2
 
 using namespace rs2;
 
-option_async_setter::option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt )
+option_async_setter::option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt, error_callback on_error )
     : _endpoint( std::move( endpoint ) )
     , _opt( opt )
+    , _on_error( std::move( on_error ) )
 {
     _worker = std::thread( [this]() { run(); } );
 }
@@ -80,17 +85,34 @@ void option_async_setter::run()
             value = _pending_value;
             _has_pending = false;
         }
+        std::string err_msg;
         try
         {
             _endpoint->set_option( _opt, value );
         }
+        catch( const rs2::error & e )
+        {
+            // Surface the FW-side reason via the log so silent rejections/clamps are
+            // diagnosable. We also forward to the optional UI callback below so the
+            // notification panel can show the user why their slider snapped back.
+            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
+                                                 << " failed: " << e.what() );
+            err_msg = e.what();
+        }
+        catch( const std::exception & e )
+        {
+            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
+                                                 << " failed: " << e.what() );
+            err_msg = e.what();
+        }
         catch( ... )
         {
-            // Errors are intentionally swallowed: this runs off the UI thread and has no
-            // safe channel to surface a message synchronously. The next periodic refresh
-            // (option_model::update_all_fields) will read the device's actual value back,
-            // so the user sees the real applied state if the FW rejected/clamped the write.
+            LOG_WARNING( "async set_option opt=" << _opt << " value=" << value
+                                                 << " failed with unknown exception" );
+            err_msg = "unknown error";
         }
+        if( ! err_msg.empty() && _on_error )
+            _on_error( err_msg );
     }
 }
 
@@ -256,7 +278,7 @@ void option_model::update_all_fields( std::string & error_message, notifications
             return;
 
         value = endpoint->get_option_value( opt );
-        _has_optimistic = false;
+        _has_user_request->store( false );
         supported = value->is_valid;
         if( supported )
         {
@@ -364,7 +386,7 @@ bool option_model::draw_combobox( notifications_model & model,
             float tmp_value = range.min + range.step * selected;
             model.add_log( rsutils::string::from()
                            << "Setting " << opt << " to " << tmp_value << " (" << labels[selected] << ")" );
-            set_option( opt, tmp_value, error_message );
+            set_option( opt, tmp_value );
             if( invalidate_flag )
                 *invalidate_flag = true;
             item_clicked = true;
@@ -383,10 +405,12 @@ bool option_model::draw_combobox( notifications_model & model,
 
 float option_model::value_as_float() const
 {
-    // While the optimistic cache is fresh, prefer the user's just-committed value.
-    // Cap at 2s in case the FW echo never matches (rejected/clamped value).
-    if( _has_optimistic && _optimistic_stopwatch.get_elapsed_ms() < 2000 )
-        return _optimistic_value;
+    // While the user-requested value is fresh, prefer it over the stale cached `value`
+    // so the slider doesn't visually snap back between dispatch and FW echo. Cap at 2 s
+    // in case the FW echoes a different value (rejected/clamped) — beyond that we want
+    // the user to see what was actually applied.
+    if( _has_user_request->load() && _user_request_stopwatch.get_elapsed_ms() < 2000 )
+        return _user_request_value;
 
     switch( value->type )
     {
@@ -586,13 +610,10 @@ bool option_model::draw_slider( notifications_model & model,
                 else
                 {
                     // run when the value is valid and the enter key is pressed to submit the new value
-                    auto option_was_set = set_option(opt, new_value, error_message);
-                    if (option_was_set)
-                    {
-                        if (invalidate_flag)
-                            *invalidate_flag = true;
-                        model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
-                    }
+                    set_option(opt, new_value);
+                    if (invalidate_flag)
+                        *invalidate_flag = true;
+                    model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
                 }
                 edit_mode = false;
             }
@@ -711,7 +732,7 @@ bool option_model::draw_checkbox( notifications_model & model,
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << ( bool_value ? "1.0" : "0.0" ) << " ("
                                                << ( bool_value ? "ON" : "OFF" ) << ")" );
 
-        set_option( opt, bool_value ? 1.f : 0.f, error_message );
+        set_option( opt, bool_value ? 1.f : 0.f );
         if (invalidate_flag)
             *invalidate_flag = true;
     }
@@ -727,11 +748,12 @@ bool option_model::slider_selected( rs2_option opt,
                                     std::string & error_message,
                                     notifications_model & model )
 {
+    check_opt( opt, __func__ );
     // Dispatch the write to a background thread so the UI/render loop keeps drawing
     // frames while the FW round-trip is in flight. The worker coalesces — only the
     // latest posted value gets applied between two FW writes, so dragging the slider
     // never queues stale values.
-    set_option_async( opt, value );
+    set_option_async( value );
     have_unset_value = false;
     if( invalidate_flag )
         *invalidate_flag = true;
@@ -744,38 +766,62 @@ bool option_model::slider_selected( rs2_option opt,
     }
     return true;
 }
-bool option_model::slider_unselected( rs2_option opt,
-                                      float value,
-                                      std::string & error_message,
-                                      notifications_model & model )
+bool option_model::slider_unselected( rs2_option /*opt*/,
+                                      float /*value*/,
+                                      std::string & /*error_message*/,
+                                      notifications_model & /*model*/ )
 {
-    bool res = false;
-    // Slider unselected, if last value was ignored, set with last value if the value was changed.
-    if( have_unset_value )
-    {
-        if( value != unset_value )
-        {
-            auto set_ok
-                = set_option( opt, unset_value, error_message, std::chrono::milliseconds( 100 ) );
-            if( set_ok )
-            {
-                model.add_log( rsutils::string::from() << "Setting " << opt << " to " << unset_value );
-                if (invalidate_flag)
-                    *invalidate_flag = true;
-                have_unset_value = false;
-                res = true;
-            }
-        }
-        else
-            have_unset_value = false;
-    }
-    return res;
+    // Intentionally a no-op. The pre-PR body retried a rate-limited write on slider
+    // release: when the synchronous set_option was throttled by `ignore_period` it
+    // returned false, slider_selected captured the value into `unset_value`, and
+    // slider_unselected re-attempted that write. That retry existed only because the
+    // rate-limiter could otherwise drop the user's final slider position.
+    //
+    // With async dispatch, no value is ever dropped: option_async_setter coalesces
+    // — between two FW writes it always delivers the latest posted value — so the
+    // user's release-position value (the last `slider_selected` call before release)
+    // is guaranteed to reach the firmware on the next worker iteration. There is no
+    // rate-limit to retry around. slider_selected accordingly clears
+    // `have_unset_value` unconditionally, so the old `if (have_unset_value) { ... }`
+    // body would be dead code anyway.
+    //
+    // The function is kept (as a no-op) so the slider_selected / slider_unselected
+    // pairing in draw_slider doesn't need to change.
+    return false;
 }
 
 bool option_model::draw_option(bool update_read_only_options,
     bool is_streaming,
     std::string& error_message, notifications_model& model)
 {
+    // Surface any pending async FW error (e.g., "exposure can't be changed while AE
+    // is enabled" on certain D4xx variants). The async worker stashes the message
+    // under _async_state->mutex; we swap it out here on the UI thread and write it
+    // to the error_message out-param. The caller chain eventually feeds that to
+    // viewer_model::popup_if_error which shows a centered modal — matching the
+    // pre-PR synchronous flow's error UX. The popup deduplicates by message and
+    // honors the user's "don't show this error again" preference, so we don't need
+    // to throttle here: a continuous failing slider drag gets one modal until
+    // dismissed, and dismissed-as-ignored errors fall back to the notifications
+    // panel automatically.
+    {
+        std::string async_err;
+        {
+            std::lock_guard< std::mutex > lk( _async_state->mutex );
+            async_err.swap( _async_state->last_error );
+        }
+        if( ! async_err.empty() )
+        {
+            try
+            {
+                error_message = rsutils::string::from()
+                              << "Failed to set " << endpoint->get_option_name( opt )
+                              << ": " << async_err;
+            }
+            catch( ... ) {}
+        }
+    }
+
     if (update_read_only_options)
     {
         update_supported(error_message);
@@ -794,32 +840,60 @@ bool option_model::draw_option(bool update_read_only_options,
         return draw(error_message, model);
 }
 
-bool option_model::set_option(rs2_option opt,
-    float req_value,
-    std::string& /*error_message*/,
-    std::chrono::steady_clock::duration /*ignore_period*/)
+void option_model::set_option(rs2_option opt, float req_value)
 {
+    check_opt( opt, __func__ );
     // All UI-thread option writes go through the async worker so the render loop is never
     // blocked on the FW round-trip (set_option is ~200 ms on UVC; readback is another ~200 ms;
     // and they serialize on the per-device USB lock against options_watcher's 1 s poll cycle).
     // Coalescing in option_async_setter replaces the previous ignore_period rate-limit, and
     // the cached `value` is refreshed by options_watcher -> on_options_changed -> update_value.
     last_set_stopwatch.reset();
-    set_option_async( opt, req_value );
-    return true;
+    set_option_async( req_value );
 }
 
-void option_model::set_option_async( rs2_option opt, float value )
+void option_model::check_opt( rs2_option opt, char const * caller ) const
+{
+    if( opt != this->opt )
+        throw std::runtime_error( rsutils::string::from()
+                                  << caller << " called on option_model bound to "
+                                  << this->opt << " with mismatched opt=" << opt );
+}
+
+void option_model::set_option_async( float value )
 {
     if( ! _async_setter )
-        _async_setter = std::make_shared< option_async_setter >( endpoint, opt );
+    {
+        // Capture shared_ptrs (not `this`) so the callback is UAF-safe if option_model
+        // is destroyed while the worker is mid-FW-call. ~option_async_setter joins the
+        // worker before its own member fields are destroyed, but option_model's other
+        // members (including _async_state and _has_user_request) may already be gone
+        // by then if the worker called back via `this`.
+        auto state             = _async_state;
+        auto has_user_request  = _has_user_request;
+        _async_setter = std::make_shared< option_async_setter >( endpoint, opt,
+            [ state, has_user_request ]( std::string const & msg )
+            {
+                {
+                    std::lock_guard< std::mutex > lk( state->mutex );
+                    state->last_error = msg;
+                }
+                // FW rejected the write: drop the user-request mask immediately so
+                // the slider snaps back to the actual cached value within a frame
+                // rather than waiting for the 2 s timeout. The user sees the snap-back
+                // plus a notification (surfaced from draw_option below) explaining why.
+                has_user_request->store( false );
+            } );
+    }
     _async_setter->post( value );
 
-    // Mask the stale cached `value` with the user's choice until the FW echo
-    // refreshes it, so draw_slider doesn't snap back to the old value next frame.
-    _optimistic_value = value;
-    _has_optimistic = true;
-    _optimistic_stopwatch.reset();
+    // Mask the stale cached `value` with the user's just-requested value until the
+    // FW echo refreshes it, so draw_slider doesn't snap back to the old value next
+    // frame. Write _user_request_value and the stopwatch BEFORE flipping the atomic
+    // so any reader that observes the flag set also sees the matching value.
+    _user_request_value = value;
+    _user_request_stopwatch.reset();
+    _has_user_request->store( true );
     // Tell the parent subdevice_model to back off its per-frame option polling for a
     // bit, otherwise the UI thread will issue a sync get_option_value() that serializes
     // on the per-device USB lock behind our worker's in-flight write (and behind any
@@ -835,5 +909,5 @@ void option_model::update_value( const rs2::option_value & updated_value, notifi
         return;
 
     value = updated_value;
-    _has_optimistic = false;
+    _has_user_request->store( false );
 }

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -864,9 +864,14 @@ void option_model::set_option_async( float value )
                 // rather than waiting for the 2 s timeout.
                 has_user_request->store( false );
             }
-            // Protective floor — at least 200 ms between FW writes on this subdevice.
+            // Bus-fairness floor between FW writes on this subdevice. The FW
+            // round-trip itself already rate-limits the bus; this small extra idle
+            // window (~20 Hz cap when FW is fast) keeps the video frame stream from
+            // starving during sustained option-write traffic. 200 ms was too long
+            // when one of the queued writes is for a slow option like exposure at
+            // high values — subsequent writes (e.g. gain) waited behind it.
             // Returns early if the dispatcher is shutting down (device disconnect).
-            c.try_sleep( std::chrono::milliseconds( 200 ) );
+            c.try_sleep( std::chrono::milliseconds( 50 ) );
         } );
 }
 
@@ -885,7 +890,7 @@ void option_model::set_option_sync( float value )
         [ this, value ]( dispatcher::cancellable_timer c )
         {
             endpoint->set_option( opt, value );
-            c.try_sleep( std::chrono::milliseconds( 200 ) );
+            c.try_sleep( std::chrono::milliseconds( 50 ) );
         },
         []() { return false; } );
 }

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -313,7 +313,7 @@ bool option_model::draw_combobox( notifications_model & model,
             float tmp_value = range.min + range.step * selected;
             model.add_log( rsutils::string::from()
                            << "Setting " << opt << " to " << tmp_value << " (" << labels[selected] << ")" );
-            set_option( opt, tmp_value );
+            set_option_async( opt, tmp_value );
             if( invalidate_flag )
                 *invalidate_flag = true;
             item_clicked = true;
@@ -537,7 +537,7 @@ bool option_model::draw_slider( notifications_model & model,
                 else
                 {
                     // run when the value is valid and the enter key is pressed to submit the new value
-                    set_option(opt, new_value);
+                    set_option_async(opt, new_value);
                     if (invalidate_flag)
                         *invalidate_flag = true;
                     model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
@@ -659,7 +659,7 @@ bool option_model::draw_checkbox( notifications_model & model,
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << ( bool_value ? "1.0" : "0.0" ) << " ("
                                                << ( bool_value ? "ON" : "OFF" ) << ")" );
 
-        set_option( opt, bool_value ? 1.f : 0.f );
+        set_option_async( opt, bool_value ? 1.f : 0.f );
         if (invalidate_flag)
             *invalidate_flag = true;
     }
@@ -675,12 +675,11 @@ bool option_model::slider_selected( rs2_option opt,
                                     std::string & /*error_message*/,
                                     notifications_model & model )
 {
-    check_opt( opt, __func__ );
     // Dispatch every UI tick: the dispatcher action coalesces (per-option
-    // _latest_pending_value), and its try_sleep(200ms) enforces the FW-write
-    // floor that used to live in this function. set_option_async is O(atomic-CAS)
-    // when a job is already pending, so per-tick calls are cheap.
-    set_option_async( value );
+    // _latest_pending_value), and its try_sleep enforces the FW-write floor.
+    // set_option_async is O(atomic-CAS) when a job is already pending, so
+    // per-tick calls are cheap.
+    set_option_async( opt, value );
     if( invalidate_flag )
         *invalidate_flag = true;
     // Throttle the log line to ~5 Hz so the notifications panel stays readable
@@ -756,17 +755,38 @@ bool option_model::draw_option(bool update_read_only_options,
         return draw(error_message, model);
 }
 
-void option_model::set_option(rs2_option opt, float req_value)
+bool option_model::set_option( rs2_option opt,
+                               float req_value,
+                               std::string & error_message,
+                               std::chrono::steady_clock::duration ignore_period )
 {
     check_opt( opt, __func__ );
-    // All UI-thread option writes go through the subdevice dispatcher so the render
-    // loop is never blocked on the FW round-trip (set_option is ~200 ms on UVC;
-    // readback is another ~200 ms; and they serialize on the per-device USB lock
-    // against options_watcher's 1 s poll cycle). The dispatcher's try_sleep(200ms)
-    // after each action enforces a uniform FW-write floor across all entry points
-    // (slider, checkbox, calibration) — no separate per-call rate-limit needed here.
-    last_set_stopwatch.reset();
-    set_option_async( req_value );
+    // Synchronous FW write. Use set_option_async from the UI thread to avoid
+    // blocking the render loop on the ~200 ms FW round-trip.
+    if( last_set_stopwatch.get_elapsed() < ignore_period )
+        return false;
+
+    try
+    {
+        last_set_stopwatch.reset();
+        endpoint->set_option( opt, req_value );
+    }
+    catch( const error & e )
+    {
+        error_message = error_to_string( e );
+    }
+
+    // Refresh the cached value once the write is done so the UI reflects whatever
+    // the FW actually accepted (which may clamp or reject the requested value).
+    try
+    {
+        value = endpoint->get_option_value( opt );
+    }
+    catch( ... )
+    {
+    }
+
+    return true;
 }
 
 void option_model::check_opt( rs2_option opt, char const * caller ) const
@@ -777,8 +797,9 @@ void option_model::check_opt( rs2_option opt, char const * caller ) const
                                   << this->opt << " with mismatched opt=" << opt );
 }
 
-void option_model::set_option_async( float value )
+void option_model::set_option_async( rs2_option opt, float value )
 {
+    check_opt( opt, __func__ );
     // Mask the stale cached `value` with the user's just-requested value until the
     // FW echo refreshes it, so draw_slider doesn't snap back to the old value next
     // frame. Write _user_request_value and the stopwatch BEFORE flipping the atomic

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -5,57 +5,21 @@
 #include <librealsense2/rs.hpp>
 #include <rsutils/time/stopwatch.h>
 #include <atomic>
-#include <condition_variable>
 #include <mutex>
-#include <thread>
 namespace rs2
 {
     struct notifications_model;
     class subdevice_model;
 
     // Holds the cross-thread state for async option writes: the latest FW error
-    // message (written by the worker thread, read+cleared by the UI thread). Held
-    // via shared_ptr by both option_model and the worker callback so the worker
-    // can outlive option_model without dangling — the worker captures shared_ptrs
+    // message (written by the dispatcher action, read+cleared by the UI thread). Held
+    // via shared_ptr by both option_model and the dispatcher action so the action
+    // can outlive option_model without dangling — the action captures shared_ptrs
     // by value, never `this`, so destruction of option_model is UAF-safe.
     struct option_async_state
     {
         std::mutex mutex;
         std::string last_error;  // non-empty = pending error to surface
-    };
-
-    // Background worker that applies option writes to the device asynchronously.
-    // Coalescing: only the latest posted value between two FW round-trips is applied,
-    // so spamming post() (e.g., during slider drag) never queues up stale values.
-    class option_async_setter
-    {
-    public:
-        // Optional callback invoked from the worker thread when set_option throws
-        // (rs2::error / std::exception / unknown). Receives a human-readable message.
-        // Used to surface FW rejections (e.g., "exposure can't be changed with AE
-        // enabled") back to the UI thread, where they become notifications.
-        using error_callback = std::function< void( std::string const & ) >;
-
-        option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt, error_callback on_error = {} );
-        ~option_async_setter();
-
-        option_async_setter( option_async_setter const & ) = delete;
-        option_async_setter & operator=( option_async_setter const & ) = delete;
-
-        void post( float value );
-
-    private:
-        void run();
-
-        std::shared_ptr< options > _endpoint;
-        rs2_option _opt;
-        error_callback _on_error;
-        std::mutex _mtx;
-        std::condition_variable _cv;
-        float _pending_value = 0.f;
-        bool _has_pending = false;
-        bool _stop = false;
-        std::thread _worker;
     };
 
     class option_model
@@ -65,12 +29,18 @@ namespace rs2
         void update_supported( std::string& error_message );
         void update_read_only_status( std::string& error_message );
         void update_all_fields( std::string& error_message, notifications_model& model );
-        // Fire-and-forget option write. Always dispatches via the async worker;
+        // Fire-and-forget option write. Always dispatches via the subdevice dispatcher;
         // FW errors are surfaced asynchronously through the next periodic readback
         // (option_model::update_all_fields), so this method has no error-out parameter
         // and no return value. The previous synchronous error_message / ignore_period
         // parameters are no longer applicable.
         void set_option( rs2_option opt, float value );
+        // Synchronous variant: blocks the caller until the dispatcher action has run
+        // the FW write. Routes through the same per-subdevice dispatcher as the async
+        // path so it can't race with concurrent UI writes on the USB bus. Used by
+        // on_chip_calib for set+verify semantics — the caller does the verify read
+        // separately via the endpoint (or option_model::value after the next readback).
+        void set_option_sync( float value );
         bool draw_option( bool update_read_only_options, bool is_streaming,
             std::string& error_message, notifications_model& model );
 
@@ -83,8 +53,6 @@ namespace rs2
         rs2_option opt;
         option_range range;
         std::shared_ptr<options> endpoint;
-        float unset_value = 0;
-        bool have_unset_value = false;
         rsutils::time::stopwatch last_set_stopwatch;
         rsutils::time::stopwatch last_slider_hold_stopwatch;
         bool* invalidate_flag = nullptr;
@@ -131,8 +99,18 @@ namespace rs2
 
         std::string adjust_description( const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace );
 
-        // Lazily created on first async dispatch; shared so option_model stays copyable.
-        std::shared_ptr< option_async_setter > _async_setter;
+        // Per-option coalescing state for the subdevice dispatcher. Every UI-thread
+        // set_option_async stores into _latest_pending_value, then atomically claims
+        // the right to enqueue a dispatcher action via _has_pending_job (CAS false→true).
+        // The action clears _has_pending_job at entry and reads back the latest value, so
+        // any post() arriving during the FW call re-enqueues for that update.
+        // Held via shared_ptr so the dispatcher action (which captures these by value)
+        // is UAF-safe across option_model destruction, AND so option_model stays
+        // copyable (std::atomic deletes its copy ctor).
+        std::shared_ptr< std::atomic< float > > _latest_pending_value
+            = std::make_shared< std::atomic< float > >( 0.f );
+        std::shared_ptr< std::atomic< bool > > _has_pending_job
+            = std::make_shared< std::atomic< bool > >( false );
 
         // Tracks the value the user just requested via the slider / checkbox / edit
         // field, and is displayed locally until the firmware confirms (or contradicts)

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -4,10 +4,40 @@
 #pragma once
 #include <librealsense2/rs.hpp>
 #include <rsutils/time/stopwatch.h>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 namespace rs2
 {
     struct notifications_model;
     class subdevice_model;
+
+    // Background worker that applies option writes to the device asynchronously.
+    // Coalescing: only the latest posted value between two FW round-trips is applied,
+    // so spamming post() (e.g., during slider drag) never queues up stale values.
+    class option_async_setter
+    {
+    public:
+        option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt );
+        ~option_async_setter();
+
+        option_async_setter( option_async_setter const & ) = delete;
+        option_async_setter & operator=( option_async_setter const & ) = delete;
+
+        void post( float value );
+
+    private:
+        void run();
+
+        std::shared_ptr< options > _endpoint;
+        rs2_option _opt;
+        std::mutex _mtx;
+        std::condition_variable _cv;
+        float _pending_value = 0.f;
+        bool _has_pending = false;
+        bool _stop = false;
+        std::thread _worker;
+    };
 
     class option_model
     {
@@ -63,7 +93,14 @@ namespace rs2
             std::string& error_message,
             notifications_model& model );
 
+        // Dispatches the option write to a background worker so the UI thread
+        // (and therefore the viewer's render loop) is not blocked on the FW round-trip.
+        void set_option_async( rs2_option opt, float value );
+
         std::string adjust_description( const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace );
+
+        // Lazily created on first async dispatch; shared so option_model stays copyable.
+        std::shared_ptr< option_async_setter > _async_setter;
     };
 
     option_model create_option_model(option_value const & opt,

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -101,6 +101,15 @@ namespace rs2
 
         // Lazily created on first async dispatch; shared so option_model stays copyable.
         std::shared_ptr< option_async_setter > _async_setter;
+
+        // Optimistic local cache so the slider doesn't visually snap back to the stale
+        // `value` between dispatch (set_option_async) and the FW echo arriving via
+        // options_watcher -> update_value or the post-gate update_all_fields poll.
+        // Cleared when either authoritative path refreshes `value`, or after the timeout
+        // below (in case FW rejects/clamps and never echoes the requested value).
+        float _optimistic_value = 0.f;
+        bool _has_optimistic = false;
+        rsutils::time::stopwatch _optimistic_stopwatch;
     };
 
     option_model create_option_model(option_value const & opt,

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -29,17 +29,23 @@ namespace rs2
         void update_supported( std::string& error_message );
         void update_read_only_status( std::string& error_message );
         void update_all_fields( std::string& error_message, notifications_model& model );
-        // Fire-and-forget option write. Always dispatches via the subdevice dispatcher;
-        // FW errors are surfaced asynchronously through the next periodic readback
-        // (option_model::update_all_fields), so this method has no error-out parameter
-        // and no return value. The previous synchronous error_message / ignore_period
-        // parameters are no longer applicable.
-        void set_option( rs2_option opt, float value );
-        // Synchronous variant: blocks the caller until the dispatcher action has run
-        // the FW write. Routes through the same per-subdevice dispatcher as the async
-        // path so it can't race with concurrent UI writes on the USB bus. Used by
-        // on_chip_calib for set+verify semantics — the caller does the verify read
-        // separately via the endpoint (or option_model::value after the next readback).
+        // Synchronous option write — thin wrapper around the rs2 API set_option,
+        // followed by a readback to refresh the cached `value`. Blocks the caller for
+        // the FW round-trip (~200 ms on UVC), so do NOT call from the UI thread when
+        // a freeze would be visible — use set_option_async() for UI-thread writes.
+        bool set_option( rs2_option opt,
+            float req_value,
+            std::string & error_message,
+            std::chrono::steady_clock::duration ignore_period = std::chrono::seconds( 0 ) );
+        // Fire-and-forget option write. Dispatches via the subdevice dispatcher so
+        // the UI thread is never blocked on the FW round-trip. FW errors are surfaced
+        // asynchronously through the next periodic readback (update_all_fields), so
+        // this method has no error-out parameter and no return value.
+        void set_option_async( rs2_option opt, float value );
+        // Blocking variant of set_option_async: routes through the same per-subdevice
+        // dispatcher so it can't race with concurrent UI writes on the USB bus, but
+        // waits for the action to run before returning. Used by on_chip_calib for
+        // set+verify semantics.
         void set_option_sync( float value );
         bool draw_option( bool update_read_only_options, bool is_streaming,
             std::string& error_message, notifications_model& model );
@@ -82,19 +88,12 @@ namespace rs2
             std::string& error_message,
             notifications_model& model );
 
-        // Dispatches the option write to a background worker so the UI thread
-        // (and therefore the viewer's render loop) is not blocked on the FW round-trip.
-        // Always uses `this->opt` as the target — option_model is bound to a single
-        // rs2_option at construction, so a separate `opt` parameter would only invite
-        // mismatch bugs.
-        void set_option_async( float value );
-
-        // Guard for the public entry points that still take an `opt` parameter
-        // (set_option, slider_selected): an option_model is bound to a single
-        // rs2_option for its lifetime, so a caller passing a different opt is a bug
-        // — throw rather than silently write to the wrong option through the cached
-        // _async_setter. `caller` is used to make the error message tell the reader
-        // which entry point detected the mismatch (pass __func__).
+        // Guard for the public entry points that take an `opt` parameter
+        // (set_option, set_option_async, slider_selected): an option_model is bound
+        // to a single rs2_option for its lifetime, so a caller passing a different
+        // opt is a bug — throw rather than silently write to the wrong option.
+        // `caller` is used to make the error message tell the reader which entry
+        // point detected the mismatch (pass __func__).
         void check_opt( rs2_option opt, char const * caller ) const;
 
         std::string adjust_description( const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace );

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -12,14 +12,18 @@ namespace rs2
     class subdevice_model;
 
     // Holds the cross-thread state for async option writes: the latest FW error
-    // message (written by the dispatcher action, read+cleared by the UI thread). Held
-    // via shared_ptr by both option_model and the dispatcher action so the action
-    // can outlive option_model without dangling — the action captures shared_ptrs
-    // by value, never `this`, so destruction of option_model is UAF-safe.
+    // message, plus a "completed write" notification carrying the value that was
+    // actually sent to FW. Written by the dispatcher action, read+cleared by the
+    // UI thread in option_model::draw_option. Held via shared_ptr by both
+    // option_model and the dispatcher action so the action can outlive option_model
+    // without dangling — the action captures shared_ptrs by value, never `this`,
+    // so destruction of option_model is UAF-safe.
     struct option_async_state
     {
         std::mutex mutex;
-        std::string last_error;  // non-empty = pending error to surface
+        std::string last_error;     // non-empty = pending error to surface
+        bool did_write = false;     // a FW write completed since the last drain
+        float written_value = 0.f;  // value that was sent to FW
     };
 
     class option_model

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <librealsense2/rs.hpp>
 #include <rsutils/time/stopwatch.h>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -12,13 +13,30 @@ namespace rs2
     struct notifications_model;
     class subdevice_model;
 
+    // Holds the cross-thread state for async option writes: the latest FW error
+    // message (written by the worker thread, read+cleared by the UI thread). Held
+    // via shared_ptr by both option_model and the worker callback so the worker
+    // can outlive option_model without dangling — the worker captures shared_ptrs
+    // by value, never `this`, so destruction of option_model is UAF-safe.
+    struct option_async_state
+    {
+        std::mutex mutex;
+        std::string last_error;  // non-empty = pending error to surface
+    };
+
     // Background worker that applies option writes to the device asynchronously.
     // Coalescing: only the latest posted value between two FW round-trips is applied,
     // so spamming post() (e.g., during slider drag) never queues up stale values.
     class option_async_setter
     {
     public:
-        option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt );
+        // Optional callback invoked from the worker thread when set_option throws
+        // (rs2::error / std::exception / unknown). Receives a human-readable message.
+        // Used to surface FW rejections (e.g., "exposure can't be changed with AE
+        // enabled") back to the UI thread, where they become notifications.
+        using error_callback = std::function< void( std::string const & ) >;
+
+        option_async_setter( std::shared_ptr< options > endpoint, rs2_option opt, error_callback on_error = {} );
         ~option_async_setter();
 
         option_async_setter( option_async_setter const & ) = delete;
@@ -31,6 +49,7 @@ namespace rs2
 
         std::shared_ptr< options > _endpoint;
         rs2_option _opt;
+        error_callback _on_error;
         std::mutex _mtx;
         std::condition_variable _cv;
         float _pending_value = 0.f;
@@ -46,10 +65,12 @@ namespace rs2
         void update_supported( std::string& error_message );
         void update_read_only_status( std::string& error_message );
         void update_all_fields( std::string& error_message, notifications_model& model );
-        bool set_option( rs2_option opt,
-            float value,
-            std::string& error_message,
-            std::chrono::steady_clock::duration ignore_period = std::chrono::seconds( 0 ) );
+        // Fire-and-forget option write. Always dispatches via the async worker;
+        // FW errors are surfaced asynchronously through the next periodic readback
+        // (option_model::update_all_fields), so this method has no error-out parameter
+        // and no return value. The previous synchronous error_message / ignore_period
+        // parameters are no longer applicable.
+        void set_option( rs2_option opt, float value );
         bool draw_option( bool update_read_only_options, bool is_streaming,
             std::string& error_message, notifications_model& model );
 
@@ -95,21 +116,57 @@ namespace rs2
 
         // Dispatches the option write to a background worker so the UI thread
         // (and therefore the viewer's render loop) is not blocked on the FW round-trip.
-        void set_option_async( rs2_option opt, float value );
+        // Always uses `this->opt` as the target — option_model is bound to a single
+        // rs2_option at construction, so a separate `opt` parameter would only invite
+        // mismatch bugs.
+        void set_option_async( float value );
+
+        // Guard for the public entry points that still take an `opt` parameter
+        // (set_option, slider_selected): an option_model is bound to a single
+        // rs2_option for its lifetime, so a caller passing a different opt is a bug
+        // — throw rather than silently write to the wrong option through the cached
+        // _async_setter. `caller` is used to make the error message tell the reader
+        // which entry point detected the mismatch (pass __func__).
+        void check_opt( rs2_option opt, char const * caller ) const;
 
         std::string adjust_description( const std::string& str_in, const std::string& to_be_replaced, const std::string& to_replace );
 
         // Lazily created on first async dispatch; shared so option_model stays copyable.
         std::shared_ptr< option_async_setter > _async_setter;
 
-        // Optimistic local cache so the slider doesn't visually snap back to the stale
-        // `value` between dispatch (set_option_async) and the FW echo arriving via
-        // options_watcher -> update_value or the post-gate update_all_fields poll.
-        // Cleared when either authoritative path refreshes `value`, or after the timeout
-        // below (in case FW rejects/clamps and never echoes the requested value).
-        float _optimistic_value = 0.f;
-        bool _has_optimistic = false;
-        rsutils::time::stopwatch _optimistic_stopwatch;
+        // Tracks the value the user just requested via the slider / checkbox / edit
+        // field, and is displayed locally until the firmware confirms (or contradicts)
+        // it. Without this mask, the slider would visually snap back to the stale
+        // cached `value` for ~1 s between when set_option_async dispatches the write
+        // and when the FW echo arrives back via either
+        //   - sensor::on_options_changed -> option_model::update_value, or
+        //   - the post-gate option_model::update_all_fields poll,
+        // then jump forward again to the new value. With the mask in place, the slider
+        // visually stays at the user's requested value across that interval.
+        //
+        // The mask is cleared as soon as either authoritative path refreshes `value`
+        // above, or after a 2-second timeout in value_as_float() — the timeout covers
+        // the case where the FW rejects/clamps the request and so never echoes back a
+        // value matching what the user asked for.
+        //
+        // _has_user_request is read on the UI thread (value_as_float) and written from
+        // both the UI thread (set_option_async, update_all_fields) AND the
+        // sensor::on_options_changed callback thread (update_value), so it must be
+        // atomic. We hold it via shared_ptr so option_model stays copyable/movable
+        // (std::atomic itself is neither). _user_request_value and _user_request_stopwatch
+        // are only written on the UI thread, between a false→true transition of the
+        // flag, so readers that load `_has_user_request == true` first see consistent
+        // values for the other two fields without further synchronization.
+        std::shared_ptr< std::atomic< bool > > _has_user_request = std::make_shared< std::atomic< bool > >( false );
+        float _user_request_value = 0.f;
+        rsutils::time::stopwatch _user_request_stopwatch;
+
+        // Cross-thread async-error state, see option_async_state for layout. Eagerly
+        // allocated so option_model copies (e.g., map-insertion of create_option_model's
+        // return value) keep the same state; the worker callback captures this
+        // shared_ptr by value, so the state outlives option_model if the worker is
+        // still in mid-FW-call when option_model destructs.
+        std::shared_ptr< option_async_state > _async_state = std::make_shared< option_async_state >();
     };
 
     option_model create_option_model(option_value const & opt,

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -13,43 +13,23 @@
 #include "subdevice-model.h"
 #include <rsutils/accelerators/gpu.h>
 
-#include <thread>
-#include <condition_variable>
-#include <functional>
-
-namespace {
-// Background worker that drains the JSON config-save block off the UI thread.
-// Coalescing: keyed by an opaque void* (subdevice identity) — if a save for
-// the same subdevice is already pending, the newer lambda replaces it, so a
-// slider drag posting many _options_invalidated events still produces at most
-// one save pass per wake-up cycle.
-class config_save_worker
+namespace rs2
 {
-public:
-    static config_save_worker & instance()
+    // --- subdevice_model::config_save_worker ---------------------------------------------------
+    // Defined out-of-line; the class is declared as a private nested type in subdevice-model.h.
+
+    subdevice_model::config_save_worker & subdevice_model::config_save_worker::instance()
     {
         static config_save_worker w;
         return w;
     }
 
-    void post( void * key, std::function< void() > job )
+    subdevice_model::config_save_worker::config_save_worker()
+        : _worker( [this] { run(); } )
     {
-        {
-            std::lock_guard< std::mutex > lk( _mtx );
-            _pending[key] = std::move( job );
-        }
-        _cv.notify_one();
     }
 
-    void cancel( void * key )
-    {
-        std::lock_guard< std::mutex > lk( _mtx );
-        _pending.erase( key );
-    }
-
-private:
-    config_save_worker() : _worker( [this] { run(); } ) {}
-    ~config_save_worker()
+    subdevice_model::config_save_worker::~config_save_worker()
     {
         {
             std::lock_guard< std::mutex > lk( _mtx );
@@ -59,7 +39,22 @@ private:
         if( _worker.joinable() ) _worker.join();
     }
 
-    void run()
+    void subdevice_model::config_save_worker::post( void * key, std::function< void() > job )
+    {
+        {
+            std::lock_guard< std::mutex > lk( _mtx );
+            _pending[key] = std::move( job );
+        }
+        _cv.notify_one();
+    }
+
+    void subdevice_model::config_save_worker::cancel( void * key )
+    {
+        std::lock_guard< std::mutex > lk( _mtx );
+        _pending.erase( key );
+    }
+
+    void subdevice_model::config_save_worker::run()
     {
         for( ;; )
         {
@@ -80,16 +75,8 @@ private:
         }
     }
 
-    std::mutex _mtx;
-    std::condition_variable _cv;
-    std::map< void *, std::function< void() > > _pending;
-    bool _stop = false;
-    std::thread _worker;  // declared last so other members are init'd before run() starts
-};
-}
+    // -------------------------------------------------------------------------------------------
 
-namespace rs2
-{
     std::vector<const char*> get_string_pointers(const std::vector<std::string>& vec)
     {
         std::vector<const char*> res;
@@ -541,6 +528,12 @@ namespace rs2
 
     subdevice_model::~subdevice_model()
     {
+        // cancel() drops any not-yet-started save job for this subdevice. If the
+        // worker has already dequeued and is running our lambda, cancel is a no-op —
+        // but that's safe because the lambda intentionally captures only shared_ptrs
+        // to the processing blocks (by value), never `this`. So `subdevice_model`'s
+        // dtor doesn't need to wait for the worker; the in-flight save will finish on
+        // its own without dereferencing any member of *this.
         config_save_worker::instance().cancel( this );
         _destructing = true;
         try
@@ -1868,20 +1861,20 @@ namespace rs2
     }
     void subdevice_model::update(std::string& error_message, notifications_model& notifications)
     {
-        // While the user is actively setting options, skip everything below:
-        //   - the _options_invalidated branch triggers save_processing_block_to_config_file
-        //     which calls config_file::set() per option, and every set() rewrites the entire
-        //     JSON config file to disk (see common/rs-config.cpp). At slider-drag rate that
-        //     turned into a disk-I/O storm on the UI thread, freezing the render loop.
-        //   - the per-frame get_option_value() polling shares the per-device USB bus with our
-        //     async option-write worker and with options_watcher's 1 s poll cycle, so leaving
-        //     it in place reintroduces the UI freeze the async dispatch is meant to fix.
-        // Both jobs are coalesced into a single pass once the user stops interacting.
+        // Two paths below are throttled while the user is actively writing options
+        // (last_user_set_stopwatch < 500 ms):
+        //   - the _options_invalidated branch posts a JSON-config save job, which is
+        //     fine to skip during a drag (the worker coalesces anyway).
+        //   - the per-frame get_option_value() polling shares the per-device USB bus
+        //     with our async option-write worker and with options_watcher's 1 s poll
+        //     cycle, so polling here would reintroduce the UI freeze the async dispatch
+        //     is meant to fix.
+        // The gate is scoped to just these two paths so that any other logic added to
+        // update() in the future (or below this point) is not silently throttled.
         // `value` stays fresh during the gate via options_watcher -> on_options_changed.
-        if (last_user_set_stopwatch.get_elapsed_ms() < 500)
-            return;
+        const bool user_writing = last_user_set_stopwatch.get_elapsed_ms() < 500;
 
-        if (_options_invalidated)
+        if (!user_writing && _options_invalidated)
         {
             next_option = 0;
             _options_invalidated = false;
@@ -1906,7 +1899,7 @@ namespace rs2
                 } );
         }
 
-        if (next_option < supported_options.size())
+        if (!user_writing && next_option < supported_options.size())
         {
             auto next = supported_options[next_option];
             if (options_metadata.find(static_cast<rs2_option>(next)) != options_metadata.end())

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -13,6 +13,81 @@
 #include "subdevice-model.h"
 #include <rsutils/accelerators/gpu.h>
 
+#include <thread>
+#include <condition_variable>
+#include <functional>
+
+namespace {
+// Background worker that drains the JSON config-save block off the UI thread.
+// Coalescing: keyed by an opaque void* (subdevice identity) — if a save for
+// the same subdevice is already pending, the newer lambda replaces it, so a
+// slider drag posting many _options_invalidated events still produces at most
+// one save pass per wake-up cycle.
+class config_save_worker
+{
+public:
+    static config_save_worker & instance()
+    {
+        static config_save_worker w;
+        return w;
+    }
+
+    void post( void * key, std::function< void() > job )
+    {
+        {
+            std::lock_guard< std::mutex > lk( _mtx );
+            _pending[key] = std::move( job );
+        }
+        _cv.notify_one();
+    }
+
+    void cancel( void * key )
+    {
+        std::lock_guard< std::mutex > lk( _mtx );
+        _pending.erase( key );
+    }
+
+private:
+    config_save_worker() : _worker( [this] { run(); } ) {}
+    ~config_save_worker()
+    {
+        {
+            std::lock_guard< std::mutex > lk( _mtx );
+            _stop = true;
+        }
+        _cv.notify_one();
+        if( _worker.joinable() ) _worker.join();
+    }
+
+    void run()
+    {
+        for( ;; )
+        {
+            std::vector< std::function< void() > > jobs;
+            bool stopping = false;
+            {
+                std::unique_lock< std::mutex > lk( _mtx );
+                _cv.wait( lk, [this] { return _stop || ! _pending.empty(); } );
+                stopping = _stop;
+                for( auto & kv : _pending ) jobs.push_back( std::move( kv.second ) );
+                _pending.clear();
+            }
+            for( auto & job : jobs )
+            {
+                try { job(); } catch( ... ) {}
+            }
+            if( stopping ) return;
+        }
+    }
+
+    std::mutex _mtx;
+    std::condition_variable _cv;
+    std::map< void *, std::function< void() > > _pending;
+    bool _stop = false;
+    std::thread _worker;  // declared last so other members are init'd before run() starts
+};
+}
+
 namespace rs2
 {
     std::vector<const char*> get_string_pointers(const std::vector<std::string>& vec)
@@ -466,6 +541,7 @@ namespace rs2
 
     subdevice_model::~subdevice_model()
     {
+        config_save_worker::instance().cancel( this );
         _destructing = true;
         try
         {
@@ -1810,13 +1886,24 @@ namespace rs2
             next_option = 0;
             _options_invalidated = false;
 
-            save_processing_block_to_config_file("colorizer", depth_colorizer);
-            save_processing_block_to_config_file("yuy2rgb", yuy2rgb);
-            save_processing_block_to_config_file("m420_to_rgb", m420_to_rgb);
-            save_processing_block_to_config_file("nv12_to_rgb", nv12_to_rgb);
-            save_processing_block_to_config_file("y411", y411);
-
-            for (auto&& pbm : post_processing) pbm->save_to_config_file();
+            // Capture by value so the worker stays UAF-safe even if `this` dies mid-save.
+            // shared_ptrs keep the underlying processing blocks alive until the job runs.
+            auto colorizer = depth_colorizer;
+            auto yuy2      = yuy2rgb;
+            auto m420      = m420_to_rgb;
+            auto nv12      = nv12_to_rgb;
+            auto y411_ptr  = y411;
+            auto pp        = post_processing;
+            config_save_worker::instance().post( this,
+                [ colorizer, yuy2, m420, nv12, y411_ptr, pp ]
+                {
+                    save_processing_block_to_config_file( "colorizer",   colorizer );
+                    save_processing_block_to_config_file( "yuy2rgb",     yuy2 );
+                    save_processing_block_to_config_file( "m420_to_rgb", m420 );
+                    save_processing_block_to_config_file( "nv12_to_rgb", nv12 );
+                    save_processing_block_to_config_file( "y411",        y411_ptr );
+                    for( auto & pbm : pp ) pbm->save_to_config_file();
+                } );
         }
 
         if (next_option < supported_options.size())

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -1792,6 +1792,19 @@ namespace rs2
     }
     void subdevice_model::update(std::string& error_message, notifications_model& notifications)
     {
+        // While the user is actively setting options, skip everything below:
+        //   - the _options_invalidated branch triggers save_processing_block_to_config_file
+        //     which calls config_file::set() per option, and every set() rewrites the entire
+        //     JSON config file to disk (see common/rs-config.cpp). At slider-drag rate that
+        //     turned into a disk-I/O storm on the UI thread, freezing the render loop.
+        //   - the per-frame get_option_value() polling shares the per-device USB bus with our
+        //     async option-write worker and with options_watcher's 1 s poll cycle, so leaving
+        //     it in place reintroduces the UI freeze the async dispatch is meant to fix.
+        // Both jobs are coalesced into a single pass once the user stops interacting.
+        // `value` stays fresh during the gate via options_watcher -> on_options_changed.
+        if (last_user_set_stopwatch.get_elapsed_ms() < 500)
+            return;
+
         if (_options_invalidated)
         {
             next_option = 0;

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -149,6 +149,10 @@ namespace rs2
         // depth ≪ 16.
         _set_dispatcher( std::make_shared< dispatcher >( 64u ) )
     {
+        // dispatcher's worker thread starts in _was_stopped=true; invoke() is a
+        // silent no-op until start() is called. (The header comment claiming it
+        // "starts out 'started'" disagrees with the constructor in src/dispatcher.cpp.)
+        _set_dispatcher->start();
         supported_options = s->get_supported_options();
         restore_processing_block("colorizer", depth_colorizer);
         restore_processing_block("yuy2rgb", yuy2rgb);

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -143,7 +143,11 @@ namespace rs2
         y411(std::make_shared<rs2::gl::y411_decoder>()),
         viewer(viewer),
         detected_objects(device_detected_objects),
-        _destructing( false )
+        _destructing( false ),
+        // Queue capacity is generous: even rapid slider drags coalesce into at most one
+        // queued job per option (see option_model::set_option_async), so realistically
+        // depth ≪ 16.
+        _set_dispatcher( std::make_shared< dispatcher >( 64u ) )
     {
         supported_options = s->get_supported_options();
         restore_processing_block("colorizer", depth_colorizer);

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -33,6 +33,7 @@
 #include <rsutils/time/periodic-timer.h>
 #include <rsutils/time/stopwatch.h>
 #include <rsutils/number/stabilized-value.h>
+#include <rsutils/concurrency/concurrency.h>
 #include "option-model.h"
 
 namespace rs2
@@ -231,6 +232,22 @@ namespace rs2
         bool uvmapping_calib_full = false;
         device_model* dev_model;
         std::string _opt_base_label;
+
+        // Single per-subdevice worker that serializes every FW option write on this
+        // sensor. Replaces the per-option threads from earlier in this PR:
+        //   - Cross-option ordering is now FIFO (no races on the per-device USB bus).
+        //   - The dispatcher action runs try_sleep(200ms) after each set_option, which
+        //     enforces the protective FW-write floor uniformly (slider drag, checkbox,
+        //     calibration — all paths).
+        //   - on_chip_calib routes through this same dispatcher via invoke_and_wait so
+        //     calibration writes can't interleave with concurrent UI writes.
+        // shared_ptr so option_model copies (the map[id] = create_option_model(...)
+        // insertion) hold the same instance. Declared after options_metadata so it is
+        // destroyed first; ~dispatcher stops/joins the worker before option_models go
+        // away, keeping in-flight actions UAF-safe.
+        std::shared_ptr< dispatcher > _set_dispatcher;
+
+        std::shared_ptr< dispatcher > set_dispatcher() const { return _set_dispatcher; }
 
     private:
         bool draw_resolutions(std::string& error_message, std::string& label, std::function<void()> streaming_tooltip, float col0, float col1);

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -28,6 +28,7 @@
 #include "updates-model.h"
 #include "calibration-model.h"
 #include <rsutils/time/periodic-timer.h>
+#include <rsutils/time/stopwatch.h>
 #include <rsutils/number/stabilized-value.h>
 #include "option-model.h"
 
@@ -182,6 +183,11 @@ namespace rs2
         std::mutex _queue_lock;
         bool _options_invalidated = false;
         int next_option = 0;
+        // Reset by option_model::set_option_async on every user-initiated option write.
+        // While this stopwatch is fresh, subdevice_model::update() skips its per-frame
+        // sync get_option_value() polling so the UI thread doesn't serialize on the
+        // per-device USB bus behind an in-flight worker write or options_watcher poll.
+        rsutils::time::stopwatch last_user_set_stopwatch;
         std::vector<rs2_option> supported_options;
         bool streaming = false;
         std::map<rs2_stream, bool> streaming_map; // used for depth and ir mixed resolutions

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -18,6 +18,9 @@
 #include <unordered_map>
 #include <fstream>
 #include <future>
+#include <thread>
+#include <condition_variable>
+#include <functional>
 
 #include "objects-in-frame.h"
 #include "processing-block-model.h"
@@ -257,5 +260,34 @@ namespace rs2
         std::atomic_bool _destructing;
         std::mutex _stop_mutex;
         std::future<void> _stop_future;
+
+        // Process-wide singleton background worker that drains the JSON config-save
+        // block off the UI thread. Coalescing: keyed by an opaque void* (subdevice
+        // identity) — if a save for the same subdevice is already pending, the newer
+        // lambda replaces it, so a slider drag posting many _options_invalidated events
+        // still produces at most one save pass per wake-up cycle. Nested + private so
+        // it stays an implementation detail of subdevice_model.
+        class config_save_worker
+        {
+        public:
+            static config_save_worker & instance();
+
+            config_save_worker( config_save_worker const & ) = delete;
+            config_save_worker & operator=( config_save_worker const & ) = delete;
+
+            void post( void * key, std::function< void() > job );
+            void cancel( void * key );
+
+        private:
+            config_save_worker();
+            ~config_save_worker();
+            void run();
+
+            std::mutex _mtx;
+            std::condition_variable _cv;
+            std::map< void *, std::function< void() > > _pending;
+            bool _stop = false;
+            std::thread _worker;  // declared last so other members are init'd before run() starts
+        };
     };
 }


### PR DESCRIPTION
Tracked by: RSDSO-20803

## Summary

Eliminates a **~1.5 s UI freeze** in realsense-viewer on every option change while streaming, plus a **slider snap-back** regression (slider would briefly jump back to the old cached value before settling on the new one).

Three independent root causes, each fixed in its own commit, plus one peer-review-feedback commit:

1. **1fd96867d** — async option-write dispatch. New option_async_setter worker takes the FW round-trip off the UI thread; last_user_set_stopwatch gate (500 ms) keeps per-frame get_option_value() polling from contending on the per-device USB lock.
2. **4fd1ff0c3** — async JSON config save. Moves save_processing_block_to_config_file x N + per-pp save_to_config_file (~400 ms of disk I/O) to a singleton config_save_worker with void*-keyed coalescing.
3. **28a2f8fa7** — user-request cache for slider feedback. Locally masks the stale option_model::value with the user's just-requested value until the FW echo arrives via options_watcher / update_all_fields (capped at 2 s for FW reject/clamp).
4. **8dee2d9d8** — review feedback. _has_user_request atomic, dead error_message / ignore_period params dropped from set_option, LOG_WARNING for FW errors in the async setter, gate scoped to just the two paths it protects, set_option_async's redundant opt removed, config_save_worker lifted to a private nested class in subdevice-model.h, and on_chip_calib bypasses option_model for its synchronous set+verify path.

Thread-safety for `rs2::config_file` (recursive_mutex around all _j / on-disk access) has been split out to #15092 so it can land independently.

Each commit compiles independently.

## Test plan

- [x] Drag Exposure slider rapidly - no freeze, no snap-back
- [x] Toggle AE / Backlight Compensation - no pause
- [x] Slider settles to FW-applied value if clamped (cache clears on echo)
- [x] On-chip calibration laser-emitter / thermal-loop verify still synchronous
- [x] All commits build (Release, MSVC) on their own
