### PR TITLE
CP: ds: default partial-device-allowed to true across SDK and viewer (#15070)

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2952,7 +2952,7 @@ namespace rs2
                     std::string excl_icon_str = rsutils::string::from() << textual_icons::exclamation_triangle
                                                 << " The following changes will take effect only after restarting the application";
                     ImGui::Text( "%s", excl_icon_str.c_str() );
-                    bool allow_partial_device = temp_cfg.get_nested< bool >( "context.partial-device-allowed", false );
+                    bool allow_partial_device = temp_cfg.get_nested< bool >( "context.partial-device-allowed", true );
                     if( ImGui::Checkbox( "Allow partial device initialization", &allow_partial_device ) )
                     {
                         temp_cfg.set_nested( "context.partial-device-allowed", allow_partial_device );

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -157,7 +157,7 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
                                       << domain_id << "; cannot create '" << participant_name << "'" );
         }
         size_t device_initialization_timeout = dds_settings.nested( "device-initialization-timeout-ms" ).default_value< size_t >( 5000 );
-        bool partial_capabilities_allowed = ctx->get_settings().nested( "partial-device-allowed" ).default_value< bool >( false );
+        bool partial_capabilities_allowed = ctx->get_settings().nested( "partial-device-allowed" ).default_value< bool >( true );
         _watcher_singleton = domain.device_watcher.instance( _participant, device_initialization_timeout, partial_capabilities_allowed );
         _subscription = _watcher_singleton->subscribe(
             [liveliness = std::weak_ptr< context >( ctx ),

--- a/src/ds/ds-private.cpp
+++ b/src/ds/ds-private.cpp
@@ -122,7 +122,7 @@ namespace librealsense
         bool is_partial_device_allowed( const std::shared_ptr< context > & ctx )
         {
             auto settings = ctx->get_settings();
-            return settings.nested( "partial-device-allowed" ).default_value< bool >( false );
+            return settings.nested( "partial-device-allowed" ).default_value< bool >( true );
         }
     } // librealsense::ds
 } // namespace librealsense


### PR DESCRIPTION
@
**TL;DR:** Cherry-pick of #15070 onto `r/2.58.1`. Flips the default of `partial-device-allowed` from `false` to `true` in the three places its read, aligning UI and SDK behavior on "allow partial by default".

## Cherry-pick details
- Source: #15070 (commit `c7284d3b4`, currently open against `development`).
- Clean cherry-pick, auto-merge on `common/viewer.cpp` due to line-offset differences only; no manual resolution.
- Depends on #15065 (CP of #15057) and #15067 (CP of #15058) being on r/2.58.1 for the new default to take effect on the USB path.

## Changes
Three one-line flips:

| File | Effect |
|---|---|
| `src/ds/ds-private.cpp` | `is_partial_device_allowed()` fallback `false`→`true` (D400/D500 USB factory default) |
| `src/dds/rsdds-device-factory.cpp` | DDS watcher `partial_capabilities_allowed` fallback `false`→`true` |
| `common/viewer.cpp` | "Allow partial device initialization" checkbox initial state `false`→`true` (fresh viewer install) |

## Verification on the CP test build
3 D455 units × 10 iterations each on Acroname hub recycle, no explicit context settings (relying on the new default):

| Device | Outcome |
|---|---|
| D455 healthy SN 207322251310 | 10/10 full IMU on first event (2.32–3.07s) |
| D455 healthy SN 035322250741 | 10/10 full IMU on first event (2.26–2.73s) |
| D455 broken-IMU SN 105322251074 | 10/10 surfaces as partial (UVC only); with old default this device was rejected entirely |

## Existing-user behavior
Users with `context.partial-device-allowed` already written in `realsense-config.json` (toggled the checkbox in a prior session) keep their explicit value — the new defaults only apply when the JSON key is absent.

## Test plan
- [x] Build clean on Windows VS 2022 (CP test build at `C:/work/git/librealsense-wt/cp-15070` + verified on `partial-allowed-default-on` development branch)
- [x] Healthy D455 enumerates with IMU (10/10 × 2 units)
- [x] Permanently-partial D455 surfaces as UVC-only (10/10)
- [ ] Smoke that explicitly setting `"partial-device-allowed": false` in `context` JSON still rejects partials
- [ ] CI: libci pipeline
@