### PR TITLE
ci: bump ros-tooling actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -43,12 +43,12 @@ jobs:
     steps:
 
       - name: setup ROS environment
-        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30 #v0.7.15
+        uses: ros-tooling/setup-ros@77bcad67a6cb15f6192d61464d99bbab658e4ca9 #v0.7.18
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - name: build librealsense ROS 2
-        uses: ros-tooling/action-ros-ci@9125cf1fa1f87e7830ed1c77f8b1885ee649b9a0 #v0.4.6
+        uses: ros-tooling/action-ros-ci@3a640b10f09b756dabe556dac5413aba369f71b0 #v0.4.8
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           skip-tests: true


### PR DESCRIPTION
@
## TL;DR
Bump `setup-ros` and `action-ros-ci` to their first Node 24 releases to silence GitHub Actions Node 20 deprecation warnings.

## Changes
`.github/workflows/build-ROS2-package-CI.yaml`:
- `ros-tooling/setup-ros` v0.7.15 → **v0.7.18** (`77bcad6`)
- `ros-tooling/action-ros-ci` v0.4.6 → **v0.4.8** (`3a640b1`)

## Why
Both prior versions run on Node 20, which GitHub has deprecated. The new pins are the first releases of each action with Node 24 support (`setup-ros` 0.7.17, `action-ros-ci` 0.4.8 both updated their `action.yml` from node20 → node24). 0.7.18 adds a small RHEL 10 dnf fix on top.

## Refs
- https://github.com/ros-tooling/setup-ros/releases/tag/0.7.17
- https://github.com/ros-tooling/setup-ros/releases/tag/0.7.18
- https://github.com/ros-tooling/action-ros-ci/releases/tag/0.4.8
@