### PR TITLE
conftest: guard against ROS 2 launch.logging breaking pytest log_cli

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -20,6 +20,16 @@ import sys
 import os
 import logging
 
+# Defense against ROS 2 launch.logging: when ROS is sourced, launch_testing's
+# pytest entry-point transitively imports launch.logging, which installs a
+# logger class whose __init__ forces propagate=False on every new logger.
+# That stops pytest's live log handler (set up below) from ever seeing test
+# logs. Reset the class and re-enable propagate on anything already created.
+logging.setLoggerClass(logging.Logger)
+for _name, _lgr in list(logging.Logger.manager.loggerDict.items()):
+    if isinstance(_lgr, logging.Logger) and not _lgr.propagate:
+        _lgr.propagate = True
+
 # unit-tests/py/ contains rspy — the shared helper library used by all RealSense tests
 current_dir = os.path.dirname(os.path.abspath(__file__))
 # pytest built-in: exclude infra-tests/e2e/ from collection (those are static test cases

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -24,11 +24,15 @@ import logging
 # pytest entry-point transitively imports launch.logging, which installs a
 # logger class whose __init__ forces propagate=False on every new logger.
 # That stops pytest's live log handler (set up below) from ever seeing test
-# logs. Reset the class and re-enable propagate on anything already created.
-logging.setLoggerClass(logging.Logger)
-for _name, _lgr in list(logging.Logger.manager.loggerDict.items()):
-    if isinstance(_lgr, logging.Logger) and not _lgr.propagate:
-        _lgr.propagate = True
+# logs. Reset the class and re-enable propagate on already-poisoned loggers.
+# No-op on clean machines — only fires when a non-stdlib Logger class is in use.
+if logging.getLoggerClass() is not logging.Logger:
+    print("-W- non-default Logger class detected (likely ROS launch.logging): "
+          "resetting class and restoring propagate")
+    logging.setLoggerClass(logging.Logger)
+    for _name, _lgr in list(logging.Logger.manager.loggerDict.items()):
+        if isinstance(_lgr, logging.Logger) and type(_lgr) is not logging.Logger and not _lgr.propagate:
+            _lgr.propagate = True
 
 # unit-tests/py/ contains rspy — the shared helper library used by all RealSense tests
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/unit-tests/infra-tests/test_e2e_ros_log_propagate.py
+++ b/unit-tests/infra-tests/test_e2e_ros_log_propagate.py
@@ -1,0 +1,70 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""Regression test for the ROS 2 launch.logging defense in conftest.py (RSDEV-9289).
+
+When ROS 2 is sourced, launch_testing's pytest entry-point pulls in
+launch.logging, which calls logging.setLoggerClass with a class that forces
+propagate=False on every new logger. That breaks pytest log_cli — test
+loggers never reach the root live-log handler.
+
+This test reproduces the damage via a shim plugin loaded before conftest
+(no ROS install needed) and asserts that conftest.py restored both the
+Logger class and propagation on already-created loggers.
+"""
+import logging
+import os
+import subprocess
+import sys
+import textwrap
+
+
+_SENTINEL = '_LRS_RUN_ROS_CANARY'
+_UNIT_TESTS_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_conftest_repairs_poisoned_logger_class(tmp_path):
+    # When invoked recursively by the outer test, behave as the canary:
+    # assert conftest already repaired the damage the shim plugin inflicted.
+    if os.environ.get(_SENTINEL):
+        assert logging.getLoggerClass() is logging.Logger, (
+            f"conftest did not reset Logger class; got {logging.getLoggerClass().__name__}"
+        )
+        assert logging.getLogger('_ros_pre_existing').propagate is True, (
+            "conftest did not restore propagate on a pre-existing poisoned logger"
+        )
+        assert type(logging.getLogger('_ros_new_after_conftest')) is logging.Logger
+        return
+
+    # Outer run: write the shim plugin and re-invoke ourselves in a subprocess
+    # with the shim loaded before conftest.
+    (tmp_path / "_ros_logging_shim.py").write_text(textwrap.dedent("""\
+        import logging
+
+        class _Poisoned(logging.getLoggerClass()):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.propagate = False
+
+        logging.setLoggerClass(_Poisoned)
+        # Pre-create a logger to mimic launch.logging's import-time effect.
+        logging.getLogger('_ros_pre_existing')
+    """))
+
+    env = os.environ.copy()
+    env[_SENTINEL] = '1'
+    env['PYTHONPATH'] = str(tmp_path) + os.pathsep + env.get('PYTHONPATH', '')
+
+    p = subprocess.run(
+        [sys.executable, '-m', 'pytest',
+         '-p', '_ros_logging_shim',
+         'infra-tests/test_e2e_ros_log_propagate.py::test_conftest_repairs_poisoned_logger_class',
+         '-q', '--no-header'],
+        cwd=_UNIT_TESTS_DIR,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        timeout=60,
+    )
+    assert p.returncode == 0, f"canary subprocess failed:\n{p.stdout}"


### PR DESCRIPTION
## Summary

When ROS 2 is sourced (e.g. `source /opt/ros/foxy/setup.bash`), pytest entry-points pull in `launch_testing`, which transitively imports `launch.logging`. That module does:

```python
class LaunchLogger(logging.getLoggerClass()):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.propagate = False

logging.setLoggerClass(LaunchLogger)
```

From then on, every `logging.getLogger(name)` returns a logger with `propagate=False`. Test loggers no longer reach the root, so pytest's `_LiveLoggingStreamHandler` never sees them — running with `-s` shows no `-I-` log lines, no `live log` banners. INFO is silently dropped; WARNING falls through to `logging.lastResort` on stderr without our `-W-` prefix. Reported as [RSDEV-9289](https://rsjira.realsenseai.com/browse/RSDEV-9289).

The fix in `unit-tests/conftest.py` resets the default logger class back to `logging.Logger` and re-enables propagation on any logger already created by the ROS import, before any of our own `getLogger()` calls.

Verified end-to-end on the affected Jetson (Foxy, pytest 7.4.4): without the fix the symptom matches the ticket exactly; with the fix, full `-I-`/`-W-` output and `live log` banners are restored. On a non-ROS PC, simulated via a 10-line shim plugin; same result.

## Test plan

- [x] All 112 infra-tests pass locally
- [x] Negative repro on local PC with ROS damage simulator → ticket symptom reproduced
- [x] Positive repro on local PC with fix applied → full log output restored
- [x] Live verification on Remi's Jetson via SSH (without modifying any tracked file there)