### PR TITLE
React viewer: FW update from user-supplied .bin file

### DIFF
--- a/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
+++ b/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
@@ -1,6 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
+import importlib.util
 import os
 import platform
 import subprocess
@@ -21,27 +22,47 @@ pytestmark = [
     ),
 ]
 
+# import-module-name → pip package name. Used purely to render a readable
+# error if a dep is missing on the agent. Jenkins is expected to install
+# wrappers/rest-api/requirements.txt + unit-tests/wrappers/rest-api/requirements.txt
+# during its Install Requirements stage.
+_REQUIRED_MODULES = {
+    "fastapi": "fastapi",
+    "uvicorn": "uvicorn",
+    "pydantic": "pydantic",
+    "multipart": "python-multipart",  # FastAPI File/UploadFile route registration
+    "aiortc": "aiortc",
+    "socketio": "python-socketio",
+    "cv2": "opencv-python",
+    "numpy": "numpy",
+    "httpx": "httpx",  # FastAPI TestClient
+}
 
-def _ensure_rest_api_deps_installed():
-    """pip-install rest-api + rest-api test deps on the current interpreter.
 
-    Jenkins/CI agents use a pre-baked Python env that doesn't auto-pick up
-    additions to requirements.txt (e.g. python-multipart, required as soon as
-    a FastAPI endpoint declares File/UploadFile). Installing here keeps the
-    wrapper self-contained instead of depending on out-of-band agent setup.
+def _fail_if_missing_packages():
+    """Pre-flight: surface a readable error if any required dep is missing.
+
+    Without this, ``test_api_service.py`` collection blows up with a cryptic
+    FastAPI route-registration error (e.g. ``Form data requires "python-multipart"``)
+    that points into framework internals instead of telling you which install
+    step is missing.
     """
-    rest_api_req = os.path.join(repo.root, "wrappers", "rest-api", "requirements.txt")
-    test_req = os.path.join(repo.root, "unit-tests", "wrappers", "rest-api", "requirements.txt")
-    cmd = [sys.executable, "-m", "pip", "install", "--user", "-q",
-           "-r", rest_api_req, "-r", test_req]
-    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                       universal_newlines=True, check=False, timeout=600)
-    if p.returncode != 0:
-        log.warning("pip install for rest-api deps returned %s:\n%s", p.returncode, p.stdout)
+    missing = [
+        pip_name for mod, pip_name in _REQUIRED_MODULES.items()
+        if importlib.util.find_spec(mod) is None
+    ]
+    if missing:
+        pytest.fail(
+            "rest-api wrapper: missing required Python package(s): "
+            + ", ".join(missing)
+            + ".\nInstall via:\n"
+            "  pip install -r wrappers/rest-api/requirements.txt\n"
+            "  pip install -r unit-tests/wrappers/rest-api/requirements.txt"
+        )
 
 
 def test_rest_api_wrapper(module_device_setup):
-    _ensure_rest_api_deps_installed()
+    _fail_if_missing_packages()
     rest_api_test = os.path.join(repo.root, "wrappers", "rest-api", "tests", "test_api_service.py")
     # The subprocess starts a fresh interpreter, so the parent's sys.path
     # injection of the locally-built pyrealsense2 (unit-tests/conftest.py)

--- a/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
+++ b/unit-tests/wrappers/rest-api/pytest-rest-api-wrapper.py
@@ -22,7 +22,26 @@ pytestmark = [
 ]
 
 
+def _ensure_rest_api_deps_installed():
+    """pip-install rest-api + rest-api test deps on the current interpreter.
+
+    Jenkins/CI agents use a pre-baked Python env that doesn't auto-pick up
+    additions to requirements.txt (e.g. python-multipart, required as soon as
+    a FastAPI endpoint declares File/UploadFile). Installing here keeps the
+    wrapper self-contained instead of depending on out-of-band agent setup.
+    """
+    rest_api_req = os.path.join(repo.root, "wrappers", "rest-api", "requirements.txt")
+    test_req = os.path.join(repo.root, "unit-tests", "wrappers", "rest-api", "requirements.txt")
+    cmd = [sys.executable, "-m", "pip", "install", "--user", "-q",
+           "-r", rest_api_req, "-r", test_req]
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                       universal_newlines=True, check=False, timeout=600)
+    if p.returncode != 0:
+        log.warning("pip install for rest-api deps returned %s:\n%s", p.returncode, p.stdout)
+
+
 def test_rest_api_wrapper(module_device_setup):
+    _ensure_rest_api_deps_installed()
     rest_api_test = os.path.join(repo.root, "wrappers", "rest-api", "tests", "test_api_service.py")
     # The subprocess starts a fresh interpreter, so the parent's sys.path
     # injection of the locally-built pyrealsense2 (unit-tests/conftest.py)

--- a/wrappers/rest-api/app/api/endpoints/firmware.py
+++ b/wrappers/rest-api/app/api/endpoints/firmware.py
@@ -1,13 +1,19 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 import logging
+from starlette.concurrency import run_in_threadpool
 
 from app.services.rs_manager import RealSenseManager, RealSenseError
 from app.api.dependencies import get_realsense_manager
 
 router = APIRouter()
+
+
+# Cap user-supplied firmware uploads. D4XX images are well under 10 MiB, so 64 MiB
+# leaves headroom for future products without letting an unrelated file through.
+MAX_FW_UPLOAD_BYTES = 64 * 1024 * 1024
 
 
 @router.get("/{device_id}/status", response_model=dict)
@@ -20,6 +26,61 @@ async def get_firmware_status(
         return rs_manager.get_firmware_status(device_id)
     except RealSenseError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except Exception as e:
+    except Exception:
         logging.exception("Unexpected error fetching firmware status for %s", device_id)
         raise HTTPException(status_code=500, detail="Unexpected error while fetching firmware status")
+
+
+_FW_UPLOAD_CHUNK = 1024 * 1024  # 1 MiB
+
+
+@router.post("/{device_id}/firmware/update_from_file", response_model=dict)
+async def update_firmware_from_file(
+    device_id: str,
+    file: UploadFile = File(...),
+    rs_manager: RealSenseManager = Depends(get_realsense_manager),
+):
+    """Trigger firmware update from a user-supplied .bin image.
+
+    Accepts multipart/form-data with a single ``file`` field. The SDK's
+    ``check_firmware_compatibility`` gates whether the image is actually applied;
+    we only do cheap sanity checks here (filename suffix and size).
+    """
+    filename = file.filename or ""
+    if not filename.lower().endswith(".bin"):
+        raise HTTPException(status_code=400, detail="Firmware file must have a .bin extension")
+
+    # Stream the upload in chunks and fail early if it exceeds the cap, so a
+    # huge POST can't materialize a huge bytes object in memory.
+    fw_buf = bytearray()
+    try:
+        while True:
+            chunk = await file.read(_FW_UPLOAD_CHUNK)
+            if not chunk:
+                break
+            fw_buf.extend(chunk)
+            if len(fw_buf) > MAX_FW_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Firmware file too large (max {MAX_FW_UPLOAD_BYTES // (1024 * 1024)} MiB)",
+                )
+    except HTTPException:
+        raise
+    except Exception:
+        logging.exception("Failed to read uploaded firmware for %s", device_id)
+        raise HTTPException(status_code=400, detail="Could not read uploaded firmware file")
+    finally:
+        await file.close()
+
+    if not fw_buf:
+        raise HTTPException(status_code=400, detail="Uploaded firmware file is empty")
+
+    try:
+        # Firmware update is blocking; run it off the event loop so Socket.IO
+        # can deliver progress / completion events in real time.
+        return await run_in_threadpool(rs_manager.update_firmware_from_bytes, device_id, bytes(fw_buf))
+    except RealSenseError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    except Exception:
+        logging.exception("Unexpected error updating firmware for %s", device_id)
+        raise HTTPException(status_code=500, detail="Unexpected error while updating firmware")

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -156,7 +156,21 @@ class RealSenseManager:
 
     def refresh_devices(self) -> List[DeviceInfo]:
         """Refresh the list of connected devices"""
+        # Skip enumeration while a firmware update is running. A concurrent
+        # call to self.ctx.devices/query_devices() invalidates the rs.device
+        # handles held by the FW-update thread (notably the DFU update_dev
+        # returned by _wait_for_dfu_device), causing the SDK to throw
+        # 'null pointer passed for argument "device"' on the subsequent
+        # update_dev.update(...) call. Return the cached snapshot instead;
+        # update_firmware_from_bytes runs a real refresh once it finishes.
         with self.lock:
+            if self._fw_updates_in_progress:
+                logging.debug(
+                    "refresh_devices: skipping ctx enumeration — FW update(s) in progress: %s",
+                    self._fw_updates_in_progress,
+                )
+                return list(self.device_infos.values())
+
             # Clear existing devices (that aren't streaming)
             for device_id in list(self.devices.keys()):
                 if device_id not in self.pipelines:
@@ -284,10 +298,15 @@ class RealSenseManager:
 
     @staticmethod
     def _is_update_device(dev: rs.device) -> bool:
-        """True if the device exposes the DFU update interface."""
+        """True if the device exposes the DFU update interface.
+
+        Some pyrealsense2 builds return an empty rs.update_device wrapper
+        (truthy Python object, null underlying pointer) instead of throwing
+        for a non-DFU device. Validate the wrapper via bool() to catch that.
+        """
         try:
-            rs.update_device(dev)
-            return True
+            up = rs.update_device(dev)
+            return bool(up)
         except Exception:
             return False
 
@@ -303,9 +322,14 @@ class RealSenseManager:
             self._ensure_fw_update_allowed(device_id)
             fw_image = self._materialize_fw_image(fw_bytes)
 
-            target_dev = self.devices.get(device_id)
-            if not target_dev:
-                raise RealSenseError(status_code=404, detail="Device not found for firmware update")
+            # Re-fetch the device handle directly from the SDK context. The cached
+            # `self.devices[device_id]` Python wrapper can outlive its underlying
+            # C++ device pointer when refresh_devices() runs concurrently (the
+            # 5-second polling loop) or when the device re-enumerates between
+            # the GET /devices call and this POST, producing a wrapper that is
+            # still truthy but whose C++ pointer is null. Passing such a handle
+            # to rs.updatable() raises `null pointer passed for argument "device"`.
+            target_dev = self._resolve_live_device(device_id)
             firmware_update_id = self._resolve_firmware_update_id(target_dev, device_id)
 
             progress_holder, on_progress = self._make_fw_progress_callback(device_id)
@@ -319,6 +343,11 @@ class RealSenseManager:
                 update_dev = self._enter_dfu_and_get_update_dev(
                     target_dev, fw_image, device_id, firmware_update_id,
                 )
+                if not update_dev:
+                    raise RealSenseError(
+                        status_code=500,
+                        detail="Could not obtain a valid DFU device handle for the update",
+                    )
 
                 logging.info("Starting firmware update on DFU device...")
                 update_dev.update(fw_image, on_progress)
@@ -342,7 +371,7 @@ class RealSenseManager:
             except RealSenseError:
                 raise
             except Exception as exc:
-                logging.error("Firmware update failed for %s: %s", device_id, exc)
+                logging.exception("Firmware update failed for %s", device_id)
                 self._emit_socket_event(
                     f"firmware_update_failed_{device_id}",
                     {"device_id": device_id, "error": str(exc)},
@@ -390,6 +419,28 @@ class RealSenseManager:
             if device_id in self._fw_updates_in_progress:
                 raise RealSenseError(status_code=409, detail="Firmware update already in progress")
             self._fw_updates_in_progress.add(device_id)
+
+    def _resolve_live_device(self, device_id: str) -> rs.device:
+        """Return an rs.device for ``device_id`` enumerated fresh from self.ctx.
+
+        Avoids using ``self.devices[device_id]`` directly: that cached wrapper
+        can be invalidated underneath by a concurrent refresh_devices() (the
+        polling loop), leaving a truthy Python object backed by a null C++
+        pointer. Raises 404 if the device is no longer visible.
+        """
+        for dev in self.ctx.query_devices():
+            try:
+                if not dev.supports(rs.camera_info.serial_number):
+                    continue
+                if dev.get_info(rs.camera_info.serial_number) == device_id:
+                    # Refresh the cache so downstream callers (refresh_devices)
+                    # observe the same live handle.
+                    with self.lock:
+                        self.devices[device_id] = dev
+                    return dev
+            except RuntimeError:
+                continue
+        raise RealSenseError(status_code=404, detail=f"Device {device_id} not found")
 
     def _ensure_fw_update_allowed(self, device_id: str) -> None:
         """Reject the update if the device is unknown or if anything is streaming."""
@@ -471,8 +522,13 @@ class RealSenseManager:
         """
         try:
             update_dev = rs.update_device(target_dev)
-            logging.info("Device is already in DFU mode")
-            return update_dev
+            # Some pyrealsense2 builds return an empty wrapper for non-DFU
+            # devices instead of throwing. bool() returns False on the empty
+            # wrapper, so treat that as "not in DFU yet" and fall through to
+            # the enter_update_state path below.
+            if update_dev:
+                logging.info("Device is already in DFU mode")
+                return update_dev
         except Exception:
             pass
 
@@ -518,6 +574,11 @@ class RealSenseManager:
                     try:
                         candidate = rs.update_device(dev)
                     except Exception:
+                        continue
+                    # Empty wrapper from a non-DFU device (some pyrealsense2
+                    # builds return one rather than throwing). Skip — calling
+                    # update() on it later raises 'null pointer for "device"'.
+                    if not candidate:
                         continue
                     try:
                         if dev.supports(rs.camera_info.firmware_update_id):

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -367,16 +367,16 @@ class RealSenseManager:
                 logging.info("Firmware download completed, waiting for device to finalize...")
                 time.sleep(3)
 
-                # After DFU the original rs.context() can stay stale — the device
-                # re-enumerates over USB but the SDK keeps reporting the empty /
-                # DFU-mode list. Drop SDK references; we'll recreate the context
-                # periodically inside the wait loop below.
+                # Drop SDK references to the pre-DFU handles; they will be
+                # invalidated by the device re-enumeration. The ctx itself is
+                # kept — replacing it would silently drop the
+                # set_devices_changed_callback registration done in __init__,
+                # and the post-DFU device-back event would never reach us.
                 update_dev = None
                 target_dev = None
                 with self.lock:
                     self.devices.clear()
                     self.device_infos.clear()
-                self._recreate_ctx("post-firmware-update")
 
                 self._wait_for_device_reconnect(device_id, firmware_update_id)
             except RealSenseError:
@@ -457,8 +457,8 @@ class RealSenseManager:
         """Reject the update if the device is unknown or if anything is streaming."""
         if device_id not in self.devices:
             raise RealSenseError(status_code=404, detail=f"Device {device_id} not found")
-        # FW update wipes self.devices/self.device_infos and recreates self.ctx,
-        # which would invalidate refs to any OTHER tracked devices. Refuse the
+        # FW update wipes self.devices/self.device_infos and the DFU
+        # transition invalidates refs to any OTHER tracked devices. Refuse the
         # update if any pipeline is active anywhere — not just on the target.
         with self.lock:
             if self.pipelines:
@@ -607,38 +607,24 @@ class RealSenseManager:
         except Exception as exc:
             logging.warning("Explicit hardware_reset() on DFU device failed (likely benign): %s", exc)
 
-    def _recreate_ctx(self, reason: str) -> None:
-        """Recreate self.ctx; the assignment is performed under self.lock."""
-        try:
-            new_ctx = rs.context()
-        except Exception as exc:
-            logging.warning("Failed to recreate rs.context (%s): %s", reason, exc)
-            return
-        # Swap under the lock so concurrent refresh_devices() callers
-        # don't observe a torn ctx assignment.
-        with self.lock:
-            self.ctx = new_ctx
-        logging.info("Recreated rs.context() (%s)", reason)
-
     def _wait_for_device_reconnect(
         self, device_id: str, firmware_update_id: str, max_wait_seconds: int = 120,
     ) -> None:
         """Wait for the device to re-enumerate in normal mode after DFU.
 
-        Periodically recreates self.ctx to kick the SDK out of any stuck state.
+        Polls ``self.ctx.query_devices()`` once a second. The SDK's
+        devices-changed callback (registered once in ``__init__``) also fires
+        when the device returns; we don't touch self.ctx here because
+        replacing it would silently drop that callback registration.
+
         Raises RealSenseError if the device sticks in DFU/recovery; logs and returns
         if it simply never reappears within the timeout (update may have succeeded).
         """
         reconnected = False
         stuck_in_dfu = False
         start_time = time.time()
-        last_ctx_refresh = time.time()
         while time.time() - start_time < max_wait_seconds:
             time.sleep(1)
-            # Every 10s, recreate the context to kick the SDK out of any stuck state.
-            if time.time() - last_ctx_refresh > 10:
-                self._recreate_ctx(f"mid-wait t+{int(time.time() - start_time)}s")
-                last_ctx_refresh = time.time()
             try:
                 devs = self.ctx.query_devices()
                 # First pass: look for the device in NORMAL mode.

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -457,14 +457,14 @@ class RealSenseManager:
         """Reject the update if the device is unknown or if anything is streaming."""
         if device_id not in self.devices:
             raise RealSenseError(status_code=404, detail=f"Device {device_id} not found")
-        # FW update wipes self.devices/self.device_infos and the DFU
-        # transition invalidates refs to any OTHER tracked devices. Refuse the
-        # update if any pipeline is active anywhere — not just on the target.
+        # Only refuse if THIS device is streaming. Since we no longer recreate
+        # self.ctx during the update, other devices' handles stay valid and
+        # their pipelines are unaffected by the DFU transition of this device.
         with self.lock:
-            if self.pipelines:
+            if device_id in self.pipelines:
                 raise RealSenseError(
                     status_code=400,
-                    detail="Stop all streaming before updating firmware",
+                    detail="Stop streaming on this device before updating firmware",
                 )
 
     @staticmethod

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -5,7 +5,7 @@ import asyncio
 import threading
 import time
 import logging
-from typing import Dict, List, Optional, Any, Tuple, Set
+from typing import Callable, Dict, List, Optional, Any, Tuple, Set
 import pyrealsense2 as rs
 import numpy as np
 import cv2
@@ -72,6 +72,9 @@ class RealSenseManager:
         # Cache of supported frame_metadata values per stream profile uid.
         # Avoids re-probing every metadata key on every frame in the hot loop.
         self._supported_md_by_profile: Dict[int, list] = {}
+
+        # Firmware update tracking (one update at a time per device)
+        self._fw_updates_in_progress: Set[str] = set()
 
         self.sio = sio
         self.metadata_socket_server = MetadataSocketServer(sio, self)
@@ -278,6 +281,399 @@ class RealSenseManager:
             "status": device.firmware_status or FW_STATUS_UNKNOWN,
             "file_available": False,
         }
+
+    @staticmethod
+    def _is_update_device(dev: rs.device) -> bool:
+        """True if the device exposes the DFU update interface."""
+        try:
+            rs.update_device(dev)
+            return True
+        except Exception:
+            return False
+
+    def update_firmware_from_bytes(self, device_id: str, fw_bytes: bytes) -> Dict[str, Any]:
+        """Run firmware update using a user-supplied image blob.
+
+        Reuses the DFU flow: check_firmware_compatibility -> enter_update_state ->
+        wait for DFU device -> update_dev.update(image, on_progress) -> wait for reconnect.
+        Emits the same Socket.IO progress / success / failure events as a bundled-image update.
+        """
+        self._claim_fw_update_slot(device_id)
+        try:
+            self._ensure_fw_update_allowed(device_id)
+            fw_image = self._materialize_fw_image(fw_bytes)
+
+            target_dev = self.devices.get(device_id)
+            if not target_dev:
+                raise RealSenseError(status_code=404, detail="Device not found for firmware update")
+            firmware_update_id = self._resolve_firmware_update_id(target_dev, device_id)
+
+            progress_holder, on_progress = self._make_fw_progress_callback(device_id)
+            # Always emit a starting progress so the UI doesn't stay at 0% forever
+            self._emit_socket_event(
+                f"firmware_progress_{device_id}",
+                {"device_id": device_id, "progress": 0.0},
+            )
+
+            try:
+                update_dev = self._enter_dfu_and_get_update_dev(
+                    target_dev, fw_image, device_id, firmware_update_id,
+                )
+
+                logging.info("Starting firmware update on DFU device...")
+                update_dev.update(fw_image, on_progress)
+                self._post_update_hardware_reset(update_dev)
+
+                logging.info("Firmware download completed, waiting for device to finalize...")
+                time.sleep(3)
+
+                # After DFU the original rs.context() can stay stale — the device
+                # re-enumerates over USB but the SDK keeps reporting the empty /
+                # DFU-mode list. Drop SDK references; we'll recreate the context
+                # periodically inside the wait loop below.
+                update_dev = None
+                target_dev = None
+                with self.lock:
+                    self.devices.clear()
+                    self.device_infos.clear()
+                self._recreate_ctx("post-firmware-update")
+
+                self._wait_for_device_reconnect(device_id, firmware_update_id)
+            except RealSenseError:
+                raise
+            except Exception as exc:
+                logging.error("Firmware update failed for %s: %s", device_id, exc)
+                self._emit_socket_event(
+                    f"firmware_update_failed_{device_id}",
+                    {"device_id": device_id, "error": str(exc)},
+                )
+                raise RealSenseError(status_code=500, detail=f"Firmware update failed: {exc}")
+
+            updated_info = self._refresh_until_device_returns(device_id)
+
+            self._emit_socket_event(
+                f"firmware_progress_{device_id}",
+                {"device_id": device_id, "progress": 1.0},
+            )
+            self._emit_socket_event(
+                f"firmware_update_success_{device_id}",
+                {
+                    "device_id": device_id,
+                    "firmware_version": updated_info.firmware_version if updated_info else None,
+                },
+            )
+
+            return {
+                "device_id": device_id,
+                "progress": progress_holder["value"],
+                "firmware_version": updated_info.firmware_version if updated_info else None,
+                "status": "success",
+            }
+        except RealSenseError as exc:
+            self._emit_socket_event(
+                f"firmware_update_failed_{device_id}",
+                {"device_id": device_id, "error": exc.detail},
+            )
+            raise
+        finally:
+            with self.lock:
+                self._fw_updates_in_progress.discard(device_id)
+
+    # ---- update_firmware_from_bytes helpers ---------------------------------
+    # Split out so the orchestrator above reads as a sequence of named steps
+    # rather than a 300-line block of intermixed locking, SDK calls, polling,
+    # and socket emission.
+
+    def _claim_fw_update_slot(self, device_id: str) -> None:
+        """Reserve the per-device FW-update slot; raise 409 if one is already running."""
+        with self.lock:
+            if device_id in self._fw_updates_in_progress:
+                raise RealSenseError(status_code=409, detail="Firmware update already in progress")
+            self._fw_updates_in_progress.add(device_id)
+
+    def _ensure_fw_update_allowed(self, device_id: str) -> None:
+        """Reject the update if the device is unknown or if anything is streaming."""
+        if device_id not in self.devices:
+            raise RealSenseError(status_code=404, detail=f"Device {device_id} not found")
+        # FW update wipes self.devices/self.device_infos and recreates self.ctx,
+        # which would invalidate refs to any OTHER tracked devices. Refuse the
+        # update if any pipeline is active anywhere — not just on the target.
+        with self.lock:
+            if self.pipelines:
+                raise RealSenseError(
+                    status_code=400,
+                    detail="Stop all streaming before updating firmware",
+                )
+
+    @staticmethod
+    def _materialize_fw_image(fw_bytes: bytes) -> bytearray:
+        """Convert the raw payload to a bytearray that pyrealsense2 can consume."""
+        # pyrealsense2 accepts bytes-like objects; bytearray keeps memory bounded
+        # (list(bytes) would balloon ~28x by boxing each byte as a Python int).
+        try:
+            return bytearray(fw_bytes)
+        except Exception as exc:
+            logging.error("Failed to materialize firmware bytes: %s", exc)
+            raise RealSenseError(status_code=400, detail="Invalid firmware payload")
+
+    @staticmethod
+    def _resolve_firmware_update_id(target_dev: rs.device, device_id: str) -> str:
+        """Return FIRMWARE_UPDATE_ID (stable across DFU transitions) or fall back to device_id."""
+        firmware_update_id: Optional[str] = None
+        try:
+            if target_dev.supports(rs.camera_info.firmware_update_id):
+                firmware_update_id = target_dev.get_info(rs.camera_info.firmware_update_id)
+            else:
+                sensors = target_dev.query_sensors()
+                if sensors:
+                    firmware_update_id = sensors[0].get_info(rs.camera_info.firmware_update_id)
+        except RuntimeError:
+            pass
+        if not firmware_update_id:
+            firmware_update_id = device_id
+        logging.info("Firmware update id for tracking: %s", firmware_update_id)
+        return firmware_update_id
+
+    def _make_fw_progress_callback(
+        self, device_id: str,
+    ) -> Tuple[Dict[str, float], Callable[[float], None]]:
+        """Build the on_progress callback and a holder dict that records the latest value.
+
+        Rate-limits emissions to ~10/sec but always lets the final 100% through.
+        """
+        progress_holder = {"value": 0.0}
+        last_emit_ts = {"value": 0.0}
+
+        def _on_progress(p: float) -> None:
+            progress_holder["value"] = p
+            now = time.time()
+            if now - last_emit_ts["value"] < 0.1 and p < 1.0:
+                return
+            last_emit_ts["value"] = now
+            self._emit_socket_event(
+                f"firmware_progress_{device_id}",
+                {"device_id": device_id, "progress": float(p)},
+            )
+
+        return progress_holder, _on_progress
+
+    def _enter_dfu_and_get_update_dev(
+        self,
+        target_dev: rs.device,
+        fw_image: bytearray,
+        device_id: str,
+        firmware_update_id: str,
+    ):
+        """Return a DFU update_device — either the device is already in DFU, or push it there.
+
+        Runs the compatibility check, drops cached refs, calls enter_update_state(), and
+        polls the SDK until the matching DFU device shows up (or raises on timeout).
+        """
+        try:
+            update_dev = rs.update_device(target_dev)
+            logging.info("Device is already in DFU mode")
+            return update_dev
+        except Exception:
+            pass
+
+        logging.info("Device is in normal mode, checking firmware compatibility...")
+        updatable = rs.updatable(target_dev)
+
+        try:
+            if not updatable.check_firmware_compatibility(fw_image):
+                raise RealSenseError(status_code=400, detail="Firmware is not compatible with this device")
+            logging.info("Firmware compatibility check passed")
+        except RealSenseError:
+            raise
+        except Exception as e:
+            logging.warning("Firmware compatibility check failed or not supported: %s", e)
+
+        # Cached refs will become invalid after enter_update_state.
+        with self.lock:
+            self.devices.pop(device_id, None)
+            self.device_infos.pop(device_id, None)
+
+        logging.info("Requesting device to enter DFU mode...")
+        updatable.enter_update_state()
+
+        update_dev = self._wait_for_dfu_device(firmware_update_id)
+        if not update_dev:
+            raise RealSenseError(
+                status_code=500,
+                detail="Device did not enter DFU mode within timeout. Please reconnect the device and try again.",
+            )
+        return update_dev
+
+    def _wait_for_dfu_device(self, firmware_update_id: str, timeout_seconds: int = 60):
+        """Poll self.ctx until a DFU device matching firmware_update_id appears; return it or None.
+
+        Falls back to "exactly one visible DFU device" when firmware_update_id isn't reported.
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout_seconds:
+            time.sleep(0.5)
+            try:
+                devs = self.ctx.query_devices()
+                for dev in devs:
+                    try:
+                        candidate = rs.update_device(dev)
+                    except Exception:
+                        continue
+                    try:
+                        if dev.supports(rs.camera_info.firmware_update_id):
+                            dev_fw_id = dev.get_info(rs.camera_info.firmware_update_id)
+                            if dev_fw_id == firmware_update_id:
+                                return candidate
+                    except RuntimeError:
+                        pass
+                    # Fallback: if exactly one DFU device is visible, assume it's ours.
+                    if sum(1 for d in devs if self._is_update_device(d)) == 1:
+                        return candidate
+            except Exception as e:
+                logging.debug("Error querying devices during DFU wait: %s", e)
+                continue
+        return None
+
+    @staticmethod
+    def _post_update_hardware_reset(update_dev) -> None:
+        # update_dev.update() is supposed to call hardware_reset() internally
+        # (see common/fw-update-helper.cpp), but on some devices/firmware
+        # combos the device stays in DFU/recovery mode. Issue an explicit
+        # reset as a belt-and-suspenders kick to force USB re-enumeration.
+        try:
+            update_dev.hardware_reset()
+            logging.info("Issued explicit hardware_reset() on DFU device after update")
+        except Exception as exc:
+            logging.warning("Explicit hardware_reset() on DFU device failed (likely benign): %s", exc)
+
+    def _recreate_ctx(self, reason: str) -> None:
+        """Recreate self.ctx; the assignment is performed under self.lock."""
+        try:
+            new_ctx = rs.context()
+        except Exception as exc:
+            logging.warning("Failed to recreate rs.context (%s): %s", reason, exc)
+            return
+        # Swap under the lock so concurrent refresh_devices() callers
+        # don't observe a torn ctx assignment.
+        with self.lock:
+            self.ctx = new_ctx
+        logging.info("Recreated rs.context() (%s)", reason)
+
+    def _wait_for_device_reconnect(
+        self, device_id: str, firmware_update_id: str, max_wait_seconds: int = 120,
+    ) -> None:
+        """Wait for the device to re-enumerate in normal mode after DFU.
+
+        Periodically recreates self.ctx to kick the SDK out of any stuck state.
+        Raises RealSenseError if the device sticks in DFU/recovery; logs and returns
+        if it simply never reappears within the timeout (update may have succeeded).
+        """
+        reconnected = False
+        stuck_in_dfu = False
+        start_time = time.time()
+        last_ctx_refresh = time.time()
+        while time.time() - start_time < max_wait_seconds:
+            time.sleep(1)
+            # Every 10s, recreate the context to kick the SDK out of any stuck state.
+            if time.time() - last_ctx_refresh > 10:
+                self._recreate_ctx(f"mid-wait t+{int(time.time() - start_time)}s")
+                last_ctx_refresh = time.time()
+            try:
+                devs = self.ctx.query_devices()
+                # First pass: look for the device in NORMAL mode.
+                for dev in devs:
+                    try:
+                        if self._is_update_device(dev):
+                            continue
+                        sensors = dev.query_sensors()
+                        if sensors:
+                            try:
+                                dev_fw_id = sensors[0].get_info(rs.camera_info.firmware_update_id)
+                                if dev_fw_id == firmware_update_id:
+                                    reconnected = True
+                                    break
+                            except RuntimeError:
+                                pass
+                        try:
+                            if dev.supports(rs.camera_info.serial_number):
+                                sn = dev.get_info(rs.camera_info.serial_number)
+                                if sn == device_id:
+                                    reconnected = True
+                                    break
+                        except RuntimeError:
+                            pass
+                    except Exception:
+                        continue
+                if reconnected:
+                    break
+                # Second pass: is the device still sitting in DFU/recovery?
+                stuck_in_dfu = False
+                for dev in devs:
+                    try:
+                        if not self._is_update_device(dev):
+                            continue
+                        try:
+                            if dev.supports(rs.camera_info.firmware_update_id):
+                                dev_fw_id = dev.get_info(rs.camera_info.firmware_update_id)
+                                if dev_fw_id == firmware_update_id:
+                                    stuck_in_dfu = True
+                                    break
+                        except RuntimeError:
+                            pass
+                        # Fallback: any DFU device counts if we don't have ID match.
+                        stuck_in_dfu = True
+                    except Exception:
+                        continue
+            except Exception as e:
+                logging.debug("Error querying devices during reconnect wait: %s", e)
+                continue
+
+        if reconnected:
+            return
+        if stuck_in_dfu:
+            logging.error(
+                "Device %s is stuck in DFU/recovery mode after firmware update. "
+                "The firmware image may be incompatible or the update did not finalize.",
+                device_id,
+            )
+            msg = (
+                "Device is stuck in recovery (DFU) mode after the update. "
+                "Please physically disconnect and reconnect the device, then try again "
+                "with a known-good firmware image."
+            )
+            self._emit_socket_event(
+                f"firmware_update_failed_{device_id}",
+                {"device_id": device_id, "error": msg},
+            )
+            raise RealSenseError(status_code=500, detail=msg)
+        logging.warning("Device did not reconnect within timeout, but update may have succeeded")
+
+    def _refresh_until_device_returns(
+        self, device_id: str, attempts: int = 8,
+    ) -> Optional[DeviceInfo]:
+        """Re-poll refresh_devices() until device_id reappears in device_infos."""
+        # The USB re-enumeration may lag behind the SDK's first query. Give it
+        # a few seconds to settle, then retry refresh until the device reappears.
+        time.sleep(3)
+        for attempt in range(attempts):
+            self.refresh_devices()
+            updated_info = self.device_infos.get(device_id)
+            if updated_info:
+                logging.info(
+                    "Device %s re-appeared after firmware update (attempt %d)",
+                    device_id, attempt + 1,
+                )
+                return updated_info
+            logging.debug(
+                "Device %s not yet visible after firmware update (attempt %d)",
+                device_id, attempt + 1,
+            )
+            time.sleep(1)
+        logging.warning(
+            "Device %s did not reappear after firmware update; "
+            "frontend will keep polling.", device_id,
+        )
+        return None
 
     def reset_device(self, device_id: str) -> bool:
         """Reset a specific device by ID"""

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -155,14 +155,15 @@ class RealSenseManager:
             logging.warning("Socket emit failed (%s): %s", event, exc)
 
     def refresh_devices(self) -> List[DeviceInfo]:
-        """Refresh the list of connected devices"""
-        # Skip enumeration while a firmware update is running. A concurrent
-        # call to self.ctx.devices/query_devices() invalidates the rs.device
-        # handles held by the FW-update thread (notably the DFU update_dev
-        # returned by _wait_for_dfu_device), causing the SDK to throw
-        # 'null pointer passed for argument "device"' on the subsequent
-        # update_dev.update(...) call. Return the cached snapshot instead;
-        # update_firmware_from_bytes runs a real refresh once it finishes.
+        """Refresh the list of connected devices.
+
+        Public entry point; skips ctx enumeration while a firmware update is in
+        progress to avoid the polling thread invalidating the FW thread's
+        ``rs.device`` handles (which causes ``null pointer passed for argument
+        "device"`` on the subsequent ``update_dev.update(...)`` call). The FW
+        thread itself uses ``_refresh_devices_locked`` directly to bypass the
+        guard once DFU is complete.
+        """
         with self.lock:
             if self._fw_updates_in_progress:
                 logging.debug(
@@ -170,7 +171,11 @@ class RealSenseManager:
                     self._fw_updates_in_progress,
                 )
                 return list(self.device_infos.values())
+        return self._refresh_devices_locked()
 
+    def _refresh_devices_locked(self) -> List[DeviceInfo]:
+        """Actual device enumeration (no FW-in-progress guard)."""
+        with self.lock:
             # Clear existing devices (that aren't streaming)
             for device_id in list(self.devices.keys()):
                 if device_id not in self.pipelines:
@@ -707,12 +712,19 @@ class RealSenseManager:
     def _refresh_until_device_returns(
         self, device_id: str, attempts: int = 8,
     ) -> Optional[DeviceInfo]:
-        """Re-poll refresh_devices() until device_id reappears in device_infos."""
+        """Re-enumerate until device_id reappears in device_infos.
+
+        Calls ``_refresh_devices_locked`` directly to bypass the
+        ``_fw_updates_in_progress`` guard on the public ``refresh_devices``: the
+        FW slot is still claimed at this point (released in the outer
+        ``finally``), but DFU has finished and we own the FW thread, so it's
+        safe — and necessary — to enumerate.
+        """
         # The USB re-enumeration may lag behind the SDK's first query. Give it
-        # a few seconds to settle, then retry refresh until the device reappears.
+        # a few seconds to settle, then retry until the device reappears.
         time.sleep(3)
         for attempt in range(attempts):
-            self.refresh_devices()
+            self._refresh_devices_locked()
             updated_info = self.device_infos.get(device_id)
             if updated_info:
                 logging.info(

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -320,7 +320,13 @@ class RealSenseManager:
         self._claim_fw_update_slot(device_id)
         try:
             self._ensure_fw_update_allowed(device_id)
-            fw_image = self._materialize_fw_image(fw_bytes)
+            # pyrealsense2 accepts bytes-like objects; bytearray keeps memory
+            # bounded (list(bytes) would balloon ~28x by boxing each byte).
+            try:
+                fw_image = bytearray(fw_bytes)
+            except Exception as exc:
+                logging.error("Failed to materialize firmware bytes: %s", exc)
+                raise RealSenseError(status_code=400, detail="Invalid firmware payload")
 
             # Re-fetch the device handle directly from the SDK context. The cached
             # `self.devices[device_id]` Python wrapper can outlive its underlying
@@ -455,17 +461,6 @@ class RealSenseManager:
                     status_code=400,
                     detail="Stop all streaming before updating firmware",
                 )
-
-    @staticmethod
-    def _materialize_fw_image(fw_bytes: bytes) -> bytearray:
-        """Convert the raw payload to a bytearray that pyrealsense2 can consume."""
-        # pyrealsense2 accepts bytes-like objects; bytearray keeps memory bounded
-        # (list(bytes) would balloon ~28x by boxing each byte as a Python int).
-        try:
-            return bytearray(fw_bytes)
-        except Exception as exc:
-            logging.error("Failed to materialize firmware bytes: %s", exc)
-            raise RealSenseError(status_code=400, detail="Invalid firmware payload")
 
     @staticmethod
     def _resolve_firmware_update_id(target_dev: rs.device, device_id: str) -> str:

--- a/wrappers/rest-api/requirements.txt
+++ b/wrappers/rest-api/requirements.txt
@@ -1,10 +1,7 @@
 fastapi==0.120.1;        platform_machine != "aarch64"
 uvicorn==0.34.0;         platform_machine != "aarch64"
 pydantic==2.10.6;        platform_machine != "aarch64"
-# Required by FastAPI to parse multipart/form-data — used by the firmware
-# update_from_file endpoint (File/UploadFile). Without it, route registration
-# raises at import time, breaking test collection.
-python-multipart==0.0.29; platform_machine != "aarch64"
+python-multipart==0.0.29; platform_machine != "aarch64" # Used internally by FastAPI to parse file uploads (e.g. FW update endpoint)
 #pyrealsense2==2.56.4.9191; platform_machine != "aarch64"
 
 # aiortc pulls av>=14 which needs FFmpeg 7 to build from source; force the prebuilt wheel

--- a/wrappers/rest-api/requirements.txt
+++ b/wrappers/rest-api/requirements.txt
@@ -1,6 +1,10 @@
 fastapi==0.120.1;        platform_machine != "aarch64"
 uvicorn==0.34.0;         platform_machine != "aarch64"
 pydantic==2.10.6;        platform_machine != "aarch64"
+# Required by FastAPI to parse multipart/form-data — used by the firmware
+# update_from_file endpoint (File/UploadFile). Without it, route registration
+# raises at import time, breaking test collection.
+python-multipart==0.0.29; platform_machine != "aarch64"
 #pyrealsense2==2.56.4.9191; platform_machine != "aarch64"
 
 # aiortc pulls av>=14 which needs FFmpeg 7 to build from source; force the prebuilt wheel

--- a/wrappers/rest-api/tests/test_api_service.py
+++ b/wrappers/rest-api/tests/test_api_service.py
@@ -338,6 +338,83 @@ class TestRealSenseAPI:
         assert status["device_id"] == "device1"
         assert "is_streaming" in status
 
+    # ----- Tests for the firmware update_from_file endpoint -----
+
+    def test_update_firmware_from_file_happy_path(self, patch_dependencies):
+        rs_manager = patch_dependencies["rs_manager"]
+        rs_manager.update_firmware_from_bytes = MagicMock(
+            return_value={
+                "device_id": "device1",
+                "progress": 1.0,
+                "firmware_version": "1.2.3",
+                "status": "success",
+            }
+        )
+        files = {"file": ("D4XX_FW.bin", b"\x00\x01\x02\x03", "application/octet-stream")}
+        response = client.post(
+            "/api/v1/devices/device1/firmware/update_from_file", files=files
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+        # Manager called with device_id + bytes payload
+        args, _ = rs_manager.update_firmware_from_bytes.call_args
+        assert args[0] == "device1"
+        assert args[1] == b"\x00\x01\x02\x03"
+
+    def test_update_firmware_from_file_rejects_non_bin_extension(self, patch_dependencies):
+        rs_manager = patch_dependencies["rs_manager"]
+        rs_manager.update_firmware_from_bytes = MagicMock()
+        files = {"file": ("firmware.txt", b"hello", "text/plain")}
+        response = client.post(
+            "/api/v1/devices/device1/firmware/update_from_file", files=files
+        )
+        assert response.status_code == 400
+        assert ".bin" in response.json()["detail"]
+        rs_manager.update_firmware_from_bytes.assert_not_called()
+
+    def test_update_firmware_from_file_rejects_empty(self, patch_dependencies):
+        rs_manager = patch_dependencies["rs_manager"]
+        rs_manager.update_firmware_from_bytes = MagicMock()
+        files = {"file": ("empty.bin", b"", "application/octet-stream")}
+        response = client.post(
+            "/api/v1/devices/device1/firmware/update_from_file", files=files
+        )
+        assert response.status_code == 400
+        assert "empty" in response.json()["detail"].lower()
+        rs_manager.update_firmware_from_bytes.assert_not_called()
+
+    def test_update_firmware_from_file_rejects_oversize(self, patch_dependencies):
+        from app.api.endpoints import firmware as firmware_module
+
+        rs_manager = patch_dependencies["rs_manager"]
+        rs_manager.update_firmware_from_bytes = MagicMock()
+        # Temporarily shrink the cap so we don't have to allocate 64 MiB just to test the path.
+        original_cap = firmware_module.MAX_FW_UPLOAD_BYTES
+        firmware_module.MAX_FW_UPLOAD_BYTES = 16
+        try:
+            files = {"file": ("big.bin", b"X" * 32, "application/octet-stream")}
+            response = client.post(
+                "/api/v1/devices/device1/firmware/update_from_file", files=files
+            )
+        finally:
+            firmware_module.MAX_FW_UPLOAD_BYTES = original_cap
+        assert response.status_code == 413
+        rs_manager.update_firmware_from_bytes.assert_not_called()
+
+    def test_update_firmware_from_file_propagates_sdk_error(self, patch_dependencies):
+        from app.services.rs_manager import RealSenseError
+
+        rs_manager = patch_dependencies["rs_manager"]
+        rs_manager.update_firmware_from_bytes = MagicMock(
+            side_effect=RealSenseError(status_code=400, detail="Firmware is not compatible")
+        )
+        files = {"file": ("bad.bin", b"\xff" * 8, "application/octet-stream")}
+        response = client.post(
+            "/api/v1/devices/device1/firmware/update_from_file", files=files
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Firmware is not compatible"
+
     # ----- Tests for the WebRTC API -----
 
     @pytest.mark.asyncio

--- a/wrappers/rest-api/tools/react-viewer/src/api/client.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios'
-import { io, Socket } from 'socket.io-client'
+import { socketService } from './socket'
 import type {
   DeviceInfo,
   SensorInfo,
@@ -31,9 +31,12 @@ const getApiBase = () => {
 
 const API_BASE = getApiBase()
 
+type FirmwareProgressCallback = (progress: number) => void
+type FirmwareErrorCallback = (error: string) => void
+type FirmwareSuccessCallback = (firmwareVersion: string | null) => void
+
 class ApiClient {
   private client: AxiosInstance
-  private socket: Socket | null = null
 
   constructor() {
     this.client = axios.create({
@@ -42,56 +45,31 @@ class ApiClient {
         'Content-Type': 'application/json',
       },
     })
-    this.initializeSocket()
   }
 
-  private initializeSocket() {
-    // Determine Socket.IO origin based on environment
-    let socketOrigin: string
-    
-    if (isDesktopApp) {
-      // Desktop app: connect to localhost:8000
-      socketOrigin = 'http://localhost:8000'
-      console.log('🖥️ Desktop app detected. Connecting to FastAPI backend at:', socketOrigin)
-    } else {
-      // Browser: use environment variable or current origin
-      socketOrigin = (import.meta as any).env?.VITE_SOCKET_ORIGIN || window.location.origin
-      console.log('🌐 Browser mode. Connecting to:', socketOrigin)
-    }
+  // ============ Firmware Socket.IO events ============
+  // These piggyback on the shared socketService connection (see api/socket.ts).
 
-    this.socket = io(socketOrigin, {
-      path: '/socket',
-      reconnectionDelay: 1000,
-      reconnection: true,
-      reconnectionAttempts: 5,
-    })
+  onFirmwareProgress(deviceId: string, callback: FirmwareProgressCallback): () => void {
+    const eventName = `firmware_progress_${deviceId}`
+    const handler = (data: unknown) => callback((data as { progress: number }).progress)
+    socketService.on(eventName, handler as (...args: unknown[]) => void)
+    return () => socketService.off(eventName, handler as (...args: unknown[]) => void)
+  }
 
-    this.socket.on('connect', () => {
-      console.log('✅ Socket.IO connected successfully', { 
-        origin: socketOrigin, 
-        id: this.socket?.id, 
-        desktop: isDesktopApp 
-      })
-    })
+  onFirmwareError(deviceId: string, callback: FirmwareErrorCallback): () => void {
+    const eventName = `firmware_update_failed_${deviceId}`
+    const handler = (data: unknown) => callback((data as { error: string }).error)
+    socketService.on(eventName, handler as (...args: unknown[]) => void)
+    return () => socketService.off(eventName, handler as (...args: unknown[]) => void)
+  }
 
-    this.socket.on('connect_error', (err: any) => {
-      console.error('❌ Socket.IO connection error', { 
-        origin: socketOrigin,
-        message: err?.message || 'Unknown error',
-        type: err?.type,
-        err,
-        desktop: isDesktopApp,
-        hint: isDesktopApp ? 'Make sure FastAPI backend is running and accessible' : 'Check if API proxy is configured'
-      })
-    })
-
-    this.socket.on('disconnect', (reason: string) => {
-      console.warn('⚠️ Socket.IO disconnected. Reason:', reason)
-    })
-
-    this.socket.on('error', (error: any) => {
-      console.error('❌ Socket.IO error:', error)
-    })
+  onFirmwareSuccess(deviceId: string, callback: FirmwareSuccessCallback): () => void {
+    const eventName = `firmware_update_success_${deviceId}`
+    const handler = (data: unknown) =>
+      callback((data as { firmware_version: string | null }).firmware_version)
+    socketService.on(eventName, handler as (...args: unknown[]) => void)
+    return () => socketService.off(eventName, handler as (...args: unknown[]) => void)
   }
 
   // ============ Health ============
@@ -130,6 +108,24 @@ class ApiClient {
 
   async resetDevice(deviceId: string): Promise<void> {
     await this.client.post(`/devices/${deviceId}/reset/`)
+  }
+
+  async updateFirmwareFromFile(
+    deviceId: string,
+    file: File
+  ): Promise<{ status: string; firmware_version?: string | null; progress?: number }> {
+    const form = new FormData()
+    form.append('file', file)
+    // Clear the per-client default Content-Type (`application/json`) so the
+    // browser sets `multipart/form-data; boundary=...` itself when posting
+    // FormData. Hard-coding `multipart/form-data` here would strip the boundary
+    // and break FastAPI parsing (422).
+    const response = await this.client.post(
+      `/devices/${deviceId}/firmware/update_from_file`,
+      form,
+      { headers: { 'Content-Type': undefined as unknown as string } },
+    )
+    return response.data
   }
 
   // ============ Sensors ============

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -55,7 +55,6 @@ export function DevicePanel() {
     stopSensorStreaming,
     checkFirmwareUpdates,
     updateFirmwareFromFile,
-    isAnyDeviceStreaming,
   } = useAppStore()
 
   const [toasts, setToasts] = useState<Toast[]>([])
@@ -63,8 +62,6 @@ export function DevicePanel() {
   const [firmwareProgressDeviceId, setFirmwareProgressDeviceId] = useState<string | null>(null)
   const [firmwareProgressState, setFirmwareProgressState] = useState<FirmwareState | null>(null)
   const [firmwareFileName, setFirmwareFileName] = useState<string | null>(null)
-
-  const isStreaming = isAnyDeviceStreaming()
 
   useEffect(() => {
     fetchDevices()
@@ -223,7 +220,6 @@ export function DevicePanel() {
                 onStopSensorStreaming={(sensorId) => stopSensorStreaming(device.device_id, sensorId)}
                 onCheckFirmwareUpdates={() => checkFirmwareUpdates(device.device_id)}
                 onUpdateFirmwareFromFile={(file) => handleUpdateFirmwareFromFile(device, file)}
-                anyDeviceStreaming={isStreaming}
                 onShowToast={addToast}
               />
             )
@@ -279,7 +275,6 @@ interface DeviceCardProps {
   onStopSensorStreaming: (sensorId: string) => void
   onCheckFirmwareUpdates: () => void
   onUpdateFirmwareFromFile: (file: File) => void
-  anyDeviceStreaming: boolean
   onShowToast: (type: ToastType, message: string) => void
 }
 
@@ -295,7 +290,6 @@ function DeviceCard({
   onStopSensorStreaming,
   onCheckFirmwareUpdates,
   onUpdateFirmwareFromFile,
-  anyDeviceStreaming,
   onShowToast,
 }: DeviceCardProps) {
   const [showMenu, setShowMenu] = useState(false)
@@ -417,9 +411,9 @@ function DeviceCard({
                         // file input lives outside the menu and persists.
                         setTimeout(() => fwPicker.open(), 0)
                       }}
-                      disabled={anyDeviceStreaming || isStreaming}
+                      disabled={isStreaming}
                       className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${
-                        anyDeviceStreaming || isStreaming
+                        isStreaming
                           ? 'text-gray-500 cursor-not-allowed'
                           : 'hover:bg-gray-700'
                       }`}

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '../store'
-import type { DeviceInfo, SensorInfo, OptionInfo, StreamConfig, DeviceState, SensorConfig } from '../api/types'
+import type { DeviceInfo, SensorInfo, OptionInfo, StreamConfig, DeviceState, FirmwareState, SensorConfig } from '../api/types'
+import { FirmwareProgressModal } from './FirmwareProgressModal'
 import { ToastContainer, type ToastType } from './Toast'
 
 interface Toast {
@@ -25,9 +26,16 @@ export function DevicePanel() {
     startSensorStreaming,
     stopSensorStreaming,
     checkFirmwareUpdates,
+    updateFirmwareFromFile,
+    isAnyDeviceStreaming,
   } = useAppStore()
 
   const [toasts, setToasts] = useState<Toast[]>([])
+  const [firmwareProgressDeviceId, setFirmwareProgressDeviceId] = useState<string | null>(null)
+  const [firmwareProgressStates, setFirmwareProgressStates] = useState<Record<string, FirmwareState>>({})
+  const [firmwareFileNames, setFirmwareFileNames] = useState<Record<string, string>>({})
+
+  const isStreaming = isAnyDeviceStreaming()
 
   useEffect(() => {
     fetchDevices()
@@ -40,6 +48,63 @@ export function DevicePanel() {
 
   const removeToast = (id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id))
+  }
+
+  const handleFirmwareProgressUpdate = (deviceId: string, progress: number) => {
+    setFirmwareProgressStates((prev) => {
+      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: true, progress: 0 }
+      return { ...prev, [deviceId]: { ...current, progress } }
+    })
+  }
+
+  const handleFirmwareSuccess = (deviceId: string, fwVersion: string | null) => {
+    setFirmwareProgressStates((prev) => {
+      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: false, progress: 1.0 }
+      return { ...prev, [deviceId]: { ...current, progress: 1.0, is_updating: false } }
+    })
+    addToast('success', `Firmware update successful! Version: ${fwVersion || 'Unknown'}`)
+  }
+
+  const handleFirmwareError = (deviceId: string, error: string) => {
+    setFirmwareProgressStates((prev) => {
+      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: false, progress: 0 }
+      return { ...prev, [deviceId]: { ...current, is_updating: false, last_error: error } }
+    })
+    addToast('error', `Firmware update failed: ${error}`)
+  }
+
+  const handleCloseFirmwareModal = () => {
+    if (firmwareProgressDeviceId) {
+      const id = firmwareProgressDeviceId
+      setFirmwareFileNames((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    }
+    setFirmwareProgressDeviceId(null)
+  }
+
+  const handleUpdateFirmwareFromFile = (device: DeviceInfo, file: File) => {
+    const deviceId = device.device_id
+    setFirmwareFileNames((prev) => ({ ...prev, [deviceId]: file.name }))
+    setFirmwareProgressDeviceId(deviceId)
+    const baseFirmware = deviceStates[deviceId]?.firmware || {
+      current: device.firmware_version,
+      recommended: device.recommended_firmware_version,
+      status: 'unknown' as const,
+      file_available: device.firmware_file_available,
+    }
+    setFirmwareProgressStates((prev) => ({
+      ...prev,
+      [deviceId]: {
+        ...baseFirmware,
+        is_updating: true,
+        progress: 0,
+        last_error: null,
+      },
+    }))
+    updateFirmwareFromFile(deviceId, file)
   }
 
   return (
@@ -129,11 +194,43 @@ export function DevicePanel() {
                 onStartSensorStreaming={(sensorId) => startSensorStreaming(device.device_id, sensorId)}
                 onStopSensorStreaming={(sensorId) => stopSensorStreaming(device.device_id, sensorId)}
                 onCheckFirmwareUpdates={() => checkFirmwareUpdates(device.device_id)}
+                onUpdateFirmwareFromFile={(file) => handleUpdateFirmwareFromFile(device, file)}
+                anyDeviceStreaming={isStreaming}
                 onShowToast={addToast}
               />
             )
           })}
         </div>
+      )}
+
+      {firmwareProgressDeviceId && (
+        <FirmwareProgressModal
+          isOpen={true}
+          device={
+            devices.find((d) => d.device_id === firmwareProgressDeviceId) || {
+              // Keep the real device_id so the modal's socket subscriptions
+              // remain bound to firmware_*_<id> across DFU/re-enumeration.
+              device_id: firmwareProgressDeviceId,
+              name: firmwareFileNames[firmwareProgressDeviceId] || 'Updating device',
+            }
+          }
+          firmware={
+            firmwareProgressStates[firmwareProgressDeviceId] || {
+              current: undefined,
+              recommended: undefined,
+              status: 'unknown' as const,
+              file_available: false,
+              is_updating: true,
+              progress: 0,
+              last_error: null,
+            }
+          }
+          fileName={firmwareFileNames[firmwareProgressDeviceId]}
+          onClose={handleCloseFirmwareModal}
+          onProgressUpdate={(progress) => handleFirmwareProgressUpdate(firmwareProgressDeviceId, progress)}
+          onSuccess={(fwVersion) => handleFirmwareSuccess(firmwareProgressDeviceId, fwVersion)}
+          onError={(err) => handleFirmwareError(firmwareProgressDeviceId, err)}
+        />
       )}
 
       {/* Toast Notifications */}
@@ -153,6 +250,8 @@ interface DeviceCardProps {
   onStartSensorStreaming: (sensorId: string) => void
   onStopSensorStreaming: (sensorId: string) => void
   onCheckFirmwareUpdates: () => void
+  onUpdateFirmwareFromFile: (file: File) => void
+  anyDeviceStreaming: boolean
   onShowToast: (type: ToastType, message: string) => void
 }
 
@@ -167,10 +266,13 @@ function DeviceCard({
   onStartSensorStreaming,
   onStopSensorStreaming,
   onCheckFirmwareUpdates,
+  onUpdateFirmwareFromFile,
+  anyDeviceStreaming,
   onShowToast,
 }: DeviceCardProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [expandedSensor, setExpandedSensor] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const isActive = deviceState?.isActive || false
   const isLoading = deviceState?.isLoading || false
@@ -205,6 +307,22 @@ function DeviceCard({
       data-testid="device-card"
       onClick={!isActive && !isLoading ? onToggle : undefined}
     >
+      {/* Hidden file input — rendered at card root so it persists when the
+          hamburger menu closes; otherwise the OS file picker resolves into
+          an unmounted input and onChange never fires. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".bin"
+        className="hidden"
+        onClick={(e) => e.stopPropagation()}
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) onUpdateFirmwareFromFile(file)
+          // Reset so selecting the same file again still triggers onChange.
+          e.target.value = ''
+        }}
+      />
       {/* Device Header */}
       <div className="p-3">
         <div className="flex items-start justify-between">
@@ -276,6 +394,22 @@ function DeviceCard({
                       </svg>
                       Check for Firmware Updates
                     </button>
+                    {!anyDeviceStreaming && !isStreaming && (
+                      <button
+                        onClick={() => {
+                          setShowMenu(false)
+                          // Defer the click so React unmounts the menu first; the
+                          // file input lives outside the menu and persists.
+                          setTimeout(() => fileInputRef.current?.click(), 0)
+                        }}
+                        className="w-full px-4 py-2 text-left text-sm hover:bg-gray-700 flex items-center gap-2"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12" />
+                        </svg>
+                        Update FW from File
+                      </button>
+                    )}
                     <div className="border-t border-gray-600 my-1" />
                     <button
                       onClick={() => {

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -92,6 +92,10 @@ export function DevicePanel() {
         : { status: 'unknown' as const, is_updating: false, progress: 1.0 }
     )
     addToast('success', `Firmware update successful! Version: ${fwVersion || 'Unknown'}`)
+    // Backend has already refreshed the device list (in _refresh_until_device_returns)
+    // by the time it emits firmware_update_success; pull the new device_infos so
+    // the UI shows the updated firmware_version without a manual Refresh click.
+    fetchDevices(true)
   }
 
   const handleFirmwareError = (error: string) => {
@@ -101,6 +105,9 @@ export function DevicePanel() {
         : { status: 'unknown' as const, is_updating: false, progress: 0, last_error: error }
     )
     addToast('error', `Firmware update failed: ${error}`)
+    // Device may or may not have returned; refresh so the UI reflects the
+    // current connection state (e.g. stuck-in-DFU disappears from the list).
+    fetchDevices(true)
   }
 
   const handleCloseFirmwareModal = () => {

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
 import { useAppStore } from '../store'
 import type { DeviceInfo, SensorInfo, OptionInfo, StreamConfig, DeviceState, FirmwareState, SensorConfig } from '../api/types'
 import { FirmwareProgressModal } from './FirmwareProgressModal'
@@ -8,6 +9,33 @@ interface Toast {
   id: string
   type: ToastType
   message: string
+}
+
+// Reusable hidden-file-input hook. Returns the JSX to render once at a stable
+// location in the tree (so the OS file picker callback fires even after the
+// menu that triggered it unmounts) and an `open()` function to trigger it.
+function useFilePicker(onPick: (file: File) => void, accept: string): {
+  open: () => void
+  input: ReactElement
+} {
+  const ref = useRef<HTMLInputElement>(null)
+  const open = () => ref.current?.click()
+  const input = (
+    <input
+      ref={ref}
+      type="file"
+      accept={accept}
+      className="hidden"
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        const f = e.target.files?.[0]
+        if (f) onPick(f)
+        // Reset so selecting the same file again still triggers onChange.
+        e.target.value = ''
+      }}
+    />
+  )
+  return { open, input }
 }
 
 export function DevicePanel() {
@@ -31,9 +59,10 @@ export function DevicePanel() {
   } = useAppStore()
 
   const [toasts, setToasts] = useState<Toast[]>([])
+  // Only one FW update can run at a time, so a single-value state is enough.
   const [firmwareProgressDeviceId, setFirmwareProgressDeviceId] = useState<string | null>(null)
-  const [firmwareProgressStates, setFirmwareProgressStates] = useState<Record<string, FirmwareState>>({})
-  const [firmwareFileNames, setFirmwareFileNames] = useState<Record<string, string>>({})
+  const [firmwareProgressState, setFirmwareProgressState] = useState<FirmwareState | null>(null)
+  const [firmwareFileName, setFirmwareFileName] = useState<string | null>(null)
 
   const isStreaming = isAnyDeviceStreaming()
 
@@ -50,44 +79,39 @@ export function DevicePanel() {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }
 
-  const handleFirmwareProgressUpdate = (deviceId: string, progress: number) => {
-    setFirmwareProgressStates((prev) => {
-      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: true, progress: 0 }
-      return { ...prev, [deviceId]: { ...current, progress } }
-    })
+  const handleFirmwareProgressUpdate = (progress: number) => {
+    setFirmwareProgressState((prev) =>
+      prev ? { ...prev, progress } : { status: 'unknown' as const, is_updating: true, progress }
+    )
   }
 
-  const handleFirmwareSuccess = (deviceId: string, fwVersion: string | null) => {
-    setFirmwareProgressStates((prev) => {
-      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: false, progress: 1.0 }
-      return { ...prev, [deviceId]: { ...current, progress: 1.0, is_updating: false } }
-    })
+  const handleFirmwareSuccess = (fwVersion: string | null) => {
+    setFirmwareProgressState((prev) =>
+      prev
+        ? { ...prev, progress: 1.0, is_updating: false }
+        : { status: 'unknown' as const, is_updating: false, progress: 1.0 }
+    )
     addToast('success', `Firmware update successful! Version: ${fwVersion || 'Unknown'}`)
   }
 
-  const handleFirmwareError = (deviceId: string, error: string) => {
-    setFirmwareProgressStates((prev) => {
-      const current = prev[deviceId] || { status: 'unknown' as const, is_updating: false, progress: 0 }
-      return { ...prev, [deviceId]: { ...current, is_updating: false, last_error: error } }
-    })
+  const handleFirmwareError = (error: string) => {
+    setFirmwareProgressState((prev) =>
+      prev
+        ? { ...prev, is_updating: false, last_error: error }
+        : { status: 'unknown' as const, is_updating: false, progress: 0, last_error: error }
+    )
     addToast('error', `Firmware update failed: ${error}`)
   }
 
   const handleCloseFirmwareModal = () => {
-    if (firmwareProgressDeviceId) {
-      const id = firmwareProgressDeviceId
-      setFirmwareFileNames((prev) => {
-        const next = { ...prev }
-        delete next[id]
-        return next
-      })
-    }
     setFirmwareProgressDeviceId(null)
+    setFirmwareProgressState(null)
+    setFirmwareFileName(null)
   }
 
   const handleUpdateFirmwareFromFile = (device: DeviceInfo, file: File) => {
     const deviceId = device.device_id
-    setFirmwareFileNames((prev) => ({ ...prev, [deviceId]: file.name }))
+    setFirmwareFileName(file.name)
     setFirmwareProgressDeviceId(deviceId)
     const baseFirmware = deviceStates[deviceId]?.firmware || {
       current: device.firmware_version,
@@ -95,15 +119,12 @@ export function DevicePanel() {
       status: 'unknown' as const,
       file_available: device.firmware_file_available,
     }
-    setFirmwareProgressStates((prev) => ({
-      ...prev,
-      [deviceId]: {
-        ...baseFirmware,
-        is_updating: true,
-        progress: 0,
-        last_error: null,
-      },
-    }))
+    setFirmwareProgressState({
+      ...baseFirmware,
+      is_updating: true,
+      progress: 0,
+      last_error: null,
+    })
     updateFirmwareFromFile(deviceId, file)
   }
 
@@ -211,11 +232,11 @@ export function DevicePanel() {
               // Keep the real device_id so the modal's socket subscriptions
               // remain bound to firmware_*_<id> across DFU/re-enumeration.
               device_id: firmwareProgressDeviceId,
-              name: firmwareFileNames[firmwareProgressDeviceId] || 'Updating device',
+              name: firmwareFileName || 'Updating device',
             }
           }
           firmware={
-            firmwareProgressStates[firmwareProgressDeviceId] || {
+            firmwareProgressState || {
               current: undefined,
               recommended: undefined,
               status: 'unknown' as const,
@@ -225,11 +246,11 @@ export function DevicePanel() {
               last_error: null,
             }
           }
-          fileName={firmwareFileNames[firmwareProgressDeviceId]}
+          fileName={firmwareFileName || undefined}
           onClose={handleCloseFirmwareModal}
-          onProgressUpdate={(progress) => handleFirmwareProgressUpdate(firmwareProgressDeviceId, progress)}
-          onSuccess={(fwVersion) => handleFirmwareSuccess(firmwareProgressDeviceId, fwVersion)}
-          onError={(err) => handleFirmwareError(firmwareProgressDeviceId, err)}
+          onProgressUpdate={handleFirmwareProgressUpdate}
+          onSuccess={handleFirmwareSuccess}
+          onError={handleFirmwareError}
         />
       )}
 
@@ -272,7 +293,7 @@ function DeviceCard({
 }: DeviceCardProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [expandedSensor, setExpandedSensor] = useState<string | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
+  const fwPicker = useFilePicker(onUpdateFirmwareFromFile, '.bin')
 
   const isActive = deviceState?.isActive || false
   const isLoading = deviceState?.isLoading || false
@@ -310,19 +331,7 @@ function DeviceCard({
       {/* Hidden file input — rendered at card root so it persists when the
           hamburger menu closes; otherwise the OS file picker resolves into
           an unmounted input and onChange never fires. */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".bin"
-        className="hidden"
-        onClick={(e) => e.stopPropagation()}
-        onChange={(e) => {
-          const file = e.target.files?.[0]
-          if (file) onUpdateFirmwareFromFile(file)
-          // Reset so selecting the same file again still triggers onChange.
-          e.target.value = ''
-        }}
-      />
+      {fwPicker.input}
       {/* Device Header */}
       <div className="p-3">
         <div className="flex items-start justify-between">
@@ -394,22 +403,25 @@ function DeviceCard({
                       </svg>
                       Check for Firmware Updates
                     </button>
-                    {!anyDeviceStreaming && !isStreaming && (
-                      <button
-                        onClick={() => {
-                          setShowMenu(false)
-                          // Defer the click so React unmounts the menu first; the
-                          // file input lives outside the menu and persists.
-                          setTimeout(() => fileInputRef.current?.click(), 0)
-                        }}
-                        className="w-full px-4 py-2 text-left text-sm hover:bg-gray-700 flex items-center gap-2"
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12" />
-                        </svg>
-                        Update FW from File
-                      </button>
-                    )}
+                    <button
+                      onClick={() => {
+                        setShowMenu(false)
+                        // Defer the click so React unmounts the menu first; the
+                        // file input lives outside the menu and persists.
+                        setTimeout(() => fwPicker.open(), 0)
+                      }}
+                      disabled={anyDeviceStreaming || isStreaming}
+                      className={`w-full px-4 py-2 text-left text-sm flex items-center gap-2 ${
+                        anyDeviceStreaming || isStreaming
+                          ? 'text-gray-500 cursor-not-allowed'
+                          : 'hover:bg-gray-700'
+                      }`}
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5-5m0 0l5 5m-5-5v12" />
+                      </svg>
+                      Update FW from File
+                    </button>
                     <div className="border-t border-gray-600 my-1" />
                     <button
                       onClick={() => {

--- a/wrappers/rest-api/tools/react-viewer/src/components/FirmwareProgressModal.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/FirmwareProgressModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from 'react'
+import { apiClient } from '../api/client'
+import type { FirmwareState } from '../api/types'
+
+interface FirmwareProgressModalProps {
+  isOpen: boolean
+  device: {
+    device_id: string
+    name: string
+  }
+  firmware: FirmwareState
+  fileName?: string
+  onClose: () => void
+  onProgressUpdate: (progress: number) => void
+  onSuccess: (firmwareVersion: string | null) => void
+  onError: (error: string) => void
+}
+
+export function FirmwareProgressModal({
+  isOpen,
+  device,
+  firmware,
+  fileName,
+  onClose,
+  onProgressUpdate,
+  onSuccess,
+  onError,
+}: FirmwareProgressModalProps) {
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const unsubscribeProgress = apiClient.onFirmwareProgress(device.device_id, (progress: number) => {
+      onProgressUpdate(progress)
+    })
+
+    const unsubscribeSuccess = apiClient.onFirmwareSuccess(device.device_id, (fwVersion: string | null) => {
+      onSuccess(fwVersion)
+      closeTimerRef.current = setTimeout(() => {
+        onClose()
+      }, 2000)
+    })
+
+    const unsubscribeError = apiClient.onFirmwareError(device.device_id, (error: string) => {
+      onError(error)
+    })
+
+    return () => {
+      unsubscribeProgress()
+      unsubscribeSuccess()
+      unsubscribeError()
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current)
+      }
+    }
+  }, [isOpen, device.device_id, onProgressUpdate, onSuccess, onError, onClose])
+
+  if (!isOpen) return null
+
+  const progress = Math.round((firmware.progress || 0) * 100)
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/60 z-40" />
+      <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl p-6 max-w-md w-full mx-4">
+          <div className="mb-4">
+            <h2 className="text-xl font-bold text-white">Firmware Update</h2>
+            <p className="text-sm text-gray-400 mt-1">{device.name}</p>
+            {fileName && (
+              <p className="text-xs text-gray-500 mt-1 truncate" title={fileName}>From file: {fileName}</p>
+            )}
+          </div>
+
+          <div className="mb-6">
+            {firmware.last_error ? (
+              <div className="p-3 bg-red-900/50 border border-red-700 rounded text-red-200 text-sm">
+                <div className="font-semibold mb-1">Update Failed</div>
+                <div>{firmware.last_error}</div>
+              </div>
+            ) : progress === 100 ? (
+              <div className="p-3 bg-green-900/50 border border-green-700 rounded text-green-200 text-sm">
+                <div className="font-semibold">✓ Update Complete</div>
+                <div className="text-sm mt-1">Firmware has been successfully installed</div>
+              </div>
+            ) : (
+              <div className="text-gray-300 text-sm">
+                <div className="font-semibold mb-1">Installing firmware...</div>
+                <div className="text-gray-400">This may take 1-2 minutes. Please do not disconnect the device.</div>
+              </div>
+            )}
+          </div>
+
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-gray-400">Progress</span>
+              <span className="text-sm font-semibold text-white">{progress}%</span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2 overflow-hidden">
+              <div
+                className={`h-full transition-all duration-300 ${
+                  firmware.last_error ? 'bg-red-500' : progress === 100 ? 'bg-green-500' : 'bg-rs-blue'
+                }`}
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+
+          {!firmware.last_error && firmware.current && (
+            <div className="mb-6 p-3 bg-gray-800 rounded text-xs text-gray-300">
+              <div>Current: <span className="text-white">{firmware.current}</span></div>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            {firmware.last_error ? (
+              <button
+                onClick={onClose}
+                className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded font-medium transition-colors"
+              >
+                Close
+              </button>
+            ) : progress === 100 ? (
+              <button
+                onClick={onClose}
+                className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded font-medium transition-colors"
+              >
+                Done
+              </button>
+            ) : (
+              <div className="flex-1 px-4 py-2 bg-gray-700 text-gray-300 rounded font-medium text-center">
+                <div className="inline-block w-4 h-4 border-2 border-rs-blue border-t-transparent rounded-full animate-spin mr-2" />
+                In Progress
+              </div>
+            )}
+          </div>
+
+          {!firmware.last_error && progress < 100 && (
+            <div className="mt-4 p-3 bg-amber-900/40 border border-amber-600 rounded text-amber-200 text-xs">
+              ⚠ Do not disconnect the device during the update
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/wrappers/rest-api/tools/react-viewer/src/components/FirmwareProgressModal.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/FirmwareProgressModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { apiClient } from '../api/client'
 import type { FirmwareState } from '../api/types'
 
@@ -26,8 +26,6 @@ export function FirmwareProgressModal({
   onSuccess,
   onError,
 }: FirmwareProgressModalProps) {
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
   useEffect(() => {
     if (!isOpen) return
 
@@ -37,9 +35,6 @@ export function FirmwareProgressModal({
 
     const unsubscribeSuccess = apiClient.onFirmwareSuccess(device.device_id, (fwVersion: string | null) => {
       onSuccess(fwVersion)
-      closeTimerRef.current = setTimeout(() => {
-        onClose()
-      }, 2000)
     })
 
     const unsubscribeError = apiClient.onFirmwareError(device.device_id, (error: string) => {
@@ -50,11 +45,8 @@ export function FirmwareProgressModal({
       unsubscribeProgress()
       unsubscribeSuccess()
       unsubscribeError()
-      if (closeTimerRef.current !== null) {
-        clearTimeout(closeTimerRef.current)
-      }
     }
-  }, [isOpen, device.device_id, onProgressUpdate, onSuccess, onError, onClose])
+  }, [isOpen, device.device_id, onProgressUpdate, onSuccess, onError])
 
   if (!isOpen) return null
 
@@ -136,11 +128,6 @@ export function FirmwareProgressModal({
             )}
           </div>
 
-          {!firmware.last_error && progress < 100 && (
-            <div className="mt-4 p-3 bg-amber-900/40 border border-amber-600 rounded text-amber-200 text-xs">
-              ⚠ Do not disconnect the device during the update
-            </div>
-          )}
         </div>
       </div>
     </>

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -114,6 +114,7 @@ interface AppState {
   hasUserInteracted: boolean // Track if user manually toggled a device (skip auto-activate)
   fetchDevices: (forceRefresh?: boolean) => Promise<void>
   checkFirmwareUpdates: (deviceId: string) => Promise<void>
+  updateFirmwareFromFile: (deviceId: string, file: File) => Promise<void>
 
   // Device activation (multi-select support)
   toggleDeviceActive: (device: DeviceInfo) => Promise<void>
@@ -284,6 +285,75 @@ export const useAppStore = create<AppState>()((set, get) => ({
       set({
         error: `Failed to fetch devices: ${error instanceof Error ? error.message : 'Unknown error'}`,
         isLoadingDevices: false,
+      })
+    }
+  },
+
+  updateFirmwareFromFile: async (deviceId: string, file: File) => {
+    set((state) => {
+      const ds = state.deviceStates[deviceId]
+      if (!ds) return state
+      const prev = ds.firmware || {
+        status: 'unknown' as FirmwareState['status'],
+        current: ds.device.firmware_version,
+        recommended: ds.device.recommended_firmware_version,
+        file_available: ds.device.firmware_file_available,
+      }
+      const nextFirmware: FirmwareState = {
+        ...prev,
+        status: prev.status ?? 'unknown',
+        is_updating: true,
+        progress: 0,
+        last_error: null,
+      }
+      return {
+        deviceStates: {
+          ...state.deviceStates,
+          [deviceId]: { ...ds, firmware: nextFirmware },
+        },
+      }
+    })
+
+    try {
+      await apiClient.updateFirmwareFromFile(deviceId, file)
+      await get().fetchDevices()
+      set((state) => {
+        const ds = state.deviceStates[deviceId]
+        if (!ds) return state
+        const prev = ds.firmware || { status: 'unknown' as FirmwareState['status'] }
+        const next: FirmwareState = { ...prev, status: prev.status ?? 'unknown', is_updating: false, progress: 1 }
+        return {
+          deviceStates: {
+            ...state.deviceStates,
+            [deviceId]: { ...ds, firmware: next },
+          },
+        }
+      })
+    } catch (error) {
+      // Prefer FastAPI's detail string when available.
+      const axiosDetail = (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      const message = typeof axiosDetail === 'string' && axiosDetail
+        ? axiosDetail
+        : error instanceof Error ? error.message : 'Firmware update failed'
+      // Surface the error only on the device's firmware state — the modal and
+      // toast (driven by the Socket.IO failure event) already inform the user;
+      // setting the global `error` banner here would triple-render the message.
+      set((state) => {
+        const ds = state.deviceStates[deviceId]
+        if (!ds) return state
+        const prev = ds.firmware || { status: 'unknown' as FirmwareState['status'] }
+        const next: FirmwareState = {
+          ...prev,
+          status: prev.status ?? 'unknown',
+          is_updating: false,
+          last_error: message,
+        }
+        return {
+          deviceStates: {
+            ...state.deviceStates,
+            [deviceId]: { ...ds, firmware: next },
+          },
+        }
       })
     }
   },


### PR DESCRIPTION
## Summary
- Implements RSDEV-9277: FW update from file in the React Viewer
- Backend: new POST /api/v1/devices/{device_id}/firmware/update_from_file endpoint accepting multipart .bin upload (64 MiB cap). Reuses the existing DFU flow (check_firmware_compatibility -> enter_update_state -> update_dev.update), emits Socket.IO progress / success / failure events.
- Frontend: new "Update FW from File" entry in the device-card hamburger menu (hidden when streaming), file picker, reuses FirmwareProgressModal with progress bar.
- Robustness fixes for the post-DFU reconnect: explicit update_dev.hardware_reset() after update() (mirrors MIPI handling in common/fw-update-helper.cpp), recreate rs.context() periodically during the wait loop, 120 s reconnect timeout, retry refresh_devices() afterwards, and surface a clear error if the device ends up stuck in recovery mode.
- Follow-up tracked in RSDEV-11404 (surface devices stuck in DFU/recovery in the sidebar so users can re-flash without a physical reconnect).

## Test plan
- [x] npm run build clean (tsc + vite)
- [x] Backend Python syntax check
- [x] Manual: stream -> hamburger -> "Update FW from File" -> pick .bin -> progress bar -> success -> device re-appears
- [ ] Multi-device case (one streaming, FW update on another)
- [ ] Negative: incompatible .bin -> backend rejects via check_firmware_compatibility -> error toast