### PR TITLE
Realsense-Viewer Viewport Grid Overlay

### DIFF
--- a/common/device-model.h
+++ b/common/device-model.h
@@ -150,6 +150,15 @@ namespace rs2
             static const char* lpc_point_size{ "viewer_model.lpc_point_size" };
             static const char* show_safety_zones_3d{ "viewer_model.show_safety_zones_3d" };
             static const char* show_safety_zones_2d{ "viewer_model.show_safety_zones_2d" };
+            namespace viewport_grid
+            {
+                static const char* horizontal_lines{ "viewer_model.grid.horizontal_lines" };
+                static const char* vertical_lines  { "viewer_model.grid.vertical_lines"   };
+                static const char* line_width      { "viewer_model.grid.line_width"        };
+                static const char* line_color_r    { "viewer_model.grid.line_color_r"      };
+                static const char* line_color_g    { "viewer_model.grid.line_color_g"      };
+                static const char* line_color_b    { "viewer_model.grid.line_color_b"      };
+            }
         }
         namespace window
         {

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -150,14 +150,14 @@ namespace rs2
             static const char* lpc_point_size{ "viewer_model.lpc_point_size" };
             static const char* show_safety_zones_3d{ "viewer_model.show_safety_zones_3d" };
             static const char* show_safety_zones_2d{ "viewer_model.show_safety_zones_2d" };
-            namespace viewport_grid
+            namespace viewport_grid_overlay
             {
-                static const char* horizontal_lines{ "viewer_model.grid.horizontal_lines" };
-                static const char* vertical_lines  { "viewer_model.grid.vertical_lines"   };
-                static const char* line_width      { "viewer_model.grid.line_width"        };
-                static const char* line_color_r    { "viewer_model.grid.line_color_r"      };
-                static const char* line_color_g    { "viewer_model.grid.line_color_g"      };
-                static const char* line_color_b    { "viewer_model.grid.line_color_b"      };
+                static const char* horizontal_lines{ "viewer_model.grid_overlay.horizontal_lines" };
+                static const char* vertical_lines  { "viewer_model.grid_overlay.vertical_lines"   };
+                static const char* line_width      { "viewer_model.grid_overlay.line_width"        };
+                static const char* line_color_r    { "viewer_model.grid_overlay.line_color_r"      };
+                static const char* line_color_g    { "viewer_model.grid_overlay.line_color_g"      };
+                static const char* line_color_b    { "viewer_model.grid_overlay.line_color_b"      };
             }
         }
         namespace window

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -113,6 +113,7 @@ config_file& config_file::instance()
 config_file::config_file( std::string const & filename )
     : _filename( filename )
     , _dirty( false )
+    , _grid_overlay_dirty( false )
     , _save_stop( false )
 {
     try
@@ -127,8 +128,39 @@ config_file::config_file( std::string const & filename )
     _save_thread = std::thread( &config_file::save_loop, this );
 }
 
+bool config_file::is_grid_overlay_path( const std::string & path )
+{
+    static const std::string prefix = "viewer_model.grid_overlay.";
+    return path.rfind( prefix, 0 ) == 0;
+}
+
 void config_file::save()
 {
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
+
+    // If nothing in this process has intentionally changed the crosshair/grid overlay
+    // section since the last flush, adopt whatever is currently on disk for it before
+    // writing. This flush can be triggered by any unrelated set() (window move/resize,
+    // device options, ...) up to once per SAVE_INTERVAL; without this, it would blindly
+    // overwrite a hand-edit made to realsense-config.json while the viewer is running
+    // with our stale in-memory copy.
+    if( ! _grid_overlay_dirty.exchange( false ) && ! _filename.empty() )
+    {
+        try
+        {
+            auto on_disk = rsutils::json_config::load_from_file( _filename );
+            if( on_disk.exists() && on_disk.contains( "viewer_model" )
+                && on_disk["viewer_model"].contains( "grid_overlay" ) )
+            {
+                _j["viewer_model"]["grid_overlay"] = on_disk["viewer_model"]["grid_overlay"];
+            }
+        }
+        catch( ... )
+        {
+            // Best effort - if the file can't be read, fall back to whatever _j already has.
+        }
+    }
+
     if( ! _filename.empty() )
         save( _filename.c_str() );
 }
@@ -162,6 +194,7 @@ void config_file::save_loop()
 config_file::config_file()
     : _j( rsutils::json::object() )
     , _dirty( false )
+    , _grid_overlay_dirty( false )
     , _save_stop( false )
 {
 }
@@ -181,7 +214,12 @@ config_file& config_file::operator=(const config_file& other)
         std::lock_guard< std::recursive_mutex > lk_this( _mutex );
         _j = std::move( j_copy );
         _defaults = std::move( defaults_copy );
+        // Assignment is always an intentional, wholesale replacement (Load Settings,
+        // Restore Defaults + Apply, etc.) - mark grid_overlay dirty too, or the next
+        // deferred flush would discard whatever value came with this assignment by
+        // merging stale on-disk content back over it.
         _dirty = true;
+        _grid_overlay_dirty = true;
     }
     return *this;
 }

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -123,7 +123,6 @@ config_file::config_file( std::string const & filename )
     }
     catch(...)
     {
-
     }
     _save_thread = std::thread( &config_file::save_loop, this );
 }

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -113,7 +113,6 @@ config_file& config_file::instance()
 config_file::config_file( std::string const & filename )
     : _filename( filename )
     , _dirty( false )
-    , _grid_overlay_dirty( false )
     , _save_stop( false )
 {
     try
@@ -128,39 +127,9 @@ config_file::config_file( std::string const & filename )
     _save_thread = std::thread( &config_file::save_loop, this );
 }
 
-bool config_file::is_grid_overlay_path( const std::string & path )
-{
-    static const std::string prefix = "viewer_model.grid_overlay.";
-    return path.rfind( prefix, 0 ) == 0;
-}
-
 void config_file::save()
 {
     std::lock_guard< std::recursive_mutex > lk( _mutex );
-
-    // If nothing in this process has intentionally changed the crosshair/grid overlay
-    // section since the last flush, adopt whatever is currently on disk for it before
-    // writing. This flush can be triggered by any unrelated set() (window move/resize,
-    // device options, ...) up to once per SAVE_INTERVAL; without this, it would blindly
-    // overwrite a hand-edit made to realsense-config.json while the viewer is running
-    // with our stale in-memory copy.
-    if( ! _grid_overlay_dirty.exchange( false ) && ! _filename.empty() )
-    {
-        try
-        {
-            auto on_disk = rsutils::json_config::load_from_file( _filename );
-            if( on_disk.exists() && on_disk.contains( "viewer_model" )
-                && on_disk["viewer_model"].contains( "grid_overlay" ) )
-            {
-                _j["viewer_model"]["grid_overlay"] = on_disk["viewer_model"]["grid_overlay"];
-            }
-        }
-        catch( ... )
-        {
-            // Best effort - if the file can't be read, fall back to whatever _j already has.
-        }
-    }
-
     if( ! _filename.empty() )
         save( _filename.c_str() );
 }
@@ -194,7 +163,6 @@ void config_file::save_loop()
 config_file::config_file()
     : _j( rsutils::json::object() )
     , _dirty( false )
-    , _grid_overlay_dirty( false )
     , _save_stop( false )
 {
 }
@@ -214,12 +182,7 @@ config_file& config_file::operator=(const config_file& other)
         std::lock_guard< std::recursive_mutex > lk_this( _mutex );
         _j = std::move( j_copy );
         _defaults = std::move( defaults_copy );
-        // Assignment is always an intentional, wholesale replacement (Load Settings,
-        // Restore Defaults + Apply, etc.) - mark grid_overlay dirty too, or the next
-        // deferred flush would discard whatever value came with this assignment by
-        // merging stale on-disk content back over it.
         _dirty = true;
-        _grid_overlay_dirty = true;
     }
     return *this;
 }

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -102,8 +102,6 @@ namespace rs2
 
         void remove(const char* key);
 
-        bool is_empty() const { return _j.empty(); }
-
         static config_file& instance();
 
         // Retrieves a value from a nested JSON structure using dot notation

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -95,12 +95,14 @@ namespace rs2
         }
 
         bool contains(const char* key) const;
-        
+
         void save(const char* filename);
 
         void reset();
 
         void remove(const char* key);
+
+        bool is_empty() const { return _j.empty(); }
 
         static config_file& instance();
 

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -158,6 +158,8 @@ namespace rs2
 
             ( *current )[keys.back()] = val;
             _dirty = true;
+            if( is_grid_overlay_path( path ) )
+                _grid_overlay_dirty = true;
         }
 
         // Sets a default value to the config and default map
@@ -201,6 +203,8 @@ namespace rs2
                 }
                 ( *current )[keys.back()] = default_val;
                 _dirty = true;
+                if( is_grid_overlay_path( path ) )
+                    _grid_overlay_dirty = true;
             }
         }
 
@@ -211,6 +215,11 @@ namespace rs2
         void save_loop();
 
         static constexpr std::chrono::milliseconds SAVE_INTERVAL{ 1000 };
+
+        // True if `path` (dot-notation) falls under the viewport grid/crosshair overlay
+        // section - the one config section save() protects from being overwritten by an
+        // unrelated flush; see _grid_overlay_dirty and save().
+        static bool is_grid_overlay_path( const std::string & path );
 
         // Serializes all reads/writes of `_j` and the on-disk file. Required because
         // viewer reads/writes config_file from multiple threads (UI thread, the
@@ -223,6 +232,7 @@ namespace rs2
         std::string _filename;
         rsutils::json _j;
         std::atomic<bool> _dirty;
+        std::atomic<bool> _grid_overlay_dirty;
         std::condition_variable _save_cv;
         std::mutex _save_cv_mutex;
         bool _save_stop;

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -156,8 +156,6 @@ namespace rs2
 
             ( *current )[keys.back()] = val;
             _dirty = true;
-            if( is_grid_overlay_path( path ) )
-                _grid_overlay_dirty = true;
         }
 
         // Sets a default value to the config and default map
@@ -201,8 +199,6 @@ namespace rs2
                 }
                 ( *current )[keys.back()] = default_val;
                 _dirty = true;
-                if( is_grid_overlay_path( path ) )
-                    _grid_overlay_dirty = true;
             }
         }
 
@@ -213,11 +209,6 @@ namespace rs2
         void save_loop();
 
         static constexpr std::chrono::milliseconds SAVE_INTERVAL{ 1000 };
-
-        // True if `path` (dot-notation) falls under the viewport grid/crosshair overlay
-        // section - the one config section save() protects from being overwritten by an
-        // unrelated flush; see _grid_overlay_dirty and save().
-        static bool is_grid_overlay_path( const std::string & path );
 
         // Serializes all reads/writes of `_j` and the on-disk file. Required because
         // viewer reads/writes config_file from multiple threads (UI thread, the
@@ -230,7 +221,6 @@ namespace rs2
         std::string _filename;
         rsutils::json _j;
         std::atomic<bool> _dirty;
-        std::atomic<bool> _grid_overlay_dirty;
         std::condition_variable _save_cv;
         std::mutex _save_cv_mutex;
         bool _save_stop;

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -31,7 +31,7 @@ namespace rs2
         show_safety_zones_2d = config_file::instance().get_or_default(
             configurations::viewer::show_safety_zones_2d, true);
         {
-            namespace cfg = configurations::viewer::viewport_grid;
+            namespace cfg = configurations::viewer::viewport_grid_overlay;
             auto& cf = config_file::instance();
 
             auto valid_lines = []( int v ) { return ( v >= 1 && v <= 5 ) ? v : 1; };
@@ -453,14 +453,13 @@ namespace rs2
     void stream_model::show_stream_header(ImFont* font, const rect &stream_rect, viewer_model& viewer)
     {
         const auto top_bar_height = 32.f;
-        auto num_of_buttons = 5;
+        auto num_of_buttons = 6; // Crosshair button is the latest addition
 
         if (!viewer.allow_stream_close) --num_of_buttons;
         if (viewer.streams.size() > 1) ++num_of_buttons;
         if (RS2_STREAM_DEPTH == profile.stream_type()) ++num_of_buttons; // Color map ruler button
         if (RS2_FORMAT_MOTION_XYZ32F == profile.format()) ++num_of_buttons; // Motion graph button
         if (RS2_STREAM_OCCUPANCY == profile.stream_type() && _normalized_zoom.w == 1) ++num_of_buttons; // Safety zones button
-        ++num_of_buttons; // Grid overlay button
 
         RsImGui_ScopePushFont(font);
         ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
@@ -601,23 +600,23 @@ namespace rs2
         ImGui::SameLine();
 
         label = rsutils::string::from() << textual_icons::grid << "##Grid " << profile.unique_id();
-        if (show_grid)
+        if (show_crosshair)
         {
             ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
             ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
             if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
             {
-                show_grid = false;
+                show_crosshair = false;
             }
             if (ImGui::IsItemHovered())
-                RsImGui::CustomTooltip("Hide crosshair/grid overlay");
+                RsImGui::CustomTooltip("Hide crosshair overlay");
             ImGui::PopStyleColor(2);
         }
         else
         {
             if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
             {
-                show_grid = true;
+                show_crosshair = true;
             }
             if (ImGui::IsItemHovered())
                 RsImGui::CustomTooltip("Show crosshair/grid overlay");
@@ -2114,7 +2113,7 @@ namespace rs2
 
             update_ae_roi_rect(stream_rect, g, error_message);
 
-            if (show_grid)
+            if (show_crosshair)
                 draw_crosshair(stream_rect, grid_h_lines, grid_v_lines, grid_line_width,
                                grid_color_r, grid_color_g, grid_color_b);
 

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -7,6 +7,8 @@
 #include "os.h"
 #include <imgui_internal.h>
 #include <realsense_imgui.h>
+#include <iomanip>
+#include <sstream>
 
 struct attribute
 {
@@ -28,6 +30,21 @@ namespace rs2
             configurations::viewer::show_stream_details, false);
         show_safety_zones_2d = config_file::instance().get_or_default(
             configurations::viewer::show_safety_zones_2d, true);
+        {
+            namespace cfg = configurations::viewer::viewport_grid;
+            auto& cf = config_file::instance();
+
+            auto valid_lines = []( int v ) { return ( v >= 1 && v <= 5 ) ? v : 1; };
+            grid_h_lines    = valid_lines( cf.get_nested<int>( cfg::horizontal_lines, 1   ) );
+            grid_v_lines    = valid_lines( cf.get_nested<int>( cfg::vertical_lines,   1   ) );
+            int w           = cf.get_nested<int>( cfg::line_width, 1 );
+            if ( w >= 1 ) grid_line_width = w;
+            int r = cf.get_nested<int>( cfg::line_color_r, 255 );
+            int g = cf.get_nested<int>( cfg::line_color_g, 255 );
+            int b = cf.get_nested<int>( cfg::line_color_b, 255 );
+            if ( r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255 )
+            { grid_color_r = r; grid_color_g = g; grid_color_b = b; }
+        }
     }
 
     std::shared_ptr<texture_buffer> stream_model::upload_frame(frame&& f)
@@ -128,6 +145,31 @@ namespace rs2
             glEnd();
         }
 
+        glPopAttrib();
+    }
+
+    static void draw_crosshair(const rect& r, int h_lines, int v_lines, int line_width,
+                               int cr, int cg, int cb)
+    {
+        glPushAttrib(GL_ENABLE_BIT | GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_CURRENT_BIT);
+        glLineWidth(static_cast<GLfloat>(line_width));
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glColor4f(cr / 255.f, cg / 255.f, cb / 255.f, 0.7f);
+        glBegin(GL_LINES);
+        for (int c = 1; c <= v_lines; ++c)
+        {
+            float x = r.x + r.w * c / static_cast<float>(v_lines + 1);
+            glVertex2f(x, r.y);
+            glVertex2f(x, r.y + r.h);
+        }
+        for (int row = 1; row <= h_lines; ++row)
+        {
+            float y = r.y + r.h * row / static_cast<float>(h_lines + 1);
+            glVertex2f(r.x, y);
+            glVertex2f(r.x + r.w, y);
+        }
+        glEnd();
         glPopAttrib();
     }
 
@@ -418,6 +460,7 @@ namespace rs2
         if (RS2_STREAM_DEPTH == profile.stream_type()) ++num_of_buttons; // Color map ruler button
         if (RS2_FORMAT_MOTION_XYZ32F == profile.format()) ++num_of_buttons; // Motion graph button
         if (RS2_STREAM_OCCUPANCY == profile.stream_type() && _normalized_zoom.w == 1) ++num_of_buttons; // Safety zones button
+        ++num_of_buttons; // Grid overlay button
 
         RsImGui_ScopePushFont(font);
         ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
@@ -556,6 +599,31 @@ namespace rs2
             }
         }
         ImGui::SameLine();
+
+        label = rsutils::string::from() << textual_icons::grid << "##Grid " << profile.unique_id();
+        if (show_grid)
+        {
+            ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
+            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
+            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            {
+                show_grid = false;
+            }
+            if (ImGui::IsItemHovered())
+                RsImGui::CustomTooltip("Hide crosshair/grid overlay");
+            ImGui::PopStyleColor(2);
+        }
+        else
+        {
+            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            {
+                show_grid = true;
+            }
+            if (ImGui::IsItemHovered())
+                RsImGui::CustomTooltip("Show crosshair/grid overlay");
+        }
+        ImGui::SameLine();
+
 
         if (RS2_STREAM_DEPTH == profile.stream_type())
         {
@@ -2045,6 +2113,11 @@ namespace rs2
             }
 
             update_ae_roi_rect(stream_rect, g, error_message);
+
+            if (show_grid)
+                draw_crosshair(stream_rect, grid_h_lines, grid_v_lines, grid_line_width,
+                               grid_color_r, grid_color_g, grid_color_b);
+
         }
         texture->show_preview(stream_rect, _normalized_zoom);
 

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -453,10 +453,11 @@ namespace rs2
     void stream_model::show_stream_header(ImFont* font, const rect &stream_rect, viewer_model& viewer)
     {
         const auto top_bar_height = 32.f;
-        auto num_of_buttons = 6; // Crosshair button is the latest addition
+        auto num_of_buttons = 5;
 
         if (!viewer.allow_stream_close) --num_of_buttons;
         if (viewer.streams.size() > 1) ++num_of_buttons;
+        if (profile.as<rs2::video_stream_profile>()) ++num_of_buttons; // Grid/crosshair button - video streams only
         if (RS2_STREAM_DEPTH == profile.stream_type()) ++num_of_buttons; // Color map ruler button
         if (RS2_FORMAT_MOTION_XYZ32F == profile.format()) ++num_of_buttons; // Motion graph button
         if (RS2_STREAM_OCCUPANCY == profile.stream_type() && _normalized_zoom.w == 1) ++num_of_buttons; // Safety zones button
@@ -599,29 +600,32 @@ namespace rs2
         }
         ImGui::SameLine();
 
-        label = rsutils::string::from() << textual_icons::grid << "##Grid " << profile.unique_id();
-        if (show_crosshair)
+        if (profile.as<rs2::video_stream_profile>()) // Grid/crosshair overlay is only meaningful on 2D video streams
         {
-            ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
-            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
-            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            label = rsutils::string::from() << textual_icons::grid << "##Grid " << profile.unique_id();
+            if (show_crosshair)
             {
-                show_crosshair = false;
+                ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
+                ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
+                if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+                {
+                    show_crosshair = false;
+                }
+                if (ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip("Hide crosshair overlay");
+                ImGui::PopStyleColor(2);
             }
-            if (ImGui::IsItemHovered())
-                RsImGui::CustomTooltip("Hide crosshair overlay");
-            ImGui::PopStyleColor(2);
-        }
-        else
-        {
-            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            else
             {
-                show_crosshair = true;
+                if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+                {
+                    show_crosshair = true;
+                }
+                if (ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip("Show crosshair/grid overlay");
             }
-            if (ImGui::IsItemHovered())
-                RsImGui::CustomTooltip("Show crosshair/grid overlay");
+            ImGui::SameLine();
         }
-        ImGui::SameLine();
 
 
         if (RS2_STREAM_DEPTH == profile.stream_type())
@@ -2113,7 +2117,7 @@ namespace rs2
 
             update_ae_roi_rect(stream_rect, g, error_message);
 
-            if (show_crosshair)
+            if (show_crosshair && profile.as<rs2::video_stream_profile>())
                 draw_crosshair(stream_rect, grid_h_lines, grid_v_lines, grid_line_width,
                                grid_color_r, grid_color_g, grid_color_b);
 

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -106,7 +106,7 @@ namespace rs2
         bool show_metadata = false;
         bool show_safety_zones_2d = true;
 
-        bool show_grid     = false;
+        bool show_crosshair     = false;
         int  grid_h_lines  = 1;
         int  grid_v_lines  = 1;
         int  grid_line_width = 1;

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -106,6 +106,14 @@ namespace rs2
         bool show_metadata = false;
         bool show_safety_zones_2d = true;
 
+        bool show_grid     = false;
+        int  grid_h_lines  = 1;
+        int  grid_v_lines  = 1;
+        int  grid_line_width = 1;
+        int  grid_color_r  = 255;
+        int  grid_color_g  = 255;
+        int  grid_color_b  = 255;
+
         std::shared_ptr<graph_model> graph;
         bool show_graph = false;
         bool graph_initialized = false;

--- a/common/textual-icons.h
+++ b/common/textual-icons.h
@@ -34,6 +34,7 @@ namespace rs2
         // A note to a maintainer - preserve order when adding values to avoid duplicates
         static const textual_icon search{ u8"\uf002" };
         static const textual_icon file_movie{ u8"\uf008" };
+        static const textual_icon grid{ u8"\uf00a" };  // fa-th: 3x3 grid of squares (viewport grid overlay)
         static const textual_icon check{ u8"\uf00c" };
         static const textual_icon times{ u8"\uf00d" };
         static const textual_icon power_off{ u8"\uf011" };

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -88,8 +88,9 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::commands_xml, "./Commands.xml");
         config_file::instance().set_default(configurations::viewer::hwlogger_xml, "./HWLoggerEvents.xml");
 
-        if( config_file::instance().is_empty() )
         {
+            // set_nested_default() only writes a key if it's missing, so this is safe to run
+            // unconditionally - it backfills the grid keys into pre-existing config files too.
             namespace cfg = configurations::viewer::viewport_grid_overlay;
             auto& cf = config_file::instance();
             cf.set_nested_default( cfg::horizontal_lines, 1   );

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -90,7 +90,7 @@ namespace rs2
 
         if( config_file::instance().is_empty() )
         {
-            namespace cfg = configurations::viewer::viewport_grid;
+            namespace cfg = configurations::viewer::viewport_grid_overlay;
             auto& cf = config_file::instance();
             cf.set_nested_default( cfg::horizontal_lines, 1   );
             cf.set_nested_default( cfg::vertical_lines,   1   );

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -88,6 +88,18 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::commands_xml, "./Commands.xml");
         config_file::instance().set_default(configurations::viewer::hwlogger_xml, "./HWLoggerEvents.xml");
 
+        if( config_file::instance().is_empty() )
+        {
+            namespace cfg = configurations::viewer::viewport_grid;
+            auto& cf = config_file::instance();
+            cf.set_nested_default( cfg::horizontal_lines, 1   );
+            cf.set_nested_default( cfg::vertical_lines,   1   );
+            cf.set_nested_default( cfg::line_width,       1   );
+            cf.set_nested_default( cfg::line_color_r,     255 );
+            cf.set_nested_default( cfg::line_color_g,     255 );
+            cf.set_nested_default( cfg::line_color_b,     255 );
+        }
+
         std::string path;
         try
         {

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3287,6 +3287,15 @@ namespace rs2
                     {
                         reload_required = true;
                         temp_cfg = config_file();
+                        {
+                            namespace cfg = configurations::viewer::viewport_grid;
+                            temp_cfg.set_nested_default( cfg::horizontal_lines, 1   );
+                            temp_cfg.set_nested_default( cfg::vertical_lines,   1   );
+                            temp_cfg.set_nested_default( cfg::line_width,       1   );
+                            temp_cfg.set_nested_default( cfg::line_color_r,     255 );
+                            temp_cfg.set_nested_default( cfg::line_color_g,     255 );
+                            temp_cfg.set_nested_default( cfg::line_color_b,     255 );
+                        }
                     }
                     ImGui::SameLine();
                     if (ImGui::Button(" Export Settings "))

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3288,7 +3288,7 @@ namespace rs2
                         reload_required = true;
                         temp_cfg = config_file();
                         {
-                            namespace cfg = configurations::viewer::viewport_grid;
+                            namespace cfg = configurations::viewer::viewport_grid_overlay;
                             temp_cfg.set_nested_default( cfg::horizontal_lines, 1   );
                             temp_cfg.set_nested_default( cfg::vertical_lines,   1   );
                             temp_cfg.set_nested_default( cfg::line_width,       1   );


### PR DESCRIPTION
## RealSense Viewer — Viewport Grid / Crosshair Overlay

### Overview
This PR introduces a **built-in** visual overlay for the RealSense Viewer: a configurable **grid / crosshair** drawn on top of video viewports.

The overlay divides the viewport into evenly spaced regions (default: 1×1 = crosshair):

<img width="617" height="385" alt="image" src="https://github.com/user-attachments/assets/cbfcd7d3-a63d-482c-8dcf-03d3cc04ebd3" />

---

## Feature: Viewport Grid / Crosshair Overlay

### Build Configuration
The feature is **always compiled in** — no CMake flag required.
Caveat - for simplisity the overlay shall be applicable for all viewports regardless of the content being displayed.

---

### UI Integration
- A new **toggle button** is added to the stream header bar  
- Icon: `[grid]`  
- Hover hint: **"Show crosshair/grid overlay"** / **"Hide crosshair/grid overlay"**
- Function: toggle a 2D grid overlay on top of the video viewport

---

### Configuration
Grid settings are loaded from the global configuration file:

~~~
%APPDATA%\realsense-config.json
~~~

---

### Customization Options
Users can configure:

- **Grid density**
  - Number of horizontal lines: `1–5`
  - Number of vertical lines: `1–5`
- **Line appearance**
  - Line width
  - Line color (RGB)

Default (1 horizontal + 1 vertical line) produces a simple **crosshair**.

---

### Configuration Structure

~~~json
{
  "viewer_model": {
    "grid_overlay": {
      "horizontal_lines": 1,
      "vertical_lines": 1,
      "line_width": 1,
      "line_color_b": 255,
      "line_color_g": 255,
      "line_color_r": 255
    }
  }
}
~~~

---

### Fallback Behavior
- If the configuration file is **missing**, or  
- If values are **invalid or incomplete**

➡️ The system falls back to the default values shown above.