### PR TITLE
Enforce 2s minimum gap between port disable and re-enable in enable_only

### DIFF
--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -12,6 +12,12 @@ from rspy import log, device_hub, signals
 import time
 import platform, re
 
+# Minimum elapsed time (seconds) required between issuing a port disable and a
+# subsequent port enable on the Acroname USBHub3p (firmware 2.12.2). Below this
+# threshold, sustained disable/enable traffic on high-current ports (observed
+# with D585S, ~1 A idle) can leave the BrainStem control endpoint unresponsive.
+_MIN_PORT_RECYCLE_GAP_S = 2.0
+
 if __name__ == '__main__':
     import os, sys, getopt
     def usage():
@@ -56,6 +62,10 @@ class Acroname(device_hub.device_hub):
             raise NoneFoundError()
         self.hub = None
         self.all_hubs = None
+        # Tracks the time we last issued a port-disable command, so that a
+        # subsequent enable can wait out the minimum recycle gap (see
+        # _MIN_PORT_RECYCLE_GAP_S). None means no disable issued yet.
+        self._last_disable_t = None
 
     def get_name(self):
         """
@@ -202,6 +212,13 @@ class Acroname(device_hub.device_hub):
         :param sleep_on_change: Number of seconds to sleep if any change is made
         :return: True if no errors found, False otherwise
         """
+        # Wait out the minimum disable->enable gap if a disable was issued recently.
+        # See _MIN_PORT_RECYCLE_GAP_S for rationale.
+        if self._last_disable_t is not None:
+            settle = _MIN_PORT_RECYCLE_GAP_S - (time.monotonic() - self._last_disable_t)
+            if settle > 0:
+                log.d(f"waiting {settle:.2f}s for Acroname port-recycle gap")
+                time.sleep(settle)
         result = True
         changed = False
         log.d(f"Enabling ports {ports if ports is not None else 'all'} on Acroname"
@@ -227,7 +244,6 @@ class Acroname(device_hub.device_hub):
         #
         if changed and sleep_on_change:
             signals.register_signal_handlers()
-            import time
             time.sleep( sleep_on_change )
         #
         return result
@@ -251,9 +267,11 @@ class Acroname(device_hub.device_hub):
                     log.e("Failed to disable port", port)
                 else:
                     changed = True
+        if changed:
+            # Mark the time so a subsequent enable can wait out the minimum gap.
+            self._last_disable_t = time.monotonic()
         if changed and sleep_on_change:
             signals.register_signal_handlers()
-            import time
             time.sleep( sleep_on_change )
         #
         return result

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -617,7 +617,14 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
                        'disabling currently enabled ports', enabled_ports )
                 sns_to_remove = { sn for sn in enabled() if get( sn ).port in enabled_ports }
                 hub.disable_ports( enabled_ports )
+                disable_t = time.time()
                 _wait_until_removed( sns_to_remove, timeout = timeout )
+                # Acroname USBHub3p firmware (2.12.2) wedges with -71 cascades when
+                # disable->enable runs faster than ~2 s on high-load devices like D585S.
+                # _wait_until_removed often returns in <1 s, so enforce the gap here.
+                settle = 2.0 - (time.time() - disable_t)
+                if settle > 0:
+                    time.sleep( settle )
             #
             if wanted_ports:
                 hub.enable_ports( wanted_ports )

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -617,14 +617,7 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
                        'disabling currently enabled ports', enabled_ports )
                 sns_to_remove = { sn for sn in enabled() if get( sn ).port in enabled_ports }
                 hub.disable_ports( enabled_ports )
-                disable_t = time.time()
                 _wait_until_removed( sns_to_remove, timeout = timeout )
-                # Acroname USBHub3p firmware (2.12.2) wedges with -71 cascades when
-                # disable->enable runs faster than ~2 s on high-load devices like D585S.
-                # _wait_until_removed often returns in <1 s, so enforce the gap here.
-                settle = 2.0 - (time.time() - disable_t)
-                if settle > 0:
-                    time.sleep( settle )
             #
             if wanted_ports:
                 hub.enable_ports( wanted_ports )


### PR DESCRIPTION
## Summary
Defensive guard in `Acroname.disable_ports` / `Acroname.enable_ports` that enforces a minimum 2 s gap between issuing a port-disable and a subsequent port-enable on the same hub. Below this threshold the Acroname USBHub3p (firmware 2.12.2) BrainStem control endpoint can stop responding under sustained disable/enable traffic on high-current ports — most reliably reproduced with D585S, which idles around 1 A.

This is **not** a fix for a deterministic failure. The wedge is intermittent in production. The patch removes the timing trigger by guaranteeing a known-safe minimum, so the failure mode cannot be hit even when other layers (test retry path, fast machine, post-streaming cleanup) compress the gap.

## Implementation
- Module-level constant `_MIN_PORT_RECYCLE_GAP_S = 2.0` in `acroname.py`
- `Acroname.__init__` adds `_last_disable_t = None`
- `Acroname.disable_ports` records `time.monotonic()` after a successful disable
- `Acroname.enable_ports` checks at start and sleeps just enough to honour the gap; logs `log.d(f"waiting {settle:.2f}s for Acroname port-recycle gap")`
- Removed two redundant `import time` shadows that would have caused `UnboundLocalError` when the module-level `time` is referenced earlier in the function

`devices.py` is untouched — initial revision had the logic there but per review (@OhadMeir) it belongs in the hub-specific class.

## Threshold data (vtglnx163, D585S on Acroname port 4)
| Inter-cycle gap | Result |
|---|---|
| 1.0 s (×10) | **Wedge: BrainStem control endpoint dies after ~8 cycles, full `-71` cascade across both stems. Recovery: physical DC power-cycle of the hub.** |
| 1.5 s (×10) | Hub stays alive, but D585S enumeration errors (`device not accepting address ... -62`); only 3/10 cycles complete USB enumeration |
| **2.0 s (×30)** | **Clean: 0 failures, no dmesg errors, full re-enumeration each cycle** |
| 3.0 s / 5.0 s | Clean |

libci 11369 showed disable→enable gaps as low as 259 ms when consecutive tests target the same device.

## Validation on real pytest workload
Ran `pytest unit-tests/live/ --device D585S --context nightly` against the same suite, **with and without the patch**:

| Metric | With patch | Without patch |
|---|---|---|
| Passed / Failed / Errors / Skipped | 29 / 2 / 2 / 115 | 29 / 2 / 2 / 115 |
| D585S re-enumerations | 23 | 30 |
| `err = -71` events | 0 | 0 |
| `cannot disable` events | 0 | 0 |
| Hub wedge | No | No |
| Duration | 358 s | 334 s |

Same exact failure list both times — the 4 non-passes are test-internal (`pytest-enumerate-devices`, `pytest-rs-convert-to-db3` FAILED; `multi_devices/*` ERROR) and not caused by hub timing. Cost of the patch on this 6-minute run: **~24 s (~7%)**.

Today we couldn't reliably trigger the wedge through pytest's natural pacing (re-enumeration takes ~3.8 s, naturally giving the hub breathing room), but yesterday's stress tests prove the trigger is real once cycle gaps drop below 2 s.

## Test plan
- [x] Local syntax check (`py_compile`)
- [x] Stress test on real hardware (vtglnx163, D585S): 30× rapid cycles at 2 s gap — clean
- [x] Real pytest workload (`--device D585S --context nightly`) with and without patch — same results
- [x] Verified pre-fix state still wedges at 1 s gap, fails enumeration at 1.5 s gap
- [ ] libci nightly run end-to-end on shared rigs

🤖 Generated with [Claude Code](https://claude.com/claude-code)