### PR TITLE
CP: mf-backend: defer device-watcher callback until HID Sensor binding completes (#15058)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ Detailed how-to guides for common tasks are maintained as skill files under `.gi
 | `.github/skills/testing.md` | Running, filtering, and debugging unit tests |
 | `.github/skills/pytest-infra.md` | Migrating tests to pytest, modifying pytest/hub infrastructure, verifying Jenkins CI results |
 | `.github/skills/git-workflow.md` | Branch/PR conventions, commit message style, push remotes |
+| `.github/skills/pr-review.md` | Opening a pull request, updating its description, replying to review comments |
 
 If a skill file exists for the task at hand, follow its instructions precisely. New skills may be added to this folder over time — check its contents before assuming none applies.
 

--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -1,0 +1,57 @@
+# Pull Request Workflow
+
+## When to Use This Skill
+
+Opening a PR, pushing new commits to one, or replying to review comments on `realsenseai/librealsense`.
+
+## Description Format
+
+Every PR description starts with a TL;DR (1–2 sentences stating the user-visible change), then the body:
+
+```markdown
+**TL;DR:** <1-2 sentences>
+
+## Summary
+- <what changed and why>
+
+## Why
+<bug, regression, or capability gap>
+
+## Test plan
+- [ ] <unit/pytest entries, marker/context/iteration counts>
+- [ ] <manual or CI verification>
+```
+
+Keep the TL;DR jargon-free. Put tables (behavior change, latency, benchmarks) in the body, never in the TL;DR.
+
+If you **know** which Jira ticket the PR is tracking (the user told you, or you opened the ticket yourself this session), append a `Tracked on [RSDEV-1234]` line right after the TL;DR — bare text, no link:
+
+```markdown
+**TL;DR:** <1-2 sentences>
+
+Tracked on [RSDEV-1234]
+```
+
+Only add this line when you are sure. If you only suspect a ticket is related, ask the user before adding it — never guess.
+
+## Before Every Push — Description Audit
+
+Re-read the PR description before `git push`. If any concrete detail in the description (iteration counts, timeouts, file paths, marker lists, behavior tables, referenced PR numbers) no longer matches what's actually on the branch, update the description in the same push (`gh pr edit <num> --body ...`).
+
+The description and the diff must stay in sync.
+
+## Responding to Review Comments
+
+- **One reply per thread.** Don't summarise multiple threads in one comment.
+- Cite the commit SHA that addresses the comment (`✅ Fixed in <sha>. <one-line summary>`).
+- For deferred items: `⏸ Deferred — <reason>`.
+- For disagreements: give a concrete reason (worked example, edge case) before declining.
+- Don't auto-resolve threads — let the reviewer decide when their concern is settled.
+
+## Handling Automated Review Bots
+
+| Bot | How to respond |
+|---|---|
+| **Aikido** (`aikido-pr-checks[bot]`) | Fix and reply with commit SHA, or reply `@AikidoSec ignore: <reason>` if the suggestion is wrong or the pattern is intentional. |
+| **rs-agentic-bot** (posts as a teammate) | Treat as a real reviewer: fix or defer; reply per thread. |
+| **Copilot suggestions** | Apply only if they preserve intent; reply with rationale if declined. |

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -7,6 +7,7 @@
 #include "mf-backend.h"
 #include "mf-uvc.h"
 #include "mf-hid.h"
+#include "../win/win-helpers.h"  // cm_node
 #include <src/core/time-service.h>
 #include <src/platform/device-watcher.h>
 #include <src/platform/command-transfer.h>
@@ -15,8 +16,10 @@
 #include "../types.h"
 #include <mfapi.h>
 #include <chrono>
+#include <set>
 #include <Windows.h>
 #include <dbt.h>
+#include <devpkey.h>  // DEVPKEY_Device_Class
 #include <cctype> // std::tolower
 #include <rsutils/time/timer.h>
 
@@ -192,6 +195,87 @@ namespace librealsense
             return std::vector<mipi_device_info>();
         }
 
+        // Returns true if any USB composite device referenced by the current
+        // enumeration has an HID-class interface that hasn't been fully
+        // surfaced yet - either the CM tree hasn't attached a child device-
+        // instance under the HID interface, OR the Sensor API hasn't yet
+        // returned a hid_device_info matching that composite's unique_id.
+        // This is a generic signal that the OS is still in the middle of
+        // binding HID drivers for the composite (e.g., the HID Sensor
+        // Collection of a D4xx/D5xx IMU camera, which on Windows binds
+        // noticeably after the UVC interfaces of the same composite device).
+        // When this is true, the watcher defers its "device added" callback
+        // so that the SDK doesn't see a half-enumerated device (which would
+        // otherwise come up as a UVC device with no Motion Module and
+        // produce "No HID info provided, IMU is disabled" / "HID Motion
+        // Sensor Failure! bad optional access" before a second supersede
+        // event fixes it).
+        //
+        // This intentionally does NOT depend on PID lists - it asks the OS
+        // and the Sensor API "is there an HID-class interface here that
+        // hasn't been fully enumerated yet?" which is the underlying truth
+        // we are waiting on.
+        static bool hid_binding_in_progress( platform::backend_device_group const & curr )
+        {
+            // Collect the composite unique_ids that the Sensor API has
+            // already surfaced HID entries for. query_hid_devices() returns
+            // hid_device_info with unique_id == composite parent UID (see
+            // mf-hid.cpp foreach_hid_device), the same key UVC interfaces
+            // use, so a direct set lookup is enough.
+            std::set< std::string > sensor_api_uids;
+            for( auto && h : curr.hid_devices )
+                sensor_api_uids.insert( h.unique_id );
+
+            // Each USB composite device shows up as the PARENT of any of its
+            // MI_xx interfaces. We discover composites via the UVC entries
+            // (every IMU-bearing camera also exposes UVC), walk up one node,
+            // then enumerate the composite's children looking for HID-class
+            // children.
+            std::set< DEVINST > visited_composites;
+            for( auto && uvc : curr.uvc_devices )
+            {
+                std::wstring path( uvc.id.begin(), uvc.id.end() );
+                cm_node iface = cm_node::from_device_path( path.c_str() );
+                if( ! iface.valid() )
+                    continue;
+                cm_node composite = iface.get_parent();
+                if( ! composite.valid() )
+                    continue;
+                if( ! visited_composites.insert( composite.get() ).second )
+                    continue;  // already checked this composite
+
+                bool has_hid_class_child = false;
+                cm_node child = composite.get_child();
+                while( child.valid() )
+                {
+                    // DEVPKEY_Device_Class is the human-readable class name
+                    // assigned by Windows ("HIDClass", "Camera", "USB", ...).
+                    // We only care about HID-class interface children of the
+                    // composite - those are where HID Sensor Collections (or
+                    // other HID device-instances) get instantiated.
+                    if( child.get_property( DEVPKEY_Device_Class ) == "HIDClass" )
+                    {
+                        has_hid_class_child = true;
+                        // No grandchild => no HID device-instance attached
+                        // yet at the CM-tree level => still binding.
+                        if( ! child.get_child().valid() )
+                            return true;
+                    }
+                    child = child.get_sibling();
+                }
+
+                // CM tree shows all HID-class children have grandchildren,
+                // but the Sensor API runs on its own thread and may not have
+                // re-enumerated yet. If the composite has HID-class
+                // interfaces but the Sensor API still returns no HID entry
+                // for this composite's unique_id, we're between "CM tree
+                // ready" and "Sensor API ready" - keep waiting.
+                if( has_hid_class_child && sensor_api_uids.count( uvc.unique_id ) == 0 )
+                    return true;
+            }
+            return false;
+        }
+
         class win_event_device_watcher : public device_watcher
         {
         public:
@@ -241,6 +325,10 @@ namespace librealsense
 
             struct extra_data {
                 rsutils::time::timer _timer{ std::chrono::milliseconds( 100 ) };
+                // Set when an arrival/removal event has triggered _changed; used
+                // to enforce a maximum total deferral while waiting for HID
+                // drivers to finish binding (see hid_binding_in_progress).
+                std::chrono::steady_clock::time_point _first_event;
 
                 bool _stopped = true;
                 bool _changed = false;
@@ -279,14 +367,33 @@ namespace librealsense
                             platform::backend_device_group curr( _backend->query_uvc_devices(),
                                                                  _backend->query_usb_devices(),
                                                                  _backend->query_hid_devices() );
-                            if( list_changed( _last.uvc_devices, curr.uvc_devices )
-                                || list_changed( _last.usb_devices, curr.usb_devices )
-                                || list_changed( _last.hid_devices, curr.hid_devices ) )
+
+                            // Generic "wait for HID to finish binding" gate: if the
+                            // OS shows an HID-class USB interface that hasn't been
+                            // populated with a child device-instance yet, the bus
+                            // is still "settling" - re-arm the debounce and check
+                            // again on the next tick. Bounded by MAX_DEFERRAL so a
+                            // misbehaving HID driver (HID class advertised but
+                            // never bound) doesn't make the device invisible
+                            // forever.
+                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 5000 );
+                            auto since_first = std::chrono::steady_clock::now() - _data._first_event;
+                            if( hid_binding_in_progress( curr ) && since_first < MAX_DEFERRAL )
                             {
-                                _callback( _last, curr );
-                                _last = curr;
+                                _data._timer.start();
+                                // Don't fire yet; fall through to sleep.
                             }
-                            _data._changed = false;
+                            else
+                            {
+                                if( list_changed( _last.uvc_devices, curr.uvc_devices )
+                                    || list_changed( _last.usb_devices, curr.usb_devices )
+                                    || list_changed( _last.hid_devices, curr.hid_devices ) )
+                                {
+                                    _callback( _last, curr );
+                                    _last = curr;
+                                }
+                                _data._changed = false;
+                            }
                         }
                         // Yield CPU resources, as this is required for connect/disconnect events only
                         std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
@@ -329,6 +436,8 @@ namespace librealsense
                             break;
                         auto data = reinterpret_cast< extra_data * >(
                             GetWindowLongPtr( hWnd, GWLP_USERDATA ) );
+                        if( ! data->_changed )
+                            data->_first_event = std::chrono::steady_clock::now();
                         data->_changed = true;
                         data->_timer.start();
                         break;
@@ -340,6 +449,8 @@ namespace librealsense
                         if( p_hdr->dbch_devicetype != DBT_DEVTYP_DEVICEINTERFACE )
                             break;
                         auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+                        if( ! data->_changed )
+                            data->_first_event = std::chrono::steady_clock::now();
                         data->_changed = true;
                         data->_timer.start();
                     }


### PR DESCRIPTION
@
**TL;DR:** Cherry-pick of #15058 onto `r/2.58.1`. On Windows, defers the device-watchers "device added" callback until the HID Sensor Collection of D4xx/D5xx IMU cameras has actually bound, so applications never receive a partial UVC-only device with no Motion Module.

## Cherry-pick details
- Source: #15058 (merge commit `9a94bd6`), merged to `development` on 2026-05-17.
- One conflict during cherry-pick: `.github/copilot-instructions.md` skill table — `r/2.58.1` already had a `git-workflow.md` row; #15058 added a `pr-review.md` row. Resolved by keeping both rows.
- All other files applied cleanly. Companion to #15065 (CP of #15057); both can land independently.

## Summary (from #15058)
- On Windows the device-watchers 100 ms debounce fires the "device added" callback as soon as the UVC interfaces of a D4xx/D5xx IMU camera bind, even though Windows takes ~1 s more to bind the HID Sensor Collection of the same composite. The SDK then builds a partial device with no Motion Module and logs `No HID info provided, IMU is disabled` / `HID Motion Sensor Failure! bad optional access`.
- This PR makes `win_event_device_watcher::run()` consult the CM tree (`DEVPKEY_Device_Class == "HIDClass"` children of the USB composite) **and** the Sensor API (`query_hid_devices()` surfaces the composites `unique_id`) before firing. The callback is held back while either signal says HID binding is incomplete.
- Bounded by `MAX_DEFERRAL = 5000 ms` so a misbehaving HID driver (HID class advertised but never bound) can never make the device invisible.

## Verification (Windows / D455 SN 114222251272)
Local Python `hardware_reset()`-based stress (from upstream PR):

| Build | Result |
|---|---|
| Baseline | 19/20 PASS — partial Motion Module observed |
| Fix v1 (CM-tree only) | 48/50 PASS |
| Fix v2 (CM-tree + Sensor API double-check) | 50/50 PASS |
| Fix v3 (5 s MAX_DEFERRAL) | **100/100 PASS** |

## Latency impact (steady state)
| Device | Time to user callback after plug | vs. before |
|---|---|---|
| D435 (no IMU) | ~100 ms | unchanged |
| D455 / D435i (IMU) | ~1.1 s | same total time-to-final-state as todays partial-then-supersede path, no intermediate partial flash |
| IMU device, misbehaving HID driver | 5 s then partial | was ~100 ms with no fix — now bounded |

## Test plan
- [x] Local build clean on Windows VS 2022 (combined branch with #15065 builds cleanly)
- [ ] D455 hot-plug on Windows
- [ ] D435 hot-plug on Windows — confirm no added latency
@