### PR TITLE
Realsense-Viewer Viewport Grid Overlay

### DIFF
--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -63,3 +63,4 @@ option(USE_EXTERNAL_LZ4 "Use externally build LZ4 library instead of building an
 option(BUILD_ASAN "Enable AddressSanitizer" OFF)
 option(BUILD_ROSBAG2 "Build and use rosbag2 recording system" ON) # temporary flag, should be removed when deprecated ROSBAG1 recording system is removed
 mark_as_advanced(BUILD_ASAN)
+option(BUILD_VIEWPORT_GRID_OVERLAY "Build 2D viewport grid overlay for realsense-viewer (configurable via config-settings.xml)" OFF)

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -150,6 +150,17 @@ namespace rs2
             static const char* lpc_point_size{ "viewer_model.lpc_point_size" };
             static const char* show_safety_zones_3d{ "viewer_model.show_safety_zones_3d" };
             static const char* show_safety_zones_2d{ "viewer_model.show_safety_zones_2d" };
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+            namespace viewport_grid
+            {
+                static const char* horizontal_lines{ "viewer_model.grid.horizontal_lines" };
+                static const char* vertical_lines  { "viewer_model.grid.vertical_lines"   };
+                static const char* line_width      { "viewer_model.grid.line_width"        };
+                static const char* line_color_r    { "viewer_model.grid.line_color_r"      };
+                static const char* line_color_g    { "viewer_model.grid.line_color_g"      };
+                static const char* line_color_b    { "viewer_model.grid.line_color_b"      };
+            }
+#endif
         }
         namespace window
         {

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -96,7 +96,6 @@ config_file::config_file( std::string const & filename )
     }
     catch(...)
     {
-
     }
 }
 

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -78,12 +78,14 @@ namespace rs2
         }
 
         bool contains(const char* key) const;
-        
+
         void save(const char* filename);
 
         void reset();
 
         void remove(const char* key);
+
+        bool is_new_file() const { return _j.empty(); }
 
         static config_file& instance();
 

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -7,6 +7,10 @@
 #include "os.h"
 #include <imgui_internal.h>
 #include <realsense_imgui.h>
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+#include <iomanip>
+#include <sstream>
+#endif
 
 struct attribute
 {
@@ -28,6 +32,23 @@ namespace rs2
             configurations::viewer::show_stream_details, false);
         show_safety_zones_2d = config_file::instance().get_or_default(
             configurations::viewer::show_safety_zones_2d, true);
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+        {
+            namespace cfg = configurations::viewer::viewport_grid;
+            auto& cf = config_file::instance();
+
+            auto valid_lines = []( int v ) { return ( v >= 1 && v <= 5 ) ? v : 1; };
+            grid_h_lines    = valid_lines( cf.get_nested<int>( cfg::horizontal_lines, 1   ) );
+            grid_v_lines    = valid_lines( cf.get_nested<int>( cfg::vertical_lines,   1   ) );
+            int w           = cf.get_nested<int>( cfg::line_width, 1 );
+            if ( w >= 1 ) grid_line_width = w;
+            int r = cf.get_nested<int>( cfg::line_color_r, 255 );
+            int g = cf.get_nested<int>( cfg::line_color_g, 255 );
+            int b = cf.get_nested<int>( cfg::line_color_b, 255 );
+            if ( r >= 0 && r <= 255 && g >= 0 && g <= 255 && b >= 0 && b <= 255 )
+            { grid_color_r = r; grid_color_g = g; grid_color_b = b; }
+        }
+#endif
     }
 
     std::shared_ptr<texture_buffer> stream_model::upload_frame(frame&& f)
@@ -130,6 +151,34 @@ namespace rs2
 
         glPopAttrib();
     }
+
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+    static void draw_2d_grid(const rect& r, int h_lines, int v_lines, int line_width,
+                              int cr, int cg, int cb)
+    {
+        glPushAttrib(GL_ENABLE_BIT | GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_CURRENT_BIT);
+        glLineWidth(static_cast<GLfloat>(line_width));
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glColor4f(cr / 255.f, cg / 255.f, cb / 255.f, 0.7f);
+        glBegin(GL_LINES);
+        for (int c = 1; c <= v_lines; ++c)
+        {
+            float x = r.x + r.w * c / static_cast<float>(v_lines + 1);
+            glVertex2f(x, r.y);
+            glVertex2f(x, r.y + r.h);
+        }
+        for (int row = 1; row <= h_lines; ++row)
+        {
+            float y = r.y + r.h * row / static_cast<float>(h_lines + 1);
+            glVertex2f(r.x, y);
+            glVertex2f(r.x + r.w, y);
+        }
+        glEnd();
+        glPopAttrib();
+    }
+
+#endif
 
     bool stream_model::is_stream_visible() const
     {
@@ -413,6 +462,9 @@ namespace rs2
         if (RS2_STREAM_DEPTH == profile.stream_type()) ++num_of_buttons; // Color map ruler button
         if (RS2_FORMAT_MOTION_XYZ32F == profile.format()) ++num_of_buttons; // Motion graph button
         if (RS2_STREAM_OCCUPANCY == profile.stream_type() && _normalized_zoom.w == 1) ++num_of_buttons; // Safety zones button
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+        ++num_of_buttons; // Grid overlay button
+#endif
 
         RsImGui_ScopePushFont(font);
         ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
@@ -547,6 +599,33 @@ namespace rs2
             }
         }
         ImGui::SameLine();
+
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+        label = rsutils::string::from() << textual_icons::grid << "##Grid " << profile.unique_id();
+        if (show_grid)
+        {
+            ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
+            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
+            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            {
+                show_grid = false;
+            }
+            if (ImGui::IsItemHovered())
+                RsImGui::CustomTooltip("Hide grid overlay");
+            ImGui::PopStyleColor(2);
+        }
+        else
+        {
+            if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+            {
+                show_grid = true;
+            }
+            if (ImGui::IsItemHovered())
+                RsImGui::CustomTooltip("Show grid overlay");
+        }
+        ImGui::SameLine();
+#endif
+
 
         if (RS2_STREAM_DEPTH == profile.stream_type())
         {
@@ -2036,6 +2115,13 @@ namespace rs2
             }
 
             update_ae_roi_rect(stream_rect, g, error_message);
+
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+            if (show_grid)
+                draw_2d_grid(stream_rect, grid_h_lines, grid_v_lines, grid_line_width,
+                             grid_color_r, grid_color_g, grid_color_b);
+#endif
+
         }
         texture->show_preview(stream_rect, _normalized_zoom);
 

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -106,6 +106,16 @@ namespace rs2
         bool show_metadata = false;
         bool show_safety_zones_2d = true;
 
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+        bool show_grid     = false;
+        int  grid_h_lines  = 1;
+        int  grid_v_lines  = 1;
+        int  grid_line_width = 1;
+        int  grid_color_r  = 255;
+        int  grid_color_g  = 255;
+        int  grid_color_b  = 255;
+#endif
+
         std::shared_ptr<graph_model> graph;
         bool show_graph = false;
         bool graph_initialized = false;

--- a/common/textual-icons.h
+++ b/common/textual-icons.h
@@ -34,6 +34,7 @@ namespace rs2
         // A note to a maintainer - preserve order when adding values to avoid duplicates
         static const textual_icon search{ u8"\uf002" };
         static const textual_icon file_movie{ u8"\uf008" };
+        static const textual_icon grid{ u8"\uf00a" };  // fa-th: 3x3 grid of squares (viewport grid overlay)
         static const textual_icon check{ u8"\uf00c" };
         static const textual_icon times{ u8"\uf00d" };
         static const textual_icon power_off{ u8"\uf011" };

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -87,6 +87,20 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::commands_xml, "./Commands.xml");
         config_file::instance().set_default(configurations::viewer::hwlogger_xml, "./HWLoggerEvents.xml");
 
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+        if( config_file::instance().is_new_file() )
+        {
+            namespace cfg = configurations::viewer::viewport_grid;
+            auto& cf = config_file::instance();
+            cf.set_nested( cfg::horizontal_lines, 1   );
+            cf.set_nested( cfg::vertical_lines,   1   );
+            cf.set_nested( cfg::line_width,       1   );
+            cf.set_nested( cfg::line_color_r,     255 );
+            cf.set_nested( cfg::line_color_g,     255 );
+            cf.set_nested( cfg::line_color_b,     255 );
+        }
+#endif
+
         std::string path;
         try
         {

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2983,6 +2983,17 @@ namespace rs2
                     {
                         reload_required = true;
                         temp_cfg = config_file();
+#ifdef BUILD_VIEWPORT_GRID_OVERLAY
+                        {
+                            namespace cfg = configurations::viewer::viewport_grid;
+                            temp_cfg.set_nested( cfg::horizontal_lines, 1   );
+                            temp_cfg.set_nested( cfg::vertical_lines,   1   );
+                            temp_cfg.set_nested( cfg::line_width,       1   );
+                            temp_cfg.set_nested( cfg::line_color_r,     255 );
+                            temp_cfg.set_nested( cfg::line_color_g,     255 );
+                            temp_cfg.set_nested( cfg::line_color_b,     255 );
+                        }
+#endif
                     }
                     ImGui::SameLine();
                     if (ImGui::Button(" Export Settings "))

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -256,6 +256,11 @@ if(OPENVINO_NGRAPH)
     target_compile_definitions(realsense-viewer PRIVATE OPENVINO_NGRAPH)
 endif()
 
+if(BUILD_VIEWPORT_GRID_OVERLAY)
+    message(STATUS "Viewport grid overlay enabled for realsense-viewer")
+    target_compile_definitions(realsense-viewer PRIVATE BUILD_VIEWPORT_GRID_OVERLAY)
+endif()
+
 source_group("SW-Update" FILES ${SW_UPDATE_FILES})
 
 include_directories(


### PR DESCRIPTION
Realsense-Viewer -- Viewport Grid Overlay

Developer-level feature for viewport segmentation.

## Feature: Viewport Grid Overlay

Compiled on-demand with default=off via CMake flag `BUILD_VIEWPORT_GRID_OVERLAY=ON`.

A new toggle button appears in the stream header bar to toggle 2D grid lines over the video viewport.

Grid configuration is loaded from `%APPDATA%\realsense-config.json`:
- Number of rows/columns (1-5)
- Grid color (RGB)
- Line width (pixels)

Values outside the valid range are replaced by defaults. Missing file or invalid values fall back to defaults.

Supersedes #15090.