### PR TITLE
multidev streaming test: enable librealsense debug logging to console

### DIFF
--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -318,6 +318,7 @@ def test_multi_stream_operation(test_devices):
       Phase 1: depth + IR only (no color)
       Phase 2: depth + IR + color
     """
+    rs.log_to_console(rs.log_severity.debug)
     device_list, ctx = test_devices
 
     log.info("=" * 80)


### PR DESCRIPTION
Follow-up to #15084. Adds `rs.log_to_console(rs.log_severity.debug)` at the start of `test_multi_stream_operation` so the SDK's internal debug logs (including any `Dropped frame. alloc_frame(...) returned nullptr` host-queue-saturation events) are captured in the per-test log when the test runs.

Motivation: the test FAILED again on rsdsk254 (Windows) in nightly #16029 (both attempts), matching the prior pattern from #15914 and #15935. The depth-drop magnitude (78-93% on D435/D455 phase 2) points at host-queue starvation rather than pure USB ISOC loss, but we need the SDK debug log from rsdsk254 to confirm.