### PR TITLE
pytest: add HH:MM:SS.mmm timestamp prefix to log lines

### DIFF
--- a/unit-tests/infra-tests/test_log_format.py
+++ b/unit-tests/infra-tests/test_log_format.py
@@ -1,0 +1,40 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests for the shared log format constants in rspy/pytest/logging_setup.py.
+
+Verifies that the timestamp prefix is well-formed (HH:MM:SS.mmm), uses the
+single-letter level abbreviation, and that msecs is rounded (not truncated).
+"""
+
+import logging
+import re
+
+from rspy.pytest.logging_setup import _LOG_FORMAT, _LOG_DATEFMT
+
+
+class TestLogFormat:
+    """_LOG_FORMAT / _LOG_DATEFMT produce a HH:MM:SS.mmm -X- <msg> line."""
+
+    def _formatted(self, level, msg, msecs=0):
+        rec = logging.LogRecord('t', level, '', 0, msg, (), None)
+        rec.msecs = msecs
+        return logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT).format(rec)
+
+    def test_shape_info(self):
+        line = self._formatted(logging.INFO, 'hello')
+        assert re.match(r'^\d{2}:\d{2}:\d{2}\.\d{3} -I- hello$', line), repr(line)
+
+    def test_shape_debug(self):
+        line = self._formatted(logging.DEBUG, 'x')
+        assert re.match(r'^\d{2}:\d{2}:\d{2}\.\d{3} -D- x$', line), repr(line)
+
+    def test_msecs_rounded_not_truncated(self):
+        # 999.9 ms must format as 1000 (rounded), not 999 (truncated by %d).
+        line = self._formatted(logging.INFO, 'x', msecs=999.9)
+        assert line.split(' ', 1)[0].endswith('.1000'), repr(line)
+
+    def test_msecs_zero_padded(self):
+        line = self._formatted(logging.INFO, 'x', msecs=7)
+        assert re.search(r'\.007 -I-', line), repr(line)

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -13,8 +13,10 @@ from rspy import repo, log as rspy_log
 log = logging.getLogger('librealsense')
 
 # Shared format for both the per-test FileHandler and the -s live CLI handler.
-# Leading timestamp is wall-clock HH:MM:SS.mmm — date is implicit (one log per test run).
-_LOG_FORMAT = '%(asctime)s.%(msecs)03d -%(levelname).1s- %(message)s'
+# Leading timestamp is local wall-clock HH:MM:SS.mmm — date is implicit (one log
+# per test run). %03.0f rounds msecs; %03d would truncate (999.9 → 999, not 1000).
+# If cross-timezone correlation is ever needed, set Formatter.converter = time.gmtime.
+_LOG_FORMAT = '%(asctime)s.%(msecs)03.0f -%(levelname).1s- %(message)s'
 _LOG_DATEFMT = '%H:%M:%S'
 
 # unit-tests/ directory — used as fallback for log output
@@ -170,6 +172,9 @@ def start_test_log(item):
     log_name = test_log_name(item)
     log_path = os.path.join(logdir, log_name)
     try:
+        # mode='w': retries of the same (file, device) overwrite the previous
+        # pass's log so the Jenkins report links to the latest attempt.
+        # Appending would interleave timestamps from different passes.
         file_handler = logging.FileHandler(log_path, mode='w')
         file_handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
         file_handler.setLevel(logging.DEBUG)

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -12,6 +12,11 @@ from rspy import repo, log as rspy_log
 
 log = logging.getLogger('librealsense')
 
+# Shared format for both the per-test FileHandler and the -s live CLI handler.
+# Leading timestamp is wall-clock HH:MM:SS.mmm — date is implicit (one log per test run).
+_LOG_FORMAT = '%(asctime)s.%(msecs)03d -%(levelname).1s- %(message)s'
+_LOG_DATEFMT = '%H:%M:%S'
+
 # unit-tests/ directory — used as fallback for log output
 _unit_tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Walk two levels up from rspy/pytest/ to get unit-tests/py/, then one more for unit-tests/
@@ -118,8 +123,8 @@ def configure_logging(config, debug_requested):
     if capture == 'no':  # -s passed: stream logs to console
         live_logging = True
         config.option.log_cli_level = log_level_name
-        config.option.log_cli_format = '-%(levelname).1s- %(message)s'
-        config.option.log_cli_date_format = ''
+        config.option.log_cli_format = _LOG_FORMAT
+        config.option.log_cli_date_format = _LOG_DATEFMT
     if debug_requested:
         logging.getLogger('paramiko').setLevel(logging.WARNING)
 
@@ -166,7 +171,7 @@ def start_test_log(item):
     log_path = os.path.join(logdir, log_name)
     try:
         file_handler = logging.FileHandler(log_path, mode='w')
-        file_handler.setFormatter(logging.Formatter('-%(levelname).1s- %(message)s'))
+        file_handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
         file_handler.setLevel(logging.DEBUG)
         logging.getLogger().addHandler(file_handler)
         _current_log_key = key


### PR DESCRIPTION
## TL;DR
Adds a wall-clock `HH:MM:SS.mmm` timestamp to every pytest log line, in both the per-test log files and the `-s` live console handler.

## Why
Failure triage from the per-test `.log` artifacts often needs to correlate events across logs (camera comms, frame arrival, hub recycle). Without a timestamp on each line, only relative ordering within one file is visible.

## What changed
`unit-tests/py/rspy/pytest/logging_setup.py`:
- New module-level `_LOG_FORMAT` / `_LOG_DATEFMT` constants used by both the `FileHandler` formatter and the `-s` `log_cli_format`.
- Format: `%(asctime)s.%(msecs)03d -%(levelname).1s- %(message)s` with `datefmt='%H:%M:%S'`. Date is implicit (one log per test run).

## Impact audit
- **Jenkins Groovy parsers** (`LRS_linux_compile_lib_ci.groovy`, `LRS_windows_compile_pipeline.groovy`): the only `^`-anchored regexes against `pytest-unit-tests.<N>.log` match either pytest's own `FAILED/ERROR` lines (not our formatter) or our bare `print(f"-I- ...")` summary lines (which bypass the formatter). CI runs without `-s`, so `log_cli_format` never fires and no stdlib log lines land in the console log. → No Groovy parser changes needed.
- **Infra regression tests** (`unit-tests/infra-tests/`): no assertions on log line shape; all 113 pass.

## Sample
Before: `-I- Test using device: Intel RealSense D455`
After:  `14:42:38.787 -I- Test using device: Intel RealSense D455`

## Test plan
- [x] `cd unit-tests && python -m pytest infra-tests/ -v` → 113 passed
- [x] Manual: per-test `.log` files show `HH:MM:SS.mmm -X- <msg>` format
- [ ] Jenkins libci run on this branch