### PR TITLE
viewer: serialize config_file access with a recursive mutex

### DIFF
--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -15,29 +15,34 @@ using namespace rs2;
 
 void config_file::set(const char* key, const char* value)
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     _j[key] = value;
     save();
 }
 
 void config_file::set_default(const char* key, const char* calculate)
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     _defaults[key] = calculate;
 }
 
 void config_file::remove(const char* key)
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     _j.erase(key);
     save();
 }
 
 void config_file::reset()
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     _j = json::object();
     save();
 }
 
 std::string config_file::get(const char* key, const char* def) const
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     auto it = _j.find(key);
     if (it != _j.end() && it->is_string())
     {
@@ -48,12 +53,14 @@ std::string config_file::get(const char* key, const char* def) const
 
 bool config_file::contains(const char* key) const
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     auto it = _j.find(key);
     return it != _j.end() && it->is_string();
 }
 
 std::string config_file::get_default(const char* key, const char* def) const
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     auto it = _defaults.find(key);
     if (it == _defaults.end()) return def;
     return it->second;
@@ -61,12 +68,14 @@ std::string config_file::get_default(const char* key, const char* def) const
 
 config_value config_file::get(const char* key) const
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     if (!contains(key)) return config_value(get_default(key, ""));
     return config_value(get(key, ""));
 }
 
 void config_file::save(const char* filename)
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     try
     {
         std::ofstream out(filename);
@@ -102,6 +111,7 @@ config_file::config_file( std::string const & filename )
 
 void config_file::save()
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
     save(_filename.c_str());
 }
 
@@ -114,6 +124,10 @@ config_file& config_file::operator=(const config_file& other)
 {
     if (this != &other)
     {
+        // Lock both sides; std::lock avoids deadlock on the (theoretical) reverse-direction race.
+        std::lock( _mutex, other._mutex );
+        std::lock_guard< std::recursive_mutex > lk_this( _mutex, std::adopt_lock );
+        std::lock_guard< std::recursive_mutex > lk_other( other._mutex, std::adopt_lock );
         _j = other._j;
         _defaults = other._defaults;
         save();
@@ -123,5 +137,8 @@ config_file& config_file::operator=(const config_file& other)
 
 bool config_file::operator==(const config_file& other) const
 {
+    std::lock( _mutex, other._mutex );
+    std::lock_guard< std::recursive_mutex > lk_this( _mutex, std::adopt_lock );
+    std::lock_guard< std::recursive_mutex > lk_other( other._mutex, std::adopt_lock );
     return _j == other._j;
 }

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -124,12 +124,17 @@ config_file& config_file::operator=(const config_file& other)
 {
     if (this != &other)
     {
-        // Lock both sides; std::lock avoids deadlock on the (theoretical) reverse-direction race.
-        std::lock( _mutex, other._mutex );
-        std::lock_guard< std::recursive_mutex > lk_this( _mutex, std::adopt_lock );
-        std::lock_guard< std::recursive_mutex > lk_other( other._mutex, std::adopt_lock );
-        _j = other._j;
-        _defaults = other._defaults;
+        // Snapshot under other's lock only, so the disk write below doesn't block readers of `other`.
+        rsutils::json j_copy;
+        std::map< std::string, std::string > defaults_copy;
+        {
+            std::lock_guard< std::recursive_mutex > lk_other( other._mutex );
+            j_copy = other._j;
+            defaults_copy = other._defaults;
+        }
+        std::lock_guard< std::recursive_mutex > lk_this( _mutex );
+        _j = std::move( j_copy );
+        _defaults = std::move( defaults_copy );
         save();
     }
     return *this;
@@ -137,6 +142,7 @@ config_file& config_file::operator=(const config_file& other)
 
 bool config_file::operator==(const config_file& other) const
 {
+    if (this == &other) return true;
     std::lock( _mutex, other._mutex );
     std::lock_guard< std::recursive_mutex > lk_this( _mutex, std::adopt_lock );
     std::lock_guard< std::recursive_mutex > lk_other( other._mutex, std::adopt_lock );

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -5,6 +5,7 @@
 #include <rsutils/json.h>
 
 #include <map>
+#include <mutex>
 #include <string>
 #include <sstream>
 #include <functional>
@@ -91,6 +92,7 @@ namespace rs2
         template< typename T >
         T get_nested( const std::string & path, const T & def ) const
         {
+            std::lock_guard< std::recursive_mutex > lk( _mutex );
             std::istringstream ss( path );
             std::string token;
             const rsutils::json * current = &_j;
@@ -116,6 +118,7 @@ namespace rs2
         template< typename T >
         void set_nested( const std::string & path, const T & val )
         {
+            std::lock_guard< std::recursive_mutex > lk( _mutex );
             std::vector< std::string > keys;
             std::istringstream ss( path );
             std::string token;
@@ -143,6 +146,7 @@ namespace rs2
         template< typename T >
         void set_nested_default( const std::string & path, const T & default_val )
         {
+            std::lock_guard< std::recursive_mutex > lk( _mutex );
             std::vector< std::string > keys;
             std::istringstream ss( path );
             std::string token;
@@ -186,6 +190,13 @@ namespace rs2
         std::string get_default(const char* key, const char* def) const;
 
         void save();
+
+        // Serializes all reads/writes of `_j` and the on-disk file. Required because
+        // viewer reads/writes config_file from multiple threads (UI thread, the
+        // config_save_worker background thread in subdevice-model.cpp, and ad-hoc
+        // call sites like the processing-block checkbox handlers in device-model.cpp).
+        // mutable so const accessors (get/contains/get_default) can lock it.
+        mutable std::recursive_mutex _mutex;
 
         std::map<std::string, std::string> _defaults;
         std::string _filename;

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <sstream>
+#include <vector>
 #include <functional>
 
 namespace rs2


### PR DESCRIPTION
## Summary

`config_file` (in `common/rs-config.{h,cpp}`) was historically touched only from the UI thread. Recent work in the viewer turned it into a multi-threaded object — the JSON config save runs on a background `config_save_worker` thread, while UI-thread call sites (e.g. processing-block checkbox handlers in `device-model.cpp`) still call `config_file::set` directly. Without serialization, concurrent calls race on the in-memory `rsutils::json` (`_j`) and on the on-disk file (two `std::ofstream` writers can produce torn/corrupted JSON).

## Change

Adds a `mutable std::recursive_mutex _mutex` member to `config_file` and wraps every member that touches `_j`, `_defaults`, or the on-disk file:

- mutators: `set`, `set_default`, `remove`, `reset`, `save()`, `save(filename)`
- accessors: `get` (both overloads), `contains`, `get_default`
- templated nested helpers in the header: `get_nested`, `set_nested`, `set_nested_default`
- `operator=` and `operator==` use `std::lock(_mutex, other._mutex)` + two `adopt_lock` guards (deadlock-safe two-mutex pattern)

Why `recursive_mutex`: `set` / `remove` / `reset` hold the lock and call `save()`, which also takes the lock; same for `operator=` which calls `save()` after copying. `mutable` lets `const` accessors lock.

This PR is split out from the larger viewer-responsiveness PR so the config-file thread-safety change can be reviewed and merged independently of the async-option-write work that motivated it.

## Test plan

- [x] Build the viewer and confirm no regressions on basic streaming + option changes.
- [x] Toggle several post-processing blocks rapidly and confirm the saved JSON config remains valid (no truncation / interleaving).
