### PR TITLE
react-viewer: enable 3D point cloud view (RSDEV-9239)

### DIFF
--- a/wrappers/rest-api/app/services/metadata_socket_server.py
+++ b/wrappers/rest-api/app/services/metadata_socket_server.py
@@ -82,12 +82,18 @@ class MetadataSocketServer:
                             # copy before encoding/dropping to avoid corrupting it for the next read.
                             metadata = {**metadata}
                             if send_point_cloud:
-                                metadata["point_cloud"] = {
-                                    **metadata["point_cloud"],
+                                pc_src = metadata["point_cloud"]
+                                pc_encoded = {
+                                    **pc_src,
                                     "vertices": base64.b64encode(
-                                        metadata["point_cloud"]["vertices"].tobytes()
+                                        pc_src["vertices"].tobytes()
                                     ).decode("utf-8"),
                                 }
+                                if "colors" in pc_src and pc_src["colors"] is not None:
+                                    pc_encoded["colors"] = base64.b64encode(
+                                        pc_src["colors"].tobytes()
+                                    ).decode("utf-8")
+                                metadata["point_cloud"] = pc_encoded
                             else:
                                 del metadata["point_cloud"]
                         all_metadata[stream_type] = metadata

--- a/wrappers/rest-api/app/services/metadata_socket_server.py
+++ b/wrappers/rest-api/app/services/metadata_socket_server.py
@@ -78,10 +78,16 @@ class MetadataSocketServer:
                             and "point_cloud" in metadata
                             and "vertices" in metadata["point_cloud"]
                         ):
+                            # get_latest_metadata returns the cached dict by reference;
+                            # copy before encoding/dropping to avoid corrupting it for the next read.
+                            metadata = {**metadata}
                             if send_point_cloud:
-                                metadata["point_cloud"]["vertices"] = base64.b64encode(
-                                    metadata["point_cloud"]["vertices"].tobytes()
-                                ).decode("utf-8")
+                                metadata["point_cloud"] = {
+                                    **metadata["point_cloud"],
+                                    "vertices": base64.b64encode(
+                                        metadata["point_cloud"]["vertices"].tobytes()
+                                    ).decode("utf-8"),
+                                }
                             else:
                                 del metadata["point_cloud"]
                         all_metadata[stream_type] = metadata

--- a/wrappers/rest-api/app/services/metadata_socket_server.py
+++ b/wrappers/rest-api/app/services/metadata_socket_server.py
@@ -28,7 +28,6 @@ class MetadataSocketServer:
         self._stop_events: Dict[str, threading.Event] = {}
         self._lock = threading.Lock()
         self._point_cloud_throttle = max(1, point_cloud_throttle)
-        self._broadcast_count = 0
 
     def _emit_event(self, event_name, data):
         """Helper method to handle emit for both sync and async server types"""
@@ -45,6 +44,11 @@ class MetadataSocketServer:
     def _broadcast_metadata_loop(self, device_id, stop_event):
         """The core loop that fetches and broadcasts metadata."""
         print(f"[MetadataBroadcaster] Starting broadcast loop for {device_id}...")
+
+        # Per-loop counter so each device's throttle is independent — a shared
+        # instance counter would race across per-device broadcaster threads and
+        # make the point-cloud "every Nth tick" pattern non-deterministic.
+        broadcast_count = 0
 
         while not stop_event.is_set():
             start_time = time.monotonic()
@@ -63,8 +67,8 @@ class MetadataSocketServer:
                 )
                 active_streams = []
 
-            self._broadcast_count += 1
-            send_point_cloud = (self._broadcast_count % self._point_cloud_throttle) == 0
+            broadcast_count += 1
+            send_point_cloud = (broadcast_count % self._point_cloud_throttle) == 0
 
             all_metadata: Dict[str, Optional[Dict]] = {}
             if is_streaming and active_streams:

--- a/wrappers/rest-api/app/services/metadata_socket_server.py
+++ b/wrappers/rest-api/app/services/metadata_socket_server.py
@@ -19,6 +19,7 @@ class MetadataSocketServer:
         sio,  # Can be either socketio.Server or socketio.AsyncServer
         rs_manager,
         update_interval: float = 1.0/30.0,  # Default to 30 FPS
+        point_cloud_throttle: int = 3,  # Include point_cloud every Nth broadcast (30/3 = 10 FPS)
     ):
         self._sio = sio
         self._rs_manager = rs_manager
@@ -26,6 +27,8 @@ class MetadataSocketServer:
         self._threads: Dict[str, threading.Thread] = {}
         self._stop_events: Dict[str, threading.Event] = {}
         self._lock = threading.Lock()
+        self._point_cloud_throttle = max(1, point_cloud_throttle)
+        self._broadcast_count = 0
 
     def _emit_event(self, event_name, data):
         """Helper method to handle emit for both sync and async server types"""
@@ -60,6 +63,9 @@ class MetadataSocketServer:
                 )
                 active_streams = []
 
+            self._broadcast_count += 1
+            send_point_cloud = (self._broadcast_count % self._point_cloud_throttle) == 0
+
             all_metadata: Dict[str, Optional[Dict]] = {}
             if is_streaming and active_streams:
                 for stream_type in active_streams:
@@ -72,9 +78,12 @@ class MetadataSocketServer:
                             and "point_cloud" in metadata
                             and "vertices" in metadata["point_cloud"]
                         ):
-                            metadata["point_cloud"]["vertices"] = base64.b64encode(
-                                metadata["point_cloud"]["vertices"].tobytes()
-                            ).decode("utf-8")
+                            if send_point_cloud:
+                                metadata["point_cloud"]["vertices"] = base64.b64encode(
+                                    metadata["point_cloud"]["vertices"].tobytes()
+                                ).decode("utf-8")
+                            else:
+                                del metadata["point_cloud"]
                         all_metadata[stream_type] = metadata
                     except Exception as e:
                         if hasattr(e, "status_code"):

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -1820,6 +1820,7 @@ class RealSenseManager:
                                 v, t = points.get_vertices(), points.get_texture_coordinates()
                                 verts = np.asanyarray(v).view(np.float32).reshape(-1, 3)
                                 verts = verts[verts[:, 2] >= 0.03]  # Filter out z < 0.03
+                                verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
                                 metadata["point_cloud"] = {"vertices": verts, "texture_coordinates": []}
 
                             # Store processed frame and metadata
@@ -2122,6 +2123,14 @@ class RealSenseManager:
             colorized = colorizer.colorize(depth_frame)
             processed_frame = np.asanyarray(colorized.get_data())
             info_source = depth_frame
+
+            if self.is_pointcloud_enabled.get(device_id, False):
+                points = self.pc.calculate(depth_frame)
+                if points:
+                    verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
+                    verts = verts[verts[:, 2] >= 0.03]
+                    verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
+                    metadata["point_cloud"] = {"vertices": verts, "texture_coordinates": []}
 
         elif "color" in frame_stream_name:
             color_frame = frame.as_video_frame()

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -1713,6 +1713,20 @@ class RealSenseManager:
                 continue
         return attrs
 
+    def _build_point_cloud_metadata(self, depth_frame) -> Optional[Dict]:
+        """Compute decimated point-cloud vertices from a depth frame, ready for serialization.
+
+        Returns None if calculate() yields nothing. Used by both the pipeline-mode
+        frame collector and the sensor-mode frame processor.
+        """
+        points = self.pc.calculate(depth_frame)
+        if not points:
+            return None
+        verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
+        verts = verts[verts[:, 2] >= 0.03]  # drop invalid near-camera points
+        verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
+        return {"vertices": verts, "texture_coordinates": []}
+
     def _collect_frames(self, device_id: str, align_processor=None):
         """Thread function to collect frames from the pipeline"""
         logging.debug("[INFO] Frame collection thread started for device %s", device_id)
@@ -1754,8 +1768,7 @@ class RealSenseManager:
                         try:
                             frame = None
                             frame_data = None
-                            points = None
-                            
+
                             # Use the rs_stream enum directly for comparison
                             if rs_stream == rs.stream.depth:
                                 frame_data = frames.get_depth_frame()
@@ -1766,8 +1779,6 @@ class RealSenseManager:
                                     self.depth_frames[device_id] = frame_data
                                     colorized = colorizer.colorize(frame_data)
                                     frame = np.asanyarray(colorized.get_data())
-                                    if self.is_pointcloud_enabled.get(device_id, False):
-                                        points = self.pc.calculate(frame_data)
                             elif rs_stream == rs.stream.color:
                                 frame_data = frames.get_color_frame()
                                 if frame_data:
@@ -1816,12 +1827,10 @@ class RealSenseManager:
                                 if motion_json_data:
                                     metadata["motion_data"] = motion_json_data
 
-                            if points:
-                                v, t = points.get_vertices(), points.get_texture_coordinates()
-                                verts = np.asanyarray(v).view(np.float32).reshape(-1, 3)
-                                verts = verts[verts[:, 2] >= 0.03]  # Filter out z < 0.03
-                                verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
-                                metadata["point_cloud"] = {"vertices": verts, "texture_coordinates": []}
+                            if rs_stream == rs.stream.depth and self.is_pointcloud_enabled.get(device_id, False):
+                                pc_meta = self._build_point_cloud_metadata(frame_data)
+                                if pc_meta:
+                                    metadata["point_cloud"] = pc_meta
 
                             # Store processed frame and metadata
                             processed_frames[active_stream] = frame
@@ -2125,12 +2134,9 @@ class RealSenseManager:
             info_source = depth_frame
 
             if self.is_pointcloud_enabled.get(device_id, False):
-                points = self.pc.calculate(depth_frame)
-                if points:
-                    verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
-                    verts = verts[verts[:, 2] >= 0.03]
-                    verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
-                    metadata["point_cloud"] = {"vertices": verts, "texture_coordinates": []}
+                pc_meta = self._build_point_cloud_metadata(depth_frame)
+                if pc_meta:
+                    metadata["point_cloud"] = pc_meta
 
         elif "color" in frame_stream_name:
             color_frame = frame.as_video_frame()

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -60,7 +60,10 @@ class RealSenseManager:
         self.lock = threading.Lock()
         self.max_queue_size = 5
         self.is_pointcloud_enabled: Dict[str, bool] = {}
-        self.pc = rs.pointcloud()
+        # One rs.pointcloud() per device: pc.map_to(color) mutates internal
+        # state, and depth/color threads from different devices would race on
+        # a shared instance (texturing device A's cloud with device B's color).
+        self.point_clouds: Dict[str, "rs.pointcloud"] = {}
 
         # Caches for pipeline/config reuse to reduce startup cost
         self.config_cache: Dict[str, Dict[str, rs.config]] = {}  # device -> signature -> config
@@ -149,6 +152,7 @@ class RealSenseManager:
         self.metadata_queues.pop(serial, None)
         self.depth_frames.pop(serial, None)
         self.color_frames.pop(serial, None)
+        self.point_clouds.pop(serial, None)
         self.devices.pop(serial, None)
         self.device_infos.pop(serial, None)
         self._supported_md_by_profile.pop(serial, None)
@@ -1481,6 +1485,8 @@ class RealSenseManager:
                     self.pipeline_signatures.pop(device_id, None)
                     self.frame_queues.pop(device_id, None)
                     self.metadata_queues.pop(device_id, None)
+                    self.color_frames.pop(device_id, None)
+                    self.point_clouds.pop(device_id, None)
                     self._supported_md_by_profile.pop(device_id, None)
                     self.stopping.discard(device_id)
                     # Reset streaming mode to idle
@@ -1723,7 +1729,7 @@ class RealSenseManager:
     # stays roughly constant regardless of stream resolution.
     POINT_CLOUD_MAX_VERTICES = 60000
 
-    def _build_point_cloud_metadata(self, depth_frame, color_frame=None) -> Optional[Dict]:
+    def _build_point_cloud_metadata(self, device_id: str, depth_frame, color_frame=None) -> Optional[Dict]:
         """Compute decimated point-cloud vertices from a depth frame, ready for serialization.
 
         When ``color_frame`` is supplied and it's an RGB8/BGR8 frame, this also
@@ -1732,15 +1738,22 @@ class RealSenseManager:
         point cloud rendering. The client falls back to a depth colormap when
         ``colors`` is absent.
 
+        Uses a per-device ``rs.pointcloud`` so map_to()/calculate() can't race
+        across devices.
+
         Returns None if calculate() yields nothing. Used by both the pipeline-mode
         frame collector and the sensor-mode frame processor.
         """
+        pc = self.point_clouds.get(device_id)
+        if pc is None:
+            pc = rs.pointcloud()
+            self.point_clouds[device_id] = pc
         if color_frame:
             try:
-                self.pc.map_to(color_frame)
+                pc.map_to(color_frame)
             except Exception:
                 color_frame = None  # not all profiles support map_to; fall back silently
-        points = self.pc.calculate(depth_frame)
+        points = pc.calculate(depth_frame)
         if not points:
             return None
         verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
@@ -1932,7 +1945,7 @@ class RealSenseManager:
                                 # parity). get_color_frame() returns an empty
                                 # falsy frame when no color stream is enabled.
                                 color_for_texture = frames.get_color_frame() or None
-                                pc_meta = self._build_point_cloud_metadata(frame_data, color_for_texture)
+                                pc_meta = self._build_point_cloud_metadata(device_id, frame_data, color_for_texture)
                                 if pc_meta:
                                     metadata["point_cloud"] = pc_meta
 
@@ -1985,6 +1998,8 @@ class RealSenseManager:
                             del self.metadata_queues[device_id]
                         if device_id in self.depth_frames:
                             del self.depth_frames[device_id]
+                        self.color_frames.pop(device_id, None)
+                        self.point_clouds.pop(device_id, None)
                         self._supported_md_by_profile.pop(device_id, None)
                         if device_id in self.device_infos:
                             self.device_infos[device_id].is_streaming = False
@@ -2248,7 +2263,7 @@ class RealSenseManager:
                     if self._is_color_streaming(device_id)
                     else None
                 )
-                pc_meta = self._build_point_cloud_metadata(depth_frame, color_for_texture)
+                pc_meta = self._build_point_cloud_metadata(device_id, depth_frame, color_for_texture)
                 if pc_meta:
                     metadata["point_cloud"] = pc_meta
 
@@ -2607,6 +2622,13 @@ class RealSenseManager:
                 self.sensor_rs_queues[device_id].pop(sensor_id, None)
                 if not self.sensor_rs_queues[device_id]:
                     del self.sensor_rs_queues[device_id]
+
+            if last_sensor_stopped:
+                # Free the cached color frame + per-device rs.pointcloud now
+                # that the device's depth thread is gone; otherwise the last
+                # frame stays pinned in the SDK pool until device removal.
+                self.color_frames.pop(device_id, None)
+                self.point_clouds.pop(device_id, None)
 
         # Stop the per-device metadata broadcaster once the last sensor on this
         # device has stopped.

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -7,7 +7,8 @@ import struct
 import threading
 import time
 import logging
-from typing import Callable, Dict, List, Optional, Any, Tuple, Set
+from collections import deque
+from typing import Callable, Deque, Dict, List, Optional, Any, Tuple, Set
 import pyrealsense2 as rs
 import numpy as np
 import cv2
@@ -31,6 +32,12 @@ from app.services.metadata_socket_server import MetadataSocketServer
 _IS_WINDOWS = platform.system() == "Windows"
 
 FW_STATUS_UNKNOWN = "unknown"
+
+# Recent color frames retained per device for texturing the 3D point cloud.
+# Five frames at 30 fps covers the typical depth/color SDK-latency offset
+# (~one capture interval); the picker selects the entry whose timestamp is
+# closest to the depth frame being processed.
+COLOR_FRAME_HISTORY = 5
 
 
 class RealSenseManager:
@@ -78,14 +85,15 @@ class RealSenseManager:
 
         # Short history of recent color frames per device for texturing the
         # 3D point cloud. Sensor-mode runs depth/color on independent threads
-        # so the depth thread looks up the most recent matching color frame
-        # here. Matching uses the hardware FRAME_TIMESTAMP metadata
-        # (device-side capture clock), not get_timestamp() — get_timestamp()
-        # can be in different domains for different sensors (HARDWARE_CLOCK
-        # vs SYSTEM_TIME), producing a fixed multi-second offset that makes
-        # raw timestamps incomparable across sensors.
-        self.color_frames: Dict[str, List[Any]] = {}  # device_id -> [rs.video_frame, ...] oldest first
-        self.COLOR_FRAME_HISTORY = 5
+        # so the depth thread looks up the closest-by-timestamp color frame
+        # here via ``_pick_color_for_depth``. Cross-sensor matching by
+        # ``frame.get_timestamp()`` only works because ``start_sensor`` sets
+        # ``global_time_enabled`` on the sensor — without that, different
+        # sensors can report timestamps in different clock domains (a fixed
+        # multi-second offset). A deque(maxlen=N) gives O(1) bounded append
+        # and atomic-under-GIL pop-on-overflow, which the previous
+        # list+pop(0) pattern did not.
+        self.color_frames: Dict[str, Deque[Any]] = {}  # device_id -> deque of rs.video_frame, oldest first
 
         # Cache of supported frame_metadata values keyed by device_id then profile uid.
         # Nested so a single device's profiles can be evicted without wiping others.
@@ -159,6 +167,10 @@ class RealSenseManager:
         self.depth_frames.pop(serial, None)
         self.color_frames.pop(serial, None)
         self.point_clouds.pop(serial, None)
+        # Drop the point-cloud-enabled flag so a re-plug of the same serial
+        # doesn't silently resume emitting PC metadata that the UI thinks is
+        # off (frontend resets to off on disconnect).
+        self.is_pointcloud_enabled.pop(serial, None)
         self.devices.pop(serial, None)
         self.device_infos.pop(serial, None)
         self._supported_md_by_profile.pop(serial, None)
@@ -1785,8 +1797,6 @@ class RealSenseManager:
             if step > 1:
                 tex = tex[::step]
             colors_rgb = self._sample_color_at_tex(tex, color_frame)
-            if colors_rgb is not None and len(colors_rgb) != len(verts):
-                colors_rgb = None
 
         # Contiguous so .tobytes() in the socket server is a straight memcpy.
         verts = np.ascontiguousarray(verts, dtype=np.float32)
@@ -1804,19 +1814,25 @@ class RealSenseManager:
         depth/color SDK-latency offset (~one capture interval) so the picked
         color reflects the same real-time moment as the depth.
         """
+        # Snapshot the deque before iterating — the color sensor thread can
+        # append/evict concurrently and `for cf in deque` is not safe against
+        # that. tuple() captures the current frame refs atomically under GIL.
         hist = self.color_frames.get(device_id)
         if not hist:
             return None
+        snapshot = tuple(hist)
+        if not snapshot:
+            return None
         try:
             depth_ts = depth_frame.get_timestamp()
-        except Exception:
-            return hist[-1]
-        best = hist[-1]
+        except RuntimeError:
+            return snapshot[-1]
+        best = snapshot[-1]
         best_dt = float("inf")
-        for cf in hist:
+        for cf in snapshot:
             try:
                 dt = abs(cf.get_timestamp() - depth_ts)
-            except Exception:
+            except RuntimeError:
                 continue
             if dt < best_dt:
                 best_dt = dt
@@ -1981,7 +1997,12 @@ class RealSenseManager:
                                 # to texture-map the cloud (cpp realsense-viewer
                                 # parity). get_color_frame() returns an empty
                                 # falsy frame when no color stream is enabled.
+                                # Apply the same color filters as the 2D path
+                                # uses so the textured cloud and the color tile
+                                # never diverge if filters become non-trivial.
                                 color_for_texture = frames.get_color_frame() or None
+                                if color_for_texture:
+                                    color_for_texture = self._apply_color_filters(device_id, color_for_texture)
                                 pc_meta = self._build_point_cloud_metadata(device_id, frame_data, color_for_texture)
                                 if pc_meta:
                                     metadata["point_cloud"] = pc_meta
@@ -2311,10 +2332,11 @@ class RealSenseManager:
             color_frame = self._apply_color_filters(device_id, color_frame)
             # Append to bounded history so the depth thread can pick the color
             # frame closest in time to the depth frame it's processing.
-            hist = self.color_frames.setdefault(device_id, [])
+            hist = self.color_frames.get(device_id)
+            if hist is None:
+                hist = deque(maxlen=COLOR_FRAME_HISTORY)
+                self.color_frames[device_id] = hist
             hist.append(color_frame)
-            while len(hist) > self.COLOR_FRAME_HISTORY:
-                hist.pop(0)
             processed_frame = np.asanyarray(color_frame.get_data())
             info_source = color_frame
 
@@ -2511,11 +2533,19 @@ class RealSenseManager:
             # timestamps in different clock domains with a fixed multi-second
             # offset, defeating cross-sensor matching for the textured point
             # cloud (observed: 1.635s offset on the D585 prototype).
-            try:
-                if sensor.supports(rs.option.global_time_enabled):
+            # WARN — not debug — when set_option fails on a sensor that
+            # supports() said yes: a partial failure silently reintroduces
+            # the cross-sensor offset and the rotation desync.
+            if sensor.supports(rs.option.global_time_enabled):
+                try:
                     sensor.set_option(rs.option.global_time_enabled, 1)
-            except Exception as e:
-                logging.debug(f"[SENSOR] global_time_enabled unavailable on {sensor_id}: {e}")
+                except RuntimeError as e:
+                    logging.warning(
+                        "[SENSOR] %s: global_time_enabled set failed (%s) — "
+                        "depth/color may stay in different clock domains and "
+                        "textured point cloud may show rotation desync.",
+                        sensor_id, e,
+                    )
 
             # Open sensor with ALL profiles
             sensor.open(profiles)
@@ -2662,6 +2692,15 @@ class RealSenseManager:
         # Clean up state
         last_sensor_stopped = False
         with self.lock:
+            # Capture the stopped sensor's stream types BEFORE removing its
+            # entry — needed below to know whether to evict cached color frames.
+            stopped_stream_types: List[str] = []
+            if (device_id in self.sensor_streams
+                    and sensor_id in self.sensor_streams[device_id]):
+                stopped_stream_types = list(
+                    self.sensor_streams[device_id][sensor_id].get("stream_types", [])
+                )
+
             if device_id in self.sensor_streams:
                 self.sensor_streams[device_id].pop(sensor_id, None)
                 if not self.sensor_streams[device_id]:
@@ -2684,11 +2723,14 @@ class RealSenseManager:
                 if not self.sensor_rs_queues[device_id]:
                     del self.sensor_rs_queues[device_id]
 
-            if last_sensor_stopped:
-                # Free the cached color frame + per-device rs.pointcloud now
-                # that the device's depth thread is gone; otherwise the last
-                # frame stays pinned in the SDK pool until device removal.
+            # Free the cached color frames if the stopped sensor was producing
+            # color — otherwise the 5 cached rs.video_frame refs stay pinned
+            # in the SDK pool while depth keeps streaming.
+            stopped_color = any(st.lower() == "color" for st in stopped_stream_types)
+            if stopped_color or last_sensor_stopped:
                 self.color_frames.pop(device_id, None)
+            if last_sensor_stopped:
+                # Per-device rs.pointcloud is only needed while depth runs.
                 self.point_clouds.pop(device_id, None)
 
         # Stop the per-device metadata broadcaster once the last sensor on this

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -73,6 +73,11 @@ class RealSenseManager:
         # Store latest raw depth frames for pixel depth queries
         self.depth_frames: Dict[str, Any] = {}  # device_id -> rs.depth_frame
 
+        # Store latest color frame for texturing the 3D point cloud (sensor-mode
+        # collectors process depth/color on separate threads, so depth needs to
+        # look up the most recent color frame here).
+        self.color_frames: Dict[str, Any] = {}  # device_id -> rs.video_frame
+
         # Cache of supported frame_metadata values keyed by device_id then profile uid.
         # Nested so a single device's profiles can be evicted without wiping others.
         # Avoids re-probing every metadata key on every frame in the hot loop.
@@ -143,6 +148,7 @@ class RealSenseManager:
         self.frame_queues.pop(serial, None)
         self.metadata_queues.pop(serial, None)
         self.depth_frames.pop(serial, None)
+        self.color_frames.pop(serial, None)
         self.devices.pop(serial, None)
         self.device_infos.pop(serial, None)
         self._supported_md_by_profile.pop(serial, None)
@@ -1717,26 +1723,108 @@ class RealSenseManager:
     # stays roughly constant regardless of stream resolution.
     POINT_CLOUD_MAX_VERTICES = 60000
 
-    def _build_point_cloud_metadata(self, depth_frame) -> Optional[Dict]:
+    def _build_point_cloud_metadata(self, depth_frame, color_frame=None) -> Optional[Dict]:
         """Compute decimated point-cloud vertices from a depth frame, ready for serialization.
+
+        When ``color_frame`` is supplied and it's an RGB8/BGR8 frame, this also
+        samples a per-vertex RGB triplet using the texture coordinates produced
+        by ``rs.pointcloud.map_to`` — mirrors the C++ realsense-viewer's textured
+        point cloud rendering. The client falls back to a depth colormap when
+        ``colors`` is absent.
 
         Returns None if calculate() yields nothing. Used by both the pipeline-mode
         frame collector and the sensor-mode frame processor.
         """
+        if color_frame:
+            try:
+                self.pc.map_to(color_frame)
+            except Exception:
+                color_frame = None  # not all profiles support map_to; fall back silently
         points = self.pc.calculate(depth_frame)
         if not points:
             return None
         verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
-        verts = verts[verts[:, 2] >= 0.03]  # drop invalid near-camera points
+
+        colors_rgb: Optional[np.ndarray] = None
+        if color_frame:
+            colors_rgb = self._sample_color_for_vertices(points, color_frame)
+            # If the sampled array length doesn't match (e.g. unsupported format
+            # produced None), don't try to align it to verts below.
+            if colors_rgb is not None and len(colors_rgb) != len(verts):
+                colors_rgb = None
+
+        mask = verts[:, 2] >= 0.03  # drop invalid near-camera points
+        verts = verts[mask]
+        if colors_rgb is not None:
+            colors_rgb = colors_rgb[mask]
+
         # Resolution-adaptive decimation: stride to a fixed vertex budget so a
         # 1280x720 cloud isn't an order of magnitude heavier than 640x480.
         count = len(verts)
         if count > self.POINT_CLOUD_MAX_VERTICES:
             step = (count // self.POINT_CLOUD_MAX_VERTICES) + 1
             verts = verts[::step]
-        # Contiguous float32 so .tobytes() in the socket server is a straight memcpy.
+            if colors_rgb is not None:
+                colors_rgb = colors_rgb[::step]
+
+        # Contiguous so .tobytes() in the socket server is a straight memcpy.
         verts = np.ascontiguousarray(verts, dtype=np.float32)
-        return {"vertices": verts, "texture_coordinates": []}
+        result: Dict[str, Any] = {"vertices": verts, "texture_coordinates": []}
+        if colors_rgb is not None:
+            result["colors"] = np.ascontiguousarray(colors_rgb, dtype=np.uint8)
+        return result
+
+    def _is_color_streaming(self, device_id: str) -> bool:
+        """Whether 'color' is currently in this device's active stream set.
+
+        Used by the sensor-mode depth thread to decide whether the cached color
+        frame in ``self.color_frames`` is still fresh enough to texture-map the
+        cloud. Pipeline mode reads color straight from the frameset and doesn't
+        need this — the frameset already drops disabled streams.
+        """
+        mode = self.streaming_mode.get(device_id)
+        if mode == "pipeline":
+            return any(s.lower() == "color" for s in self.active_streams.get(device_id, set()))
+        if device_id in self.sensor_streams:
+            for sensor_info in self.sensor_streams[device_id].values():
+                if not sensor_info.get("is_streaming", False):
+                    continue
+                if any(st.lower() == "color" for st in sensor_info.get("stream_types", [])):
+                    return True
+        return False
+
+    @staticmethod
+    def _sample_color_for_vertices(points, color_frame) -> Optional[np.ndarray]:
+        """Return Nx3 uint8 RGB sampled at each vertex's texture coordinate, or None.
+
+        Only handles RGB8 / BGR8 color frames — other formats (YUYV, Y16, …) fall
+        back to no texture and the client renders the depth colormap.
+        """
+        try:
+            color_format = color_frame.get_profile().format()
+        except Exception:
+            return None
+        if color_format not in (rs.format.rgb8, rs.format.bgr8):
+            return None
+
+        tex = np.asanyarray(points.get_texture_coordinates()).view(np.float32).reshape(-1, 2)
+        cim = np.asanyarray(color_frame.get_data())
+        if cim.ndim != 3 or cim.shape[2] < 3:
+            return None
+        H, W = cim.shape[:2]
+        u = tex[:, 0]
+        v = tex[:, 1]
+        # rs2 emits tex coords outside [0,1] for depth pixels that don't project
+        # into the color frame — mark those black instead of clamping (clamping
+        # would smear the frame borders across off-screen points).
+        valid = (u >= 0.0) & (u <= 1.0) & (v >= 0.0) & (v <= 1.0)
+        xi = np.clip((u * W).astype(np.int32), 0, W - 1)
+        yi = np.clip((v * H).astype(np.int32), 0, H - 1)
+        sampled = cim[yi, xi][:, :3].astype(np.uint8, copy=True)
+        sampled[~valid] = 0
+        if color_format == rs.format.bgr8:
+            sampled = sampled[:, ::-1]  # BGR -> RGB so the client doesn't need to swap
+        return sampled
 
     def _collect_frames(self, device_id: str, align_processor=None):
         """Thread function to collect frames from the pipeline"""
@@ -1839,7 +1927,12 @@ class RealSenseManager:
                                     metadata["motion_data"] = motion_json_data
 
                             if rs_stream == rs.stream.depth and self.is_pointcloud_enabled.get(device_id, False):
-                                pc_meta = self._build_point_cloud_metadata(frame_data)
+                                # If color is also active in this frameset, use it
+                                # to texture-map the cloud (cpp realsense-viewer
+                                # parity). get_color_frame() returns an empty
+                                # falsy frame when no color stream is enabled.
+                                color_for_texture = frames.get_color_frame() or None
+                                pc_meta = self._build_point_cloud_metadata(frame_data, color_for_texture)
                                 if pc_meta:
                                     metadata["point_cloud"] = pc_meta
 
@@ -2145,13 +2238,24 @@ class RealSenseManager:
             info_source = depth_frame
 
             if self.is_pointcloud_enabled.get(device_id, False):
-                pc_meta = self._build_point_cloud_metadata(depth_frame)
+                # Sensor mode runs depth/color on separate threads so there is
+                # no frameset — fall back to the most recent color frame cached
+                # by the color thread, but only if color is *still* an active
+                # stream. Without that check the depth thread would keep
+                # texturing with a stale frame after the user disables color.
+                color_for_texture = (
+                    self.color_frames.get(device_id)
+                    if self._is_color_streaming(device_id)
+                    else None
+                )
+                pc_meta = self._build_point_cloud_metadata(depth_frame, color_for_texture)
                 if pc_meta:
                     metadata["point_cloud"] = pc_meta
 
         elif "color" in frame_stream_name:
             color_frame = frame.as_video_frame()
             color_frame = self._apply_color_filters(device_id, color_frame)
+            self.color_frames[device_id] = color_frame  # cache for textured PC in sensor mode
             processed_frame = np.asanyarray(color_frame.get_data())
             info_source = color_frame
 

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -76,10 +76,16 @@ class RealSenseManager:
         # Store latest raw depth frames for pixel depth queries
         self.depth_frames: Dict[str, Any] = {}  # device_id -> rs.depth_frame
 
-        # Store latest color frame for texturing the 3D point cloud (sensor-mode
-        # collectors process depth/color on separate threads, so depth needs to
-        # look up the most recent color frame here).
-        self.color_frames: Dict[str, Any] = {}  # device_id -> rs.video_frame
+        # Short history of recent color frames per device for texturing the
+        # 3D point cloud. Sensor-mode runs depth/color on independent threads
+        # so the depth thread looks up the most recent matching color frame
+        # here. Matching uses the hardware FRAME_TIMESTAMP metadata
+        # (device-side capture clock), not get_timestamp() — get_timestamp()
+        # can be in different domains for different sensors (HARDWARE_CLOCK
+        # vs SYSTEM_TIME), producing a fixed multi-second offset that makes
+        # raw timestamps incomparable across sensors.
+        self.color_frames: Dict[str, List[Any]] = {}  # device_id -> [rs.video_frame, ...] oldest first
+        self.COLOR_FRAME_HISTORY = 5
 
         # Cache of supported frame_metadata values keyed by device_id then profile uid.
         # Nested so a single device's profiles can be evicted without wiping others.
@@ -1758,27 +1764,29 @@ class RealSenseManager:
             return None
         verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
 
-        colors_rgb: Optional[np.ndarray] = None
-        if color_frame:
-            colors_rgb = self._sample_color_for_vertices(points, color_frame)
-            # If the sampled array length doesn't match (e.g. unsupported format
-            # produced None), don't try to align it to verts below.
-            if colors_rgb is not None and len(colors_rgb) != len(verts):
-                colors_rgb = None
-
+        # Mask + decimate BEFORE sampling colors — at 1280x720 the full vertex
+        # buffer is ~921K entries, and sampling/copying 900K colors per depth
+        # frame was bottlenecking the depth thread down to ~1 Hz (the rotation
+        # desync the user reported: by the time depth_T was ready, color was
+        # already at color_T+1s). Sampling at the final ~60K decimated indices
+        # is ~15x less work.
         mask = verts[:, 2] >= 0.03  # drop invalid near-camera points
         verts = verts[mask]
-        if colors_rgb is not None:
-            colors_rgb = colors_rgb[mask]
-
-        # Resolution-adaptive decimation: stride to a fixed vertex budget so a
-        # 1280x720 cloud isn't an order of magnitude heavier than 640x480.
         count = len(verts)
+        step = 1
         if count > self.POINT_CLOUD_MAX_VERTICES:
             step = (count // self.POINT_CLOUD_MAX_VERTICES) + 1
             verts = verts[::step]
-            if colors_rgb is not None:
-                colors_rgb = colors_rgb[::step]
+
+        colors_rgb: Optional[np.ndarray] = None
+        if color_frame:
+            tex = np.asanyarray(points.get_texture_coordinates()).view(np.float32).reshape(-1, 2)
+            tex = tex[mask]
+            if step > 1:
+                tex = tex[::step]
+            colors_rgb = self._sample_color_at_tex(tex, color_frame)
+            if colors_rgb is not None and len(colors_rgb) != len(verts):
+                colors_rgb = None
 
         # Contiguous so .tobytes() in the socket server is a straight memcpy.
         verts = np.ascontiguousarray(verts, dtype=np.float32)
@@ -1786,6 +1794,34 @@ class RealSenseManager:
         if colors_rgb is not None:
             result["colors"] = np.ascontiguousarray(colors_rgb, dtype=np.uint8)
         return result
+
+    def _pick_color_for_depth(self, device_id: str, depth_frame) -> Optional[Any]:
+        """Pick the cached color frame whose timestamp is closest to the depth
+        frame's. Both timestamps come from ``frame.get_timestamp()``, which —
+        with ``global_time_enabled`` set on the sensors at start time — are
+        translated by the SDK into a unified system-time domain regardless of
+        which sensor produced them. The short history covers the typical
+        depth/color SDK-latency offset (~one capture interval) so the picked
+        color reflects the same real-time moment as the depth.
+        """
+        hist = self.color_frames.get(device_id)
+        if not hist:
+            return None
+        try:
+            depth_ts = depth_frame.get_timestamp()
+        except Exception:
+            return hist[-1]
+        best = hist[-1]
+        best_dt = float("inf")
+        for cf in hist:
+            try:
+                dt = abs(cf.get_timestamp() - depth_ts)
+            except Exception:
+                continue
+            if dt < best_dt:
+                best_dt = dt
+                best = cf
+        return best
 
     def _is_color_streaming(self, device_id: str) -> bool:
         """Whether 'color' is currently in this device's active stream set.
@@ -1807,11 +1843,14 @@ class RealSenseManager:
         return False
 
     @staticmethod
-    def _sample_color_for_vertices(points, color_frame) -> Optional[np.ndarray]:
-        """Return Nx3 uint8 RGB sampled at each vertex's texture coordinate, or None.
+    def _sample_color_at_tex(tex: np.ndarray, color_frame) -> Optional[np.ndarray]:
+        """Return Nx3 uint8 RGB sampled at the supplied texture coordinates.
 
-        Only handles RGB8 / BGR8 color frames — other formats (YUYV, Y16, …) fall
-        back to no texture and the client renders the depth colormap.
+        ``tex`` is the already-masked, already-decimated tex-coord array (Nx2,
+        u/v in [0,1]) — sampling per-vertex on the full pre-decimation buffer
+        is too slow at 1280x720. Only handles RGB8 / BGR8 color frames; other
+        formats (YUYV, Y16, …) return None and the client falls back to the
+        depth colormap.
         """
         try:
             color_format = color_frame.get_profile().format()
@@ -1819,8 +1858,6 @@ class RealSenseManager:
             return None
         if color_format not in (rs.format.rgb8, rs.format.bgr8):
             return None
-
-        tex = np.asanyarray(points.get_texture_coordinates()).view(np.float32).reshape(-1, 2)
         cim = np.asanyarray(color_frame.get_data())
         if cim.ndim != 3 or cim.shape[2] < 3:
             return None
@@ -2254,12 +2291,14 @@ class RealSenseManager:
 
             if self.is_pointcloud_enabled.get(device_id, False):
                 # Sensor mode runs depth/color on separate threads so there is
-                # no frameset — fall back to the most recent color frame cached
-                # by the color thread, but only if color is *still* an active
-                # stream. Without that check the depth thread would keep
-                # texturing with a stale frame after the user disables color.
+                # no frameset — pick the cached color frame whose timestamp is
+                # closest to this depth frame's, otherwise rotations show
+                # colors leading the geometry (color has lower SDK latency).
+                # Only do this if color is still streaming; without that check
+                # the depth thread would keep texturing with a stale frame
+                # after the user disables color.
                 color_for_texture = (
-                    self.color_frames.get(device_id)
+                    self._pick_color_for_depth(device_id, depth_frame)
                     if self._is_color_streaming(device_id)
                     else None
                 )
@@ -2270,7 +2309,12 @@ class RealSenseManager:
         elif "color" in frame_stream_name:
             color_frame = frame.as_video_frame()
             color_frame = self._apply_color_filters(device_id, color_frame)
-            self.color_frames[device_id] = color_frame  # cache for textured PC in sensor mode
+            # Append to bounded history so the depth thread can pick the color
+            # frame closest in time to the depth frame it's processing.
+            hist = self.color_frames.setdefault(device_id, [])
+            hist.append(color_frame)
+            while len(hist) > self.COLOR_FRAME_HISTORY:
+                hist.pop(0)
             processed_frame = np.asanyarray(color_frame.get_data())
             info_source = color_frame
 
@@ -2460,12 +2504,29 @@ class RealSenseManager:
             
             # Validate profile compatibility (same FPS required)
             self._validate_profile_compatibility(profiles)
-            
+
+            # Translate sensor timestamps to a unified system-time domain so
+            # depth/color frames from independent sensors on the same device
+            # are directly comparable. Without this, sensors can report
+            # timestamps in different clock domains with a fixed multi-second
+            # offset, defeating cross-sensor matching for the textured point
+            # cloud (observed: 1.635s offset on the D585 prototype).
+            try:
+                if sensor.supports(rs.option.global_time_enabled):
+                    sensor.set_option(rs.option.global_time_enabled, 1)
+            except Exception as e:
+                logging.debug(f"[SENSOR] global_time_enabled unavailable on {sensor_id}: {e}")
+
             # Open sensor with ALL profiles
             sensor.open(profiles)
             
-            # Create frame queue
-            rs_queue = rs.frame_queue(50, keep_frames=True)
+            # Small queue so the collector always sees fresh frames. A larger
+            # capacity (the old value was 50) lets a 1.6s FIFO backlog build up
+            # at 30 fps and the depth thread ends up always processing
+            # 1.6s-stale frames — visible as the textured 3D cloud where the
+            # color (no PC math, no backlog) reacts to motion immediately and
+            # the depth geometry lags ~1.6s behind.
+            rs_queue = rs.frame_queue(2)
             
             # Start sensor
             sensor.start(rs_queue)

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -1713,6 +1713,10 @@ class RealSenseManager:
                 continue
         return attrs
 
+    # Cap the number of vertices shipped per frame so payload/decode/render cost
+    # stays roughly constant regardless of stream resolution.
+    POINT_CLOUD_MAX_VERTICES = 60000
+
     def _build_point_cloud_metadata(self, depth_frame) -> Optional[Dict]:
         """Compute decimated point-cloud vertices from a depth frame, ready for serialization.
 
@@ -1724,7 +1728,14 @@ class RealSenseManager:
             return None
         verts = np.asanyarray(points.get_vertices()).view(np.float32).reshape(-1, 3)
         verts = verts[verts[:, 2] >= 0.03]  # drop invalid near-camera points
-        verts = verts[::4]  # decimate to keep payload under Socket.IO buffer cap
+        # Resolution-adaptive decimation: stride to a fixed vertex budget so a
+        # 1280x720 cloud isn't an order of magnitude heavier than 640x480.
+        count = len(verts)
+        if count > self.POINT_CLOUD_MAX_VERTICES:
+            step = (count // self.POINT_CLOUD_MAX_VERTICES) + 1
+            verts = verts[::step]
+        # Contiguous float32 so .tobytes() in the socket server is a straight memcpy.
+        verts = np.ascontiguousarray(verts, dtype=np.float32)
         return {"vertices": verts, "texture_coordinates": []}
 
     def _collect_frames(self, device_id: str, align_processor=None):

--- a/wrappers/rest-api/app/services/socketio.py
+++ b/wrappers/rest-api/app/services/socketio.py
@@ -4,7 +4,8 @@
 import socketio
 
 # Create Socket.IO Server
-sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins='*')
+# max_http_buffer_size raised to 10 MB to fit point cloud frames (default 1 MB is too small).
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins='*', max_http_buffer_size=10_000_000)
 
 # Setup basic event handlers
 @sio.event

--- a/wrappers/rest-api/main.py
+++ b/wrappers/rest-api/main.py
@@ -1,9 +1,48 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
+import sys
+from pathlib import Path
+
+
+def _prefer_local_pyrealsense2() -> None:
+    # Prefer locally-built pyrealsense2 (e.g. build/Release/) over any PyPI
+    # wheel — newer devices (e.g. D585 Prototype, PID 0x0C08) may not be
+    # recognized by the published wheel and only show up when loading the
+    # module built from this branch.
+    import os
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    build_dir = repo_root / "build"
+    if not build_dir.is_dir():
+        return
+    candidates = []
+    for pattern in ("pyrealsense2*.pyd", "pyrealsense2*.so"):
+        candidates.extend(build_dir.rglob(pattern))
+    candidates.extend(build_dir.rglob("pyrealsense2/__init__.py"))
+    if not candidates:
+        return
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    seen, target_dirs = set(), []
+    for path in candidates:
+        target_dir = path.parent.parent if path.name == "__init__.py" else path.parent
+        key = str(target_dir)
+        if key in seen:
+            continue
+        seen.add(key)
+        target_dirs.append(key)
+    sys.path[0:0] = target_dirs
+    if hasattr(os, "add_dll_directory"):
+        for key in target_dirs:
+            try:
+                os.add_dll_directory(key)
+            except (OSError, FileNotFoundError):
+                pass
+
+
+_prefer_local_pyrealsense2()
+
 import asyncio
 import uvicorn
-import sys
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/wrappers/rest-api/tools/react-viewer/src/App.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/App.tsx
@@ -55,13 +55,15 @@ function App() {
         <main className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
           {hasActiveDevices ? (
             <>
-              {/* Stream/PointCloud View */}
-              <div className="flex-1 p-4 min-h-0 overflow-hidden">
-                {viewMode === '2d' ? (
+              {/* Stream/PointCloud View — keep both mounted so WebRTC stays alive
+                  when switching 3D → 2D (otherwise StreamViewer remount renegotiates). */}
+              <div className="flex-1 p-4 min-h-0 overflow-hidden relative">
+                <div className={`absolute inset-4 ${viewMode === '2d' ? '' : 'invisible pointer-events-none'}`}>
                   <StreamViewer />
-                ) : (
+                </div>
+                <div className={`absolute inset-4 ${viewMode === '3d' ? '' : 'invisible pointer-events-none'}`}>
                   <PointCloudViewer />
-                )}
+                </div>
               </div>
 
               {/* IMU Viewer (collapsible) */}

--- a/wrappers/rest-api/tools/react-viewer/src/api/types.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/types.ts
@@ -128,6 +128,10 @@ export interface PointCloudData {
   // Raw float32 bytes (Socket.IO binary attachment) or base64-encoded string (legacy server).
   vertices: ArrayBuffer | string
   texture_coordinates: number[]
+  // Per-vertex RGB triplets (uint8, 3 bytes per vertex), matching `vertices` 1:1
+  // when the server textured the cloud from a live color frame. Same wire
+  // encoding as vertices: ArrayBuffer over binary socket, base64 string otherwise.
+  colors?: ArrayBuffer | string
 }
 
 export interface MetadataUpdate {

--- a/wrappers/rest-api/tools/react-viewer/src/api/types.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/types.ts
@@ -125,7 +125,8 @@ export interface IMUData {
 }
 
 export interface PointCloudData {
-  vertices: string // Base64-encoded Float32Array
+  // Raw float32 bytes (Socket.IO binary attachment) or base64-encoded string (legacy server).
+  vertices: ArrayBuffer | string
   texture_coordinates: number[]
 }
 

--- a/wrappers/rest-api/tools/react-viewer/src/components/Header.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/Header.tsx
@@ -127,12 +127,11 @@ export function Header() {
                   2D View
                 </button>
                 <button
-                  disabled
-                  title="3D View feature coming soon"
-                  className={`px-4 py-1 rounded-md text-sm transition-colors cursor-not-allowed ${
+                  onClick={() => setViewMode('3d')}
+                  className={`px-4 py-1 rounded-md text-sm transition-colors ${
                     viewMode === '3d'
                       ? 'bg-rs-blue text-white'
-                      : 'text-gray-500 opacity-50'
+                      : 'text-gray-300 hover:text-white'
                   }`}
                 >
                   3D View

--- a/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useEffect, memo } from 'react'
+import { useRef, useEffect, useLayoutEffect, memo } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, PerspectiveCamera } from '@react-three/drei'
 import * as THREE from 'three'
@@ -19,7 +19,7 @@ const circleSprite = (() => {
 })()
 
 export function PointCloudViewer() {
-  const { pointCloudVertices, pointCloudColors, isStreaming } = useAppStore()
+  const { pointCloudVertices, pointCloudColors, isStreaming, viewMode } = useAppStore()
 
   return (
     <div className="h-full flex flex-col">
@@ -41,7 +41,7 @@ export function PointCloudViewer() {
       {/* 3D Canvas */}
       <div className="flex-1 bg-black rounded-b-lg overflow-hidden">
         {pointCloudVertices ? (
-          <Canvas>
+          <Canvas frameloop={viewMode === '3d' ? 'always' : 'never'}>
             {/* Head-on, on the depth optical axis (sensor POV) — matches the C++ viewer's
                 default 3D camera and the 2D framing, so raw-cloud edge artifacts stay
                 behind surfaces instead of reading as floating noise from an oblique angle. */}
@@ -110,15 +110,26 @@ function PointCloud({ vertices, sampledColors }: PointCloudProps) {
     return () => geo.dispose()
   }, [geometry])
 
-  useMemo(() => {
+  // useLayoutEffect rather than useMemo: this writes side effects (typed-array
+  // mutations, EMA range advance) which useMemo's contract doesn't guarantee
+  // will fire — the runtime is allowed to drop a memoized value and re-run.
+  useLayoutEffect(() => {
     const geo = geometry
     const n = vertices.length
     const count = (n / 3) | 0
 
+    // Empty frame: nothing to upload. Skip before the attribute access — the
+    // first frame may carry zero valid points (all depth pixels < 0.03m), and
+    // posAttr would be undefined here.
+    if (count === 0) {
+      geo.setDrawRange(0, 0)
+      return
+    }
+
     // Grow-only: reallocate buffers only when a frame exceeds current capacity (in vertices).
     // After the first few frames this stops firing entirely (steady state = no allocation).
     // Capacity is tracked in vertices so the float arrays stay a multiple of 3 (a fractional
-    // BufferAttribute.count makes computeBoundingSphere read past the array → NaN).
+    // BufferAttribute.count would read past the array on writes).
     if (capacityRef.current < count) {
       const vcap = count + (count >> 2) + 1 // +25% headroom to avoid frequent regrows
       geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(vcap * 3), 3))
@@ -214,14 +225,16 @@ function PointCloud({ vertices, sampledColors }: PointCloudProps) {
     }
 
     // Only the first `count` vertices are valid this frame; render exactly those.
+    // No computeBoundingSphere: it reads posAttr.count (= full grown capacity),
+    // which includes stale/zero trailing positions and inflates the sphere.
+    // frustumCulled={false} on the <points> below makes the missing sphere safe.
     posAttr.needsUpdate = true
     colAttr.needsUpdate = true
     geo.setDrawRange(0, count)
-    geo.computeBoundingSphere()
   }, [vertices, sampledColors])
 
   return (
-    <points geometry={geometry}>
+    <points geometry={geometry} frustumCulled={false}>
       <pointsMaterial
         size={3}
         sizeAttenuation={false}

--- a/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
@@ -1,26 +1,16 @@
-import { useRef, useMemo, useEffect } from 'react'
-import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { useMemo } from 'react'
+import { Canvas } from '@react-three/fiber'
 import { OrbitControls, PerspectiveCamera } from '@react-three/drei'
 import * as THREE from 'three'
 import { useAppStore } from '../store'
 
 export function PointCloudViewer() {
-  const { pointCloudVertices, isPointCloudEnabled, togglePointCloud, isStreaming } = useAppStore()
+  const { pointCloudVertices, isStreaming } = useAppStore()
 
   return (
     <div className="h-full flex flex-col">
       {/* Controls */}
-      <div className="flex items-center gap-4 p-2 bg-gray-800 rounded-t-lg">
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={isPointCloudEnabled}
-            onChange={() => togglePointCloud()}
-            disabled={!isStreaming}
-            className="control-checkbox"
-          />
-          <span className="text-sm">Enable Point Cloud</span>
-        </label>
+      <div className="flex items-center justify-end gap-4 p-2 bg-gray-800 rounded-t-lg">
         <button
           onClick={() => {
             if (pointCloudVertices) {
@@ -36,10 +26,10 @@ export function PointCloudViewer() {
 
       {/* 3D Canvas */}
       <div className="flex-1 bg-black rounded-b-lg overflow-hidden">
-        {isPointCloudEnabled && pointCloudVertices ? (
+        {pointCloudVertices ? (
           <Canvas>
-            <PerspectiveCamera makeDefault position={[0, 0, 2]} />
-            <OrbitControls enablePan enableZoom enableRotate />
+            <PerspectiveCamera makeDefault position={[0, 0.3, 0.3]} />
+            <OrbitControls enablePan enableZoom enableRotate target={[0, 0, -1]} />
             <ambientLight intensity={0.5} />
             <PointCloud vertices={pointCloudVertices} />
             <Axes />
@@ -64,8 +54,8 @@ export function PointCloudViewer() {
               <p className="text-lg">3D Point Cloud View</p>
               <p className="text-sm mt-1">
                 {isStreaming
-                  ? 'Enable point cloud in controls above'
-                  : 'Start streaming and enable point cloud'}
+                  ? 'Waiting for point cloud data…'
+                  : 'Start streaming depth to see points'}
               </p>
             </div>
           </div>
@@ -80,61 +70,82 @@ interface PointCloudProps {
 }
 
 function PointCloud({ vertices }: PointCloudProps) {
-  const pointsRef = useRef<THREE.Points>(null)
-  const { camera } = useThree()
-
-  // Create geometry from vertices
   const geometry = useMemo(() => {
     const geo = new THREE.BufferGeometry()
-    
-    // Vertices array is [x1, y1, z1, x2, y2, z2, ...]
-    const positions = new Float32Array(vertices.length)
-    const colors = new Float32Array(vertices.length)
+    const n = vertices.length
+    const positions = new Float32Array(n)
+    const colors = new Float32Array(n)
+    const BINS = 64
 
-    for (let i = 0; i < vertices.length; i += 3) {
-      // Copy positions
+    let zMin = Infinity
+    let zMax = -Infinity
+    for (let i = 2; i < n; i += 3) {
+      const z = vertices[i]
+      if (z < zMin) zMin = z
+      if (z > zMax) zMax = z
+    }
+
+    // Histogram + CDF (matches rs.colorizer histogram_eq default) so a few far-z
+    // outliers don't crush the visible scene into a single color band.
+    const cdf = new Float32Array(BINS)
+    const binScale = isFinite(zMin) && zMax > zMin ? BINS / (zMax - zMin) : 0
+    if (binScale > 0) {
+      const hist = new Uint32Array(BINS)
+      for (let i = 2; i < n; i += 3) {
+        let bin = Math.floor((vertices[i] - zMin) * binScale)
+        if (bin >= BINS) bin = BINS - 1
+        else if (bin < 0) bin = 0
+        hist[bin]++
+      }
+      let acc = 0
+      for (let b = 0; b < BINS; b++) {
+        acc += hist[b]
+        cdf[b] = acc
+      }
+      if (acc > 0) for (let b = 0; b < BINS; b++) cdf[b] /= acc
+    }
+
+    for (let i = 0; i < n; i += 3) {
+      // RealSense: x-right, y-down, z-forward (meters)
+      // Three.js:  x-right, y-up,   z-toward-camera
       positions[i] = vertices[i]
-      positions[i + 1] = vertices[i + 1]
-      positions[i + 2] = vertices[i + 2]
+      positions[i + 1] = -vertices[i + 1]
+      positions[i + 2] = -vertices[i + 2]
 
-      // Color based on depth (Z value)
-      const z = vertices[i + 2]
-      const normalizedZ = Math.min(Math.max((z + 1) / 4, 0), 1) // Normalize depth to 0-1
-      
-      // Create a gradient from blue (near) to red (far)
-      colors[i] = normalizedZ // R
-      colors[i + 1] = 0.2 // G
-      colors[i + 2] = 1 - normalizedZ // B
+      let t = 0
+      if (binScale > 0) {
+        let bin = Math.floor((vertices[i + 2] - zMin) * binScale)
+        if (bin >= BINS) bin = BINS - 1
+        else if (bin < 0) bin = 0
+        t = cdf[bin]
+      }
+      const c = jetColor(t)
+      colors[i] = c[0]
+      colors[i + 1] = c[1]
+      colors[i + 2] = c[2]
     }
 
     geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
     geo.setAttribute('color', new THREE.BufferAttribute(colors, 3))
     geo.computeBoundingSphere()
-
     return geo
   }, [vertices])
 
-  // Center camera on point cloud
-  useEffect(() => {
-    if (geometry.boundingSphere) {
-      const center = geometry.boundingSphere.center
-      camera.lookAt(center)
-    }
-  }, [geometry, camera])
-
-  // Rotate slowly for effect
-  useFrame(() => {
-    if (pointsRef.current) {
-      // Optional: Add subtle rotation
-      // pointsRef.current.rotation.y += 0.001
-    }
-  })
-
   return (
-    <points ref={pointsRef} geometry={geometry}>
+    <points geometry={geometry}>
       <pointsMaterial size={0.005} vertexColors sizeAttenuation />
     </points>
   )
+}
+
+// Jet colormap (blue → cyan → green → yellow → red) — matches librealsense rs.colorizer default.
+function jetColor(t: number): [number, number, number] {
+  const v = Math.min(Math.max(t, 0), 1)
+  if (v < 0.125) return [0, 0, 0.5 + v * 4]
+  if (v < 0.375) return [0, (v - 0.125) * 4, 1]
+  if (v < 0.625) return [(v - 0.375) * 4, 1, 1 - (v - 0.375) * 4]
+  if (v < 0.875) return [1, 1 - (v - 0.625) * 4, 0]
+  return [1 - (v - 0.875) * 4, 0, 0]
 }
 
 function Axes() {

--- a/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
@@ -1,8 +1,22 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useEffect, memo } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, PerspectiveCamera } from '@react-three/drei'
 import * as THREE from 'three'
 import { useAppStore } from '../store'
+
+// Round point sprite (built once). Default square points read as a coarse pixel grid;
+// a circular alpha mask + alphaTest makes points blend into a smoother surface.
+const circleSprite = (() => {
+  const s = 64
+  const cv = document.createElement('canvas')
+  cv.width = cv.height = s
+  const ctx = cv.getContext('2d')!
+  ctx.beginPath()
+  ctx.arc(s / 2, s / 2, s / 2 - 2, 0, Math.PI * 2)
+  ctx.fillStyle = '#fff'
+  ctx.fill()
+  return new THREE.CanvasTexture(cv)
+})()
 
 export function PointCloudViewer() {
   const { pointCloudVertices, isStreaming } = useAppStore()
@@ -28,12 +42,14 @@ export function PointCloudViewer() {
       <div className="flex-1 bg-black rounded-b-lg overflow-hidden">
         {pointCloudVertices ? (
           <Canvas>
-            <PerspectiveCamera makeDefault position={[0, 0.3, 0.3]} />
+            {/* Head-on, on the depth optical axis (sensor POV) — matches the C++ viewer's
+                default 3D camera and the 2D framing, so raw-cloud edge artifacts stay
+                behind surfaces instead of reading as floating noise from an oblique angle. */}
+            <PerspectiveCamera makeDefault position={[0, 0, 1]} fov={45} />
             <OrbitControls enablePan enableZoom enableRotate target={[0, 0, -1]} />
             <ambientLight intensity={0.5} />
             <PointCloud vertices={pointCloudVertices} />
-            <Axes />
-            <gridHelper args={[10, 10, '#444', '#333']} />
+            <SceneDecor />
           </Canvas>
         ) : (
           <div className="h-full flex items-center justify-center text-gray-500">
@@ -70,120 +86,189 @@ interface PointCloudProps {
 }
 
 function PointCloud({ vertices }: PointCloudProps) {
-  const geometry = useMemo(() => {
-    const geo = new THREE.BufferGeometry()
-    const n = vertices.length
-    const positions = new Float32Array(n)
-    const colors = new Float32Array(n)
-    const BINS = 64
+  // One persistent geometry with grow-only fixed-capacity attributes. Inspired by the
+  // C++ viewer's upload_points: the GPU buffers are allocated once (regrown only when a
+  // frame needs more room) and rewritten in place every frame — no per-frame BufferGeometry
+  // or BufferAttribute allocation, so no GPU-buffer leak. setDrawRange limits rendering to
+  // the live vertex count, since the point count varies frame to frame.
+  const geometryRef = useRef<THREE.BufferGeometry>()
+  const capacityRef = useRef(0)
+  // EMA-smoothed depth range, derived from robust percentiles of the cloud so the
+  // gradient uses the full blue→red span (farthest points reach red) while staying
+  // temporally stable — and ignoring sparse far outliers that would wash everything blue.
+  const rangeRef = useRef<{ near: number; far: number }>({ near: NaN, far: NaN })
+  const histRef = useRef<Uint32Array>(new Uint32Array(128))
+  if (!geometryRef.current) geometryRef.current = new THREE.BufferGeometry()
+  const geometry = geometryRef.current
 
-    let zMin = Infinity
-    let zMax = -Infinity
+  useEffect(() => {
+    const geo = geometry
+    return () => geo.dispose()
+  }, [geometry])
+
+  useMemo(() => {
+    const geo = geometry
+    const n = vertices.length
+    const count = (n / 3) | 0
+
+    // Grow-only: reallocate buffers only when a frame exceeds current capacity (in vertices).
+    // After the first few frames this stops firing entirely (steady state = no allocation).
+    // Capacity is tracked in vertices so the float arrays stay a multiple of 3 (a fractional
+    // BufferAttribute.count makes computeBoundingSphere read past the array → NaN).
+    if (capacityRef.current < count) {
+      const vcap = count + (count >> 2) + 1 // +25% headroom to avoid frequent regrows
+      geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(vcap * 3), 3))
+      geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(vcap * 3), 3))
+      capacityRef.current = vcap
+    }
+    const posAttr = geo.getAttribute('position') as THREE.BufferAttribute
+    const colAttr = geo.getAttribute('color') as THREE.BufferAttribute
+    const positions = posAttr.array as Float32Array
+    const colors = colAttr.array as Float32Array
+
+    // Robust depth range via a coarse histogram → 2nd/98th percentile, then EMA-smoothed.
+    // Percentiles (not raw min/max) reject sparse far/near outliers that would otherwise
+    // stretch the range and wash the whole scene to one color; EMA keeps it stable.
+    const HMAX = 10 // meters; histogram window
+    const NB = histRef.current.length
+    const hist = histRef.current
+    hist.fill(0)
+    const sc = NB / HMAX
+    let total = 0
     for (let i = 2; i < n; i += 3) {
       const z = vertices[i]
-      if (z < zMin) zMin = z
-      if (z > zMax) zMax = z
+      if (z <= 0) continue
+      let b = (z * sc) | 0
+      if (b >= NB) b = NB - 1
+      hist[b]++
+      total++
     }
-
-    // Histogram + CDF (matches rs.colorizer histogram_eq default) so a few far-z
-    // outliers don't crush the visible scene into a single color band.
-    const cdf = new Float32Array(BINS)
-    const binScale = isFinite(zMin) && zMax > zMin ? BINS / (zMax - zMin) : 0
-    if (binScale > 0) {
-      const hist = new Uint32Array(BINS)
-      for (let i = 2; i < n; i += 3) {
-        let bin = Math.floor((vertices[i] - zMin) * binScale)
-        if (bin >= BINS) bin = BINS - 1
-        else if (bin < 0) bin = 0
-        hist[bin]++
-      }
+    let zlo = NaN
+    let zhi = NaN
+    if (total > 0) {
+      const loT = total * 0.02
+      const hiT = total * 0.98
       let acc = 0
-      for (let b = 0; b < BINS; b++) {
+      let loB = -1
+      let hiB = NB - 1
+      for (let b = 0; b < NB; b++) {
         acc += hist[b]
-        cdf[b] = acc
+        if (loB < 0 && acc >= loT) loB = b
+        if (acc >= hiT) { hiB = b; break }
       }
-      if (acc > 0) for (let b = 0; b < BINS; b++) cdf[b] /= acc
+      if (loB < 0) loB = 0
+      zlo = loB / sc
+      zhi = (hiB + 1) / sc
     }
+    const r = rangeRef.current
+    if (!isFinite(r.near) || !isFinite(r.far)) {
+      r.near = isFinite(zlo) ? zlo : 0
+      r.far = isFinite(zhi) ? zhi : HMAX
+    } else if (isFinite(zlo) && isFinite(zhi) && zhi > zlo) {
+      const A = 0.1 // ~10-frame time constant
+      r.near += (zlo - r.near) * A
+      r.far += (zhi - r.far) * A
+    }
+    const near = r.near
+    const far = r.far
+    const span = far > near ? far - near : 1
+    const invSpan = 1 / span
 
     for (let i = 0; i < n; i += 3) {
       // RealSense: x-right, y-down, z-forward (meters)
       // Three.js:  x-right, y-up,   z-toward-camera
+      const z = vertices[i + 2]
       positions[i] = vertices[i]
       positions[i + 1] = -vertices[i + 1]
-      positions[i + 2] = -vertices[i + 2]
+      positions[i + 2] = -z
 
-      let t = 0
-      if (binScale > 0) {
-        let bin = Math.floor((vertices[i + 2] - zMin) * binScale)
-        if (bin >= BINS) bin = BINS - 1
-        else if (bin < 0) bin = 0
-        t = cdf[bin]
-      }
+      let t = (z - near) * invSpan
+      if (t < 0) t = 0
+      else if (t > 1) t = 1
       const c = jetColor(t)
       colors[i] = c[0]
       colors[i + 1] = c[1]
       colors[i + 2] = c[2]
     }
 
-    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3))
+    // Only the first `count` vertices are valid this frame; render exactly those.
+    posAttr.needsUpdate = true
+    colAttr.needsUpdate = true
+    geo.setDrawRange(0, count)
     geo.computeBoundingSphere()
-    return geo
   }, [vertices])
 
   return (
     <points geometry={geometry}>
-      <pointsMaterial size={0.005} vertexColors sizeAttenuation />
+      <pointsMaterial
+        size={3}
+        sizeAttenuation={false}
+        vertexColors
+        map={circleSprite}
+        alphaTest={0.5}
+        transparent={false}
+      />
     </points>
   )
 }
 
-// Jet colormap (blue → cyan → green → yellow → red) — matches librealsense rs.colorizer default.
+// Depth colormap matching the 2D view's DepthLegend 'jet' (see DepthLegend.tsx):
+// near = blue → cyan → yellow → red → dark red = far. Linear interpolation between
+// the same 5 stops the legend uses, so 2D and 3D agree.
+const JET_STOPS: [number, number, number][] = [
+  [0, 0, 1],        // near  - blue
+  [0, 1, 1],        //         cyan
+  [1, 1, 0],        //         yellow
+  [1, 0, 0],        //         red
+  [50 / 255, 0, 0], // far   - dark red
+]
 function jetColor(t: number): [number, number, number] {
   const v = Math.min(Math.max(t, 0), 1)
-  if (v < 0.125) return [0, 0, 0.5 + v * 4]
-  if (v < 0.375) return [0, (v - 0.125) * 4, 1]
-  if (v < 0.625) return [(v - 0.375) * 4, 1, 1 - (v - 0.375) * 4]
-  if (v < 0.875) return [1, 1 - (v - 0.625) * 4, 0]
-  return [1 - (v - 0.875) * 4, 0, 0]
+  const seg = v * (JET_STOPS.length - 1)
+  const i = Math.min(Math.floor(seg), JET_STOPS.length - 2)
+  const f = seg - i
+  const a = JET_STOPS[i]
+  const b = JET_STOPS[i + 1]
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f, a[2] + (b[2] - a[2]) * f]
 }
 
-function Axes() {
+// Module-level constants: stable array identity so r3f never rebuilds these
+// buffers. Previously these were `new Float32Array([...])` inline, which created
+// fresh arrays every render → r3f reconstructed the GPU buffers each frame (leak).
+const AXIS_X = new Float32Array([0, 0, 0, 1, 0, 0])
+const AXIS_Y = new Float32Array([0, 0, 0, 0, 1, 0])
+const AXIS_Z = new Float32Array([0, 0, 0, 0, 0, 1])
+
+// Static scene helpers (axes + grid). memo + no props => rendered exactly once,
+// so their buffers are allocated a single time regardless of parent re-renders.
+const SceneDecor = memo(function SceneDecor() {
   return (
     <group>
       {/* X axis - Red */}
       <line>
         <bufferGeometry>
-          <bufferAttribute
-            attach="attributes-position"
-            args={[new Float32Array([0, 0, 0, 1, 0, 0]), 3]}
-          />
+          <bufferAttribute attach="attributes-position" args={[AXIS_X, 3]} />
         </bufferGeometry>
         <lineBasicMaterial color="red" />
       </line>
       {/* Y axis - Green */}
       <line>
         <bufferGeometry>
-          <bufferAttribute
-            attach="attributes-position"
-            args={[new Float32Array([0, 0, 0, 0, 1, 0]), 3]}
-          />
+          <bufferAttribute attach="attributes-position" args={[AXIS_Y, 3]} />
         </bufferGeometry>
         <lineBasicMaterial color="green" />
       </line>
       {/* Z axis - Blue */}
       <line>
         <bufferGeometry>
-          <bufferAttribute
-            attach="attributes-position"
-            args={[new Float32Array([0, 0, 0, 0, 0, 1]), 3]}
-          />
+          <bufferAttribute attach="attributes-position" args={[AXIS_Z, 3]} />
         </bufferGeometry>
         <lineBasicMaterial color="blue" />
       </line>
+      <gridHelper args={[10, 10, '#444', '#333']} />
     </group>
   )
-}
+})
 
 function exportToPLY(vertices: Float32Array) {
   const numPoints = vertices.length / 3

--- a/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/PointCloudViewer.tsx
@@ -19,7 +19,7 @@ const circleSprite = (() => {
 })()
 
 export function PointCloudViewer() {
-  const { pointCloudVertices, isStreaming } = useAppStore()
+  const { pointCloudVertices, pointCloudColors, isStreaming } = useAppStore()
 
   return (
     <div className="h-full flex flex-col">
@@ -48,7 +48,7 @@ export function PointCloudViewer() {
             <PerspectiveCamera makeDefault position={[0, 0, 1]} fov={45} />
             <OrbitControls enablePan enableZoom enableRotate target={[0, 0, -1]} />
             <ambientLight intensity={0.5} />
-            <PointCloud vertices={pointCloudVertices} />
+            <PointCloud vertices={pointCloudVertices} sampledColors={pointCloudColors} />
             <SceneDecor />
           </Canvas>
         ) : (
@@ -83,9 +83,13 @@ export function PointCloudViewer() {
 
 interface PointCloudProps {
   vertices: Float32Array
+  // Optional 1:1 per-vertex RGB sampled from the live color frame on the server
+  // (3 bytes per vertex). When present the cloud is texture-mapped (cpp viewer
+  // parity); when null the per-vertex color falls back to the depth colormap.
+  sampledColors: Uint8Array | null
 }
 
-function PointCloud({ vertices }: PointCloudProps) {
+function PointCloud({ vertices, sampledColors }: PointCloudProps) {
   // One persistent geometry with grow-only fixed-capacity attributes. Inspired by the
   // C++ viewer's upload_points: the GPU buffers are allocated once (regrown only when a
   // frame needs more room) and rewritten in place every frame — no per-frame BufferGeometry
@@ -126,69 +130,87 @@ function PointCloud({ vertices }: PointCloudProps) {
     const positions = posAttr.array as Float32Array
     const colors = colAttr.array as Float32Array
 
-    // Robust depth range via a coarse histogram → 2nd/98th percentile, then EMA-smoothed.
-    // Percentiles (not raw min/max) reject sparse far/near outliers that would otherwise
-    // stretch the range and wash the whole scene to one color; EMA keeps it stable.
-    const HMAX = 10 // meters; histogram window
-    const NB = histRef.current.length
-    const hist = histRef.current
-    hist.fill(0)
-    const sc = NB / HMAX
-    let total = 0
-    for (let i = 2; i < n; i += 3) {
-      const z = vertices[i]
-      if (z <= 0) continue
-      let b = (z * sc) | 0
-      if (b >= NB) b = NB - 1
-      hist[b]++
-      total++
-    }
-    let zlo = NaN
-    let zhi = NaN
-    if (total > 0) {
-      const loT = total * 0.02
-      const hiT = total * 0.98
-      let acc = 0
-      let loB = -1
-      let hiB = NB - 1
-      for (let b = 0; b < NB; b++) {
-        acc += hist[b]
-        if (loB < 0 && acc >= loT) loB = b
-        if (acc >= hiT) { hiB = b; break }
+    // Use server-sampled RGB (textured PC) when the array length matches the
+    // current vertex count. The server sends 3 uint8 bytes per vertex, aligned
+    // 1:1 with `vertices`. Length mismatch can happen for one tick when a
+    // stale frame arrives during decimation-step change → fall back to the
+    // depth colormap that frame.
+    const useSampled = !!sampledColors && sampledColors.length === count * 3
+    if (useSampled) {
+      const src = sampledColors as Uint8Array
+      const INV_255 = 1 / 255
+      for (let i = 0; i < n; i += 3) {
+        // RealSense: x-right, y-down, z-forward (m).  Three.js: x-right, y-up, z-toward-camera.
+        positions[i] = vertices[i]
+        positions[i + 1] = -vertices[i + 1]
+        positions[i + 2] = -vertices[i + 2]
+        colors[i] = src[i] * INV_255
+        colors[i + 1] = src[i + 1] * INV_255
+        colors[i + 2] = src[i + 2] * INV_255
       }
-      if (loB < 0) loB = 0
-      zlo = loB / sc
-      zhi = (hiB + 1) / sc
-    }
-    const r = rangeRef.current
-    if (!isFinite(r.near) || !isFinite(r.far)) {
-      r.near = isFinite(zlo) ? zlo : 0
-      r.far = isFinite(zhi) ? zhi : HMAX
-    } else if (isFinite(zlo) && isFinite(zhi) && zhi > zlo) {
-      const A = 0.1 // ~10-frame time constant
-      r.near += (zlo - r.near) * A
-      r.far += (zhi - r.far) * A
-    }
-    const near = r.near
-    const far = r.far
-    const span = far > near ? far - near : 1
-    const invSpan = 1 / span
+    } else {
+      // Robust depth range via a coarse histogram → 2nd/98th percentile, then EMA-smoothed.
+      // Percentiles (not raw min/max) reject sparse far/near outliers that would otherwise
+      // stretch the range and wash the whole scene to one color; EMA keeps it stable.
+      const HMAX = 10 // meters; histogram window
+      const NB = histRef.current.length
+      const hist = histRef.current
+      hist.fill(0)
+      const sc = NB / HMAX
+      let total = 0
+      for (let i = 2; i < n; i += 3) {
+        const z = vertices[i]
+        if (z <= 0) continue
+        let b = (z * sc) | 0
+        if (b >= NB) b = NB - 1
+        hist[b]++
+        total++
+      }
+      let zlo = NaN
+      let zhi = NaN
+      if (total > 0) {
+        const loT = total * 0.02
+        const hiT = total * 0.98
+        let acc = 0
+        let loB = -1
+        let hiB = NB - 1
+        for (let b = 0; b < NB; b++) {
+          acc += hist[b]
+          if (loB < 0 && acc >= loT) loB = b
+          if (acc >= hiT) { hiB = b; break }
+        }
+        if (loB < 0) loB = 0
+        zlo = loB / sc
+        zhi = (hiB + 1) / sc
+      }
+      const r = rangeRef.current
+      if (!isFinite(r.near) || !isFinite(r.far)) {
+        r.near = isFinite(zlo) ? zlo : 0
+        r.far = isFinite(zhi) ? zhi : HMAX
+      } else if (isFinite(zlo) && isFinite(zhi) && zhi > zlo) {
+        const A = 0.1 // ~10-frame time constant
+        r.near += (zlo - r.near) * A
+        r.far += (zhi - r.far) * A
+      }
+      const near = r.near
+      const far = r.far
+      const span = far > near ? far - near : 1
+      const invSpan = 1 / span
 
-    for (let i = 0; i < n; i += 3) {
-      // RealSense: x-right, y-down, z-forward (meters)
-      // Three.js:  x-right, y-up,   z-toward-camera
-      const z = vertices[i + 2]
-      positions[i] = vertices[i]
-      positions[i + 1] = -vertices[i + 1]
-      positions[i + 2] = -z
+      for (let i = 0; i < n; i += 3) {
+        const z = vertices[i + 2]
+        positions[i] = vertices[i]
+        positions[i + 1] = -vertices[i + 1]
+        positions[i + 2] = -z
 
-      let t = (z - near) * invSpan
-      if (t < 0) t = 0
-      else if (t > 1) t = 1
-      const c = jetColor(t)
-      colors[i] = c[0]
-      colors[i + 1] = c[1]
-      colors[i + 2] = c[2]
+        let t = (z - near) * invSpan
+        if (t < 0) t = 0
+        else if (t > 1) t = 1
+        const c = jetColor(t)
+        colors[i] = c[0]
+        colors[i + 1] = c[1]
+        colors[i + 2] = c[2]
+      }
     }
 
     // Only the first `count` vertices are valid this frame; render exactly those.
@@ -196,7 +218,7 @@ function PointCloud({ vertices }: PointCloudProps) {
     colAttr.needsUpdate = true
     geo.setDrawRange(0, count)
     geo.computeBoundingSphere()
-  }, [vertices])
+  }, [vertices, sampledColors])
 
   return (
     <points geometry={geometry}>

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -19,6 +19,23 @@ import type {
 // Used to await completion before allowing a new start
 const pendingStopPromises = new Map<string, Promise<void>>()
 
+// Server sends point-cloud buffers as raw bytes over a Socket.IO binary
+// attachment (ArrayBuffer); older servers / non-binary transports fall back to
+// base64 strings. These helpers normalize both forms to typed arrays.
+function decodeUint8Payload(raw: ArrayBuffer | string): Uint8Array {
+  if (typeof raw === 'string') {
+    return Uint8Array.from(atob(raw), (c) => c.charCodeAt(0))
+  }
+  if (raw instanceof ArrayBuffer) return new Uint8Array(raw)
+  const view = raw as ArrayBufferLike & { byteOffset?: number; byteLength: number }
+  return new Uint8Array(view, view.byteOffset ?? 0, view.byteLength)
+}
+
+function decodeFloat32Payload(raw: ArrayBuffer | string): Float32Array {
+  const u8 = decodeUint8Payload(raw)
+  return new Float32Array(u8.buffer, u8.byteOffset, u8.byteLength >> 2)
+}
+
 function buildStreamConfigs(sensors: SensorInfo[]): StreamConfig[] {
   const configs: StreamConfig[] = []
   for (const sensor of sensors) {
@@ -204,6 +221,11 @@ interface AppState {
   isLoadingOptions: boolean
   isPointCloudEnabled: boolean
   pointCloudVertices: Float32Array | null
+  // Per-vertex RGB sampled from the live color frame on the server (1 Uint8 per
+  // channel, 3 channels per vertex; aligned 1:1 with pointCloudVertices). Null
+  // when the server didn't texture the cloud (no color stream / unsupported
+  // format) — the 3D viewer falls back to a depth colormap in that case.
+  pointCloudColors: Uint8Array | null
 }
 
 export const useAppStore = create<AppState>()((set, get) => ({
@@ -762,6 +784,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
     // stop. If another device is still streaming its next frame will repopulate.
     set((state) => ({
       pointCloudVertices: null,
+      pointCloudColors: null,
       deviceStates: {
         ...state.deviceStates,
         [deviceId]: {
@@ -962,6 +985,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
         // Drop last point cloud so the 3D canvas doesn't freeze on the last
         // frame; a still-streaming sensor will repopulate within one frame.
         pointCloudVertices: null,
+        pointCloudColors: null,
         deviceStates: {
           ...s.deviceStates,
           [deviceId]: {
@@ -1113,18 +1137,14 @@ export const useAppStore = create<AppState>()((set, get) => ({
         // them would repopulate the cleared cloud and freeze the 3D canvas.
         if (!get().deviceStates[deviceId]?.isStreaming) continue
         try {
-          const raw = streamData.point_cloud.vertices
-          let vertices: Float32Array
-          if (typeof raw === 'string') {
-            const bytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0))
-            vertices = new Float32Array(bytes.buffer)
-          } else if (raw instanceof ArrayBuffer) {
-            vertices = new Float32Array(raw)
-          } else {
-            const u8 = new Uint8Array(raw as ArrayBufferLike)
-            vertices = new Float32Array(u8.buffer, u8.byteOffset, u8.byteLength >> 2)
-          }
-          set({ pointCloudVertices: vertices })
+          const vertices = decodeFloat32Payload(streamData.point_cloud.vertices)
+          // Colors are sampled server-side from the color frame (cpp-viewer
+          // parity). Present only when depth+color are both active and the
+          // color format is RGB8/BGR8.
+          const colors = streamData.point_cloud.colors
+            ? decodeUint8Payload(streamData.point_cloud.colors)
+            : null
+          set({ pointCloudVertices: vertices, pointCloudColors: colors })
         } catch (error) {
           console.error('Failed to decode point cloud data:', error)
         }
@@ -1204,7 +1224,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
         await Promise.all(
           activeDevices.map(ds => apiClient.disablePointCloud(ds.device.device_id))
         )
-        set({ pointCloudVertices: null })
+        set({ pointCloudVertices: null, pointCloudColors: null })
       }
     } catch (err) {
       set({
@@ -1467,4 +1487,5 @@ export const useAppStore = create<AppState>()((set, get) => ({
   },
 
   pointCloudVertices: null,
+  pointCloudColors: null,
 }))

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -171,7 +171,7 @@ interface AppState {
 
   // UI state
   viewMode: ViewMode
-  setViewMode: (mode: ViewMode) => void
+  setViewMode: (mode: ViewMode) => Promise<void>
   isIMUViewerExpanded: boolean
   toggleIMUViewer: () => void
 
@@ -1173,25 +1173,29 @@ export const useAppStore = create<AppState>()((set, get) => ({
 
   // UI state
   viewMode: '2d',
-  setViewMode: (mode) => {
+  setViewMode: async (mode) => {
     const prev = get().viewMode
     if (prev === mode) return
     set({ viewMode: mode })
 
     const activeDevices = Object.values(get().deviceStates).filter(ds => ds.isActive)
-    if (mode === '3d') {
-      for (const ds of activeDevices) {
-        apiClient
-          .enablePointCloud(ds.device.device_id)
-          .catch(err => console.error(`enablePointCloud(${ds.device.device_id}) failed:`, err))
+    try {
+      if (mode === '3d') {
+        await Promise.all(
+          activeDevices.map(ds => apiClient.enablePointCloud(ds.device.device_id))
+        )
+      } else {
+        await Promise.all(
+          activeDevices.map(ds => apiClient.disablePointCloud(ds.device.device_id))
+        )
+        set({ pointCloudVertices: null })
       }
-    } else {
-      for (const ds of activeDevices) {
-        apiClient
-          .disablePointCloud(ds.device.device_id)
-          .catch(err => console.error(`disablePointCloud(${ds.device.device_id}) failed:`, err))
-      }
-      set({ pointCloudVertices: null })
+    } catch (err) {
+      set({
+        error: `Failed to ${mode === '3d' ? 'enable' : 'disable'} point cloud: ${
+          err instanceof Error ? err.message : 'Unknown error'
+        }`,
+      })
     }
   },
   isIMUViewerExpanded: false,

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -1098,16 +1098,22 @@ export const useAppStore = create<AppState>()((set, get) => ({
         }
       }
 
-      // Extract point cloud data if present
+      // Extract point cloud data if present.
+      // Server sends raw float32 bytes as a Socket.IO binary attachment (ArrayBuffer);
+      // fall back to base64 string for older servers.
       if (streamData.point_cloud?.vertices) {
         try {
-          const base64Data = streamData.point_cloud.vertices
-          const binaryString = atob(base64Data)
-          const bytes = new Uint8Array(binaryString.length)
-          for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i)
+          const raw = streamData.point_cloud.vertices
+          let vertices: Float32Array
+          if (typeof raw === 'string') {
+            const bytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0))
+            vertices = new Float32Array(bytes.buffer)
+          } else if (raw instanceof ArrayBuffer) {
+            vertices = new Float32Array(raw)
+          } else {
+            const u8 = new Uint8Array(raw as ArrayBufferLike)
+            vertices = new Float32Array(u8.buffer, u8.byteOffset, u8.byteLength >> 2)
           }
-          const vertices = new Float32Array(bytes.buffer)
           set({ pointCloudVertices: vertices })
         } catch (error) {
           console.error('Failed to decode point cloud data:', error)

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -19,16 +19,13 @@ import type {
 // Used to await completion before allowing a new start
 const pendingStopPromises = new Map<string, Promise<void>>()
 
-// Server sends point-cloud buffers as raw bytes over a Socket.IO binary
-// attachment (ArrayBuffer); older servers / non-binary transports fall back to
-// base64 strings. These helpers normalize both forms to typed arrays.
+// Server sends point-cloud buffers as base64 strings over Socket.IO; the
+// ArrayBuffer branch is here for a future binary-attachment transport.
 function decodeUint8Payload(raw: ArrayBuffer | string): Uint8Array {
   if (typeof raw === 'string') {
     return Uint8Array.from(atob(raw), (c) => c.charCodeAt(0))
   }
-  if (raw instanceof ArrayBuffer) return new Uint8Array(raw)
-  const view = raw as ArrayBufferLike & { byteOffset?: number; byteLength: number }
-  return new Uint8Array(view, view.byteOffset ?? 0, view.byteLength)
+  return new Uint8Array(raw)
 }
 
 function decodeFloat32Payload(raw: ArrayBuffer | string): Float32Array {
@@ -1227,7 +1224,13 @@ export const useAppStore = create<AppState>()((set, get) => ({
         set({ pointCloudVertices: null, pointCloudColors: null })
       }
     } catch (err) {
+      // Roll back so the user can retry — otherwise viewMode is wedged at the
+      // new mode and the `prev === mode` short-circuit at the top blocks the
+      // retry click. Server may be partly-applied; the user is informed via
+      // the error message and a re-click will reissue enable/disable on all
+      // active devices.
       set({
+        viewMode: prev,
         error: `Failed to ${mode === '3d' ? 'enable' : 'disable'} point cloud: ${
           err instanceof Error ? err.message : 'Unknown error'
         }`,

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -757,8 +757,11 @@ export const useAppStore = create<AppState>()((set, get) => ({
   },
 
   stopDeviceStreaming: async (deviceId) => {
-    // Optimistically mark stopping and hide stream immediately
+    // Optimistically mark stopping and hide stream immediately. Also drop the
+    // last point cloud so the 3D canvas doesn't show a frozen last frame after
+    // stop. If another device is still streaming its next frame will repopulate.
     set((state) => ({
+      pointCloudVertices: null,
       deviceStates: {
         ...state.deviceStates,
         [deviceId]: {
@@ -956,6 +959,9 @@ export const useAppStore = create<AppState>()((set, get) => ({
       )
 
       return {
+        // Drop last point cloud so the 3D canvas doesn't freeze on the last
+        // frame; a still-streaming sensor will repopulate within one frame.
+        pointCloudVertices: null,
         deviceStates: {
           ...s.deviceStates,
           [deviceId]: {
@@ -1102,6 +1108,10 @@ export const useAppStore = create<AppState>()((set, get) => ({
       // Server sends raw float32 bytes as a Socket.IO binary attachment (ArrayBuffer);
       // fall back to base64 string for older servers.
       if (streamData.point_cloud?.vertices) {
+        // Drop frames that arrive after the device was stopped — the server's
+        // stop_broadcast can race with frames already in flight, and accepting
+        // them would repopulate the cleared cloud and freeze the 3D canvas.
+        if (!get().deviceStates[deviceId]?.isStreaming) continue
         try {
           const raw = streamData.point_cloud.vertices
           let vertices: Float32Array

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -1173,7 +1173,27 @@ export const useAppStore = create<AppState>()((set, get) => ({
 
   // UI state
   viewMode: '2d',
-  setViewMode: (mode) => set({ viewMode: mode }),
+  setViewMode: (mode) => {
+    const prev = get().viewMode
+    if (prev === mode) return
+    set({ viewMode: mode })
+
+    const activeDevices = Object.values(get().deviceStates).filter(ds => ds.isActive)
+    if (mode === '3d') {
+      for (const ds of activeDevices) {
+        apiClient
+          .enablePointCloud(ds.device.device_id)
+          .catch(err => console.error(`enablePointCloud(${ds.device.device_id}) failed:`, err))
+      }
+    } else {
+      for (const ds of activeDevices) {
+        apiClient
+          .disablePointCloud(ds.device.device_id)
+          .catch(err => console.error(`disablePointCloud(${ds.device.device_id}) failed:`, err))
+      }
+      set({ pointCloudVertices: null })
+    }
+  },
   isIMUViewerExpanded: false,
   toggleIMUViewer: () => set((state) => ({ isIMUViewerExpanded: !state.isIMUViewerExpanded })),
 

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/components/Header.test.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/components/Header.test.tsx
@@ -26,7 +26,7 @@ describe('Header', () => {
     expect(screen.getByText(/3D View/i)).toBeInTheDocument()
   })
 
-  it('3D view button is disabled', () => {
+  it('3D view button is enabled', () => {
     render(<Header />, {
       initialStoreState: {
         deviceStates: {
@@ -39,23 +39,7 @@ describe('Header', () => {
     })
 
     const button = screen.getByText(/3D View/i).closest('button')
-    expect(button).toBeDisabled()
-  })
-
-  it('3D view button has "coming soon" tooltip', () => {
-    render(<Header />, {
-      initialStoreState: {
-        deviceStates: {
-          '123': {
-            isActive: true,
-            device: { device_id: '123', name: 'Test Device' },
-          } as any,
-        },
-      },
-    })
-
-    const button = screen.getByText(/3D View/i).closest('button')
-    expect(button).toHaveAttribute('title', '3D View feature coming soon')
+    expect(button).not.toBeDisabled()
   })
 
   it('does not show view toggle when no active devices', () => {

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/store/store.test.ts
@@ -75,23 +75,17 @@ describe('AppStore', () => {
   })
 
   describe('View Mode', () => {
-    it('sets view mode to single', () => {
-      useAppStore.getState().setViewMode('single')
-      
-      expect(useAppStore.getState().viewMode).toBe('single')
+    it('switches to 3d', async () => {
+      await useAppStore.getState().setViewMode('3d')
+
+      expect(useAppStore.getState().viewMode).toBe('3d')
     })
 
-    it('sets view mode to pointcloud', () => {
-      useAppStore.getState().setViewMode('pointcloud')
-      
-      expect(useAppStore.getState().viewMode).toBe('pointcloud')
-    })
+    it('switches back to 2d', async () => {
+      await useAppStore.getState().setViewMode('3d')
+      await useAppStore.getState().setViewMode('2d')
 
-    it('sets view mode to grid', () => {
-      useAppStore.getState().setViewMode('single')
-      useAppStore.getState().setViewMode('grid')
-      
-      expect(useAppStore.getState().viewMode).toBe('grid')
+      expect(useAppStore.getState().viewMode).toBe('2d')
     })
   })
 


### PR DESCRIPTION
Tracked by: RSDEV-9239

## Summary

Phase 2 / 3D view of the React viewer (RSDEV-9239). The 3D View button was
permanently disabled with a "coming soon" tooltip; the underlying pipeline
existed but was not wired up and the backend never produced point cloud frames
in sensor mode. This PR makes 3D actually work end-to-end:

- Enable the 3D View button (Header.tsx); the checkbox in PointCloudViewer
  is replaced by auto-activation when the user enters 3D and deactivation
  on leaving (store.setViewMode side-effect).
- Backend: compute point cloud in sensor mode too (rs_manager._process_sensor_frame),
  not just pipeline mode. The is_pointcloud_enabled flag was a no-op for the
  per-sensor streaming path the DevicePanel uses.
- Bandwidth: a 640×480 point cloud is ~5 MB / frame and was being shoved
  through Socket.IO at 30 fps, stalling the server.
    - decimate `verts[::4]`
    - throttle point_cloud emission to every 3rd metadata broadcast (10 fps)
    - raise socketio.AsyncServer max_http_buffer_size to 10 MB
- PointCloudViewer rendering: flip Y/Z to convert RealSense (y-down, z-forward)
  to Three.js (y-up, z-toward-camera); replace the custom blue→red gradient
  with a histogram-equalized jet colormap matching `rs.colorizer()`'s
  default `histogram_eq=1.0`; move initial camera + OrbitControls target
  so the cloud is centered.
- App.tsx: keep StreamViewer and PointCloudViewer both mounted across view
  toggle (visibility-swap rather than conditional render) so the WebRTC
  peer survives 3D → 2D switches — no more "Connecting…" flash.

Not in scope (future PR): color-to-depth texture alignment.

## Test plan

- [ ] Start streaming depth (sensor mode via DevicePanel) → click **3D View** → point cloud renders within a frame
- [ ] Cloud is oriented correctly (Y-up, scene in front of viewer) and colored across the full jet range, similar to the 2D depth thumbnail
- [ ] Switch back to 2D → no "Connecting…" delay, WebRTC video resumes instantly
- [ ] Server stays responsive (no stalls) for several minutes of continuous 3D streaming
- [ ] Export PLY button still produces a valid `.ply`