### PR TITLE
react-viewer: force re-enumeration on manual Refresh

### DIFF
--- a/wrappers/rest-api/tools/react-viewer/src/api/client.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/client.ts
@@ -107,7 +107,7 @@ class ApiClient {
 
   async getDevices(forceRefresh: boolean = false): Promise<DeviceInfo[]> {
     const response = await this.client.get<DeviceInfo[]>('/devices/', {
-      params: forceRefresh ? { force_refresh: true } : undefined,
+      params: { force_refresh: forceRefresh || undefined },
     })
     return response.data
   }

--- a/wrappers/rest-api/tools/react-viewer/src/api/client.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/client.ts
@@ -105,8 +105,10 @@ class ApiClient {
 
   // ============ Devices ============
 
-  async getDevices(): Promise<DeviceInfo[]> {
-    const response = await this.client.get<DeviceInfo[]>('/devices/')
+  async getDevices(forceRefresh: boolean = false): Promise<DeviceInfo[]> {
+    const response = await this.client.get<DeviceInfo[]>('/devices/', {
+      params: forceRefresh ? { force_refresh: true } : undefined,
+    })
     return response.data
   }
 

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -57,8 +57,10 @@ export function DevicePanel() {
         <button
           onClick={() => fetchDevices(true)}
           disabled={isLoadingDevices}
+          aria-label={isLoadingDevices ? 'Refreshing devices…' : 'Refresh devices'}
+          aria-busy={isLoadingDevices}
           className="p-2 hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          title="Refresh devices"
+          title={isLoadingDevices ? 'Refreshing…' : 'Refresh devices'}
         >
           <svg
             className={`w-5 h-5 ${isLoadingDevices ? 'animate-spin' : ''}`}

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -55,8 +55,9 @@ export function DevicePanel() {
       <div className="flex items-center justify-between mb-4">
         <h2 className="panel-header mb-0">Devices</h2>
         <button
-          onClick={() => fetchDevices()}
-          className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+          onClick={() => fetchDevices(true)}
+          disabled={isLoadingDevices}
+          className="p-2 hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           title="Refresh devices"
         >
           <svg

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -112,7 +112,7 @@ interface AppState {
   deviceStates: Record<string, DeviceState> // keyed by device_id
   isLoadingDevices: boolean
   hasUserInteracted: boolean // Track if user manually toggled a device (skip auto-activate)
-  fetchDevices: () => Promise<void>
+  fetchDevices: (forceRefresh?: boolean) => Promise<void>
   checkFirmwareUpdates: (deviceId: string) => Promise<void>
 
   // Device activation (multi-select support)
@@ -215,10 +215,10 @@ export const useAppStore = create<AppState>()((set, get) => ({
   isLoadingDevices: false,
   hasUserInteracted: false,
   
-  fetchDevices: async () => {
+  fetchDevices: async (forceRefresh = false) => {
     set({ isLoadingDevices: true, error: null })
     try {
-      const devices = await apiClient.getDevices()
+      const devices = await apiClient.getDevices(forceRefresh)
       // Update devices list, preserve existing device states for known devices
       set((state) => {
         const newDeviceStates = { ...state.deviceStates }
@@ -259,7 +259,14 @@ export const useAppStore = create<AppState>()((set, get) => ({
           }
         }
 
-        return { devices, deviceStates: newDeviceStates, isLoadingDevices: false }
+        // Drop selectedDevice pointer if its device disappeared
+        const selectedStillPresent =
+          state.selectedDevice && devices.some(d => d.device_id === state.selectedDevice!.device_id)
+        const selectedDevice = selectedStillPresent
+          ? devices.find(d => d.device_id === state.selectedDevice!.device_id) || null
+          : null
+
+        return { devices, deviceStates: newDeviceStates, selectedDevice, isLoadingDevices: false }
       })
       
       // Auto-activate if exactly 1 device and user hasn't manually interacted

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -216,6 +216,9 @@ export const useAppStore = create<AppState>()((set, get) => ({
   hasUserInteracted: false,
   
   fetchDevices: async (forceRefresh = false) => {
+    // Guard against concurrent fetches: a slow force-refresh must not be clobbered
+    // by a cache-hit poll that resolves after it.
+    if (get().isLoadingDevices) return
     set({ isLoadingDevices: true, error: null })
     try {
       const devices = await apiClient.getDevices(forceRefresh)
@@ -259,12 +262,14 @@ export const useAppStore = create<AppState>()((set, get) => ({
           }
         }
 
-        // Drop selectedDevice pointer if its device disappeared
-        const selectedStillPresent =
-          state.selectedDevice && devices.some(d => d.device_id === state.selectedDevice!.device_id)
-        const selectedDevice = selectedStillPresent
-          ? devices.find(d => d.device_id === state.selectedDevice!.device_id) || null
-          : null
+        // Only reconcile selectedDevice on a forced re-enumeration. The 5s poll
+        // can return a momentarily-stale cached list and must not silently null
+        // the user's selection.
+        let selectedDevice = state.selectedDevice
+        if (forceRefresh && state.selectedDevice) {
+          selectedDevice =
+            devices.find(d => d.device_id === state.selectedDevice!.device_id) || null
+        }
 
         return { devices, deviceStates: newDeviceStates, selectedDevice, isLoadingDevices: false }
       })

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
@@ -214,7 +214,7 @@ describe('API Client', () => {
   describe('Firmware', () => {
     it('fetches firmware status', async () => {
       server.use(
-        http.get('/api/v1/devices/:deviceId/status/', () => {
+        http.get('/api/v1/devices/:deviceId/status', () => {
           return HttpResponse.json({
             device_id: mockDevice.device_id,
             current: '5.16.0.1',

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
@@ -4,6 +4,18 @@ import { server } from '../../mocks/server'
 import { mockDeviceList, mockDevice } from '../../mocks/fixtures/devices'
 import { mockSensors, mockDepthOptions } from '../../mocks/fixtures/sensors'
 
+// Helper: capture the query string the apiClient sends on /devices/
+function captureDevicesQuery(): { current: string | null } {
+  const seen = { current: null as string | null }
+  server.use(
+    http.get('/api/v1/devices/', ({ request }) => {
+      seen.current = new URL(request.url).search
+      return HttpResponse.json(mockDeviceList)
+    })
+  )
+  return seen
+}
+
 // Note: apiClient is a singleton, so we need to import it fresh or reset state
 // For these tests, we'll test the API endpoints through MSW handlers
 
@@ -28,11 +40,29 @@ describe('API Client', () => {
     it('returns device properties correctly', async () => {
       const devices = await apiClient.getDevices()
       const device = devices.find((d: any) => d.device_id === mockDevice.device_id)
-      
+
       expect(device).toBeDefined()
       expect(device.name).toBe('RealSense D435')
       expect(device.serial_number).toBe('123456789')
       expect(device.firmware_version).toBe('5.16.0.1')
+    })
+
+    it('omits force_refresh from the query by default', async () => {
+      const seen = captureDevicesQuery()
+      await apiClient.getDevices()
+      expect(seen.current).toBe('')
+    })
+
+    it('omits force_refresh when forceRefresh=false', async () => {
+      const seen = captureDevicesQuery()
+      await apiClient.getDevices(false)
+      expect(seen.current).toBe('')
+    })
+
+    it('sends force_refresh=true when forceRefresh=true', async () => {
+      const seen = captureDevicesQuery()
+      await apiClient.getDevices(true)
+      expect(seen.current).toContain('force_refresh=true')
     })
   })
 

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/components/DevicePanel.test.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/components/DevicePanel.test.tsx
@@ -173,13 +173,36 @@ describe('DevicePanel', () => {
     it('calls fetchDevices when refresh is clicked', async () => {
       const fetchDevices = vi.fn().mockResolvedValue(undefined)
       useAppStore.setState({ fetchDevices })
-      
+
       render(<DevicePanel />)
-      
+
       const refreshButton = screen.getByTitle('Refresh devices')
       await userEvent.click(refreshButton)
-      
+
       expect(fetchDevices).toHaveBeenCalled()
+    })
+
+    it('passes forceRefresh=true when refresh is clicked manually', async () => {
+      const fetchDevices = vi.fn().mockResolvedValue(undefined)
+      useAppStore.setState({ fetchDevices })
+
+      render(<DevicePanel />)
+
+      const refreshButton = screen.getByLabelText('Refresh devices')
+      await userEvent.click(refreshButton)
+
+      // The polling effect also calls fetchDevices() with no args on mount.
+      // The manual-click call must explicitly pass true.
+      expect(fetchDevices).toHaveBeenCalledWith(true)
+    })
+
+    it('is disabled while a fetch is in flight', () => {
+      useAppStore.setState({ isLoadingDevices: true })
+
+      render(<DevicePanel />)
+
+      const refreshButton = screen.getByLabelText('Refreshing devices…')
+      expect(refreshButton).toBeDisabled()
     })
   })
 

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/components/DevicePanel.test.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/components/DevicePanel.test.tsx
@@ -197,9 +197,12 @@ describe('DevicePanel', () => {
     })
 
     it('is disabled while a fetch is in flight', () => {
-      useAppStore.setState({ isLoadingDevices: true })
-
-      render(<DevicePanel />)
+      // Must use initialStoreState (not pre-render setState) because
+      // renderWithProviders calls resetStore() first, which would reset
+      // isLoadingDevices back to false.
+      render(<DevicePanel />, {
+        initialStoreState: { isLoadingDevices: true },
+      })
 
       const refreshButton = screen.getByLabelText('Refreshing devices…')
       expect(refreshButton).toBeDisabled()

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/components/StreamViewer.test.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/components/StreamViewer.test.tsx
@@ -29,7 +29,10 @@ describe('StreamViewer', () => {
       const device = createMockDevice()
       const deviceState = createMockDeviceState(device, {
         isActive: true,
-        streamConfigs: [createMockStreamConfig({ enabled: false })],
+        // Use `enable` (singular) — the actual StreamConfig field name. The
+        // mock factory defaults `enable: true`, so the wrong field name leaves
+        // the stream enabled and the empty-state branch never renders.
+        streamConfigs: [createMockStreamConfig({ enable: false })],
       })
       
       render(<StreamViewer />, {

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../mocks/server'
 import { useAppStore } from '@/store'
 import { resetStore, createMockDevice, createMockDeviceState, createMockSensor, createMockOption } from '../../utils/test-utils'
 
@@ -246,6 +248,64 @@ describe('AppStore', () => {
       })
       
       expect(useAppStore.getState().isAnyDeviceStreaming()).toBe(false)
+    })
+  })
+
+  describe('fetchDevices', () => {
+    const presentDevice = createMockDevice({ device_id: 'present-1', serial_number: 'present-1' })
+    const goneDevice = createMockDevice({ device_id: 'gone-1', serial_number: 'gone-1' })
+
+    function mockDevicesEndpoint(list: ReturnType<typeof createMockDevice>[]) {
+      server.use(
+        http.get('/api/v1/devices/', () => HttpResponse.json(list))
+      )
+    }
+
+    it('clears selectedDevice on forceRefresh when its device disappeared', async () => {
+      useAppStore.setState({ selectedDevice: goneDevice, hasUserInteracted: true })
+      mockDevicesEndpoint([presentDevice])
+
+      await useAppStore.getState().fetchDevices(true)
+
+      expect(useAppStore.getState().selectedDevice).toBeNull()
+    })
+
+    it('keeps selectedDevice on forceRefresh when its device is still present', async () => {
+      useAppStore.setState({ selectedDevice: presentDevice, hasUserInteracted: true })
+      mockDevicesEndpoint([presentDevice])
+
+      await useAppStore.getState().fetchDevices(true)
+
+      expect(useAppStore.getState().selectedDevice?.device_id).toBe(presentDevice.device_id)
+    })
+
+    it('does NOT clear selectedDevice on the polling path even if the cached list omits it', async () => {
+      // Simulates a transient cache hiccup: poll returns a list missing the selected device.
+      useAppStore.setState({ selectedDevice: goneDevice, hasUserInteracted: true })
+      mockDevicesEndpoint([presentDevice])
+
+      await useAppStore.getState().fetchDevices(/* default false */)
+
+      expect(useAppStore.getState().selectedDevice?.device_id).toBe(goneDevice.device_id)
+    })
+
+    it('guards against concurrent fetches', async () => {
+      let calls = 0
+      server.use(
+        http.get('/api/v1/devices/', async () => {
+          calls += 1
+          // Hold the response so the second call overlaps the first.
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          return HttpResponse.json([presentDevice])
+        })
+      )
+
+      const first = useAppStore.getState().fetchDevices(true)
+      // Second call starts while the first is still in flight → must short-circuit.
+      const second = useAppStore.getState().fetchDevices(true)
+      await Promise.all([first, second])
+
+      expect(calls).toBe(1)
     })
   })
 

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
@@ -21,10 +21,10 @@ describe('AppStore', () => {
       expect(state.error).toBeNull()
     })
 
-    it('starts with grid view mode', () => {
+    it('starts in 2d view mode', () => {
       const state = useAppStore.getState()
-      
-      expect(state.viewMode).toBe('grid')
+
+      expect(state.viewMode).toBe('2d')
     })
 
     it('starts with chat closed', () => {

--- a/wrappers/rest-api/tools/react-viewer/tests/utils/test-utils.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/utils/test-utils.tsx
@@ -150,6 +150,9 @@ export function renderWithProviders(
   }
 }
 
-// Re-export everything from React Testing Library except render (avoid duplicate export)
+// Re-export everything from React Testing Library, but alias the wrapped
+// `renderWithProviders` as `render` so tests that import `render` from this
+// module get the version that honours `initialStoreState`. The explicit
+// named export takes precedence over the one re-exported by `export *`.
 export * from '@testing-library/react'
-export { renderWithProviders }
+export { renderWithProviders as render }


### PR DESCRIPTION
**TL;DR:** Fix the React Viewer Refresh button so it actually re-enumerates devices on the backend instead of returning the cached list.

Tracked on [RSDEV-11351]

## Summary
- `apiClient.getDevices(forceRefresh)` now sends `?force_refresh=true` when requested.
- `store.fetchDevices(forceRefresh?)` forwards the flag, early-returns if a fetch is already in flight (concurrent-call guard), and only reconciles `selectedDevice` on the forced-refresh path so the cached 5s poll cannot null the user selection.
- `DevicePanel` Refresh button calls `fetchDevices(true)`; the 5s polling effect still uses the cached path so it does not hammer the device. Button is disabled while a fetch is in flight, with a dynamic `aria-label` (and matching `title`) plus `aria-busy`.

## Why
The backend `GET /devices/` short-circuits to the cached enumeration unless `force_refresh=true` is passed. The frontend never passed it, so clicking Refresh was effectively a no-op — newly connected devices did not appear and disconnected ones lingered until the next process restart.

Preserved by the existing `fetchDevices` merge logic (still verified):
- Devices missing from the new list have their state dropped.
- For still-present devices, `isActive` / `isStreaming` / sensors / options / streamConfigs are kept; `device` + `firmware` are refreshed.
- Backend `refresh_devices()` already keeps streaming devices intact.

Hot-plug auto-refresh remains out of scope per the ticket.

## Test infrastructure
The new unit tests required unblocking `tests/utils/test-utils.tsx`, which had a duplicate `renderWithProviders` export that prevented several test files from loading at all. Restored the obvious intent (`export { renderWithProviders as render }`, per the comment in the file) so those files run again. Doing so surfaced a handful of latent pre-existing test failures that had been hidden by the parse error — fixed them in passing since they were tiny and unrelated to the Refresh work:
- `client.test.ts > Firmware`: MSW override path `/status/` corrected to `/status` to match the client request.
- `store.test.ts > Initial State`: assertion updated from `'grid'` to `'2d'` to match the actual store default.
- `StreamViewer.test.tsx > Empty State`: mock used `enabled: false` instead of the real field name `enable: false`, so the stream was never disabled in the test.

## New tests for this change
- `client.test.ts > getDevices` (×3): default/false/true query-string assertions.
- `store.test.ts > fetchDevices` (×4): selectedDevice cleared on forced refresh when missing, preserved when present, untouched on the polling path, and concurrent calls collapse to one network request.
- `DevicePanel.test.tsx > Refresh Button` (×2): manual click passes `true`, button is disabled while loading.

## Test plan
- [x] Manual: `npm run dev`, click Refresh, confirm `force_refresh=true` in DevTools.
- [x] Manual: unplug a device + click Refresh -> drops from list.
- [x] Manual: with an active/streaming device still present, click Refresh -> activation and streaming survive.
- [x] `npm test` green locally.
- [ ] CI build green.