### PR TITLE
rspy: bump wait_until_all_ports_disabled default to 10s for DDS removal

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -156,9 +156,12 @@ class Device:
         return self._is_dds
 
 
-def wait_until_all_ports_disabled( timeout = 5 ):
+def wait_until_all_ports_disabled( timeout = 10 ):
     """
-    Waits for all ports to be disabled
+    Waits for all ports to be disabled.
+    Default 10s accommodates DDS devices (e.g. D555 over PoE), whose removal is
+    only detected after the DDS participant lease (3s) expires past the last
+    announcement (1.5s cycle).
     """
     for retry in range( timeout ):
         if len( enabled() ) == 0:

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -37,6 +37,12 @@ sys.path.insert( 1, pyrs_dir )
 
 MAX_ENUMERATION_TIME = 20  # [sec]
 
+# Worst-case device removal delay after port disable / hw_reset.
+# DDS devices (e.g. D555 over PoE) are only declared gone after the participant
+# lease (3s) expires past the last announcement (1.5s cycle), plus propagation
+# latency in the device-changed callback. Observed on D555/PoE: ~8s after PoE cut.
+PORTS_DISABLED_TIMEOUT = 10  # [sec]
+
 # We need both pyrealsense2 and hub. We can work without hub, but
 # without pyrealsense2 no devices at all will be returned.
 from rspy import device_hub
@@ -156,17 +162,16 @@ class Device:
         return self._is_dds
 
 
-def wait_until_all_ports_disabled( timeout = 10 ):
+def wait_until_all_ports_disabled( timeout = PORTS_DISABLED_TIMEOUT ):
     """
     Waits for all ports to be disabled.
-    Default 10s accommodates DDS devices (e.g. D555 over PoE), whose removal is
-    only detected after the DDS participant lease (3s) expires past the last
-    announcement (1.5s cycle).
     """
     for retry in range( timeout ):
         if len( enabled() ) == 0:
             return True
         time.sleep( 1 )
+    if len( enabled() ) == 0:
+        return True
     log.w( 'Timed out waiting for 0 devices' )
     return False
 
@@ -654,7 +659,7 @@ def enable_all():
     hub.enable_ports()
 
 
-def _wait_until_removed( serial_numbers, timeout = 5 ):
+def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):
     """
     Wait until the given serial numbers are all offline
 


### PR DESCRIPTION
## TL;DR
Bump `wait_until_all_ports_disabled()` default timeout from 5s to 10s so D555 (DDS over PoE) has time to drop after the Unifi switch cuts power.

## Background
On nightly builds we saw

```
14:06:24 -D- Disabling ports all on Unifi Switch
14:06:29 -W- Timed out waiting for 0 devices    (5.3s after disable)
14:06:32 -D- device removed: 343622300739       (D555 — 7.8s after disable)
```

D555 is an Ethernet-only camera powered through the Unifi PoE switch. Even after PoE is cut, librealsense only sees the device as removed once the DDS participant lease expires:

- `dds-participant.cpp`: `leaseDuration = 3.0s`, `leaseDuration_announcementperiod = 1.5s`
- Worst case: ~4.5s at the protocol level + propagation latency in the device-changed callback.

So the 5s default has always been borderline for DDS devices; we only avoided the warning by luck of announcement timing. With more frequent DDS use this is now firing routinely.

## Change
`unit-tests/py/rspy/devices.py`: default timeout `5 → 10`. All call sites use the default, so the bump applies uniformly. Added a comment explaining the DDS rationale.

