### PR TITLE
Fix options-watcher test

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -170,6 +170,10 @@ def pytest_addoption(parser):
 # Shared context tags (e.g. "nightly", "weekly") — tests check this to adjust behavior
 context_list = []
 
+# Module-scoped retry: tracks which (module, repeat_step) passes had failures.
+# Used by --retries to skip retry passes when the previous pass was clean.
+_module_pass_had_failure = {}  # (module_file, step) -> True
+
 
 def pytest_configure(config):
     """Early setup: register markers, configure defaults, and query connected devices."""
@@ -191,6 +195,17 @@ def pytest_configure(config):
     if repeat_val and config.getoption('count', default=1) <= 1:
         config.option.count = repeat_val
         config.option.repeat_scope = 'module'
+
+    # --retries N → module-scoped retry.  Run all tests in a file; if any fail,
+    # recycle the device and rerun the *entire* module — up to N extra attempts.
+    # Implemented on top of pytest-repeat (count = N+1, module scope).
+    # pytest-retry's function-level retry is disabled so only module-level kicks in.
+    retries_val = config.getoption('retries', default=0)
+    if retries_val and config.getoption('count', default=1) <= 1:
+        config.option.retries = 0           # disable pytest-retry function-level retry
+        config.option.count = retries_val + 1
+        config.option.repeat_scope = 'module'
+        config._module_retry_mode = True    # flag checked by our skip-if-no-failures hook
 
     # Parse and store context
     context_str = config.getoption("--context", default="")
@@ -325,7 +340,7 @@ def pytest_runtest_protocol(item, nextitem):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """Log test duration and any failures/errors."""
+    """Log test duration and any failures/errors.  Track per-module failures for --retries."""
     outcome = yield
     report = outcome.get_result()
 
@@ -339,6 +354,26 @@ def pytest_runtest_makereport(item, call):
     if call.when == "call":
         ensure_newline()
         log.debug(f"Test execution took {report.duration:.3f}s")
+
+    # Record module-level failure for --retries skip-if-clean logic
+    if report.when == "call" and report.failed and getattr(item.config, '_module_retry_mode', False):
+        callspec = getattr(item, 'callspec', None)
+        step = callspec.params.get('__pytest_repeat_step_number', 0) if callspec else 0
+        mod = item.module.__file__
+        _module_pass_had_failure[(mod, step)] = True
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    """Skip retry passes whose previous pass had no failures (--retries optimisation)."""
+    if not getattr(item.config, '_module_retry_mode', False):
+        return
+    callspec = getattr(item, 'callspec', None)
+    step = callspec.params.get('__pytest_repeat_step_number', 0) if callspec else 0
+    if step > 0:
+        mod = item.module.__file__
+        if not _module_pass_had_failure.get((mod, step - 1), False):
+            pytest.skip("Module retry skipped — no failures in previous pass")
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
@@ -473,17 +508,14 @@ def module_device_setup(request):
         log.debug(f"Test will use first matching device: {serial_number}")
 
     # Enable only this device; recycle only once per module (like run-unit-tests.py),
-    # but also recycle on retries and repeats (--repeat / --count).
+    # and at the start of each module-scoped repeat pass (--repeat).
     device = devices.get(serial_number)
     device_name = device.name if device else serial_number
     log.info(f"Configuration: {device_name} [{serial_number}]")
 
     module = request.node.module
-    nodeid = request.node.nodeid
     no_reset = request.config.getoption("--no-reset", default=False)
     last_device = getattr(module, '_last_device_serial', None)
-    last_test = getattr(module, '_last_test_nodeid', None)
-    is_retry = (last_test == nodeid)
     device_changed = (last_device is not None and last_device != serial_number)
     first_setup = (last_device is None)
 
@@ -494,11 +526,10 @@ def module_device_setup(request):
     last_repeat_step = getattr(module, '_last_repeat_step', None)
     is_new_repeat_pass = repeat_step is not None and last_repeat_step is not None and repeat_step != last_repeat_step
 
-    recycle = not no_reset and (first_setup or device_changed or is_retry or is_new_repeat_pass)
+    recycle = not no_reset and (first_setup or device_changed or is_new_repeat_pass)
 
     if not recycle and not first_setup:
         log.debug(f"Device {serial_number} already enabled, skipping hub setup")
-        module._last_test_nodeid = nodeid
         module._last_repeat_step = repeat_step
         yield serial_number
         return
@@ -507,7 +538,6 @@ def module_device_setup(request):
         log.debug(f"{'Recycling' if recycle else 'Enabling'} device via hub...")
         devices.enable_only([serial_number], recycle=recycle)
         module._last_device_serial = serial_number
-        module._last_test_nodeid = nodeid
         module._last_repeat_step = repeat_step
         log.debug(f"Device enabled and ready")
     except Exception as e:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -151,7 +151,7 @@ def pytest_addoption(parser):
         default=0,
         type=int,
         dest="repeat_count",
-        help="Repeat each test N times (alias for pytest-repeat's --count)."
+        help="Run all tests in each file N times (module-scoped alias for pytest-repeat's --count). Use --count for per-test repetition."
     )
     # --debug and -r/--regex conflict with pytest built-ins and are consumed before
     # pytest parses args. Document them here so they show up in --help:
@@ -185,10 +185,12 @@ def pytest_configure(config):
     if tag_value and not config.option.markexpr:
         config.option.markexpr = tag_value
 
-    # --repeat N → pytest-repeat's --count N (only if --count wasn't explicitly set)
+    # --repeat N → pytest-repeat's --count N + module scope (only if --count wasn't explicitly set).
+    # Using --repeat (our alias) always runs the full file N times; use --count for per-test repetition.
     repeat_val = config.getoption('repeat_count', default=0)
     if repeat_val and config.getoption('count', default=1) <= 1:
         config.option.count = repeat_val
+        config.option.repeat_scope = 'module'
 
     # Parse and store context
     context_str = config.getoption("--context", default="")
@@ -482,14 +484,22 @@ def module_device_setup(request):
     last_device = getattr(module, '_last_device_serial', None)
     last_test = getattr(module, '_last_test_nodeid', None)
     is_retry = (last_test == nodeid)
-    is_repeat = request.config.getoption("count", default=1) > 1
     device_changed = (last_device is not None and last_device != serial_number)
     first_setup = (last_device is None)
-    recycle = not no_reset and (first_setup or device_changed or is_retry or is_repeat)
+
+    # Detect the start of a new module-scoped repeat pass.
+    # pytest-repeat parametrizes __pytest_repeat_step_number (0-based); recycle when it advances.
+    callspec = getattr(request.node, 'callspec', None)
+    repeat_step = callspec.params.get('__pytest_repeat_step_number') if callspec else None
+    last_repeat_step = getattr(module, '_last_repeat_step', None)
+    is_new_repeat_pass = repeat_step is not None and last_repeat_step is not None and repeat_step != last_repeat_step
+
+    recycle = not no_reset and (first_setup or device_changed or is_retry or is_new_repeat_pass)
 
     if not recycle and not first_setup:
         log.debug(f"Device {serial_number} already enabled, skipping hub setup")
         module._last_test_nodeid = nodeid
+        module._last_repeat_step = repeat_step
         yield serial_number
         return
 
@@ -498,6 +508,7 @@ def module_device_setup(request):
         devices.enable_only([serial_number], recycle=recycle)
         module._last_device_serial = serial_number
         module._last_test_nodeid = nodeid
+        module._last_repeat_step = repeat_step
         log.debug(f"Device enabled and ready")
     except Exception as e:
         pytest.fail(f"Failed to enable device {serial_number}: {e}")

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -199,13 +199,15 @@ def pytest_configure(config):
     # --retries N → module-scoped retry.  Run all tests in a file; if any fail,
     # recycle the device and rerun the *entire* module — up to N extra attempts.
     # Implemented on top of pytest-repeat (count = N+1, module scope).
-    # pytest-retry's function-level retry is disabled so only module-level kicks in.
+    # pytest-retry's function-level retry is ALWAYS disabled when --retries is used.
     retries_val = config.getoption('retries', default=0)
-    if retries_val and config.getoption('count', default=1) <= 1:
+    if retries_val:
         config.option.retries = 0           # disable pytest-retry function-level retry
-        config.option.count = retries_val + 1
-        config.option.repeat_scope = 'module'
-        config._module_retry_mode = True    # flag checked by our skip-if-no-failures hook
+        if config.getoption('count', default=1) <= 1:
+            # --retries without --repeat: add retry passes via pytest-repeat
+            config.option.count = retries_val + 1
+            config.option.repeat_scope = 'module'
+            config._module_retry_mode = True    # skip retry passes when previous pass was clean
 
     # Parse and store context
     context_str = config.getoption("--context", default="")

--- a/unit-tests/infra-tests/e2e/pytest-retry.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry.py
@@ -1,14 +1,18 @@
-# Test that fails on first attempt, passes on retry.
-# Used to verify --retries triggers device recycle on retry.
+# Test module-scoped retry: the module has two tests, one fails on the first pass.
+# --retries 1 should rerun the entire module (both tests) after recycling.
 import pytest
 
 pytestmark = [pytest.mark.device("D455")]
 
-_attempt = 0
+_fail_attempt = 0
+
+def test_always_passes(module_device_setup):
+    """This test always passes — included to verify the entire module reruns."""
+    pass
 
 def test_fails_then_passes(module_device_setup):
-    """Fail on first run, pass on retry."""
-    global _attempt
-    _attempt += 1
-    if _attempt == 1:
-        assert False, "intentional first-run failure"
+    """Fail on first pass (step 0), pass on retry (step 1)."""
+    global _fail_attempt
+    _fail_attempt += 1
+    if _fail_attempt == 1:
+        assert False, "intentional first-pass failure"

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -67,10 +67,14 @@ class TestCliOptionsRegistered:
         assert rc == 0
 
     def test_retries(self):
-        """--retries 1 should retry a failed test and recycle the device on retry."""
+        """--retries 1 should rerun the entire module on failure, recycling the device."""
         rc, out, tracking = run_e2e("pytest-retry.py", "--retries", "1")
-        assert_outcomes(out, passed=1)
+        # Pass 0: test_always_passes PASSED, test_fails_then_passes FAILED
+        # Pass 1 (retry): device recycled, both tests rerun → both PASSED
+        # pytest-repeat reports: 3 passed (2 from pass 1 + 1 from pass 0 survivor), 1 failed (pass 0)
+        assert_outcomes(out, passed=3, failed=1)
         calls = tracking["enable_only_calls"]
+        # Two enable_only calls: initial setup (pass 0) + recycle (pass 1 = new repeat pass)
         assert len(calls) == 2
         assert all(c['recycle'] is True for c in calls)
 

--- a/unit-tests/live/options/pytest-options-watcher.py
+++ b/unit-tests/live/options/pytest-options-watcher.py
@@ -13,28 +13,38 @@ pytestmark = [
     pytest.mark.context("nightly"),
 ]
 
-changed_options = 0
-_depth_sensor = None  # module-level ref; cleared before each test to release old subscription
-
-
-def _notification_callback(opt_list):
-    global changed_options
-    log.debug(f"notification_callback called with {len(opt_list)} options")
-    for opt in opt_list:
-        log.debug(f"    {opt.id} -> {opt.value}")
-        if _depth_sensor and not _depth_sensor.is_option_read_only(opt.id):  # Ignore accidental temperature changes
-            changed_options += 1
+# Generation counter: each setup_depth_watcher call bumps this, making previous callbacks no-ops.
+_generation = 0
+_depth_sensor = None
 
 
 def setup_depth_watcher(test_device):
-    """Release old sensor subscription, zero changed_options, register watcher, return depth_sensor."""
-    global changed_options, _depth_sensor
-    _depth_sensor = None  # drop old sensor ref → GC → old callback subscription cancelled
-    changed_options = 0
+    """Register a fresh options-watcher and return (depth_sensor, count).
+
+    Each call advances a generation counter.  Callbacks from earlier generations
+    silently ignore events, so there is no need for explicit teardown — stale
+    callbacks from crashed or retried tests cannot pollute the counter.
+
+    count is a mutable [0] list; read it as count[0].
+    """
+    global _generation, _depth_sensor
+    _generation += 1
+    my_gen = _generation
+    count = [0]
+
+    def callback(opt_list):
+        if my_gen != _generation:
+            return  # stale callback from a previous test — ignore
+        log.debug(f"notification_callback called with {len(opt_list)} options")
+        for opt in opt_list:
+            log.debug(f"    {opt.id} -> {opt.value}")
+            if _depth_sensor and not _depth_sensor.is_option_read_only(opt.id):  # ignore temperature noise
+                count[0] += 1
+
     dev, ctx = test_device
     _depth_sensor = dev.first_depth_sensor()
-    _depth_sensor.on_options_changed(_notification_callback)
-    return _depth_sensor
+    _depth_sensor.on_options_changed(callback)
+    return _depth_sensor, count
 
 
 def test_disable_auto_exposure(test_device):
@@ -47,17 +57,17 @@ def test_disable_auto_exposure(test_device):
 
 
 def test_set_one_option(test_device):
-    depth_sensor = setup_depth_watcher(test_device)
+    depth_sensor, count = setup_depth_watcher(test_device)
 
     current_gain = depth_sensor.get_option(rs.option.gain)
     depth_sensor.set_option(rs.option.gain, current_gain + 1)
     assert depth_sensor.get_option(rs.option.gain) == current_gain + 1
     time.sleep(1.5)  # default options-watcher update interval is 1 second
-    assert changed_options == 1
+    assert count[0] == 1
 
 
 def test_set_multiple_options(test_device):
-    depth_sensor = setup_depth_watcher(test_device)
+    depth_sensor, count = setup_depth_watcher(test_device)
 
     current_gain = depth_sensor.get_option(rs.option.gain)
     depth_sensor.set_option(rs.option.gain, current_gain + 1)
@@ -66,25 +76,28 @@ def test_set_multiple_options(test_device):
     depth_sensor.set_option(rs.option.exposure, current_exposure + 1)
     assert depth_sensor.get_option(rs.option.exposure) == current_exposure + 1
     time.sleep(2.5)  # default options-watcher update interval is 1 second, multiple options might be updated on different intervals
-    assert changed_options == 2
+    assert count[0] == 2
 
 
 def test_no_sporadic_changes(test_device):
-    setup_depth_watcher(test_device)
+    _, count = setup_depth_watcher(test_device)
 
     time.sleep(3)
-    assert changed_options == 0
+    assert count[0] == 0
 
 
 def test_cancel_subscription(test_device):
-    global _depth_sensor
-    setup_depth_watcher(test_device)
+    global _depth_sensor, _generation
+    # Index [1] avoids keeping a local reference to the sensor — only _depth_sensor holds it.
+    count = setup_depth_watcher(test_device)[1]
 
-    _depth_sensor = None  # release sensor, cancelling its subscription
+    _generation += 1       # invalidate the callback immediately
+    _depth_sensor = None   # last reference gone → GC → subscription cancelled
+
     dev, ctx = test_device
     depth_sensor = dev.first_depth_sensor()  # new sensor, no callback registered
     current_gain = depth_sensor.get_option(rs.option.gain)
     depth_sensor.set_option(rs.option.gain, current_gain + 1)
     assert depth_sensor.get_option(rs.option.gain) == current_gain + 1
     time.sleep(1.5)  # default options-watcher update interval is 1 second
-    assert changed_options == 0
+    assert count[0] == 0

--- a/unit-tests/live/options/pytest-options-watcher.py
+++ b/unit-tests/live/options/pytest-options-watcher.py
@@ -44,6 +44,7 @@ def setup_depth_watcher(test_device):
     dev, ctx = test_device
     _depth_sensor = dev.first_depth_sensor()
     _depth_sensor.on_options_changed(callback)
+    time.sleep(0.5)  # let the options-watcher establish its baseline before making changes
     return _depth_sensor, count
 
 


### PR DESCRIPTION
Tracked on [RSDEV-9288]

Pytest infrastructure improvements:
1. Recycle device at module scope, was cycled at function scope.
2. Retry+repeat at module scope, a failed test was retried again before moving on to next test in the module