### PR TITLE
Stop FW error polling cleanly on device destruction

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -544,6 +544,14 @@ namespace librealsense
         init( dev_info->get_context(), dev_info->get_group() );
     }
 
+    d400_device::~d400_device()
+    {
+        // Signal background loops (polling_error_handler) so they exit cleanly on the
+        // next tick instead of firing one more failing FW query before being joined.
+        if( _device_alive )
+            _device_alive->store( false );
+    }
+
     void d400_device::init(std::shared_ptr<context> ctx,
         const platform::backend_device_group& group)
     {
@@ -728,6 +736,7 @@ namespace librealsense
 
                     _polling_error_handler = std::make_shared<polling_error_handler>(1000,
                         error_control,
+                        std::weak_ptr<std::atomic<bool>>( _device_alive ),
                         raw_depth_sensor->get_notifications_processor(),
                         std::make_shared< ds_notification_decoder >( d400_fw_error_report ) );
 

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -548,8 +548,7 @@ namespace librealsense
     {
         // Signal background loops (polling_error_handler) so they exit cleanly on the
         // next tick instead of firing one more failing FW query before being joined.
-        if( _device_alive )
-            _device_alive->store( false );
+        _device_alive->store( false );
     }
 
     void d400_device::init(std::shared_ptr<context> ctx,

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -5,6 +5,8 @@
 
 #include "d400-private.h"
 
+#include <atomic>
+
 #include "algo.h"
 #include "error-handling.h"
 #include "core/debug.h"
@@ -82,6 +84,7 @@ namespace librealsense
         }
 
         d400_device( std::shared_ptr< const d400_info > const & );
+        ~d400_device();
 
         std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) override;
 
@@ -150,6 +153,8 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
+        std::shared_ptr<std::atomic<bool>> _device_alive
+            = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;
         std::shared_ptr<ds_thermal_monitor> _thermal_monitor;
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _left_right_extrinsics;

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -84,7 +84,7 @@ namespace librealsense
         }
 
         d400_device( std::shared_ptr< const d400_info > const & );
-        ~d400_device();
+        ~d400_device() override;
 
         std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) override;
 
@@ -153,6 +153,10 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
+        // MUST be declared before _polling_error_handler — destruction order matters:
+        // members destruct in reverse declaration order, so _polling_error_handler's
+        // worker thread joins (and dereferences this weak_ptr) while _device_alive is
+        // still alive.
         std::shared_ptr<std::atomic<bool>> _device_alive
             = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -384,6 +384,12 @@ namespace librealsense
         init( dev_info->get_context(), dev_info->get_group() );
     }
 
+    d500_device::~d500_device()
+    {
+        if( _device_alive )
+            _device_alive->store( false );
+    }
+
     void d500_device::init(std::shared_ptr<context> ctx,
         const platform::backend_device_group& group)
     {
@@ -583,6 +589,7 @@ namespace librealsense
             _polling_error_handler = std::make_shared< polling_error_handler >(
                 1000,
                 error_control,
+                std::weak_ptr<std::atomic<bool>>( _device_alive ),
                 raw_depth_sensor->get_notifications_processor(),
                 std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -386,8 +386,9 @@ namespace librealsense
 
     d500_device::~d500_device()
     {
-        if( _device_alive )
-            _device_alive->store( false );
+        // Signal background loops (polling_error_handler) so they exit cleanly on the
+        // next tick instead of firing one more failing FW query before being joined.
+        _device_alive->store( false );
     }
 
     void d500_device::init(std::shared_ptr<context> ctx,

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -83,7 +83,7 @@ namespace librealsense
         }
 
         d500_device( std::shared_ptr< const d500_info > const & );
-        ~d500_device();
+        ~d500_device() override;
 
         std::shared_ptr<ds::d500_hwmon_response> _hw_monitor_response;
 
@@ -144,6 +144,10 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
+        // MUST be declared before _polling_error_handler — destruction order matters:
+        // members destruct in reverse declaration order, so _polling_error_handler's
+        // worker thread joins (and dereferences this weak_ptr) while _device_alive is
+        // still alive.
         std::shared_ptr<std::atomic<bool>> _device_alive
             = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "d500-private.h"
+
+#include <atomic>
 #include "hw_monitor_extended_buffers.h"
 
 #include "core/debug.h"
@@ -81,6 +83,7 @@ namespace librealsense
         }
 
         d500_device( std::shared_ptr< const d500_info > const & );
+        ~d500_device();
 
         std::shared_ptr<ds::d500_hwmon_response> _hw_monitor_response;
 
@@ -141,6 +144,8 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
+        std::shared_ptr<std::atomic<bool>> _device_alive
+            = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;
         std::shared_ptr<ds_thermal_monitor> _thermal_monitor;
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _left_right_extrinsics;

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -13,9 +13,11 @@
 namespace librealsense
 {
     polling_error_handler::polling_error_handler(unsigned int poll_intervals_ms, std::shared_ptr<option> option,
+        std::weak_ptr<std::atomic<bool>> device_alive,
         std::shared_ptr <notifications_processor> processor, std::shared_ptr<notification_decoder> decoder)
         :_poll_intervals_ms(poll_intervals_ms),
-        _option(option),
+        _option(std::move(option)),
+        _device_alive(std::move(device_alive)),
         _notifications_processor(processor),
         _decoder(decoder)
     {
@@ -33,6 +35,7 @@ namespace librealsense
         _poll_intervals_ms = h._poll_intervals_ms;
         _active_object = h._active_object;
         _option = h._option;
+        _device_alive = h._device_alive;
         _notifications_processor = h._notifications_processor;
         _decoder = h._decoder;
     }
@@ -41,6 +44,7 @@ namespace librealsense
     {
         if( poll_intervals_ms )
             _poll_intervals_ms = poll_intervals_ms;
+        _silenced = false;
         _active_object->start();
     }
     void polling_error_handler::stop()
@@ -54,6 +58,18 @@ namespace librealsense
         {
             if( ! _silenced )
             {
+                // The owning device sets *_device_alive = false in its destructor body,
+                // before any of its members destruct. That's our signal to exit cleanly
+                // without firing another (failing) FW query.
+                if( auto alive = _device_alive.lock() )
+                {
+                    if( ! alive->load() )
+                    {
+                        LOG_DEBUG( "Device marked dead; shutting down polling loop" );
+                        _silenced = true;
+                        return;
+                    }
+                }
                 try
                 {
                     auto val = static_cast< uint8_t >( _option->query() );

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -44,7 +44,6 @@ namespace librealsense
     {
         if( poll_intervals_ms )
             _poll_intervals_ms = poll_intervals_ms;
-        _silenced = false;
         _active_object->start();
     }
     void polling_error_handler::stop()
@@ -60,15 +59,15 @@ namespace librealsense
             {
                 // The owning device sets *_device_alive = false in its destructor body,
                 // before any of its members destruct. That's our signal to exit cleanly
-                // without firing another (failing) FW query.
-                if( auto alive = _device_alive.lock() )
+                // without firing another (failing) FW query. An expired weak_ptr is
+                // treated the same as a false flag for robustness against destruction
+                // ordering changes.
+                auto alive = _device_alive.lock();
+                if( ! alive || ! alive->load() )
                 {
-                    if( ! alive->load() )
-                    {
-                        LOG_DEBUG( "Device marked dead; shutting down polling loop" );
-                        _silenced = true;
-                        return;
-                    }
+                    LOG_DEBUG( "Device marked dead; shutting down polling loop" );
+                    _silenced = true;
+                    return;
                 }
                 try
                 {

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -18,8 +18,8 @@ namespace librealsense
         :_poll_intervals_ms(poll_intervals_ms),
         _option(std::move(option)),
         _device_alive(std::move(device_alive)),
-        _notifications_processor(processor),
-        _decoder(decoder)
+        _notifications_processor(std::move(processor)),
+        _decoder(std::move(decoder))
     {
         _active_object = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
             {  polling(cancellable_timer);  });
@@ -28,16 +28,6 @@ namespace librealsense
     polling_error_handler::~polling_error_handler()
     {
         stop();
-    }
-
-    polling_error_handler::polling_error_handler(const polling_error_handler& h)
-    {
-        _poll_intervals_ms = h._poll_intervals_ms;
-        _active_object = h._active_object;
-        _option = h._option;
-        _device_alive = h._device_alive;
-        _notifications_processor = h._notifications_processor;
-        _decoder = h._decoder;
     }
 
     void polling_error_handler::start( unsigned int poll_intervals_ms )

--- a/src/error-handling.h
+++ b/src/error-handling.h
@@ -5,6 +5,9 @@
 #include "core/option-interface.h"
 #include <rsutils/concurrency/concurrency.h>
 
+#include <atomic>
+#include <memory>
+
 
 namespace librealsense
 {
@@ -16,6 +19,7 @@ namespace librealsense
     {
     public:
         polling_error_handler(unsigned int poll_intervals_ms, std::shared_ptr<option> option,
+            std::weak_ptr<std::atomic<bool>> device_alive,
             std::shared_ptr<notifications_processor> processor, std::shared_ptr<notification_decoder> decoder);
         ~polling_error_handler();
 
@@ -32,6 +36,7 @@ namespace librealsense
         unsigned int _poll_intervals_ms;
         bool _silenced = false;
         std::shared_ptr<option> _option;
+        std::weak_ptr<std::atomic<bool>> _device_alive;
         std::shared_ptr < active_object<> > _active_object;
         std::weak_ptr<notifications_processor> _notifications_processor;
         std::shared_ptr<notification_decoder> _decoder;

--- a/src/error-handling.h
+++ b/src/error-handling.h
@@ -23,7 +23,8 @@ namespace librealsense
             std::shared_ptr<notifications_processor> processor, std::shared_ptr<notification_decoder> decoder);
         ~polling_error_handler();
 
-        polling_error_handler(const polling_error_handler& h);
+        polling_error_handler(const polling_error_handler &) = delete;
+        polling_error_handler & operator=(const polling_error_handler &) = delete;
 
         unsigned int get_polling_interval() const { return _poll_intervals_ms; }
 


### PR DESCRIPTION
**TL;DR:** Stops the FW error-polling thread from spamming `acquire_power failed` + `Error during polling error handler` during device destruction, by signaling the polling thread via a `_device_alive` flag flipped in `~d400_device` / `~d500_device` before any member is torn down.

## Problem
When a USB device is disconnected, the FW error-polling thread can fire one or more in-flight queries during the destruction window. Each query fails inside `MFCreateDeviceSource` and emits two `LOG_ERROR` lines (`acquire_power failed` + `Error during polling error handler`). The polling thread only fully stops when `~polling_error_handler` runs and joins it — by which point another query may already be in flight.

## Fix
Add a `std::shared_ptr<std::atomic<bool>>` "device alive" flag owned by `d400_device` / `d500_device`. The destructor body sets it to `false` **before** any member starts destructing. `polling_error_handler` holds a `weak_ptr` to it and checks it at the top of each iteration (after the cancellable sleep, before the FW query). When the device starts tearing down, the next polling tick sees the flag, sets `_silenced = true`, and returns without firing another query.

## Notes
- Member declaration order in `d400_device` / `d500_device` puts `_device_alive` **before** `_polling_error_handler` so the polling_error_handler joins its thread while the atomic is still alive; the `atomic<bool>` is only torn down after no one is reading it.
- No mutex needed: `shared_ptr` is never reassigned after construction; `atomic<bool>::store` is atomic; `weak_ptr::lock` is thread-safe.
- The async-USB-enumeration duplicate-`d400_device` case (UVC enumerates before HID for D455-class devices) is now already handled by PR #15057 (`partial-device-allowed` defaults to false) — so only one `d400_device` is created per physical camera and the destructor-based mechanism here covers the full disconnect path.

## Result
- 0 `Error during polling error handler` lines after the backend `Device disconnected` notice (verified locally with realsense-viewer + unplug on D455).
- Destructor joins the polling thread cleanly without waiting for an in-flight MF call.

## Test plan
- [x] Build Debug on Windows
- [x] D455 disconnect via realsense-viewer — 0 `Error during polling error handler` lines after the backend `Device disconnected` notice
- [ ] D585S disconnect via realsense-viewer