### PR TITLE
Default partial-device-allowed to true across SDK and viewer - for back compat IMU BMI 088 support

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3022,7 +3022,7 @@ namespace rs2
                     std::string excl_icon_str = rsutils::string::from() << textual_icons::exclamation_triangle
                                                 << " The following changes will take effect only after restarting the application";
                     ImGui::Text( "%s", excl_icon_str.c_str() );
-                    bool allow_partial_device = temp_cfg.get_nested< bool >( "context.partial-device-allowed", false );
+                    bool allow_partial_device = temp_cfg.get_nested< bool >( "context.partial-device-allowed", true );
                     if( ImGui::Checkbox( "Allow partial device initialization", &allow_partial_device ) )
                     {
                         temp_cfg.set_nested( "context.partial-device-allowed", allow_partial_device );

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -157,7 +157,7 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
                                       << domain_id << "; cannot create '" << participant_name << "'" );
         }
         size_t device_initialization_timeout = dds_settings.nested( "device-initialization-timeout-ms" ).default_value< size_t >( 5000 );
-        bool partial_capabilities_allowed = ctx->get_settings().nested( "partial-device-allowed" ).default_value< bool >( false );
+        bool partial_capabilities_allowed = ctx->get_settings().nested( "partial-device-allowed" ).default_value< bool >( true );
         _watcher_singleton = domain.device_watcher.instance( _participant, device_initialization_timeout, partial_capabilities_allowed );
         _subscription = _watcher_singleton->subscribe(
             [liveliness = std::weak_ptr< context >( ctx ),

--- a/src/ds/ds-private.cpp
+++ b/src/ds/ds-private.cpp
@@ -122,7 +122,7 @@ namespace librealsense
         bool is_partial_device_allowed( const std::shared_ptr< context > & ctx )
         {
             auto settings = ctx->get_settings();
-            return settings.nested( "partial-device-allowed" ).default_value< bool >( false );
+            return settings.nested( "partial-device-allowed" ).default_value< bool >( true );
         }
     } // librealsense::ds
 } // namespace librealsense


### PR DESCRIPTION
@
**TL;DR:** Flip the default of `partial-device-allowed` from `false` to `true` in the three places its read. With the watcher-level HID-binding deferral from #15058 (5 s `MAX_DEFERRAL`) in place, partial enumeration is the rare slow-HID corner case rather than the common path — surfacing the partial device and letting the supersede event upgrade it ~3 s later is a better UX than rejecting it outright and showing "no device" for that window.

## Changes
Three one-line flips, no logic changes:

| File | Line | Effect |
|---|---|---|
| `src/ds/ds-private.cpp` | `is_partial_device_allowed()` fallback `false`→`true` | SDK D400/D500 USB factory default |
| `src/dds/rsdds-device-factory.cpp` | watcher singleton `partial_capabilities_allowed` fallback `false`→`true` | DDS factory default |
| `common/viewer.cpp` | "Allow partial device initialization" checkbox initial state `false`→`true` | Viewer UI default for fresh users |

Aligning all three keeps UI and SDK behavior coherent: fresh users see a checked box and the SDK behaves as the box says.

## Existing-user behavior
Users who have already toggled the checkbox have `context.partial-device-allowed` written in their `realsense-config.json` — the SDK reads that explicit value and the new defaults dont apply to them.

## Verification
Hot-plug stress on D455 via Acroname hub, 10 iterations (`partial-device-allowed: true`, observing both `added` events per cycle):

| Outcome | Count |
|---|---|
| Full from first event (HID bound within 5 s) | 8/10 |
| Partial → full supersede (~3 s gap) | 2/10 |
| Partial only (no supersede) | 0/10 |
| No device | 0/10 |

With the new default, the 2/10 slow-HID cases produce a brief no-IMU window that auto-recovers, instead of a 3–4 s "device not found" gap under the old default.

## Test plan
- [ ] Build clean on Windows VS 2022 (verified locally on combined branch with #15057+#15058)
- [ ] Smoke that explicitly setting `"partial-device-allowed": false` in `context` JSON still rejects partials
- [ ] CI: libci pipeline
@