### PR TITLE
Cherry Pick PR #15012 from OhadMeir: Fix Python wrapper possible deadlockas

### DIFF
--- a/unit-tests/live/hw-reset/pytest-notifications-callback-gil.py
+++ b/unit-tests/live/hw-reset/pytest-notifications-callback-gil.py
@@ -1,0 +1,239 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Python wrapper deadlock regression test. See LRS-1040
+# The test loops hardware_reset while a background thread injects FW errors, and on each
+# iteration re-registers set_notifications_callback while a notification is in flight.
+# Runs in a subprocess so a GIL deadlock can be killed instead of hanging pytest.
+
+import os
+import sys
+import subprocess
+
+import pytest
+import pyrealsense2 as rs
+
+from rspy import devices
+
+
+# How long the parent waits for the child to complete. 20 iterations typically
+# take a few minutes; this is generous slack for slow USB reconnects. A real
+# GIL deadlock makes no progress at all, so any value beyond expected runtime
+# works -- it just sets the upper bound on how long CI waits before declaring
+# failure.
+CHILD_TIMEOUT_S = 300
+
+
+pytestmark = [
+    pytest.mark.device( "D455" ), # The HWM injection is a D400 FW mechanism. Since this is a SW bug it's enough testing the flow on one device type only.
+    pytest.mark.context( "weekly" ),
+    # Override the conftest default (200s) so our proc.wait(CHILD_TIMEOUT_S)
+    # fires first on a hang. pytest-timeout's "thread" method on Windows kills
+    # the whole pytest process via os._exit(1), bypassing our cleanup and
+    # leaving no FAILED report -- so its timeout must be > CHILD_TIMEOUT_S
+    # plus a buffer for terminate/kill of the child.
+    pytest.mark.timeout( CHILD_TIMEOUT_S + 20 ),
+]
+
+
+# ============================================================================
+# Test (parent process)
+# ============================================================================
+
+def test_hw_reset_with_notifications_callback_no_gil_deadlock( test_device ):
+    dev, _ctx = test_device
+    target_sn = dev.get_info( rs.camera_info.serial_number )
+
+    # The pytest infra (conftest.py) locates the freshly-built pyrealsense2.pyd
+    # via repo.find_pyrs_dir() and adds its directory to sys.path -- but the
+    # spawned child gets only what we hand it via env. Build PYTHONPATH from
+    # the .pyd directory plus the parent's sys.path so the child can resolve
+    # both `import pyrealsense2` and `from rspy import ...`.
+    env = os.environ.copy()
+    env[ "PYTHONPATH" ] = os.pathsep.join(
+        [ os.path.dirname( rs.__file__ ) ] + [ p for p in sys.path if p ]
+    )
+
+    proc = subprocess.Popen(
+        [ sys.executable, __file__, "--child", target_sn ],
+        env = env,
+    )
+    try:
+        rc = proc.wait( timeout = CHILD_TIMEOUT_S )
+    except subprocess.TimeoutExpired:
+        # Child is hung -- almost certainly the GIL deadlock has regressed.
+        proc.terminate()
+        try:
+            proc.wait( timeout = 5 )
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        pytest.fail(
+            f"GIL deadlock regression: child did not complete within "
+            f"{CHILD_TIMEOUT_S} [sec]"
+        )
+
+    assert rc == 0, f"child process exited with code {rc} (see child stderr above)"
+
+
+# ============================================================================
+# Child process body.
+# Reached only when this file is run as a script by the parent test above
+# (subprocess.Popen([..., __file__, "--child", serial])). Pytest collection
+# imports the module but never runs anything below the if __name__ guard.
+# ============================================================================
+
+def _run_child( target_sn ):
+    """Re-acquire the device by serial number, register callbacks, and run
+    the deadlock-prone hardware_reset loop. Pre-fix this hangs; post-fix it
+    returns and the process exits 0. Any AssertionError or other exception
+    escapes uncaught -> non-zero exit code, which the parent reports as a
+    test failure."""
+    import threading
+    import time
+
+    from rspy.timer import Timer
+
+    ITERATIONS              = 20
+    CALLBACK_SLEEP_S        = 0.3  # GIL-releasing sleep inside notification_cb. Gives main plenty of time to enter the C++ call that previously deadlocked.
+    HWM_TRIGGER_INTERVAL_S  = 0.8  # background thread fires HWM at this cadence
+    NOTIF_WAIT_TIMEOUT_S    = 5    # max wait per iteration for an in-flight notification
+
+    OPCODE_TRIGGER_ERROR    = 0x4D # HWM opcode that injects a firmware error
+    ERROR_ID_MM_FORCE_PAUSE = 9    # error ID -> "Motion Module force pause"
+
+    state = {
+        'sn'                  : target_sn,
+        'current_dev'         : None,
+        'device_added'        : False,
+        'callback_in_progress': threading.Event(),
+        'stop_trigger'        : threading.Event(),
+        'notif_count'         : 0,
+    }
+
+    def trigger_mm_error( proto ):
+        raw = proto.build_command( OPCODE_TRIGGER_ERROR, ERROR_ID_MM_FORCE_PAUSE )
+        reply = list( proto.send_and_receive_raw_data( raw ) )
+        return reply[ :4 ] == [ OPCODE_TRIGGER_ERROR, 0, 0, 0 ]
+
+    def notification_cb( notif ):
+        state[ 'notif_count' ] += 1
+        # Tell main we entered the callback. Worker is now holding _dispatch_mutex while we sleep below.
+        # GIL is about to be released by time.sleep().
+        state[ 'callback_in_progress' ].set()
+        time.sleep( CALLBACK_SLEEP_S )
+
+    def devices_changed_cb( info ):
+        for candidate in info.get_new_devices():
+            try:
+                if candidate.get_info( rs.camera_info.serial_number ) == state[ 'sn' ]:
+                    # Reassigning current_dev drops the previous device's Python ref. If this is the last ref, the C++ destructor
+                    # cascade fires here -- exercising the destruction-path deadlock.
+                    state[ 'current_dev' ] = candidate
+                    state[ 'device_added' ] = True
+            except RuntimeError:
+                continue
+
+    def hwm_trigger_loop():
+        """Continuously inject FW errors so a notification is always in flight."""
+        while not state[ 'stop_trigger' ].is_set():
+            try:
+                proto = rs.debug_protocol( state[ 'current_dev' ] )
+                trigger_mm_error( proto )
+            except Exception:
+                # Expected during reset / disconnect windows.
+                pass
+            time.sleep( HWM_TRIGGER_INTERVAL_S )
+
+    def setup_sensor( device ):
+        for s in device.query_sensors():
+            if s.supports( rs.option.error_polling_enabled ):
+                s.set_notifications_callback( notification_cb )
+                s.set_option( rs.option.error_polling_enabled, 1 )
+                return s
+        return None
+
+    # Acquire the device fresh in this process by serial number.
+    ctx = rs.context()
+    t = Timer( devices.MAX_ENUMERATION_TIME )
+    t.start()
+    while not t.has_expired():
+        for d in ctx.query_devices():
+            try:
+                if d.get_info( rs.camera_info.serial_number ) == target_sn:
+                    state[ 'current_dev' ] = d
+                    break
+            except RuntimeError:
+                continue
+        if state[ 'current_dev' ] is not None:
+            break
+        time.sleep( 0.1 )
+    assert state[ 'current_dev' ] is not None, ( f"could not find device {target_sn} within {devices.MAX_ENUMERATION_TIME} [sec]" )
+
+    ctx.set_devices_changed_callback( devices_changed_cb )
+    time.sleep( 1 )  # let the device settle before the first reset
+
+    sensor = setup_sensor( state[ 'current_dev' ] )
+    assert sensor is not None, "device has no sensor with error_polling_enabled"
+
+    # Start the background HWM thread first, then wait for any notification to
+    # confirm the injection mechanism works on this device / firmware. The
+    # thread fires every HWM_TRIGGER_INTERVAL_S; the polling-error handler runs
+    # on its own ~1 s cycle, so the first dispatched notification typically
+    # arrives within a couple of seconds.
+    hwm_thread = threading.Thread( target = hwm_trigger_loop, daemon = True )
+    hwm_thread.start()
+    assert state[ 'callback_in_progress' ].wait( timeout = NOTIF_WAIT_TIMEOUT_S ), (
+        f"no notification within {NOTIF_WAIT_TIMEOUT_S} [sec] of starting HWM "
+        f"injection -- HWM 0x4D/9 may not be supported on this device/firmware"
+    )
+    state[ 'callback_in_progress' ].clear()
+    try:
+        for i in range( 1, ITERATIONS + 1 ):
+            state[ 'callback_in_progress' ].clear()
+            state[ 'device_added' ] = False
+
+            state[ 'current_dev' ].hardware_reset()
+
+            t = Timer( devices.MAX_ENUMERATION_TIME )
+            t.start()
+            while not t.has_expired():
+                if state[ 'device_added' ]:
+                    break
+                time.sleep( 0.05 )
+            assert state[ 'device_added' ], (
+                f"iter {i}: device did not reconnect within "
+                f"{devices.MAX_ENUMERATION_TIME} [sec]"
+            )
+
+            # Re-register the callback on the new device. With the HWM thread
+            # firing continuously, this is the original LRS-1040 race window:
+            # the previous worker may already be in notification_cb's
+            # time.sleep() when we reach _notifications_processor::set_callback
+            # -> dispatcher::stop().
+            sensor = setup_sensor( state[ 'current_dev' ] )
+            assert sensor is not None, f"iter {i}: no error-polling sensor on new device"
+
+            # Force the deadlock window deterministically: wait until the
+            # worker is mid-time.sleep (callback_in_progress signalled, GIL
+            # released, _dispatch_mutex held), then call set_notifications_callback
+            # again. Pre-fix this hangs forever on the first iteration that
+            # makes it here; post-fix it returns within a callback sleep.
+            if state[ 'callback_in_progress' ].wait( timeout = NOTIF_WAIT_TIMEOUT_S ):
+                state[ 'callback_in_progress' ].clear()
+                sensor.set_notifications_callback( notification_cb )
+    finally:
+        state[ 'stop_trigger' ].set()
+        hwm_thread.join( timeout = 5 )
+
+    assert state[ 'notif_count' ] > 0, (
+        "no notifications received -- deadlock window was never exercised"
+    )
+
+
+if __name__ == "__main__":
+    if len( sys.argv ) >= 3 and sys.argv[ 1 ] == "--child":
+        _run_child( sys.argv[ 2 ] )
+        sys.exit( 0 )
+    print( f"usage: python {sys.argv[0]} --child <serial>", file = sys.stderr )
+    sys.exit( 2 )

--- a/wrappers/python/pyrealsense2.h
+++ b/wrappers/python/pyrealsense2.h
@@ -8,6 +8,32 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #define NAME pyrealsense2
 #define SNAME "pyrealsense2"
 
+// GIL-releasing custom deleter for pybind11 holder types.
+//
+// When a Python reference to a librealsense wrapper (rs.device, rs.sensor, rs.debug_protocol, ...) is dropped,
+// CPython calls tp_dealloc on the wrapper while the calling thread still holds the GIL.
+// The default holder (std::unique_ptr<T>) runs the C++ destructor, which might wait for a Python callback on another thread
+// (e.g. notifications_processor::~notifications_processor() ) that might need to re-acquire the GIL, causing a deadlock if
+// we don't release the GIL before the destructor runs.
+//
+// This deleter releases the GIL before delete and re-acquires it after, so the destructor runs without the GIL.
+// Any nested gil_scoped_acquire (e.g. pybind11's func_handle destructor freeing a stored Python callback) just
+// re-acquires it briefly -- safe and standard.
+template < typename T >
+struct gil_releasing_deleter
+{
+    void operator()( T * p ) const noexcept
+    {
+        py::gil_scoped_release release;
+        delete p;
+    }
+};
+
+template < typename T >
+using py_holder = std::unique_ptr< T, gil_releasing_deleter< T > >;
+
+PYBIND11_DECLARE_HOLDER_TYPE( T, py_holder< T > )
+
 // For rs2_format
 #include "../include/librealsense2/h/rs_sensor.h"
 

--- a/wrappers/python/pyrs_advanced_mode.cpp
+++ b/wrappers/python/pyrs_advanced_mode.cpp
@@ -256,7 +256,7 @@ void init_advanced_mode(py::module &m) {
 }
 
 void init_serializable_device(py::module& m) {
-    py::class_<rs2::serializable_device> serializable_device(m, "serializable_device");
+    py::class_<rs2::serializable_device, py_holder<rs2::serializable_device>> serializable_device(m, "serializable_device");
     serializable_device.def(py::init<rs2::device>(), "device"_a)
         .def("serialize_json", &rs2::serializable_device::serialize_json)
         .def("load_json", &rs2::serializable_device::load_json, "json_content"_a);

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -30,9 +30,9 @@ void init_context(py::module &m) {
         .def_property_readonly("sensors", &rs2::context::query_all_sensors, "A flat list of "
                                "all available sensors from all RealSense devices. Identical to calling query_all_sensors.")
         .def("get_sensor_parent", &rs2::context::get_sensor_parent, "s"_a) // no docstring in C++
-        .def("set_devices_changed_callback", [](rs2::context& self, std::function<void(rs2::event_information)> &callback) {
-            self.set_devices_changed_callback(callback);
-        }, "Register devices changed callback.", "callback"_a)
+        .def("set_devices_changed_callback", [](rs2::context& self, std::function<void(rs2::event_information)> callback) {
+            self.set_devices_changed_callback(std::move(callback));
+        }, "Register devices changed callback.", "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("load_device", &rs2::context::load_device, "Creates a devices from a RealSense file.\n"
              "On successful load, the device will be appended to the context and a devices_changed event triggered.",
              "filename"_a)

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -12,7 +12,11 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 
 void init_device(py::module &m) {
     /** rs_device.hpp **/
-    py::class_<rs2::device> device(m, "device"); // No docstring in C++
+    // rs2::device destructor calls functions that might wait for Python callbacks to finish (e.g. dispatcher::stop)
+    // Those callbacks need to hold the GIL so the py_holder releases our hold of the GIL to let them run.
+    // Not releasing the GIL might lead to a deadlock (in certain scenario/timing).
+    // Note - device inheritors need to use py_holder as well.
+    py::class_<rs2::device, py_holder<rs2::device>> device(m, "device"); // No docstring in C++
     device.def("query_sensors", &rs2::device::query_sensors, "Returns the list of adjacent devices, "
                "sharing the same physical parent composite device.")
         .def_property_readonly("sensors", &rs2::device::query_sensors, "List of adjacent devices, "
@@ -27,7 +31,8 @@ void init_device(py::module &m) {
         .def("supports", &rs2::device::supports, "Check if specific camera info is supported.", "info"_a)
         .def("get_info", &rs2::device::get_info, "Retrieve camera specific information, "
              "like versions of various internal components", "info"_a)
-        .def("hardware_reset", &rs2::device::hardware_reset, "Send hardware reset request to the device")
+        .def("hardware_reset", &rs2::device::hardware_reset, "Send hardware reset request to the device",
+             py::call_guard<py::gil_scoped_release>())
         .def(py::init<>())
         .def("__nonzero__", &rs2::device::operator bool) // Called to implement truth value testing in Python 2
         .def("__bool__", &rs2::device::operator bool) // Called to implement truth value testing in Python 3
@@ -90,34 +95,34 @@ void init_device(py::module &m) {
 
     // not binding update_progress_callback, templated
 
-    py::class_<rs2::updatable, rs2::device> updatable(m, "updatable"); // No docstring in C++
+    py::class_<rs2::updatable, rs2::device, py_holder<rs2::updatable>> updatable(m, "updatable"); // No docstring in C++
     updatable.def(py::init<rs2::device>())
         .def("enter_update_state", &rs2::updatable::enter_update_state, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.", py::call_guard<py::gil_scoped_release>())
         .def("create_flash_backup", (std::vector<uint8_t>(rs2::updatable::*)() const) &rs2::updatable::create_flash_backup,
              "Create backup of camera flash memory. Such backup does not constitute valid firmware image, and cannot be "
              "loaded back to the device, but it does contain all calibration and device information.", py::call_guard<py::gil_scoped_release>())
-        .def("create_flash_backup", [](rs2::updatable& self, std::function<void(float)> f) { return self.create_flash_backup(f); },
+        .def("create_flash_backup", [](rs2::updatable& self, std::function<void(float)> f) { return self.create_flash_backup(std::move(f)); },
              "Create backup of camera flash memory. Such backup does not constitute valid firmware image, and cannot be "
              "loaded back to the device, but it does contain all calibration and device information.",
              "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("update_unsigned", (void(rs2::updatable::*)(const std::vector<uint8_t>&, int) const) &rs2::updatable::update_unsigned,
              "Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread.", "fw_image"_a,
              "update_mode"_a = RS2_UNSIGNED_UPDATE_MODE_UPDATE, py::call_guard<py::gil_scoped_release>())
-        .def("update_unsigned", [](rs2::updatable& self, const std::vector<uint8_t>& fw_image, std::function<void(float)> f, int update_mode) { return self.update_unsigned(fw_image, f, update_mode); },
+        .def("update_unsigned", [](rs2::updatable& self, const std::vector<uint8_t>& fw_image, std::function<void(float)> f, int update_mode) { return self.update_unsigned(fw_image, std::move(f), update_mode); },
              "Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread and provides progress notifications via the callback.",
              "fw_image"_a, "callback"_a, "update_mode"_a = RS2_UNSIGNED_UPDATE_MODE_UPDATE, py::call_guard<py::gil_scoped_release>())
         .def("check_firmware_compatibility", &rs2::updatable::check_firmware_compatibility, "Check firmware compatibility with device. "
             "This method should be called before burning a signed firmware.", "image"_a);
 
-    py::class_<rs2::update_device, rs2::device> update_device(m, "update_device");
+    py::class_<rs2::update_device, rs2::device, py_holder<rs2::update_device>> update_device(m, "update_device");
     update_device.def(py::init<rs2::device>())
         .def("update", [](rs2::update_device& self, const std::vector<uint8_t>& fw_image) { return self.update(fw_image); },
              "Update an updatable device to the provided firmware. This call is executed on the caller's thread.", "fw_image"_a, py::call_guard<py::gil_scoped_release>())
-        .def("update", [](rs2::update_device& self, const std::vector<uint8_t>& fw_image, std::function<void(float)> f) { return self.update(fw_image, f); },
+        .def("update", [](rs2::update_device& self, const std::vector<uint8_t>& fw_image, std::function<void(float)> f) { return self.update(fw_image, std::move(f)); },
              "Update an updatable device to the provided firmware. This call is executed on the caller's thread and provides progress notifications via the callback.",
              "fw_image"_a, "callback"_a, py::call_guard<py::gil_scoped_release>());
 
-    py::class_<rs2::auto_calibrated_device, rs2::device> auto_calibrated_device(m, "auto_calibrated_device");
+    py::class_<rs2::auto_calibrated_device, rs2::device, py_holder<rs2::auto_calibrated_device>> auto_calibrated_device(m, "auto_calibrated_device");
     auto_calibrated_device.def(py::init<rs2::device>(), "device"_a)
         .def("write_calibration", &rs2::auto_calibrated_device::write_calibration, "Write calibration that was set by set_calibration_table to device's EEPROM.", py::call_guard<py::gil_scoped_release>())
         .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, std::string json_content, int timeout_ms)
@@ -129,7 +134,7 @@ void init_device(py::module &m) {
         .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, std::string json_content, std::function<void(float)> f, int timeout_ms)
         {
             float health;
-            rs2::calibration_table table = self.run_on_chip_calibration(json_content, &health, f, timeout_ms);
+            rs2::calibration_table table = self.run_on_chip_calibration(json_content, &health, std::move(f), timeout_ms);
             return std::make_tuple(table, std::make_tuple(health, 0.0));
         },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread and provides progress notifications via the callback.", "json_content"_a, "callback"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, std::string json_content, int timeout_ms)
@@ -141,7 +146,7 @@ void init_device(py::module &m) {
         .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, std::string json_content, std::function<void(float)> callback, int timeout_ms)
         {
             float health[] = { 0,0 };
-            rs2::calibration_table table = self.run_tare_calibration(ground_truth_mm, json_content, health, callback, timeout_ms);
+            rs2::calibration_table table = self.run_tare_calibration(ground_truth_mm, json_content, health, std::move(callback), timeout_ms);
             return std::make_tuple(table, std::make_tuple(health[0], health[1]));
         }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread and it supports progress notifications via the callback.", "ground_truth_mm"_a, "json_content"_a, "callback"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
         .def("process_calibration_frame", [](const rs2::auto_calibrated_device& self, rs2::frame frame, int timeout_ms)
@@ -153,7 +158,7 @@ void init_device(py::module &m) {
         .def("process_calibration_frame", [](const rs2::auto_calibrated_device& self, rs2::frame frame, std::function<void(float)> callback, int timeout_ms)
             {
             float health[] = { 0,0 };
-            rs2::calibration_table table = self.process_calibration_frame(frame, health, callback, timeout_ms);
+            rs2::calibration_table table = self.process_calibration_frame(frame, health, std::move(callback), timeout_ms);
             return std::make_tuple(table, std::make_tuple(health[0], health[1]));
             }, "This will add a frame to the calibration process initiated by run_tare_calibration or run_on_chip_calibration as host assistant process. This call is executed on the caller's thread and it supports progress notifications via the callback.", "frame"_a, "callback"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_focal_length_calibration", [](const rs2::auto_calibrated_device& self, rs2::frame_queue left_queue, rs2::frame_queue right_queue,
@@ -172,7 +177,7 @@ void init_device(py::module &m) {
                 float ratio = 0.f;
                 float angle = 0.f;
             return std::make_tuple(self.run_focal_length_calibration(left_queue, right_queue, target_width_mm, target_heigth_mm, adjust_both_sides,
-                &ratio, &angle, callback), ratio, angle);
+                &ratio, &angle, std::move(callback)), ratio, angle);
         }, "Run target-based focal length calibration. This call is executed on the caller's thread and provides progress notifications via the callback.",
             "left_queue"_a, "right_queue"_a, "target_width_mm"_a, "target_heigth_mm"_a, "adjust_both_sides"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_uv_map_calibration", [](const rs2::auto_calibrated_device& self, rs2::frame_queue left, rs2::frame_queue color, rs2::frame_queue depth,
@@ -188,7 +193,7 @@ void init_device(py::module &m) {
             {
                 constexpr int health_check_params = 4; // px, py, fx, fy for the calibration
                 float health[health_check_params];
-                return std::make_tuple(self.run_uv_map_calibration(left, color, depth, py_px_only, health, health_check_params, callback), health);
+                return std::make_tuple(self.run_uv_map_calibration(left, color, depth, py_px_only, health, health_check_params, std::move(callback)), health);
             }, "Run target-based Depth-RGB UV-map calibraion. This call is executed on the caller's thread and provides progress notifications via the callback.",
             "left"_a, "color"_a, "depth"_a, "py_px_only"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("calculate_target_z", [](const rs2::auto_calibrated_device& self, rs2::frame_queue queue1, rs2::frame_queue queue2, rs2::frame_queue queue3,
@@ -200,7 +205,7 @@ void init_device(py::module &m) {
         .def("calculate_target_z", [](const rs2::auto_calibrated_device& self, rs2::frame_queue queue1, rs2::frame_queue queue2, rs2::frame_queue queue3,
             float target_width_mm, float target_height_mm, std::function<void(float)> callback)
             {
-                return self.calculate_target_z(queue1, queue2, queue3, target_width_mm, target_height_mm, callback);
+                return self.calculate_target_z(queue1, queue2, queue3, target_width_mm, target_height_mm, std::move(callback));
             }, "Calculate Z for calibration target - distance to the target's plane. This call is executed on the caller's thread and provides progress notifications via the callback.",
             "queue1"_a, "queue2"_a, "queue3"_a, "target_width_mm"_a, "target_height_mm"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("get_calibration_table", &rs2::auto_calibrated_device::get_calibration_table, "Read current calibration table from flash.")
@@ -209,7 +214,7 @@ void init_device(py::module &m) {
         .def("get_calibration_config", &rs2::auto_calibrated_device::get_calibration_config, "Get Calibration Config Table", py::call_guard<py::gil_scoped_release>())
         .def("set_calibration_config", &rs2::auto_calibrated_device::set_calibration_config, "Set Calibration Config Table", "calibration_config_json_str"_a, py::call_guard<py::gil_scoped_release>());
 
-    py::class_<rs2::device_calibration, rs2::device> device_calibration( m, "device_calibration" );
+    py::class_<rs2::device_calibration, rs2::device, py_holder<rs2::device_calibration>> device_calibration( m, "device_calibration" );
     device_calibration.def( py::init<rs2::device>(), "device"_a )
         .def( "trigger_device_calibration",
             []( rs2::device_calibration & self, rs2_calibration_type type )
@@ -221,8 +226,8 @@ void init_device(py::module &m) {
         .def( "register_calibration_change_callback",
             []( rs2::device_calibration& self, std::function<void( rs2_calibration_status )> callback )
             {
-                self.register_calibration_change_callback( 
-                    [callback]( rs2_calibration_status status )
+                self.register_calibration_change_callback(
+                    [callback = std::move(callback)]( rs2_calibration_status status )
                     {
                         try
                         {
@@ -241,13 +246,13 @@ void init_device(py::module &m) {
             "Register (only once!) a callback that gets called for each change in calibration", "callback"_a );
 
 
-    py::class_<rs2::calibration_change_device, rs2::device> calibration_change_device(m, "calibration_change_device");
+    py::class_<rs2::calibration_change_device, rs2::device, py_holder<rs2::calibration_change_device>> calibration_change_device(m, "calibration_change_device");
     calibration_change_device.def(py::init<rs2::device>(), "device"_a)
         .def("register_calibration_change_callback",
             [](rs2::calibration_change_device& self, std::function<void(rs2_calibration_status)> callback)
             {
                 self.register_calibration_change_callback(
-                    [callback](rs2_calibration_status status)
+                    [callback = std::move(callback)](rs2_calibration_status status)
                     {
                         try
                         {
@@ -265,7 +270,7 @@ void init_device(py::module &m) {
             },
             "Register (only once!) a callback that gets called for each change in calibration", "callback"_a);
 
-    py::class_<rs2::debug_protocol> debug_protocol(m, "debug_protocol"); // No docstring in C++
+    py::class_<rs2::debug_protocol, py_holder<rs2::debug_protocol>> debug_protocol(m, "debug_protocol"); // No docstring in C++
     debug_protocol.def(py::init<rs2::device>())
         .def("build_command", &rs2::debug_protocol::build_command, "opcode"_a, "param1"_a = 0, 
             "param2"_a = 0, "param3"_a = 0, "param4"_a = 0, "data"_a = std::vector<uint8_t>()) 

--- a/wrappers/python/pyrs_eth_config.cpp
+++ b/wrappers/python/pyrs_eth_config.cpp
@@ -35,8 +35,8 @@ void init_eth_config(py::module &m) {
         .value( "dynamic_usb_first", RS2_LINK_PRIORITY_DYNAMIC_USB_FIRST );
 
     // Bind the eth_config_device class
-    py::class_< rs2::eth_config_device, rs2::device > eth_config_device( m, "eth_config_device",
-                                                                         "Ethernet configuration extension for devices that support ethernet configuration");
+    py::class_< rs2::eth_config_device, rs2::device, py_holder<rs2::eth_config_device> > eth_config_device( m, "eth_config_device",
+                                                                                                            "Ethernet configuration extension for devices that support ethernet configuration");
     eth_config_device.def( py::init< rs2::device >(), "device"_a, "Create eth_config_device from regular device" )
         .def( "supports_eth_config", &rs2::eth_config_device::supports_eth_config, "Check if device supports ethernet configuration" )
         .def( "get_link_speed", &rs2::eth_config_device::get_link_speed, "Get Ethernet link speed, 0 if not linked" )

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -177,7 +177,7 @@ void init_internal(py::module &m) {
     
     /** rs_internal.hpp **/
     // rs2::software_sensor
-    py::class_<rs2::software_sensor, rs2::sensor> software_sensor(m, "software_sensor");
+    py::class_<rs2::software_sensor, rs2::sensor, py_holder<rs2::software_sensor>> software_sensor(m, "software_sensor");
     software_sensor
         .def( "add_video_stream",
               &rs2::software_sensor::add_video_stream,
@@ -201,7 +201,7 @@ void init_internal(py::module &m) {
         .def("on_notification", &rs2::software_sensor::on_notification, "notif"_a);
 
     // rs2::software_device
-    py::class_<rs2::software_device, rs2::device> software_device(m, "software_device");
+    py::class_<rs2::software_device, rs2::device, py_holder<rs2::software_device>> software_device(m, "software_device");
     software_device.def(py::init<>())
         .def("add_sensor", &rs2::software_device::add_sensor, "Add software sensor with given name "
             "to the software device.", "name"_a)
@@ -237,7 +237,7 @@ void init_internal(py::module &m) {
         .def("get_sequence_id", &rs2::firmware_log_parsed_message::sequence_id, "Get sequence id");
 
     // rs2::firmware_logger
-    py::class_<rs2::firmware_logger, rs2::device> firmware_logger(m, "firmware_logger");
+    py::class_<rs2::firmware_logger, rs2::device, py_holder<rs2::firmware_logger>> firmware_logger(m, "firmware_logger");
     firmware_logger.def(py::init<rs2::device>(), "device"_a)
         .def("create_message", &rs2::firmware_logger::create_message, "Create FW Log")
         .def("create_parsed_message", &rs2::firmware_logger::create_parsed_message, "Create FW Parsed Log")

--- a/wrappers/python/pyrs_record_playback.cpp
+++ b/wrappers/python/pyrs_record_playback.cpp
@@ -8,7 +8,7 @@ void init_record_playback(py::module &m) {
     /** rs_record_playback.hpp **/
 // Not binding status_changed_callback, templated
 
-    py::class_<rs2::playback, rs2::device> playback(m, "playback"); // No docstring in C++
+    py::class_<rs2::playback, rs2::device, py_holder<rs2::playback>> playback(m, "playback"); // No docstring in C++
     playback.def(py::init<rs2::device>(), "device"_a)
         .def("pause", &rs2::playback::pause, "Pauses the playback. Calling pause() in \"Paused\" status does nothing. If "
              "pause() is called while playback status is \"Playing\" or \"Stopped\", the playback will not play until resume() is called.")
@@ -24,13 +24,14 @@ void init_record_playback(py::module &m) {
              "and the application controls the framerate of playback via callback duration.", "real_time"_a)
         // set_playback_speed?
         .def("set_status_changed_callback", [](rs2::playback& self, std::function<void(rs2_playback_status)> callback) {
-            self.set_status_changed_callback(callback);
+            self.set_status_changed_callback(std::move(callback));
         }, "Register to receive callback from playback device upon its status changes. Callbacks are invoked from the reading thread, "
-           "and as such any heavy processing in the callback handler will affect the reading thread and may cause frame drops/high latency.", "callback"_a)
+           "and as such any heavy processing in the callback handler will affect the reading thread and may cause frame drops/high latency.", "callback"_a,
+           py::call_guard<py::gil_scoped_release>())
         .def("current_status", &rs2::playback::current_status, "Returns the current state of the playback device");
     // Stop?
 
-    py::class_<rs2::recorder, rs2::device> recorder(m, "recorder", "Records the given device and saves it to the given file as rosbag format.");
+    py::class_<rs2::recorder, rs2::device, py_holder<rs2::recorder>> recorder(m, "recorder", "Records the given device and saves it to the given file as rosbag format.");
     recorder.def(py::init<const std::string&, rs2::device>())
         .def(py::init<const std::string&, rs2::device, bool>())
         .def("pause", &rs2::recorder::pause, "Pause the recording device without stopping the actual device from streaming.")

--- a/wrappers/python/pyrs_sensor.cpp
+++ b/wrappers/python/pyrs_sensor.cpp
@@ -36,7 +36,11 @@ void init_sensor(py::module &m) {
 
     // not binding notifications_callback, templated
 
-    py::class_<rs2::sensor, rs2::options> sensor(m, "sensor"); // No docstring in C++
+    // rs2::sensor destructor calls functions that might wait for Python callbacks to finish (e.g. dispatcher::stop)
+    // Those callbacks need to hold the GIL so the py_holder releases our hold of the GIL to let them run.
+    // Not releasing the GIL might lead to a deadlock (in certain scenario/timing).
+    // Note - sensor inheritors need to use py_holder as well.
+    py::class_<rs2::sensor, rs2::options, py_holder<rs2::sensor>> sensor(m, "sensor"); // No docstring in C++
     sensor.def("open", (void (rs2::sensor::*)(const rs2::stream_profile&) const) &rs2::sensor::open,
                "Open sensor for exclusive access, by commiting to a configuration", "profile"_a, py::call_guard<py::gil_scoped_release>())
         .def("supports", (bool (rs2::sensor::*)(rs2_camera_info) const) &rs2::sensor::supports,
@@ -46,14 +50,14 @@ void init_sensor(py::module &m) {
         .def("get_info", &rs2::sensor::get_info, "Retrieve camera specific information, "
              "like versions of various internal components.", "info"_a)
         .def("set_notifications_callback", [](const rs2::sensor& self, std::function<void(rs2::notification)> callback) {
-            self.set_notifications_callback(callback);
-        }, "Register Notifications callback", "callback"_a)
+            self.set_notifications_callback(std::move(callback));
+        }, "Register Notifications callback", "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("open", (void (rs2::sensor::*)(const std::vector<rs2::stream_profile>&) const) &rs2::sensor::open,
              "Open sensor for exclusive access, by committing to a composite configuration, specifying one or "
              "more stream profiles.", "profiles"_a, py::call_guard<py::gil_scoped_release>())
         .def("close", &rs2::sensor::close, "Close sensor for exclusive access.", py::call_guard<py::gil_scoped_release>())
         .def("start", [](const rs2::sensor& self, std::function<void(rs2::frame)> callback) {
-            self.start(callback);
+            self.start(std::move(callback));
         }, "Start passing frames into user provided callback.", "callback"_a,py::call_guard< py::gil_scoped_release >())
         .def("start", [](const rs2::sensor& self, rs2::syncer& syncer) {
             self.start(syncer);
@@ -114,26 +118,26 @@ void init_sensor(py::module &m) {
             return *sptr;
             }, "frame"_a);
 
-    py::class_<rs2::roi_sensor, rs2::sensor> roi_sensor(m, "roi_sensor"); // No docstring in C++
+    py::class_<rs2::roi_sensor, rs2::sensor, py_holder<rs2::roi_sensor>> roi_sensor(m, "roi_sensor"); // No docstring in C++
     roi_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("set_region_of_interest", &rs2::roi_sensor::set_region_of_interest, "roi"_a) // No docstring in C++
         .def("get_region_of_interest", &rs2::roi_sensor::get_region_of_interest); // No docstring in C++
 
-    py::class_<rs2::depth_sensor, rs2::sensor> depth_sensor(m, "depth_sensor"); // No docstring in C++
+    py::class_<rs2::depth_sensor, rs2::sensor, py_holder<rs2::depth_sensor>> depth_sensor(m, "depth_sensor"); // No docstring in C++
     depth_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("get_depth_scale", &rs2::depth_sensor::get_depth_scale,
             "Retrieves mapping between the units of the depth image and meters.");
 
-    py::class_<rs2::color_sensor, rs2::sensor> color_sensor(m, "color_sensor"); // No docstring in C++
+    py::class_<rs2::color_sensor, rs2::sensor, py_holder<rs2::color_sensor>> color_sensor(m, "color_sensor"); // No docstring in C++
     color_sensor.def(py::init<rs2::sensor>(), "sensor"_a);
 
-    py::class_<rs2::motion_sensor, rs2::sensor> motion_sensor(m, "motion_sensor"); // No docstring in C++
+    py::class_<rs2::motion_sensor, rs2::sensor, py_holder<rs2::motion_sensor>> motion_sensor(m, "motion_sensor"); // No docstring in C++
     motion_sensor.def(py::init<rs2::sensor>(), "sensor"_a);
 
-    py::class_<rs2::fisheye_sensor, rs2::sensor> fisheye_sensor(m, "fisheye_sensor"); // No docstring in C++
+    py::class_<rs2::fisheye_sensor, rs2::sensor, py_holder<rs2::fisheye_sensor>> fisheye_sensor(m, "fisheye_sensor"); // No docstring in C++
     fisheye_sensor.def(py::init<rs2::sensor>(), "sensor"_a);
 
-    py::class_<rs2::safety_sensor, rs2::sensor> safety_sensor(m, "safety_sensor"); // No docstring in C++
+    py::class_<rs2::safety_sensor, rs2::sensor, py_holder<rs2::safety_sensor>> safety_sensor(m, "safety_sensor"); // No docstring in C++
     safety_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("get_safety_preset", &rs2::safety_sensor::get_safety_preset, "get safety preset at index", "index"_a, py::call_guard<py::gil_scoped_release>())
         .def("set_safety_preset", &rs2::safety_sensor::set_safety_preset, "set safety preset at index", "index"_a, "safety_preset"_a, py::call_guard<py::gil_scoped_release>())
@@ -145,24 +149,24 @@ void init_sensor(py::module &m) {
         .def("get_application_config", &rs2::safety_sensor::get_application_config, "get application config", py::call_guard<py::gil_scoped_release>())
         .def("set_application_config", &rs2::safety_sensor::set_application_config, "set application config", "application_config_json_str"_a, py::call_guard<py::gil_scoped_release>());
 
-    py::class_<rs2::max_usable_range_sensor, rs2::sensor> mur_sensor(m, "max_usable_range_sensor");
+    py::class_<rs2::max_usable_range_sensor, rs2::sensor, py_holder<rs2::max_usable_range_sensor>> mur_sensor(m, "max_usable_range_sensor");
     mur_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("get_max_usable_depth_range",
             &rs2::max_usable_range_sensor::get_max_usable_depth_range,
             py::call_guard< py::gil_scoped_release >());
     
-    py::class_< rs2::debug_stream_sensor, rs2::sensor > ds_sensor( m, "debug_stream_sensor" );
+    py::class_< rs2::debug_stream_sensor, rs2::sensor, py_holder<rs2::debug_stream_sensor> > ds_sensor( m, "debug_stream_sensor" );
     ds_sensor.def( py::init< rs2::sensor >(), "sensor"_a )
         .def( "get_debug_stream_profiles",
                &rs2::debug_stream_sensor::get_debug_stream_profiles,
               py::call_guard< py::gil_scoped_release >() );
 
     // rs2::depth_stereo_sensor
-    py::class_<rs2::depth_stereo_sensor, rs2::depth_sensor> depth_stereo_sensor(m, "depth_stereo_sensor"); // No docstring in C++
+    py::class_<rs2::depth_stereo_sensor, rs2::depth_sensor, py_holder<rs2::depth_stereo_sensor>> depth_stereo_sensor(m, "depth_stereo_sensor"); // No docstring in C++
     depth_stereo_sensor.def(py::init<rs2::sensor>())
         .def("get_stereo_baseline", &rs2::depth_stereo_sensor::get_stereo_baseline, "Retrieve the stereoscopic baseline value from the sensor.");
 
-    py::class_<rs2::pose_sensor, rs2::sensor> pose_sensor(m, "pose_sensor"); // No docstring in C++
+    py::class_<rs2::pose_sensor, rs2::sensor, py_holder<rs2::pose_sensor>> pose_sensor(m, "pose_sensor"); // No docstring in C++
     pose_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("import_localization_map", &rs2::pose_sensor::import_localization_map,
              "Load relocalization map onto device. Only one relocalization map can be imported at a time; "
@@ -197,7 +201,7 @@ void init_sensor(py::module &m) {
                 .def("__nonzero__", &rs2::pose_sensor::operator bool) // Called to implement truth value testing in Python 2
                 .def("__bool__", &rs2::pose_sensor::operator bool); // Called to implement truth value testing in Python 3
 
-    py::class_<rs2::wheel_odometer, rs2::sensor> wheel_odometer(m, "wheel_odometer"); // No docstring in C++
+    py::class_<rs2::wheel_odometer, rs2::sensor, py_holder<rs2::wheel_odometer>> wheel_odometer(m, "wheel_odometer"); // No docstring in C++
     wheel_odometer.def(py::init<rs2::sensor>(), "sensor"_a)
         .def("load_wheel_odometery_config", &rs2::wheel_odometer::load_wheel_odometery_config,
             "Load Wheel odometer settings from host to device.", "odometry_config_buf"_a)


### PR DESCRIPTION
https://github.com/realsenseai/librealsense/pull/15012 tracked on [LRS-1040]

Root cause - one thread registers a callback taking the GIL and a lock, while another thread calls the previously registered callback taking the lock than the GIL. Depending on timing might cause the threads to wait for each other.
Solution - callback registration thread releases the GIL while waiting for the lock.