### PR TITLE
viewer: jetson cuda-not-used hint as info, not warning

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -906,7 +906,7 @@ namespace rs2
                     "but realsense-viewer is not using CUDA.\n"
                     "For better performance, rebuild librealsense with -DBUILD_WITH_CUDA=ON.";
                 auto n = not_model->add_notification({ message,
-                     RS2_LOG_SEVERITY_WARN,
+                     RS2_LOG_SEVERITY_INFO,
                      RS2_NOTIFICATION_CATEGORY_COUNT });
                 n->enable_complex_dismiss = true;
                 n->delay_id = "jetson-cuda-not-used";


### PR DESCRIPTION
## Summary
- On NVIDIA Jetson, when the CUDA runtime is installed but `realsense-viewer` was built without CUDA, the startup hint was displayed with a red panel (severity `WARN`).
- This case is a missed optimization, not an error or warning - switched the notification severity to `INFO` so it renders with the neutral grey panel, same look as the "Frame Metadata Disabled" notification.
- The other two CUDA cases (runtime missing, CUDA build but runtime init failed) remain `WARN` since those reflect actual problems.

## Test plan
- [x] Run `realsense-viewer` on a Jetson with `/usr/local/cuda` present and a non-CUDA build -> notification appears with grey background, not red.
- [ ] Verify the "runtime missing" and "runtime init failed" cases still appear red.

before: 
<img width="205" height="71" alt="cuda_before" src="https://github.com/user-attachments/assets/1878fee6-6478-46bc-acb7-f400b10082a5" />

after:
<img width="207" height="95" alt="cuda_after" src="https://github.com/user-attachments/assets/fe176494-589c-41f0-b9df-e343079fb71c" />
