### PR TITLE
pyrealsense2: expose __version__ and __full_version__ at package level

### DIFF
--- a/wrappers/python/pyrealsense2/__init__.py
+++ b/wrappers/python/pyrealsense2/__init__.py
@@ -1,2 +1,5 @@
 # py libs (pyd/so) should be copied to pyrealsense2 folder
 from .pyrealsense2 import *
+# `from ... import *` skips dunder names, so re-export them explicitly
+# to make `pyrealsense2.__version__` work instead of `pyrealsense2.pyrealsense2.__version__`.
+from .pyrealsense2 import __version__, __full_version__


### PR DESCRIPTION
Currently, fetching the wrapper version requires the awkward double-nested path `pyrealsense2.pyrealsense2.__version__`, because `pyrealsense2/__init__.py` uses `from .pyrealsense2 import *`, and Python's star-import skips dunder names.

This change explicitly re-exports `__version__` and `__full_version__` from the C extension so that `pyrealsense2.__version__` works as expected. The old nested path still works, so this is non-breaking.

After installing python wheel (locally built):
>>> print(rs.__version__)
2.57.0
>>> print(rs.pyrealsense2.__version__)
2.57.0
