### PR TITLE
test-eth-config: toggle link timeout instead of doubling

### DIFF
--- a/unit-tests/live/config/test-eth-config.py
+++ b/unit-tests/live/config/test-eth-config.py
@@ -38,8 +38,9 @@ with test.closure("Test link timeout configuration"):
     # Toggle between two safe in-range values (both within 2000-30000 and divisible by 100).
     # Doubling the current value is unsafe: if the device persists a high value from a prior
     # run, doubling it overflows the valid range and leaves the camera stuck at that value.
-    link_timeout_values = ( 8000, 10000 )
-    new_link_timeout = link_timeout_values[1] if orig_config.link.timeout == link_timeout_values[0] else link_timeout_values[0]
+    # If the camera is not already at 8000 (the baseline), normalize to 8000 first; this also
+    # self-heals any unit stuck at an out-of-toggle value (e.g. 16000) on the first run.
+    new_link_timeout = 8000 if orig_config.link.timeout != 8000 else 10000
     new_config.link.timeout = new_link_timeout
     set_eth_config( new_config )
     updated_config = get_eth_config()
@@ -205,7 +206,7 @@ with test.closure("Test configuration failures"): # Failures depending on versio
 with test.closure("Test python wrapper functionality"):
     eth_device = rs.eth_config_device( dev )
     orig_link_timeout = eth_device.get_link_timeout()
-    new_link_timeout = link_timeout_values[1] if orig_link_timeout == link_timeout_values[0] else link_timeout_values[0]
+    new_link_timeout = 8000 if orig_link_timeout != 8000 else 10000
     eth_device.set_link_timeout( new_link_timeout )
     updated_link_timeout = eth_device.get_link_timeout()
     test.check( updated_link_timeout == new_link_timeout )

--- a/unit-tests/live/config/test-eth-config.py
+++ b/unit-tests/live/config/test-eth-config.py
@@ -15,6 +15,12 @@ set_eth_config_opcode = 0xBA
 default_values_param = 0
 current_values_param = 1
 
+# Safe in-range link timeout values used by the toggle below: both within the 2000-30000
+# range validated by eth_config::validate() and divisible by 100. BASELINE is also used to
+# normalize units stuck at an abnormal value (e.g. 16000 from an interrupted prior run).
+LINK_TIMEOUT_BASELINE = 8000
+LINK_TIMEOUT_ALT      = 10000
+
 
 dev, ctx = test.find_first_device_or_exit()
 
@@ -34,13 +40,16 @@ with test.closure("Test DDS support"):
     orig_config = get_eth_config()
     new_config = get_eth_config() # Get a new config object to keep orig_config intact
 
+    # If the device's persisted link.timeout is outside our toggle set, overwrite it in
+    # orig_config so the final "Restore configuration" closure writes a sane value back to
+    # flash. This permanently heals units stuck at abnormal values (e.g. 16000 from prior
+    # interrupted runs) without any manual intervention.
+    if orig_config.link.timeout not in ( LINK_TIMEOUT_BASELINE, LINK_TIMEOUT_ALT ):
+        orig_config.link.timeout = LINK_TIMEOUT_BASELINE
+
 with test.closure("Test link timeout configuration"):
-    # Toggle between two safe in-range values (both within 2000-30000 and divisible by 100).
-    # Doubling the current value is unsafe: if the device persists a high value from a prior
-    # run, doubling it overflows the valid range and leaves the camera stuck at that value.
-    # If the camera is not already at 8000 (the baseline), normalize to 8000 first; this also
-    # self-heals any unit stuck at an out-of-toggle value (e.g. 16000) on the first run.
-    new_link_timeout = 8000 if orig_config.link.timeout != 8000 else 10000
+    # Toggle between two safe in-range values (avoid doubling - it can overflow the 2000-30000 range).
+    new_link_timeout = LINK_TIMEOUT_BASELINE if orig_config.link.timeout != LINK_TIMEOUT_BASELINE else LINK_TIMEOUT_ALT
     new_config.link.timeout = new_link_timeout
     set_eth_config( new_config )
     updated_config = get_eth_config()
@@ -206,7 +215,7 @@ with test.closure("Test configuration failures"): # Failures depending on versio
 with test.closure("Test python wrapper functionality"):
     eth_device = rs.eth_config_device( dev )
     orig_link_timeout = eth_device.get_link_timeout()
-    new_link_timeout = 8000 if orig_link_timeout != 8000 else 10000
+    new_link_timeout = LINK_TIMEOUT_BASELINE if orig_link_timeout != LINK_TIMEOUT_BASELINE else LINK_TIMEOUT_ALT
     eth_device.set_link_timeout( new_link_timeout )
     updated_link_timeout = eth_device.get_link_timeout()
     test.check( updated_link_timeout == new_link_timeout )

--- a/unit-tests/live/config/test-eth-config.py
+++ b/unit-tests/live/config/test-eth-config.py
@@ -35,10 +35,15 @@ with test.closure("Test DDS support"):
     new_config = get_eth_config() # Get a new config object to keep orig_config intact
 
 with test.closure("Test link timeout configuration"):
-    new_config.link.timeout *= 2
+    # Toggle between two safe in-range values (both within 2000-30000 and divisible by 100).
+    # Doubling the current value is unsafe: if the device persists a high value from a prior
+    # run, doubling it overflows the valid range and leaves the camera stuck at that value.
+    link_timeout_values = ( 8000, 10000 )
+    new_link_timeout = link_timeout_values[1] if orig_config.link.timeout == link_timeout_values[0] else link_timeout_values[0]
+    new_config.link.timeout = new_link_timeout
     set_eth_config( new_config )
     updated_config = get_eth_config()
-    test.check( updated_config.link.timeout == orig_config.link.timeout * 2 )
+    test.check( updated_config.link.timeout == new_link_timeout )
 
     if new_config.header.version >= 5:
         new_config.link.timeout = 1000
@@ -200,9 +205,10 @@ with test.closure("Test configuration failures"): # Failures depending on versio
 with test.closure("Test python wrapper functionality"):
     eth_device = rs.eth_config_device( dev )
     orig_link_timeout = eth_device.get_link_timeout()
-    eth_device.set_link_timeout( orig_link_timeout * 2 )
+    new_link_timeout = link_timeout_values[1] if orig_link_timeout == link_timeout_values[0] else link_timeout_values[0]
+    eth_device.set_link_timeout( new_link_timeout )
     updated_link_timeout = eth_device.get_link_timeout()
-    test.check( updated_link_timeout == orig_link_timeout * 2 )
+    test.check( updated_link_timeout == new_link_timeout )
     
     orig_ip, orig_actual_ip = eth_device.get_ip_address()
     eth_device.set_ip_address( rs.ip_address( 127, 0, 0, 1 ) )


### PR DESCRIPTION
@
## Why

In Jenkins build [LRS_libci_pipeline #15735](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/15735/)
the `test-live-config-eth-config` test failed on D555 S/N **343622300739** (FW 7.56.37776.6014)
with 5 cascading failures, all rooted in:

```
ValueError: Link timeout should be 2000-30000. Current 32000
```

Build #15734 (~2h earlier, same FW, same librealsense SHA, different D555 unit) passed cleanly — so this is **not** a FW or library regression.

### Root cause

The test doubles the current link timeout:

```python
new_config.link.timeout *= 2     # line 38
set_eth_config( new_config )
```

`set_eth_config` calls `eth_config::build_command()` which runs `validate()` host-side. Since PR #14550 (Dec 2025), `validate()` rejects link timeouts outside `2000-30000`.

D555 S/N 343622300739 has `link.timeout = 16000` persisted in flash (likely from an interrupted run, or a pre-validator run that left a doubled value). On every subsequent run:

- `orig = 16000` -> `*2 = 32000` -> host-side `validate()` throws - the call never reaches the camera.
- `new_config.link.timeout` stays at 32000, so every following closure (MTU, transmission delay, UDP TTL, python wrapper) fails the same way.
- "Restore configuration" writes back `orig_config` (16000, in range), so the camera *stays* at 16000 - the failure perpetuates on every run.

Note: the camera is not stuck at 32000 - `validate()` blocked it host-side. It is stuck at 16000.

### Fix

Replace doubling with: **set to 8000 if not already 8000, else set to 10000.**

- Bounded - no unbounded growth regardless of how many runs.
- Self-healing - first run on a unit stuck at any other value (e.g. 16000) writes 8000 over it, recovering the camera automatically. No manual intervention needed.
- Still verifies the change took effect (read-after-write check unchanged).

Same change applied to the python-wrapper closure that also doubled.
Negative coverage (1000 / 31000 / 2345) and the field restore at end of closure are unchanged.

## Test plan

- [ ] libci runs automatically on PR push; eth-config test passes on the previously-failing D555 unit.
- [ ] On second run after merge, camera is at 8000 -> test sets 10000.
@