### PR TITLE
test-fw-update: tolerate older D400 FW without DFU_READ_CNT opcode

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -94,6 +94,9 @@ def get_downgrade_counter(device):
         opcode = 0x93  # DFU_READ_CNT — reads the actual downgrade counter from flash payload header
         raw_cmd = rs.debug_protocol(device).build_command(opcode)
         counter = send_hardware_monitor_command(device, raw_cmd)
+        # FW < 5.16 doesn't implement DFU_READ_CNT and returns an empty payload
+        if len(counter) < 2:
+            return None
         return counter[0] | (counter[1] << 8)  # uint16_t little-endian
     if product_line == "D500":
         return 0  # D500 do not have downgrade counter
@@ -201,7 +204,9 @@ if current_fw_version == custom_fw_version:
 
 downgrade_counter = get_downgrade_counter( device )
 log.d( 'downgrade counter:', downgrade_counter )
-if downgrade_counter == 0xFFFF:
+if downgrade_counter is None:
+    log.d( 'downgrade counter not supported by current FW; skipping reset/check' )
+elif downgrade_counter == 0xFFFF:
     log.d( 'downgrade counter is uninitialized (0xFFFF), skipping reset' )
     downgrade_counter = 0
 elif downgrade_counter >= 19:


### PR DESCRIPTION
## TL;DR
`get_downgrade_counter` crashed with `IndexError` whenever a D400 was running a FW older than the introduction of `DFU_READ_CNT` (opcode 0x93) — e.g. 5.15.1 left behind by a previous failed run. Treat the empty response as "counter not supported" and skip the reset/check.

## Summary
- `get_downgrade_counter()` now returns `None` if the response payload from opcode `0x93` is shorter than 2 bytes (older FW just echoes the opcode header with no body).
- Pre-flash caller logs *"downgrade counter not supported by current FW; skipping reset/check"* and falls through to the actual `rs-fw-update` invocation instead of aborting the test.
- Post-flash caller already just logs the value, so it tolerates `None` without further changes.

## Why
Observed in [LRS_linux_compile_lib_ci #11902](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/11902/artifact/x86_64/static/Release/unit-tests/test-fw-update.log) — D435/D455 were stuck on 5.15.1 from an earlier broken run, so every subsequent run failed at the pre-flash counter read before it could flash the recovery image. Confirmed against FW source (`DS5_B0_DEV/CoreServicesLib/dfu_interface.c::DfuReadCounter`) — when `ReadPayloadHeader` fails or the opcode isn't routed, no `uint16_t` is copied into the response buffer.

## Test plan
- [ ] LibCI passes on D435/D455 currently on 5.15.1 (cameras get reflashed back to 5.17.x via custom-fw URL)
- [ ] LibCI continues to pass on D455 already at the target FW (skip path)
- [ ] D555 unaffected (early-returns 0)