### PR TITLE
react-viewer: bump openssl 0.10.79, tar 0.4.45, bytes 1.11.1 - Aikido  CVEs, lockfile only

### DIFF
--- a/wrappers/rest-api/tools/react-viewer/src-tauri/Cargo.lock
+++ b/wrappers/rest-api/tools/react-viewer/src-tauri/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-rs"
@@ -641,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1893,15 +1893,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1925,9 +1924,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2512,7 +2511,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3087,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -3303,7 +3302,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3910,7 +3909,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Security: Fix CVEs reported by Aikido scan in the React Viewer Tauri app (`wrappers/rest-api/tools/react-viewer/src-tauri`).

## openssl 0.10.75 ? 0.10.79
- **CVE-2026-41898** (9.8 CRITICAL) - PSK/cookie FFI callback trampolines forward unchecked length to OpenSSL, enabling buffer overflow. Fixed in 0.10.78.
- **CVE-2026-41681** (9.8 CRITICAL) - `MdCtxRef::digest_final()` stack buffer overflow from unchecked `EVP_MD_CTX_size` write. Fixed in 0.10.78.
- Plus additional callback-length validation fixes in 0.10.78 covering a related CVE cluster (some IDs still RESERVED in NVD; omitted here).

## tar 0.4.44 ? 0.4.45
- **CVE-2026-33055** (8.1 HIGH, RUSTSEC-2026-0068) - PAX size header inconsistency causing parser-divergence file-size confusion.
- **CVE-2026-33056** (5.1 MEDIUM, RUSTSEC-2026-0067) - symlink-following in `unpack_in` allows chmod of directories outside the extraction root.

## bytes 1.11.0 ? 1.11.1
- **CVE-2026-25541** (7.5 HIGH, RUSTSEC-2026-0007) - integer overflow in `BytesMut::reserve` causing OOB memory access.

## Scope
Lockfile-only patch - `Cargo.toml` unchanged. Verified with `cargo fetch --locked` (real checksums match crates.io).

## Followup
The Tauri app does not currently build on Ubuntu 22 due to an unrelated `wry 0.24.11` ? `webkit2gtk` trait-scope mismatch (E0599 on `set_enable_webgl` / `SettingsExt`). Tracked separately in **RSDEV-9390** - out of scope for this lockfile fix.