### PR TITLE
Temporary disable pytest-options-watcher in CI

### DIFF
--- a/unit-tests/live/options/pytest-options-watcher.py
+++ b/unit-tests/live/options/pytest-options-watcher.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.device("D400*"),
     pytest.mark.device_each("D555"),
     pytest.mark.context("nightly"),
+    pytest.mark.skip(reason="Disabling till CI failure stabilized. See RSDEV-9288")
 ]
 
 changed_options = 0


### PR DESCRIPTION
Tracked on [RSDEV-9288]
