### PR TITLE
add feature minz close range docs & examples

### DIFF
--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -1,0 +1,602 @@
+# librealsense2-enhanced-depth (Close-Range)
+
+These examples demonstrate usage of the **Enhanced depth** library. The library
+is a closed-source depth enhancement module designed to operate on top of the
+Intel RealSense SDK 2.0 pipeline. It improves minimum sensing distance (min-Z)
+to ~12 cm on NVIDIA Jetson platforms. It integrates transparently into
+existing RealSense-based applications and requires no modification to camera
+firmware and/or SDK.
+
+---
+
+## Table of Contents
+
+- [What's Included](#whats-included)
+- [Installation](#installation)
+- [Running the Bundled Examples](#running-the-bundled-examples)
+  - [Python (headless stats): `range_depth.py`](#python-headless-stats-range_depthpy)
+  - [Python (live windowed compare): `live_minz_compare.py`](#python-live-windowed-compare-live_minz_comparepy)
+  - [C++: `range_depth.cpp`](#c-range_depthcpp)
+- [Quick Start](#quick-start)
+  - [Python](#quick-start-python)
+  - [C++](#quick-start-c)
+- [Python API](#python-api)
+  - [Calibration](#calibration)
+  - [DepthRangeImprover](#depthrangeimprover)
+  - [Utilities](#utilities)
+- [C++ API](#c-api)
+  - [Calibration (C++)](#calibration-c)
+  - [DepthRangeImprover (C++)](#depthrangeimprover-c)
+  - [Utilities (C++)](#utilities-c)
+- [FrameMetadata](#framemetadata)
+- [CLI Tools](#cli-tools)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## What's Included
+
+Latency measured at 640x480 on Jetson AGX Orin.
+
+| Component | Class | What it does |
+|-----------|-------|-------------|
+| Close-range improvement | `DepthRangeImprover` | Extends min distance from 520 mm to 120 mm |
+
+---
+
+## Installation
+
+```bash
+sudo dpkg -i librealsense2-enhanced-depth-*.deb
+```
+
+Everything installs to `/opt/librealsense2-enhanced-depth/`. No venv needed — uses system Python 3.
+
+The deb depends on `librealsense2` (≥ matching version) — install both from the
+same Artifactory / apt source so the SONAMEs line up.
+
+---
+
+## Running the Bundled Examples
+
+This folder ships three minimal end-to-end demos that pull live IR + depth
+from a connected RealSense D4xx, push the frames through `DepthRangeImprover`,
+and either print stats or display the result.
+
+| Example | What it does | Extra deps |
+|---|---|---|
+| [`range_depth.py`](#python-headless-stats-range_depthpy) | Headless Python stats: prints valid-pixel counts + recovered close-range pixels per frame | none beyond the SDK |
+| [`live_minz_compare.py`](#python-live-windowed-compare-live_minz_comparepy) | Two live windows side-by-side: raw HW depth vs MinZ-improved depth | OpenCV (`python3-opencv`) |
+| [`range_depth.cpp`](#c-range_depthcpp) | C++ equivalent of `range_depth.py` (headless stats) | librealsense2-dev |
+
+### Python (headless stats): `range_depth.py`
+
+Once the deb is installed, run directly with system Python:
+
+```bash
+python3 range_depth.py
+```
+
+(Adjust resolution / frame count by editing the `enable_stream` calls in the
+file — the example is intentionally short and self-contained.)
+
+The Python module path `/opt/librealsense2-enhanced-depth/python/` is added to
+`sys.path` automatically by the package's `postinst`. If you're running from
+a non-standard install or a build tree, set:
+
+```bash
+export PYTHONPATH=/opt/librealsense2-enhanced-depth/python:$PYTHONPATH
+python3 range_depth.py
+```
+
+### Python (live windowed compare): `live_minz_compare.py`
+
+Visual side-by-side: opens two OpenCV windows showing **raw HW depth** (left,
+black-out below ~520 mm) and **MinZ-improved depth** (right, close-range
+filled in via the Enhanced Depth library). Useful for eyeballing what MinZ recovers.
+
+```bash
+sudo apt install python3-opencv      # one-time, if not already installed
+python3 live_minz_compare.py         # press 'q' or ESC in either window to stop
+```
+
+The script doesn't pop up empty windows during camera warm-up — it prints
+`Waiting for first frame…` to the terminal and only opens the windows once
+real frames arrive. Status line below the live windows shows per-frame valid
+pixel counts and the gain.
+
+If you're running from a non-standard install or build tree, the same
+`PYTHONPATH` override applies:
+
+```bash
+export PYTHONPATH=/opt/librealsense2-enhanced-depth/python:$PYTHONPATH
+python3 live_minz_compare.py
+```
+
+### C++: `range_depth.cpp`
+
+The example links against two libraries:
+
+| Library | From package | Purpose |
+|---|---|---|
+| `librealsense2` | `librealsense2-dev` | camera capture (the same SDK this folder lives in) |
+| `librs_depth_range` | `librealsense2-enhanced-depth` | the close-range processor |
+
+Both expose `pkg-config` files, so the simplest one-line build is:
+
+```bash
+g++ -std=c++17 range_depth.cpp \
+    -I/opt/librealsense2-enhanced-depth/include \
+    -L/opt/librealsense2-enhanced-depth/lib \
+    -lrs_depth_range \
+    -Wl,-rpath,/opt/librealsense2-enhanced-depth/lib \
+    $(pkg-config --cflags --libs realsense2) \
+    -o range_depth
+
+./range_depth
+```
+
+If you'd rather build it as part of a CMake project, drop this snippet into a
+`CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.10)
+project(range_depth)
+
+find_package(realsense2 REQUIRED)
+
+add_executable(range_depth range_depth.cpp)
+set_property(TARGET range_depth PROPERTY CXX_STANDARD 17)
+
+target_include_directories(range_depth PRIVATE
+    /opt/librealsense2-enhanced-depth/include
+)
+target_link_directories(range_depth PRIVATE
+    /opt/librealsense2-enhanced-depth/lib
+)
+target_link_libraries(range_depth PRIVATE
+    realsense2::realsense2
+    rs_depth_range
+)
+set_target_properties(range_depth PROPERTIES
+    INSTALL_RPATH /opt/librealsense2-enhanced-depth/lib
+    BUILD_RPATH   /opt/librealsense2-enhanced-depth/lib
+)
+```
+
+Then standard CMake build:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+./range_depth
+```
+
+> **Tip:** the linker hint `-Wl,-rpath,…` (or CMake's `INSTALL_RPATH`) bakes
+> the install path into the binary so the dynamic loader finds
+> `librs_depth_range.so` without you having to set `LD_LIBRARY_PATH` at run time.
+
+---
+
+## Quick Start
+
+### Quick Start: Python
+
+```python
+import pyrealsense2 as rs
+import numpy as np
+from rs_depth import Calibration, DepthRangeImprover, FrameMetadata
+
+pipeline = rs.pipeline()
+cfg = rs.config()
+cfg.enable_stream(rs.stream.infrared, 1, 640, 480, rs.format.y8, 30)
+cfg.enable_stream(rs.stream.infrared, 2, 640, 480, rs.format.y8, 30)
+cfg.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
+profile = pipeline.start(cfg)
+
+ir_stream = profile.get_stream(rs.stream.infrared, 1).as_video_stream_profile()
+ir_intrin = ir_stream.get_intrinsics()
+ir_extrin = ir_stream.get_extrinsics_to(profile.get_stream(rs.stream.infrared, 2))
+cal = Calibration.from_sdk(ir_intrin, ir_extrin)
+
+depth_range = DepthRangeImprover(cal)
+
+frameset = pipeline.wait_for_frames()
+ir_left  = np.asanyarray(frameset.get_infrared_frame(1).get_data())
+ir_right = np.asanyarray(frameset.get_infrared_frame(2).get_data())
+depth_mm = np.asanyarray(frameset.get_depth_frame().get_data())
+meta     = FrameMetadata.from_rs2_frameset(frameset)
+
+# Close-range improvement → uint16 mm, shape (H, W)
+improved = depth_range.process(ir_left, ir_right, depth_mm, metadata=meta)
+
+pipeline.stop()
+```
+
+---
+
+### Quick Start: C++
+
+```cpp
+#include <rs_depth_calibration.hpp>
+#include <rs_depth_range.hpp>
+#include <librealsense2/rs.hpp>
+
+rs2::pipeline pipeline;
+rs2::config cfg;
+cfg.enable_stream(RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 30);
+cfg.enable_stream(RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 30);
+cfg.enable_stream(RS2_STREAM_DEPTH,       640, 480, RS2_FORMAT_Z16, 30);
+auto profile = pipeline.start(cfg);
+
+auto ir_stream = profile.get_stream(RS2_STREAM_INFRARED, 1).as<rs2::video_stream_profile>();
+auto intrin = ir_stream.get_intrinsics();
+auto extrin = ir_stream.get_extrinsics_to(profile.get_stream(RS2_STREAM_INFRARED, 2));
+auto cal = rs_depth::Calibration::from_params(intrin.fx, std::abs(extrin.translation[0]));
+
+rs_depth::DepthRangeImprover depth_range(cal);
+
+auto frames = pipeline.wait_for_frames();
+auto ir_l = frames.get_infrared_frame(1);
+auto ir_r = frames.get_infrared_frame(2);
+auto depth = frames.get_depth_frame();
+
+// Mirrors Python's FrameMetadata.from_rs2_frameset.
+auto meta = FrameMetadata::from_rs2_frameset(frames);
+
+std::vector<uint16_t> depth_out(640 * 480);
+depth_range.process((const uint8_t*)ir_l.get_data(),
+                    (const uint8_t*)ir_r.get_data(),
+                    (const uint16_t*)depth.get_data(),
+                    depth_out.data(), meta);
+
+pipeline.stop();
+```
+
+---
+
+## Python API
+
+### Calibration
+
+Full D4xx camera calibration. Construct once, pass everywhere.
+
+```python
+from rs_depth import Calibration
+```
+
+| Constructor | When to use |
+|-------------|-------------|
+| `Calibration.from_sdk(ir_intrinsics, ir_extrinsics, rgb_intrinsics=..., depth_to_rgb=...)` | `rs2_intrinsics` / `rs2_extrinsics` objects |
+| `Calibration.from_params(focal_length_px, baseline_m)` | Plain scalars (minimal fallback) |
+
+**IR / Depth fields** (GETINTCAL ID 25 / RECPARAMSGET):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `focal_length_px` | `float` | fx at the active streaming resolution |
+| `baseline_m` | `float` | Stereo baseline in metres |
+| `fy`, `ppx`, `ppy` | `float` | Depth stream intrinsics |
+| `width`, `height` | `int` | Resolution these params apply to |
+| `ir_distortion_model` | `int` | `rs2_distortion` enum value |
+| `ir_distortion_coeffs` | `tuple[float, ...]` | Brown model (k1, k2, p1, p2, k3) |
+
+**RGB fields** (GETINTCAL ID 32):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rgb_fx`, `rgb_fy` | `float` | RGB focal lengths in pixels |
+| `rgb_ppx`, `rgb_ppy` | `float` | RGB principal point |
+| `rgb_width`, `rgb_height` | `int` | RGB stream resolution |
+| `rgb_distortion_model` | `int` | `rs2_distortion` enum value |
+| `rgb_distortion_coeffs` | `tuple[float, ...]` | Brown model (k1, k2, p1, p2, k3) |
+| `depth_to_rgb_rotation` | `tuple[float, ...]` | 9-float column-major 3×3 rotation |
+| `depth_to_rgb_translation` | `tuple[float, ...]` | 3-float translation in metres |
+
+---
+
+### DepthRangeImprover
+
+Extends RealSense minimum working distance from ~520 mm to ~120 mm.
+Recovers close-range depth that the RealSense hardware cannot measure and blends it with the hardware depth for a seamless result.
+
+```python
+from rs_depth import DepthRangeImprover
+
+DepthRangeImprover(
+    calibration,                      # Calibration — required
+    min_z_threshold_mm=None,          # Auto from calibration (F*B/105); pass int to override
+    scale_factor=0.35,                # Downscale factor for processing (speed vs quality)
+    crop_region=None,                 # (x1, y1, x2, y2) — process only this ROI;
+                                      # output is always full-size (hw depth fills the background)
+)
+```
+
+#### `DepthRangeImprover.process(ir_left, ir_right, depth_mm)`
+
+```python
+depth_mm = improver.process(ir_left, ir_right, depth_mm, metadata=meta)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ir_left` | `np.ndarray (H, W) uint8` | Left IR image. |
+| `ir_right` | `np.ndarray (H, W) uint8` | Right IR image. |
+| `depth_mm` | `np.ndarray (H, W) uint16` | RealSense hardware depth in mm. |
+| `metadata` | `FrameMetadata` | **Required.** Per-frame metadata. |
+| **Returns** | `np.ndarray (H, W) uint16` | Merged depth in **millimetres**. |
+
+---
+
+### Utilities
+
+```python
+from rs_depth import convert_depth, split_y8i, discover_backends
+
+# Unit conversion
+depth_m  = convert_depth(depth_mm, "mm", "meters")
+depth_mm = convert_depth(depth_m, "meters", "mm")
+
+# Y8I interleaved frame → separate left/right (zero-copy views)
+left, right = split_y8i(y8i_frame)  # (H, W, 2) → two (H, W) uint8
+depth_mm = depth_range.process(left, right, hw_depth_mm)
+
+# Check what's installed at runtime
+status = discover_backends()
+print(status.has_depth_range)  # True
+```
+
+---
+
+## C++ API
+
+Headers at `/opt/librealsense2-enhanced-depth/include/`, library at `/opt/librealsense2-enhanced-depth/lib/`.
+
+---
+
+### Calibration (C++)
+
+```cpp
+#include <rs_depth_calibration.hpp>
+```
+
+| Constructor | When to use |
+|-------------|-------------|
+| `Calibration::from_sdk(ir_intrin, ir_extrin, rgb_intrin*, depth_to_rgb*)` | `rs2_intrinsics` / `rs2_extrinsics` from librealsense2. Available when `<librealsense2/rs.hpp>` is included before this header. |
+| `Calibration::from_raw_tables(data25, size25, data32, size32, rec, rec_sz, w, h)` | Raw firmware blobs |
+| `Calibration::from_params(focal_length_px, baseline_m)` | Plain scalars (minimal fallback) |
+
+**IR / Depth fields** (GETINTCAL ID 25 / RECPARAMSGET):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `focal_length_px` | `float` | fx at the active streaming resolution |
+| `baseline_m` | `float` | Stereo baseline in metres |
+| `fy`, `ppx`, `ppy` | `float` | Depth stream intrinsics (0 if not set) |
+| `width`, `height` | `int` | Resolution these params apply to |
+| `ir_distortion_model` | `int` | `rs2_distortion` enum value |
+| `ir_distortion_coeffs[5]` | `float[]` | Brown model (k1, k2, p1, p2, k3) |
+
+**RGB fields** (GETINTCAL ID 32):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rgb_fx`, `rgb_fy` | `float` | RGB focal lengths in pixels |
+| `rgb_ppx`, `rgb_ppy` | `float` | RGB principal point |
+| `rgb_width`, `rgb_height` | `int` | RGB stream resolution |
+| `rgb_distortion_model` | `int` | `rs2_distortion` enum value |
+| `rgb_distortion_coeffs[5]` | `float[]` | Brown model (k1, k2, p1, p2, k3) |
+| `depth_to_rgb_rotation[9]` | `float[]` | Column-major 3×3 rotation |
+| `depth_to_rgb_translation[3]` | `float[]` | Translation in metres |
+
+---
+
+### DepthRangeImprover (C++)
+
+Extends RealSense minimum working distance from ~520 mm to ~120 mm.
+Pure C++ — no Python runtime required.
+
+```cpp
+#include <rs_depth_calibration.hpp>
+#include <rs_depth_range.hpp>
+```
+
+```cpp
+rs_depth::DepthRangeImprover(
+    calibration,                    // Calibration — required
+    crop_region     = {-1,-1,-1,-1},// {x1, y1, x2, y2} — process only this ROI;
+                                    // output is always full-size (hw depth fills the background)
+    min_z_threshold = 0,            // 0 = auto from calibration (F*B/105); pass mm to override
+    scale_factor    = 0.35f         // Downscale factor for processing (speed vs quality)
+);
+```
+
+#### `DepthRangeImprover::process(ir_left, ir_right, depth_mm, depth_out, metadata)`
+
+```cpp
+depth_range.process(ir_left, ir_right, depth_mm, depth_out, metadata);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ir_left` | `const uint8_t* (H×W)` | Left IR image — grayscale, row-major |
+| `ir_right` | `const uint8_t* (H×W)` | Right IR image |
+| `depth_mm` | `const uint16_t* (H×W)` | RealSense hardware depth in mm |
+| `depth_out` | `uint16_t* (H×W)` | Caller-allocated output — improved depth in **millimetres** |
+| `metadata` | `const FrameMetadata&` | **Required.** Per-frame metadata (carries `width`, `height`, exposure, gain, etc.). |
+
+```sh
+g++ -std=c++17 your_app.cpp \
+    -I/opt/librealsense2-enhanced-depth/include \
+    -L/opt/librealsense2-enhanced-depth/lib -lrs_depth_range \
+    -Wl,-rpath,/opt/librealsense2-enhanced-depth/lib \
+    -o your_app
+```
+
+---
+
+### Utilities (C++)
+
+```cpp
+#include <rs_depth_utils.hpp>
+```
+
+```cpp
+// Unit conversion
+std::vector<float>    depth_m(n);
+std::vector<uint16_t> depth_mm(n);
+
+rs_depth::convert_depth(depth_mm.data(), depth_m.data(),  n);  // mm  → metres
+rs_depth::convert_depth(depth_m.data(),  depth_mm.data(), n);  // metres → mm
+
+// Y8I split — mirrors Python: split_y8i()
+std::vector<uint8_t> left(w * h), right(w * h);
+rs_depth::split_y8i(y8i_data, left.data(), right.data(), w, h);
+depth_range.process(left.data(), right.data(), hw_depth, depth_out, metadata);
+
+// Backend discovery
+auto status = rs_depth::discover_backends();
+status.has_depth_range;  // true
+```
+
+---
+
+## FrameMetadata
+
+Per-frame metadata from the RealSense sensor. Contains per-stream metadata
+(IR, depth, color) plus frame-level format info. Constructed from native
+`pyrealsense2` frames or manually.
+
+```python
+from rs_depth import FrameMetadata, StreamMetadata
+
+# From native pyrealsense2
+frameset = pipeline.wait_for_frames()
+meta = FrameMetadata.from_rs2_frameset(frameset)
+
+# Manual construction
+meta = FrameMetadata(width=640, height=480, ir=StreamMetadata(exposure_us=8000))
+```
+
+#### StreamMetadata fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `frame_number` | `int` | Frame counter |
+| `timestamp_us` | `float` | Device clock (microseconds) |
+| `arrival_time_us` | `float` | System clock (microseconds) |
+| `sensor_timestamp_us` | `float` | Mid-exposure timestamp |
+| `backend_timestamp_us` | `float` | Backend receive timestamp |
+| `exposure_us` | `int` | Actual exposure (microseconds) |
+| `gain` | `int` | Sensor gain |
+| `auto_exposure` | `bool` | Auto-exposure on/off |
+| `actual_fps` | `float` | Measured FPS × 1000 |
+| `laser_power` | `int` | Laser power (0–360) |
+| `emitter_mode` | `int` | 0=off, 1=laser, 2=auto |
+| `temperature` | `float` | Sensor temperature (Celsius) |
+| `white_balance` | `int` | White balance (Kelvin) |
+| `brightness` | `int` | Brightness level |
+| `contrast` | `int` | Contrast level |
+| `saturation` | `int` | Saturation level |
+
+#### FrameMetadata fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ir` | `StreamMetadata` | Metadata from the IR frame |
+| `depth` | `StreamMetadata` | Metadata from the depth frame |
+| `color` | `StreamMetadata` | Metadata from the color frame |
+| `ir_format` | `str` | IR format: `"y8"`, `"y16"`, or `"y12i"` |
+| `width` | `int` | Frame width |
+| `height` | `int` | Frame height |
+
+Convenience properties on `FrameMetadata` (read IR first, fall back to depth):
+`frame_number`, `timestamp_us`, `exposure_us`, `gain`, `laser_power`,
+`temperature`, `actual_fps`.
+
+> **Note:** Not all fields are available on all devices. Unsupported fields
+> default to 0. Full per-frame metadata requires the librealsense UVC kernel
+> patch.
+
+---
+
+## CLI Tools
+
+All CLI tools are in `/usr/bin/` and activate the correct Python environment automatically.
+
+### `rs-depth-live` — Live camera
+
+```bash
+rs-depth-live --range-depth
+rs-depth-live --range-depth --show-rgb --show-irs --show-raw-depth
+rs-depth-live --range-depth --headless --frames 100
+rs-depth-live --range-depth --crop-region 128 96 512 384    # ROI crop (384×288)
+rs-depth-live --range-depth --record /tmp/out                # record all streams
+rs-depth-live --record /tmp/calib --ir-format y16            # calibration recording (Y16 IR + color, no depth)
+rs-depth-live --record /tmp/raw --ir-format y8               # raw recording (all streams, no processing)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--range-depth` | Enable close-range depth improvement |
+| `--output-unit UNIT` | `meters` (default) or `mm` |
+| `--crop-region X1 Y1 X2 Y2` | Process only this ROI; output is always full-size |
+| `--show-rgb` | Show RGB color stream |
+| `--show-irs` | Show left/right IR streams |
+| `--show-raw-depth` | Show raw hardware depth for comparison |
+| `--record DIR` | Record streams to a directory (`.bag` + calibration JSON + raw firmware blobs) |
+| `--ir-format FORMAT` | IR recording format: `y8` (default — all streams), `y16` (16-bit IR + color at 1280×800, no depth), or `y12i` (12-bit interleaved, device-dependent) |
+| `--headless` | No GUI — for benchmarking or SSH sessions |
+| `--frames N` | Stop after N frames |
+| `--width`, `--height`, `--fps` | Camera resolution and framerate |
+
+**Recording modes:**
+
+| `--ir-format` | Streams recorded | Resolution | Use case |
+|---------------|-----------------|------------|----------|
+| `y8` (default) | IR L/R (Y8) + Depth (Z16) + Color (BGR8) | User-specified | General capture, debugging, replay with processing |
+| `y16` | IR L/R (Y16) + Color (BGR8) | 1280×800 (forced) | White-balance calibration (16-bit IR dynamic range) |
+| `y12i` | IR L/R (Y12I) + Color (BGR8) | 1280×800 (forced) | Calibration (12-bit interleaved, not all devices) |
+
+All modes save calibration data alongside the `.bag`: `calibration_*.json` and raw firmware blobs (`getintcal_id25`, `getintcal_id32`, `recparamsget`).
+
+### `rs-depth-playback` — Replay .bag files
+
+```bash
+rs-depth-playback /tmp/out --range-depth
+rs-depth-playback /tmp/out --no-realtime   # process every frame without dropping
+rs-depth-playback /tmp/calib               # Y16/Y12I calibration — display only, no processing
+```
+
+Playback auto-detects IR format from the `.bag` and adjusts display accordingly.
+Controls: `q`/ESC quit · SPACE pause/resume.
+
+---
+
+## Troubleshooting
+
+### Camera not detected
+
+```
+ERROR: Failed to start RealSense camera
+```
+
+Check that the camera is connected and not in use by another process:
+```bash
+rs-enumerate-devices    # from librealsense2-utils
+```
+
+### No display (headless / SSH)
+
+```bash
+rs-depth-live --range-depth --headless --frames 100
+```
+
+### Check which backends are installed
+
+```python
+from rs_depth import discover_backends
+print(discover_backends())
+# BackendStatus(close-range)
+```

--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -7,6 +7,10 @@ to ~12 cm on NVIDIA Jetson platforms. It integrates transparently into
 existing RealSense-based applications and requires no modification to camera
 firmware and/or SDK.
 
+<p align="center">
+  <a href="https://realsenseai.com/case-studies/?capability_application=autonomous-mobile-robots"><img src="https://librealsense.realsenseai.com/readme-media/minz/minz_600.gif" width="720"/></a>
+</p>
+
 ---
 
 ## Table of Contents

--- a/examples/enhanced-depth-range/live_minz_compare.py
+++ b/examples/enhanced-depth-range/live_minz_compare.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+"""Live side-by-side comparison: raw HW depth vs MinZ-improved depth.
+
+Streams from a RealSense D4xx and shows two live OpenCV windows:
+
+    ┌─────────────────────┐    ┌─────────────────────┐
+    │ Raw HW depth        │    │ MinZ-improved depth │
+    │ (camera output)     │    │ (close-range filled)│
+    └─────────────────────┘    └─────────────────────┘
+
+Pixels closer than the camera's MinZ threshold (~520 mm by default) are
+typically dropped by the hardware (shown black on the left). The MinZ
+processor recovers them via the Enhanced Depth library (right window).
+
+Run:
+    python3 live_minz_compare.py        # press 'q' or ESC to stop
+"""
+
+import sys
+
+import cv2
+import numpy as np
+import pyrealsense2 as rs
+
+from rs_depth import Calibration, DepthRangeImprover
+
+
+# ── 1. Open the camera ──────────────────────────────────────────────────
+pipeline = rs.pipeline()
+cfg = rs.config()
+cfg.enable_stream(rs.stream.infrared, 1, 640, 480, rs.format.y8,  30)
+cfg.enable_stream(rs.stream.infrared, 2, 640, 480, rs.format.y8,  30)
+cfg.enable_stream(rs.stream.depth,       640, 480, rs.format.z16, 30)
+profile = pipeline.start(cfg)
+
+# ── 2. Build calibration from the camera's own intrinsics/extrinsics ────
+ir1 = profile.get_stream(rs.stream.infrared, 1).as_video_stream_profile()
+ir2 = profile.get_stream(rs.stream.infrared, 2).as_video_stream_profile()
+calib = Calibration.from_sdk(ir1.get_intrinsics(), ir1.get_extrinsics_to(ir2))
+
+# ── 3. Construct the improver ───────────────────────────────────────────
+improver = DepthRangeImprover(calib)
+print(f"MinZ threshold: {improver.min_z_threshold_mm} mm")
+print("Press 'q' or ESC to stop\n")
+
+# ── 4. Helpers ──────────────────────────────────────────────────────────
+# Visualisation depth range — invalid (depth==0) and beyond MAX_MM both
+# render as black so the eye notices them clearly.
+MIN_MM, MAX_MM = 120, 3000
+
+
+def colorize_depth_mm(depth_mm: np.ndarray) -> np.ndarray:
+    """uint16 mm → BGR uint8 with TURBO colormap, invalid pixels black."""
+    valid = (depth_mm > 0) & (depth_mm <= MAX_MM)
+    norm = np.zeros(depth_mm.shape, dtype=np.uint8)
+    if valid.any():
+        d = np.clip(depth_mm, MIN_MM, MAX_MM).astype(np.float32)
+        norm[valid] = ((d[valid] - MIN_MM) / (MAX_MM - MIN_MM) * 255.0).astype(np.uint8)
+    bgr = cv2.applyColorMap(norm, cv2.COLORMAP_TURBO)
+    bgr[~valid] = (0, 0, 0)
+    return bgr
+
+
+WIN_HW, WIN_IMP = "Raw HW depth", "MinZ-improved depth"
+
+# ── 5. Stream + improve + display loop ──────────────────────────────────
+# Windows are NOT pre-created — letting cv2.imshow create them on the
+# first frame avoids empty black windows popping up while we wait for
+# the camera to stream. Print a "waiting" line so the terminal isn't
+# silent during the warm-up.
+sys.stdout.write("Waiting for first frame… ")
+sys.stdout.flush()
+
+first_frame_drawn = False
+
+try:
+    while True:
+        f = pipeline.wait_for_frames()
+        ir_left  = np.asanyarray(f.get_infrared_frame(1).get_data())
+        ir_right = np.asanyarray(f.get_infrared_frame(2).get_data())
+        depth_hw = np.asanyarray(f.get_depth_frame().get_data())
+
+        depth_imp = improver.process(ir_left, ir_right, depth_hw)
+
+        if not first_frame_drawn:
+            sys.stdout.write("got it. Streaming. Press 'q' or ESC to stop.\n")
+            sys.stdout.flush()
+            first_frame_drawn = True
+
+        cv2.imshow(WIN_HW,  colorize_depth_mm(depth_hw))
+        cv2.imshow(WIN_IMP, colorize_depth_mm(depth_imp))
+
+        # Status line below the live windows.
+        n_hw  = int((depth_hw  > 0).sum())
+        n_imp = int((depth_imp > 0).sum())
+        sys.stdout.write(
+            f"\rframe {f.get_frame_number():>5} │ "
+            f"valid pixels: HW {n_hw:>7,} → improved {n_imp:>7,} "
+            f"(+{n_imp - n_hw:>6,})"
+        )
+        sys.stdout.flush()
+
+        key = cv2.waitKey(1) & 0xFF
+        if key in (ord('q'), 27):  # 27 = ESC
+            break
+except KeyboardInterrupt:
+    pass
+finally:
+    print()
+    pipeline.stop()
+    cv2.destroyAllWindows()

--- a/examples/enhanced-depth-range/range_depth.cpp
+++ b/examples/enhanced-depth-range/range_depth.cpp
@@ -1,0 +1,106 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+// Live MinZ (close-range depth) demo using rs_depth + librealsense2.
+//
+// Streams from a RealSense D4xx, runs DepthRangeImprover on each frame, and
+// prints a single live-updating status line showing how much of the
+// close-range band MinZ recovered that the camera couldn't see on its own.
+//
+// Build:
+//   g++ -std=c++17 range_depth.cpp \
+//       -I/opt/librealsense2-enhanced-depth/include \
+//       -L/opt/librealsense2-enhanced-depth/lib -lrs_depth_range \
+//       -Wl,-rpath,/opt/librealsense2-enhanced-depth/lib \
+//       $(pkg-config --cflags --libs realsense2) \
+//       -o range_depth
+//
+// Run:
+//   ./range_depth        # Ctrl-C to stop
+
+#include <librealsense2/rs.hpp>
+#include <rs_depth_calibration.hpp>
+#include <rs_depth_range.hpp>
+
+#include <cmath>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+static volatile std::sig_atomic_t g_stop = 0;
+
+int main() {
+    std::signal(SIGINT, [](int){ g_stop = 1; });
+    constexpr int W = 640, H = 480, FPS = 30;
+    constexpr int N = W * H;
+
+    // ── 1. Open the camera ────────────────────────────────────────────
+    rs2::pipeline pipe;
+    rs2::config   cfg;
+    cfg.enable_stream(RS2_STREAM_INFRARED, 1, W, H, RS2_FORMAT_Y8,  FPS);
+    cfg.enable_stream(RS2_STREAM_INFRARED, 2, W, H, RS2_FORMAT_Y8,  FPS);
+    cfg.enable_stream(RS2_STREAM_DEPTH,       W, H, RS2_FORMAT_Z16, FPS);
+    auto profile = pipe.start(cfg);
+
+    // ── 2. Build calibration from the camera's own intrinsics/extrinsics
+    auto ir1 = profile.get_stream(RS2_STREAM_INFRARED, 1).as<rs2::video_stream_profile>();
+    auto ir2 = profile.get_stream(RS2_STREAM_INFRARED, 2).as<rs2::video_stream_profile>();
+    auto calib = rs_depth::Calibration::from_sdk(ir1.get_intrinsics(),
+                                                 ir1.get_extrinsics_to(ir2));
+
+    // ── 3. Construct the improver (auto threshold = focal × baseline / 105)
+    rs_depth::DepthRangeImprover improver(calib);
+    const int T = calib.min_z_threshold_mm();
+    std::printf("MinZ threshold: %d mm  (pixels closer than this are improved)\n", T);
+    std::printf("Press Ctrl-C to stop\n\n");
+
+    // ── 4. Stream + improve + live status line ────────────────────────
+    std::vector<uint16_t> depth_imp(N);
+    long long hw_total = 0, imp_total = 0, rescued_total = 0;
+    int frames_seen = 0;
+
+    while (!g_stop) {
+        rs2::frameset frames = pipe.wait_for_frames();
+        auto ir_l  = frames.get_infrared_frame(1);
+        auto ir_r  = frames.get_infrared_frame(2);
+        auto depth = frames.get_depth_frame();
+
+        const uint8_t*  ir_left  = static_cast<const uint8_t*>(ir_l.get_data());
+        const uint8_t*  ir_right = static_cast<const uint8_t*>(ir_r.get_data());
+        const uint16_t* depth_hw = static_cast<const uint16_t*>(depth.get_data());
+
+        // Mirrors Python's FrameMetadata.from_rs2_frameset — extracts width,
+        // height, exposure/gain/laser-power/temperature for IR + depth + color.
+        auto meta = FrameMetadata::from_rs2_frameset(frames);
+        improver.process(ir_left, ir_right, depth_hw, depth_imp.data(), meta);
+
+        int n_hw = 0, n_imp = 0, rescued = 0;
+        for (int i = 0; i < N; ++i) {
+            const bool hw_close  = depth_hw[i]  > 0 && depth_hw[i]  < T;
+            const bool imp_close = depth_imp[i] > 0 && depth_imp[i] < T;
+            if (hw_close)               ++n_hw;
+            if (imp_close)              ++n_imp;
+            if (depth_hw[i] == 0 && imp_close) ++rescued;
+        }
+
+        const double hw_pct  = 100.0 * n_hw  / N;
+        const double imp_pct = 100.0 * n_imp / N;
+        const double recovery_pct = (n_imp > 0) ? 100.0 * (n_imp - n_hw) / n_imp : 0.0;
+
+        std::printf("\rframe %5lld | close-range: HW %5.2f%% -> improved %5.2f%% "
+                    "| MinZ recovered %5.1f%% | +%6d px",
+                    static_cast<long long>(depth.get_frame_number()),
+                    hw_pct, imp_pct, recovery_pct, rescued);
+        std::fflush(stdout);
+
+        hw_total      += n_hw;
+        imp_total     += n_imp;
+        rescued_total += rescued;
+        ++frames_seen;
+    }
+
+    std::printf("\n");
+    pipe.stop();
+    return 0;
+}

--- a/examples/enhanced-depth-range/range_depth.py
+++ b/examples/enhanced-depth-range/range_depth.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""Live MinZ (close-range depth) demo using rs_depth + pyrealsense2.
+
+Streams from a RealSense D4xx, runs DepthRangeImprover on each frame, and
+prints a single live-updating status line showing how much of the close-range
+band MinZ recovered that the camera couldn't see on its own.
+
+Run:
+    python3 range_depth.py        # Ctrl-C to stop
+"""
+
+import sys
+
+import numpy as np
+import pyrealsense2 as rs
+
+from rs_depth import Calibration, DepthRangeImprover
+
+
+# ── 1. Open the camera ──────────────────────────────────────────────────
+pipeline = rs.pipeline()
+cfg = rs.config()
+cfg.enable_stream(rs.stream.infrared, 1, 640, 480, rs.format.y8,  30)
+cfg.enable_stream(rs.stream.infrared, 2, 640, 480, rs.format.y8,  30)
+cfg.enable_stream(rs.stream.depth,       640, 480, rs.format.z16, 30)
+profile = pipeline.start(cfg)
+
+# ── 2. Build calibration from the camera's own intrinsics/extrinsics ────
+ir1 = profile.get_stream(rs.stream.infrared, 1).as_video_stream_profile()
+ir2 = profile.get_stream(rs.stream.infrared, 2).as_video_stream_profile()
+calib = Calibration.from_sdk(ir1.get_intrinsics(), ir1.get_extrinsics_to(ir2))
+
+# ── 3. Construct the improver (auto threshold = focal × baseline / 105) ─
+improver = DepthRangeImprover(calib)
+T = improver.min_z_threshold_mm
+N = 640 * 480
+print(f"MinZ threshold: {T} mm  (pixels closer than this are improved)")
+print("Press Ctrl-C to stop\n")
+
+# ── 4. Stream + improve + live status line ──────────────────────────────
+hw_total = imp_total = rescued_total = frames_seen = 0
+
+try:
+    while True:
+        f = pipeline.wait_for_frames()
+        ir_left  = np.asanyarray(f.get_infrared_frame(1).get_data())
+        ir_right = np.asanyarray(f.get_infrared_frame(2).get_data())
+        depth_hw = np.asanyarray(f.get_depth_frame().get_data())
+
+        depth_imp = improver.process(ir_left, ir_right, depth_hw)
+
+        n_hw    = int(((depth_hw  > 0) & (depth_hw  < T)).sum())
+        n_imp   = int(((depth_imp > 0) & (depth_imp < T)).sum())
+        rescued = int(((depth_hw == 0) & (depth_imp > 0) & (depth_imp < T)).sum())
+
+        hw_pct       = 100.0 * n_hw / N
+        imp_pct      = 100.0 * n_imp / N
+        recovery_pct = 100.0 * (n_imp - n_hw) / n_imp if n_imp > 0 else 0.0
+
+        sys.stdout.write(
+            f"\rframe {f.get_frame_number():>5} │ close-range: "
+            f"HW {hw_pct:5.2f}% → improved {imp_pct:5.2f}% "
+            f"│ MinZ recovered {recovery_pct:5.1f}% │ +{rescued:>6} px"
+        )
+        sys.stdout.flush()
+
+        hw_total      += n_hw
+        imp_total     += n_imp
+        rescued_total += rescued
+        frames_seen   += 1
+except KeyboardInterrupt:
+    pass
+finally:
+    print()
+    pipeline.stop()

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -36,6 +36,7 @@ For a detailed explanations and API documentation see our [Documentation](../doc
 |[Sensor Control](./sensor-control)| C++ | A tutorial for using the `rs2::sensor` API | :star::star::star: | [![Depth Sensing - Structured Light, Stereo and L500](https://img.shields.io/badge/-Depth-5bc3ff.svg)](./depth.md) |
 |[GrabCuts](../wrappers/opencv/grabcuts)| C++ & [OpenCV](https://github.com/realsenseai/librealsense/tree/master/wrappers/opencv#getting-started) | Simple background removal using the GrabCut algorithm | :star::star::star: | [![Depth Sensing - Structured Light, Stereo and L500](https://img.shields.io/badge/-Depth-5bc3ff.svg)](./depth.md)  |
 |[Latency](../wrappers/opencv/latency-tool)| C++ & [OpenCV](https://github.com/realsenseai/librealsense/tree/master/wrappers/opencv#getting-started) | Basic latency estimation using computer vision | :star::star::star: | [![Depth Sensing - Structured Light, Stereo and L500](https://img.shields.io/badge/-Depth-5bc3ff.svg)](./depth.md)  |
+|[Enhanced Depth (MinZ)](./enhanced-depth-range) | C++ & Python | Extends close-range min sensing distance from ~520 mm down to ~120 mm on Jetson — headless stats, live side-by-side compare, and a C++ demo | :star::star::star: | [![Depth Sensing - Structured Light, Stereo and L500](https://img.shields.io/badge/-Depth-5bc3ff.svg)](./depth.md) |
 
 ### Community Projects:
 


### PR DESCRIPTION
## Summary

Adds a self-contained example folder under `examples/enhanced-depth-range/`
demonstrating the close-range depth improvement (`DepthRangeImprover`) shipped
in the companion `librealsense2-enhanced-depth` Debian package, which extends
the D4xx minimum working distance from ~520 mm down to ~120 