### PR TITLE
CP: ds: honor partial-device-allowed setting for d400/d500 USB enumeration (#15057)

### DIFF
--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -1164,9 +1164,16 @@ namespace librealsense
         }
         catch( const std::exception& e )
         {
-            LOG_ERROR( rsutils::string::from() << "Failed to create device for PID 0x" << std::hex << std::setw( 4 )
-                                               << std::setfill( '0' ) << (int)pid << "! (" << e.what() << ")" );
-            // Create a device with partial capabilities instead of failing
+            // Create a device with partial capabilities instead of failing,
+            // but only if the caller opted in via `partial-device-allowed`.
+            if( ! ds::is_partial_device_allowed( get_context() ) )
+            {
+                LOG_ERROR( rsutils::string::from() << "Failed to create device for PID 0x" << std::hex << std::setw( 4 )
+                                                   << std::setfill( '0' ) << (int)pid << "! (" << e.what() << ")" );
+                throw;
+            }
+            LOG_WARNING( "PID 0x" << std::hex << std::setw( 4 ) << std::setfill( '0' ) << (int)pid
+                                  << " - falling back to partial device (partial-device-allowed=true): " << e.what() );
             return std::make_shared< rs400_device >( dev_info, register_device_notifications );
         }
     }

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -13,7 +13,9 @@
 #include <src/backend.h>
 #include <src/platform/platform-utils.h>
 #include <src/metadata.h>
+#include <src/context.h>
 #include "ds/ds-timestamp.h"
+#include "ds/ds-private.h"
 #include "d400-options.h"
 #include "d400-info.h"
 #include "stream.h"
@@ -39,6 +41,8 @@ namespace librealsense
 
     rs2_motion_device_intrinsic d400_motion_base::get_motion_intrinsics(rs2_stream stream) const
     {
+        if( _has_motion_module_failed )
+            throw std::runtime_error( "Motion module is not available on this device" );
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
@@ -137,7 +141,12 @@ namespace librealsense
             _has_motion_module_failed = true;
             auto device_name = get_info( RS2_CAMERA_INFO_NAME );
             auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            LOG_ERROR( device_name << " #" << serial << " - Base Motion Sensor Failure! " << e.what() );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - Base Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - Base Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
 
     }
@@ -182,7 +191,12 @@ namespace librealsense
             _has_motion_module_failed = true;
             auto device_name = get_info( RS2_CAMERA_INFO_NAME );
             auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            LOG_ERROR( device_name << " #" << serial << " - HID Motion Sensor Failure! " << e.what() );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - HID Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - HID Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
     }
 
@@ -249,7 +263,12 @@ namespace librealsense
             _has_motion_module_failed = true;
             auto device_name = get_info( RS2_CAMERA_INFO_NAME );
             auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            LOG_ERROR( device_name << " #" << serial << " - UVC Motion Sensor Failure! " << e.what() );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - UVC Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - UVC Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
 
     }

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -322,11 +322,18 @@ public:
         }
         catch( const std::exception & e )
         {
-            LOG_ERROR( rsutils::string::from() << "Failed to create device for PID 0x" << std::hex << std::setw( 4 )
-                                               << std::setfill( '0' ) << (int)pid << "! (" << e.what() << ")" );
-            // Create a device with partial capabilities instead of failing
+            // Create a device with partial capabilities instead of failing,
+            // but only if the caller opted in via `partial-device-allowed`.
+            if( ! ds::is_partial_device_allowed( get_context() ) )
+            {
+                LOG_ERROR( rsutils::string::from() << "Failed to create device for PID 0x" << std::hex << std::setw( 4 )
+                                                   << std::setfill( '0' ) << (int)pid << "! (" << e.what() << ")" );
+                throw;
+            }
+            LOG_WARNING( "PID 0x" << std::hex << std::setw( 4 ) << std::setfill( '0' ) << (int)pid
+                                  << " - falling back to partial device (partial-device-allowed=true): " << e.what() );
             return std::make_shared< rs500_device >( dev_info );
-        }        
+        }
     }
 
     std::vector<std::shared_ptr<d500_info>> d500_info::pick_d500_devices(
@@ -407,19 +414,25 @@ public:
     std::shared_ptr<matcher> rs_d585_device::create_matcher(const frame_holder& frame) const
     {
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get() };
-        std::vector<stream_interface*> mm_streams = { _ds_motion_common->get_accel_stream().get(), 
-                                                      _ds_motion_common->get_gyro_stream().get()};
-        streams.insert(streams.end(), mm_streams.begin(), mm_streams.end());
+        if (!_has_motion_module_failed)
+        {
+            std::vector<stream_interface*> mm_streams = { _ds_motion_common->get_accel_stream().get(),
+                                                          _ds_motion_common->get_gyro_stream().get()};
+            streams.insert(streams.end(), mm_streams.begin(), mm_streams.end());
+        }
         return matcher_factory::create(RS2_MATCHER_DEFAULT, streams);
     }
 
     std::shared_ptr<matcher> rs_d585s_device::create_matcher(const frame_holder& frame) const
     {
-        std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get(), 
+        std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get(),
             _safety_stream.get(), _occupancy_stream.get(), _point_cloud_stream.get()};
-        std::vector<stream_interface*> mm_streams = { _ds_motion_common->get_accel_stream().get(),
-                                                      _ds_motion_common->get_gyro_stream().get() };
-        streams.insert(streams.end(), mm_streams.begin(), mm_streams.end());
+        if (!_has_motion_module_failed)
+        {
+            std::vector<stream_interface*> mm_streams = { _ds_motion_common->get_accel_stream().get(),
+                                                          _ds_motion_common->get_gyro_stream().get() };
+            streams.insert(streams.end(), mm_streams.begin(), mm_streams.end());
+        }
         return matcher_factory::create(RS2_MATCHER_DEFAULT, streams);
     }
 }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -11,8 +11,10 @@
 #include <cstddef>
 
 #include <src/metadata.h>
+#include <src/context.h>
 #include "ds/ds-timestamp.h"
 #include "ds/ds-options.h"
+#include "ds/ds-private.h"
 #include "d500-info.h"
 #include "stream.h"
 #include "proc/motion-transform.h"
@@ -27,6 +29,8 @@ namespace librealsense
 
     rs2_motion_device_intrinsic d500_motion::get_motion_intrinsics(rs2_stream stream) const
     {
+        if( _has_motion_module_failed )
+            throw std::runtime_error( "Motion module is not available on this device" );
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
@@ -74,10 +78,15 @@ namespace librealsense
         }
         catch (const std::exception& e)
         {
+            _has_motion_module_failed = true;
             auto device_name = get_info( RS2_CAMERA_INFO_NAME );
             auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            LOG_ERROR( "Device Name : " << device_name << " Serial : " << serial
-                << " HID Motion Sensor Failure! "  << e.what() );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - HID Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - HID Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
 
     }

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -26,6 +26,12 @@ namespace librealsense
         friend class ds_motion_sensor;
 
         std::shared_ptr<ds_motion_common> _ds_motion_common;
+        // Set when HID motion-sensor construction failed and the partial device
+        // was allowed by the `partial-device-allowed` setting. Callers that
+        // access `_ds_motion_common` (e.g. derived create_matcher) must gate on
+        // this flag because `_ds_motion_common` remains null in the partial
+        // case. Mirrors the same flag in d400_motion_base.
+        bool _has_motion_module_failed = false;
 
     private:
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);

--- a/unit-tests/live/hw-reset/pytest-hub-recycle-imu.py
+++ b/unit-tests/live/hw-reset/pytest-hub-recycle-imu.py
@@ -1,0 +1,107 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Hub-recycle stress test: power-cycles the USB port the device under test is
+# connected to (true cold plug-in via the OS, not an in-band hardware_reset),
+# then verifies that the re-enumerated device exposes its full sensor set,
+# in particular the Motion Module on IMU-bearing devices.
+#
+# This catches the partial-enumeration race where, on Windows, the device-
+# watcher's debounce fires a "device added" callback before the HID Sensor
+# Collection has bound at T0+~1s, surfacing a UVC-only device with no IMU and
+# triggering "No HID info provided, IMU is disabled" / "HID Motion Sensor
+# Failure! bad optional access" in the log.
+#
+# Uses the existing rspy.devices.enable_only(recycle=True) flow so the hub
+# singleton and per-device port resolution are reused from the test fixtures.
+
+import pytest
+import pyrealsense2 as rs
+from rspy import devices
+import logging
+log = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.device_each("D400*"),
+    pytest.mark.device_each("D500*"),
+    pytest.mark.device_type("USB"),   # hub-recycle is meaningful only on USB
+    pytest.mark.context("nightly"),
+    pytest.mark.timeout(300),
+]
+
+
+ITERATIONS_NIGHTLY = 5
+ITERATIONS_WEEKLY  = 20
+
+
+def _sensor_names( dev ):
+    return [ s.get_info( rs.camera_info.name ) for s in dev.query_sensors() ]
+
+
+def _find_device_by_sn( ctx, sn ):
+    for d in ctx.query_devices():
+        if d.supports( rs.camera_info.serial_number ) and d.get_info( rs.camera_info.serial_number ) == sn:
+            return d
+    return None
+
+
+def test_hub_recycle_imu_presence( test_device, test_context_var ):
+    dev, ctx = test_device
+    sn = dev.get_info( rs.camera_info.serial_number )
+
+    # The device_type("USB") marker filters out non-USB cameras at collection
+    # time. The Motion-Module check below is what we can't express as a marker
+    # today: skip cleanly for D4xx/D5xx products that don't carry an IMU.
+    if not any( "Motion" in n for n in _sensor_names( dev ) ):
+        pytest.skip( f"{dev.get_info( rs.camera_info.name )} has no Motion Module - test does not apply" )
+
+    if devices.get( sn ).port is None:
+        pytest.fail( f"Hub is present but could not resolve a port for serial {sn} - "
+                     "refusing to recycle all ports to avoid disturbing other devices on the hub." )
+
+    iterations = ITERATIONS_WEEKLY if 'weekly' in test_context_var else ITERATIONS_NIGHTLY
+    log.info( f"Hub-recycle IMU-presence test: {iterations} iterations on serial {sn}, "
+              f"hub port {devices.get( sn ).port}" )
+
+    missing_imu = []
+    no_reappear = []
+
+    for i in range( 1, iterations + 1 ):
+        log.debug( f"[{i}/{iterations}] recycling port" )
+        try:
+            # Recycles just this device's port (disable -> wait_until_removed
+            # -> enable -> wait_for re-enumeration), so other devices on the
+            # same hub are not disturbed.
+            devices.enable_only( [sn], recycle=True, timeout=devices.MAX_ENUMERATION_TIME )
+        except Exception as e:
+            log.error( f"[{i}/{iterations}] enable_only failed: {e}" )
+            no_reappear.append( i )
+            continue
+
+        new_dev = _find_device_by_sn( ctx, sn )
+        if new_dev is None:
+            log.error( f"[{i}/{iterations}] device with serial {sn} not in context after recycle" )
+            no_reappear.append( i )
+            continue
+
+        try:
+            names = _sensor_names( new_dev )
+        except RuntimeError as e:
+            log.error( f"[{i}/{iterations}] query_sensors raised: {e}" )
+            missing_imu.append( i )
+            continue
+
+        if any( "Motion" in n for n in names ):
+            log.debug( f"[{i}/{iterations}] OK: {names}" )
+        else:
+            log.error( f"[{i}/{iterations}] Motion Module MISSING: {names}" )
+            missing_imu.append( i )
+
+    if no_reappear:
+        log.error( f"Iterations that did not re-enumerate: {no_reappear}" )
+    if missing_imu:
+        log.error( f"Iterations with missing Motion Module: {missing_imu}" )
+
+    assert not no_reappear, f"{len(no_reappear)}/{iterations} iterations: device did not re-enumerate"
+    assert not missing_imu, f"{len(missing_imu)}/{iterations} iterations: device re-enumerated without Motion Module"


### PR DESCRIPTION
@
**TL;DR:** Cherry-pick of #15057 onto `r/2.58.1`. Wires the existing `partial-device-allowed` context setting into the d400/d500 USB enumeration path so applications can reject a partial device (no IMU) instead of silently receiving one, and aligns d400/d500 around the same `_has_motion_module_failed` flag and `LOG_ERROR`-only-on-fail messaging.

## Cherry-pick details
- Source: #15057 (merge commit `141b0f8`), merged to `development` on 2026-05-17.
- One conflict during cherry-pick: `unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py` (subprocess timeout bump, unrelated to this fix) — file does not exist on `r/2.58.1`, so the change was dropped. All other files applied cleanly.

## Summary (from #15057)
- Wires `ds::is_partial_device_allowed(ctx)` into the catch blocks of `d400-motion` (all three motion ctors), `d400-factory`, `d500-motion`, `d500-factory`.
- The setting key (`partial-device-allowed`) defaults to `false`; the DDS factory already honored it. This change makes the USB d400/d500 path honor the same default.
- Aligns d400/d500 around `_has_motion_module_failed`; both classes `get_motion_intrinsics` and matchers gate on the flag.
- `LOG_ERROR` only fires when the device is actually being failed; `partial-device-allowed=true` fallback is a single `LOG_WARNING`.

## Behavior change with default settings
| Scenario | Before | After (default) |
|---|---|---|
| Partial USB enumeration (e.g. UVC ready, HID not yet bound) | Device surfaces without Motion Module + warning | Device construction throws; partial device is **not** surfaced |
| `partial-device-allowed: true` in context JSON | Same | Same (opt back in, fallback logged as `LOG_WARNING`) |

Applications that explicitly want the legacy permissive behavior should set:
```json
{ "partial-device-allowed": true }
```

## Test plan
- [ ] Build clean on Windows VS 2022
- [ ] `unit-tests/live/hw-reset/pytest-hub-recycle-imu.py` (included)
- [ ] Smoke that `partial-device-allowed: true` restores legacy permissive behavior
@