### PR TITLE
Aggregate --retries attempts per logical test in summary, JUnit, and exit code

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -231,6 +231,10 @@ def pytest_configure(config):
             config.option.count = retries_val + 1
             config.option.repeat_scope = 'module'
             config._module_retry_mode = True    # skip retry passes when previous pass was clean
+            # Clear any stale state from a previous in-process session and start buffering
+            # reports for this run's aggregation.
+            retry_aggregation.reset()
+            retry_aggregation.enable()
 
     # We override pytest-repeat's `__pytest_repeat_step_number` to module scope so
     # module-scoped fixtures (e.g. module_device_setup) can depend on it and re-instantiate

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -193,10 +193,6 @@ def pytest_addoption(parser):
 # Shared context tags (e.g. "nightly", "weekly") — tests check this to adjust behavior
 context_list = []
 
-# Module-scoped retry: tracks which (module, repeat_step) passes had failures.
-# Used by --retries to skip retry passes when the previous pass was clean.
-_module_pass_had_failure = {}  # (module_file, step) -> True
-
 
 def pytest_configure(config):
     """Early setup: register markers, configure defaults, and query connected devices."""
@@ -232,9 +228,11 @@ def pytest_configure(config):
             config.option.repeat_scope = 'module'
             config._module_retry_mode = True    # skip retry passes when previous pass was clean
             # Clear any stale state from a previous in-process session and start buffering
-            # reports for this run's aggregation.
+            # reports for this run's aggregation. Register the module as a plugin so its
+            # tryfirst pytest_runtest_protocol hook can bypass the protocol for clean retries.
             retry_aggregation.reset()
             retry_aggregation.enable()
+            config.pluginmanager.register(retry_aggregation, "rs_retry_aggregation")
 
     # We override pytest-repeat's `__pytest_repeat_step_number` to module scope so
     # module-scoped fixtures (e.g. module_device_setup) can depend on it and re-instantiate
@@ -377,17 +375,25 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item, nextitem):
-    """Wrap each test with log separators and write per-test log file."""
-    file_handler = start_test_log(item)
-    ensure_newline()
-    log.info("-" * 80)
-    log.info(f"Test: {item.nodeid}")
-    log.info("-" * 80)
+    """Wrap each test with log separators and write per-test log file.
+
+    For retry-skip-if-clean items, skip log creation entirely - the plugin's
+    tryfirst pytest_runtest_protocol returns True before we get here, so no
+    test phases will run; opening a log file would just create an empty stub.
+    """
+    bypass = retry_aggregation.should_skip_if_clean(item)
+    if not bypass:
+        file_handler = start_test_log(item)
+        ensure_newline()
+        log.info("-" * 80)
+        log.info(f"Test: {item.nodeid}")
+        log.info("-" * 80)
 
     outcome = yield
-    stop_test_log(file_handler, nextitem)
 
-    ensure_newline()
+    if not bypass:
+        stop_test_log(file_handler, nextitem)
+        ensure_newline()
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -415,26 +421,29 @@ def pytest_runtest_makereport(item, call):
     if report.failed and getattr(item.config, '_module_retry_mode', False):
         callspec = getattr(item, 'callspec', None)
         step = callspec.params.get('__pytest_repeat_step_number', 0) if callspec else 0
-        mod = item.module.__file__
-        _module_pass_had_failure[(mod, step)] = True
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_setup(item):
-    """Skip retry passes whose previous pass had no failures (--retries optimisation)."""
-    if not getattr(item.config, '_module_retry_mode', False):
-        return
-    callspec = getattr(item, 'callspec', None)
-    step = callspec.params.get('__pytest_repeat_step_number', 0) if callspec else 0
-    if step > 0:
-        mod = item.module.__file__
-        if not _module_pass_had_failure.get((mod, step - 1), False):
-            pytest.skip("Module retry skipped — no failures in previous pass")
+        retry_aggregation.record_module_failure(item.module.__file__, step)
 
 
 def pytest_runtest_logreport(report):
     """Buffer call-phase reports for --retries aggregation (cheap no-op otherwise)."""
     retry_aggregation.record_report(report)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_teststatus(report, config):
+    """Hide skip-if-clean retry entries from per-line output and stats buckets.
+
+    With ``--retries N``, pytest-repeat parametrizes every test at ``count = N+1``;
+    the conftest's setup hook then ``pytest.skip()``s any retry pass after a clean
+    module. Those SKIPPED reports are pure optimisation noise — they didn't run
+    and aren't a real test skip. Returning ``("", "", "")`` makes
+    ``TerminalReporter.pytest_runtest_logreport`` early-return without printing
+    a per-line entry and without appending to stats. Real ``pytest.skip()`` calls
+    in tests are untouched.
+    """
+    if getattr(config, '_module_retry_mode', False) and retry_aggregation.is_retry_skip_if_clean(report):
+        return "", "", ""
+    return None
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -63,6 +63,7 @@ from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
 from rspy.pytest.device_helpers import resolve_device_each_serials, _MISSING_SENTINEL_PREFIX, _SKIP_SENTINEL_PREFIX
 from rspy.pytest.collection import filter_and_sort_items
 from rspy.pytest.plugins import check_required_plugins
+from rspy.pytest import retry_aggregation
 
 log = logging.getLogger('librealsense')
 
@@ -427,9 +428,45 @@ def pytest_runtest_setup(item):
             pytest.skip("Module retry skipped — no failures in previous pass")
 
 
+def pytest_runtest_logreport(report):
+    """Buffer call-phase reports for --retries aggregation (cheap no-op otherwise)."""
+    retry_aggregation.record_report(report)
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Reconcile --retries aggregation.
+
+    pre-yield: reconcile terminalreporter.stats and adjust session.exitstatus so the
+        downstream summary line and the process exit code reflect logical-test counts.
+    post-yield: rewrite JUnit XML *after* the junitxml plugin's hookwrapper writes it.
+    """
+    config = session.config
+    if getattr(config, '_module_retry_mode', False):
+        terminalreporter = config.pluginmanager.get_plugin('terminalreporter')
+        if terminalreporter is not None:
+            rescued, hard_failed = retry_aggregation.reconcile_terminal_stats(terminalreporter)
+            config._retry_summary_lists = (rescued, hard_failed)
+            retry_aggregation.adjust_session_exitstatus(session, terminalreporter)
+
+    yield
+
+    if getattr(config, '_module_retry_mode', False):
+        xmlpath = getattr(config.option, 'xmlpath', None)
+        if xmlpath:
+            retry_aggregation.rewrite_junit_xml(xmlpath)
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    """Print pass/fail/skip summary for Jenkins Groovy parsing."""
+    """Print the Jenkins-friendly summary and the retry rescue/fail listing.
+
+    Stats and exit code were already reconciled in pytest_sessionfinish's pre-yield.
+    """
     print_terminal_summary(terminalreporter)
+    rescued, hard_failed = getattr(config, '_retry_summary_lists', ([], []))
+    if rescued or hard_failed:
+        retry_aggregation.print_retry_summary(terminalreporter, rescued, hard_failed)
 
 
 # ============================================================================

--- a/unit-tests/infra-tests/e2e/pytest-retry-rescued.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-rescued.py
@@ -1,0 +1,17 @@
+# All failures here are rescued by a retry; exit code must be 0 (green).
+import pytest
+
+pytestmark = [pytest.mark.device("D455")]
+
+_flake = 0
+
+def test_always_passes(module_device_setup):
+    """Always passes — verifies de-duplication when the module re-runs."""
+    pass
+
+def test_flaky_passes_on_retry(module_device_setup):
+    """Fails on step 0, passes on step 1 → rescued."""
+    global _flake
+    _flake += 1
+    if _flake == 1:
+        assert False, "intentional first-pass failure"

--- a/unit-tests/infra-tests/e2e/pytest-retry.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry.py
@@ -1,18 +1,22 @@
-# Test module-scoped retry: the module has two tests, one fails on the first pass.
-# --retries 1 should rerun the entire module (both tests) after recycling.
+# Test module-scoped retry aggregation: three logical tests exercise the three
+# outcomes the conftest reconciler must collapse.
 import pytest
 
 pytestmark = [pytest.mark.device("D455")]
 
-_fail_attempt = 0
+_fail_then_pass_attempt = 0
 
 def test_always_passes(module_device_setup):
-    """This test always passes — included to verify the entire module reruns."""
+    """Logical PASS — runs twice (module reruns) but reports once."""
     pass
 
 def test_fails_then_passes(module_device_setup):
-    """Fail on first pass (step 0), pass on retry (step 1)."""
-    global _fail_attempt
-    _fail_attempt += 1
-    if _fail_attempt == 1:
+    """Logical PASS via retry — fails on step 0, passes on step 1 (rescued)."""
+    global _fail_then_pass_attempt
+    _fail_then_pass_attempt += 1
+    if _fail_then_pass_attempt == 1:
         assert False, "intentional first-pass failure"
+
+def test_always_fails(module_device_setup):
+    """Logical FAIL — fails every attempt; report keeps one FAILED."""
+    assert False, "intentional permanent failure"

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -67,12 +67,18 @@ class TestCliOptionsRegistered:
         assert rc == 0
 
     def test_retries(self):
-        """--retries 1 should rerun the entire module on failure, recycling the device."""
+        """--retries 1 aggregates per logical test: rescues count as PASS, hard failures
+        contribute one FAILED, and tests that incidentally re-ran are de-duplicated."""
         rc, out, tracking = run_e2e("pytest-retry.py", "--retries", "1")
-        # Pass 0: test_always_passes PASSED, test_fails_then_passes FAILED
-        # Pass 1 (retry): device recycled, both tests rerun → both PASSED
-        # pytest-repeat reports: 3 passed (2 from pass 1 + 1 from pass 0 survivor), 1 failed (pass 0)
-        assert_outcomes(out, passed=3, failed=1)
+        # Logical outcomes after aggregation:
+        #   test_always_passes        → PASS (ran twice, kept once)
+        #   test_fails_then_passes    → PASS (rescued by retry)
+        #   test_always_fails         → FAIL (kept the last failed attempt)
+        assert_outcomes(out, passed=2, failed=1)
+        assert rc != 0, "test_always_fails should still drive a non-zero exit"
+        # Console must surface the rescue informatively (non-failing tests still flagged).
+        assert "RETRY-RESCUED" in out
+        assert "test_fails_then_passes" in out
         calls = tracking["enable_only_calls"]
         # Two enable_only calls: initial setup (pass 0) + recycle (pass 1 = new repeat pass)
         assert len(calls) == 2
@@ -89,12 +95,20 @@ class TestCliOptionsRegistered:
         before the original pass and observe an empty failure record."""
         rc, out, tracking = run_e2e("pytest-retry-setup-fail.py", "--retries", "1")
         # Pass 0: fixture raises in setup → 1 error.
-        # Pass 1 (retry): fixture returns → 1 passed.
-        assert_outcomes(out, passed=1, error=1)
+        # Pass 1 (retry): fixture returns → 1 passed (rescued by aggregation).
+        assert_outcomes(out, passed=1)
+        assert rc == 0, "setup error rescued by retry → exit code should be 0"
         calls = tracking["enable_only_calls"]
         # Two enable_only calls: pass 0 setup + pass 1 retry recycle.
         assert len(calls) == 2
         assert all(c['recycle'] is True for c in calls)
+
+    def test_retries_all_recovered(self):
+        """When every failure is rescued by a retry, the job exits 0 (green)."""
+        rc, out, _ = run_e2e("pytest-retry-rescued.py", "--retries", "1")
+        assert_outcomes(out, passed=2)
+        assert rc == 0, "all failures rescued → exit code should be 0"
+        assert "RETRY-RESCUED" in out
 
     def test_repeat(self):
         """--repeat 3 should repeat the test 3 times, recycling the device each time."""

--- a/unit-tests/infra-tests/test_retry_aggregation.py
+++ b/unit-tests/infra-tests/test_retry_aggregation.py
@@ -1,0 +1,116 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""Regression tests for the pure functions in rspy.pytest.retry_aggregation.
+
+Kept focused: each test guards a behaviour the e2e tests don't exercise directly
+(canonical-id false-positives, mixed setup/call rescue paths, JUnit edge cases).
+"""
+
+import os
+import sys
+import tempfile
+import types
+import xml.etree.ElementTree as ET
+
+import pytest
+
+_unit_tests_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+_py_dir = os.path.join(_unit_tests_dir, 'py')
+if _py_dir not in sys.path:
+    sys.path.insert(0, _py_dir)
+
+from rspy.pytest import retry_aggregation as ra
+
+
+class TestCanonicalId:
+
+    def test_valid_repeat_suffix_stripped(self):
+        assert ra.canonical_id("test_y[D455-114222251278-1-2]") == "test_y[D455-114222251278]"
+
+    def test_serial_tail_not_misinterpreted_as_repeat(self):
+        # count=1 is not a valid pytest-repeat tail (need >= 2 attempts).
+        assert ra.canonical_id("test_y[D455-7-1]") == "test_y[D455-7-1]"
+
+    def test_step_gt_count_rejected(self):
+        # step beyond count is impossible for pytest-repeat.
+        assert ra.canonical_id("test_y[D455-5-2]") == "test_y[D455-5-2]"
+
+
+def _mk_report(passed=False, failed=False):
+    return types.SimpleNamespace(passed=passed, failed=failed)
+
+
+class TestClassifyGroups:
+
+    def setup_method(self):
+        ra.reset()
+
+    def test_rescued_drops_failed_attempt(self):
+        f1, p2 = _mk_report(failed=True), _mk_report(passed=True)
+        ra._call_reports['t1'] = [(1, f1), (2, p2)]
+        rescued, hard_failed, _, fail_drop, err_drop = ra._classify_groups()
+        assert rescued == ['t1'] and hard_failed == []
+        assert fail_drop == [f1] and err_drop == []
+
+    def test_setup_error_rescued_by_call_pass(self):
+        e1, p2 = _mk_report(failed=True), _mk_report(passed=True)
+        ra._call_reports['t1'] = [(2, p2)]
+        ra._error_reports['t1'] = [(1, e1)]
+        rescued, hard_failed, _, fail_drop, err_drop = ra._classify_groups()
+        assert rescued == ['t1'] and hard_failed == []
+        assert err_drop == [e1] and fail_drop == []
+
+
+def _write_xml(content):
+    fd, path = tempfile.mkstemp(suffix='.xml')
+    os.close(fd)
+    with open(path, 'w') as f:
+        f.write(content)
+    return path
+
+
+class TestRewriteJunitXml:
+
+    def test_rescued_failure_becomes_clean_passed_with_summed_time(self):
+        xml = """<?xml version='1.0' encoding='utf-8'?>
+<testsuites><testsuite name="pytest" tests="2" failures="1" errors="0" skipped="0" time="2.0">
+  <testcase classname="m" name="test_x[D455-1-2]" time="0.1">
+    <failure message="boom">boom</failure>
+  </testcase>
+  <testcase classname="m" name="test_x[D455-2-2]" time="0.2" />
+</testsuite></testsuites>"""
+        path = _write_xml(xml)
+        try:
+            ra.rewrite_junit_xml(path)
+            ts = ET.parse(path).getroot().find('testsuite')
+            tcs = ts.findall('testcase')
+            assert len(tcs) == 1
+            assert tcs[0].get('name') == 'test_x[D455]'
+            assert tcs[0].findall('failure') == []
+            assert ts.get('failures') == '0' and ts.get('tests') == '1'
+            assert float(tcs[0].get('time')) == pytest.approx(0.3)
+        finally:
+            os.unlink(path)
+
+    def test_skipped_in_middle_not_treated_as_pass(self):
+        """FAIL -> SKIPPED -> PASS: the kept entry must be the PASS, not SKIPPED."""
+        xml = """<?xml version='1.0' encoding='utf-8'?>
+<testsuites><testsuite name="pytest" tests="3" failures="1" errors="0" skipped="1" time="3.0">
+  <testcase classname="m" name="test_x[D455-1-3]" time="0.1">
+    <failure message="boom">boom</failure>
+  </testcase>
+  <testcase classname="m" name="test_x[D455-2-3]" time="0.05">
+    <skipped message="conditional skip" />
+  </testcase>
+  <testcase classname="m" name="test_x[D455-3-3]" time="0.2" />
+</testsuite></testsuites>"""
+        path = _write_xml(xml)
+        try:
+            ra.rewrite_junit_xml(path)
+            tcs = ET.parse(path).getroot().find('testsuite').findall('testcase')
+            assert len(tcs) == 1
+            assert tcs[0].findall('failure') == []
+            assert tcs[0].findall('skipped') == []
+        finally:
+            os.unlink(path)

--- a/unit-tests/py/rspy/pytest/retry_aggregation.py
+++ b/unit-tests/py/rspy/pytest/retry_aggregation.py
@@ -35,6 +35,9 @@ import pytest
 
 log = logging.getLogger('librealsense')
 
+# NOT thread-safe: assumes single-process (non-xdist) execution. If pytest-xdist
+# is adopted, these dicts must be replaced with a per-worker mechanism.
+#
 # Per-logical-test buffer for 'call'-phase reports. Populated as tests run.
 # Key:  canonical nodeid (pytest-repeat suffix stripped).
 # Value: list of (step, TestReport) tuples.
@@ -44,7 +47,18 @@ _call_reports = {}
 # in TerminalReporter.stats). Same key/shape as _call_reports.
 _error_reports = {}
 
+# Activated by conftest.py when --retries is in use. While inactive, record_report
+# is a no-op so the buffers don't accumulate TestReport objects across a long
+# session that never asked for retries.
+_enabled = False
+
 _STEP_SUFFIX_RE = re.compile(r'\[([^\]]*)\]$')
+
+
+def enable():
+    """Activate report buffering. Called by conftest at --retries setup."""
+    global _enabled
+    _enabled = True
 
 
 def reset():
@@ -61,6 +75,12 @@ def canonical_id(nodeid_or_name):
         test_x[D455-114222251278-1-2]  -> test_x[D455-114222251278]
         test_x[1-2]                     -> test_x
         test_x[D455]                    -> test_x[D455]   # no repeat suffix
+        test_x[SN-7-8]                  -> test_x[SN-7-8] # not a valid repeat tail
+
+    The last two components must look like pytest-repeat's ``step-count`` pair:
+    both decimal, ``count >= 2``, and ``1 <= step <= count``. Any other tail is
+    treated as part of the parametrize id and left alone, so test ids whose
+    serial numbers happen to end in digits aren't mis-merged.
     """
     m = _STEP_SUFFIX_RE.search(nodeid_or_name)
     if not m:
@@ -68,28 +88,40 @@ def canonical_id(nodeid_or_name):
     parts = m.group(1).split('-')
     if len(parts) < 2 or not parts[-1].isdigit() or not parts[-2].isdigit():
         return nodeid_or_name
+    step_val, count_val = int(parts[-2]), int(parts[-1])
+    if count_val < 2 or step_val < 1 or step_val > count_val:
+        return nodeid_or_name
     base = nodeid_or_name[:m.start()]
     remaining = parts[:-2]
     return f"{base}[{'-'.join(remaining)}]" if remaining else base
 
 
 def _step_from_nodeid(nodeid):
+    """Return the pytest-repeat step (1-indexed) or None if the tail isn't a valid pair."""
     m = _STEP_SUFFIX_RE.search(nodeid)
     if not m:
         return None
     parts = m.group(1).split('-')
     if len(parts) < 2 or not parts[-1].isdigit() or not parts[-2].isdigit():
         return None
-    return int(parts[-2])
+    step_val, count_val = int(parts[-2]), int(parts[-1])
+    if count_val < 2 or step_val < 1 or step_val > count_val:
+        return None
+    return step_val
 
 
 def record_report(report):
     """Buffer report keyed by canonical id.
 
+    No-op unless ``enable()`` was called (i.e. unless --retries is active), so a
+    plain pytest run doesn't accumulate TestReport objects in module-level dicts.
+
     'call' phase reports are tracked for pass/fail aggregation. Failed
     'setup'/'teardown' reports (which surface as 'error' in the terminal stats)
     are tracked separately so a later successful call attempt can rescue them.
     """
+    if not _enabled:
+        return
     cid = canonical_id(report.nodeid)
     step = _step_from_nodeid(report.nodeid) or 0
     if report.when == 'call':
@@ -221,9 +253,12 @@ def rewrite_junit_xml(xmlpath):
     """Collapse parametrized retry attempts into one ``<testcase>`` per logical test.
 
     For each group of ``<testcase>`` sharing the same (classname, canonical name):
-        - If any attempt has no failure/error child → keep one PASSED testcase
-          (strip any failure/error children from the kept entry).
+        - If any attempt has no failure/error/skipped child → keep one PASSED
+          testcase (strip any failure/error children from the kept entry).
         - Else → keep the last testcase (most recent failure).
+
+    The kept ``<testcase>``'s ``time`` attribute is replaced with the SUM of all
+    attempts so trend graphs reflect the real cost of a retried test.
 
     Updates the parent ``<testsuite>`` aggregate counts.
     """
@@ -261,7 +296,9 @@ def rewrite_junit_xml(xmlpath):
             if has_pass:
                 keep = next(
                     (tc for tc in tcs
-                     if not tc.findall('failure') and not tc.findall('error')),
+                     if not tc.findall('failure')
+                     and not tc.findall('error')
+                     and not tc.findall('skipped')),
                     tcs[-1],
                 )
                 for child in list(keep):
@@ -269,6 +306,13 @@ def rewrite_junit_xml(xmlpath):
                         keep.remove(child)
             else:
                 keep = tcs[-1]
+            total_time = 0.0
+            for tc in tcs:
+                try:
+                    total_time += float(tc.get('time', '0') or 0)
+                except ValueError:
+                    pass
+            keep.set('time', f'{total_time:.3f}')
             keep.set('name', key[1])
             for tc in tcs:
                 if tc is not keep:

--- a/unit-tests/py/rspy/pytest/retry_aggregation.py
+++ b/unit-tests/py/rspy/pytest/retry_aggregation.py
@@ -1,0 +1,283 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""Aggregate --retries attempts per logical test.
+
+Background
+----------
+``--retries N`` is implemented on top of pytest-repeat (see conftest.py): the
+whole module re-runs N times when any test in it fails, with the device
+recycled between passes. Each test in the module appears N+1 times in the
+report (one per pass), with pytest-repeat's ``-<step>-<count>`` suffix
+appended to the parametrize id (e.g. ``[D455-114222251278-1-2]`` /
+``[D455-114222251278-2-2]``).
+
+Per-line output during the run is intentionally left untouched: every attempt
+prints its true PASSED/FAILED status, so flakes remain visible in the console.
+This module collapses those attempts in the *aggregate* surfaces (terminal
+summary line, JUnit XML, exit code) so a single logical test contributes one
+outcome:
+
+- PASSED if any attempt passed.
+- FAILED if every attempt failed.
+- SKIPPED if every attempt was skipped (e.g. skip-if-clean optimisation).
+
+Hooks live in conftest.py and call into this module.
+"""
+
+import logging
+import os
+import re
+import xml.etree.ElementTree as ET
+
+import pytest
+
+
+log = logging.getLogger('librealsense')
+
+# Per-logical-test buffer for 'call'-phase reports. Populated as tests run.
+# Key:  canonical nodeid (pytest-repeat suffix stripped).
+# Value: list of (step, TestReport) tuples.
+_call_reports = {}
+
+# Per-logical-test buffer for setup/teardown failures (which surface as 'error'
+# in TerminalReporter.stats). Same key/shape as _call_reports.
+_error_reports = {}
+
+_STEP_SUFFIX_RE = re.compile(r'\[([^\]]*)\]$')
+
+
+def reset():
+    """Clear state (for tests that re-enter pytest_configure within one process)."""
+    _call_reports.clear()
+    _error_reports.clear()
+
+
+def canonical_id(nodeid_or_name):
+    """Strip pytest-repeat's '-<step>-<count>' tail.
+
+    Examples (count=2)::
+
+        test_x[D455-114222251278-1-2]  -> test_x[D455-114222251278]
+        test_x[1-2]                     -> test_x
+        test_x[D455]                    -> test_x[D455]   # no repeat suffix
+    """
+    m = _STEP_SUFFIX_RE.search(nodeid_or_name)
+    if not m:
+        return nodeid_or_name
+    parts = m.group(1).split('-')
+    if len(parts) < 2 or not parts[-1].isdigit() or not parts[-2].isdigit():
+        return nodeid_or_name
+    base = nodeid_or_name[:m.start()]
+    remaining = parts[:-2]
+    return f"{base}[{'-'.join(remaining)}]" if remaining else base
+
+
+def _step_from_nodeid(nodeid):
+    m = _STEP_SUFFIX_RE.search(nodeid)
+    if not m:
+        return None
+    parts = m.group(1).split('-')
+    if len(parts) < 2 or not parts[-1].isdigit() or not parts[-2].isdigit():
+        return None
+    return int(parts[-2])
+
+
+def record_report(report):
+    """Buffer report keyed by canonical id.
+
+    'call' phase reports are tracked for pass/fail aggregation. Failed
+    'setup'/'teardown' reports (which surface as 'error' in the terminal stats)
+    are tracked separately so a later successful call attempt can rescue them.
+    """
+    cid = canonical_id(report.nodeid)
+    step = _step_from_nodeid(report.nodeid) or 0
+    if report.when == 'call':
+        _call_reports.setdefault(cid, []).append((step, report))
+    elif report.when in ('setup', 'teardown') and report.failed:
+        _error_reports.setdefault(cid, []).append((step, report))
+
+
+def _classify_groups():
+    """Group buffered reports per logical test and decide what to drop from stats.
+
+    Returns ``(rescued, hard_failed, dup_passes, failed_to_drop, errors_to_drop)``:
+        rescued         -- canonical ids where some attempt didn't pass but a later one did
+        hard_failed     -- canonical ids where every attempt failed (call FAILED or setup ERROR)
+        dup_passes      -- TestReport objects to remove from stats['passed']
+        failed_to_drop  -- TestReport objects to remove from stats['failed']
+        errors_to_drop  -- TestReport objects to remove from stats['error']
+
+    Rescued tests have all their failed call reports + all error reports dropped.
+    Hard-failed tests keep only the most recent failure/error overall.
+    All-passed tests that ran more than once keep the first pass.
+    """
+    rescued, hard_failed = [], []
+    dup_passes, failed_to_drop, errors_to_drop = [], [], []
+
+    all_cids = set(_call_reports) | set(_error_reports)
+    for cid in all_cids:
+        call_attempts = sorted(_call_reports.get(cid, []), key=lambda x: x[0])
+        error_attempts = sorted(_error_reports.get(cid, []), key=lambda x: x[0])
+        passed = [r for _, r in call_attempts if r.passed]
+        failed_calls = [r for _, r in call_attempts if r.failed]
+        errors = [r for _, r in error_attempts]
+        had_failure = bool(failed_calls or errors)
+
+        if not had_failure:
+            if len(passed) > 1:
+                dup_passes.extend(passed[1:])
+            continue
+
+        if passed:
+            rescued.append(cid)
+            failed_to_drop.extend(failed_calls)
+            errors_to_drop.extend(errors)
+            if len(passed) > 1:
+                dup_passes.extend(passed[1:])
+            continue
+
+        hard_failed.append(cid)
+        all_failures = sorted(
+            [(s, r, 'call') for s, r in call_attempts if r.failed]
+            + [(s, r, 'error') for s, r in error_attempts],
+            key=lambda x: x[0],
+        )
+        for _, r, kind in all_failures[:-1]:
+            if kind == 'call':
+                failed_to_drop.append(r)
+            else:
+                errors_to_drop.append(r)
+
+    return rescued, hard_failed, dup_passes, failed_to_drop, errors_to_drop
+
+
+def reconcile_terminal_stats(terminalreporter):
+    """Rewrite ``terminalreporter.stats`` so each logical test contributes once.
+
+    Returns ``(rescued, hard_failed)`` lists for the caller to print as a summary.
+    """
+    if not _call_reports and not _error_reports:
+        return [], []
+
+    rescued, hard_failed, dup_passes, failed_drop, errors_drop = _classify_groups()
+
+    if not (dup_passes or failed_drop or errors_drop):
+        return rescued, hard_failed
+
+    stats = terminalreporter.stats
+    drop_failed_ids = {id(r) for r in failed_drop}
+    drop_error_ids = {id(r) for r in errors_drop}
+    drop_passed_ids = {id(r) for r in dup_passes}
+
+    if 'failed' in stats:
+        stats['failed'] = [r for r in stats['failed'] if id(r) not in drop_failed_ids]
+    if 'error' in stats:
+        stats['error'] = [r for r in stats['error'] if id(r) not in drop_error_ids]
+    if 'passed' in stats:
+        stats['passed'] = [r for r in stats['passed'] if id(r) not in drop_passed_ids]
+
+    return rescued, hard_failed
+
+
+def adjust_session_exitstatus(session, terminalreporter):
+    """Recompute ``session.testsfailed`` from reconciled stats and flip exit status.
+
+    Counts both 'failed' (call assertions) and 'error' (setup/teardown failures);
+    pytest's wrap_session reads ``session.exitstatus`` after pytest_sessionfinish,
+    so updating it here propagates to the process return code.
+    """
+    stats = terminalreporter.stats
+    n_unrescued = len(stats.get('failed', [])) + len(stats.get('error', []))
+    session.testsfailed = n_unrescued
+    if n_unrescued == 0 and session.exitstatus == pytest.ExitCode.TESTS_FAILED:
+        session.exitstatus = pytest.ExitCode.OK
+
+
+def print_retry_summary(terminalreporter, rescued, hard_failed):
+    """Print a clearly-marked retry summary so CI logs surface what was retried."""
+    if not rescued and not hard_failed:
+        return
+    tr = terminalreporter
+    tr.write_sep('=', 'retry summary', bold=True)
+    if rescued:
+        tr.write_line(
+            f"{len(rescued)} test(s) recovered after retry - overall result PASS:",
+            yellow=True,
+        )
+        for cid in rescued:
+            tr.write_line(f"  RETRY-RESCUED {cid}", yellow=True)
+    if hard_failed:
+        tr.write_line(
+            f"{len(hard_failed)} test(s) still failing after retry:",
+            red=True,
+        )
+        for cid in hard_failed:
+            tr.write_line(f"  RETRY-FAIL    {cid}", red=True)
+    tr.write_line("")
+
+
+def rewrite_junit_xml(xmlpath):
+    """Collapse parametrized retry attempts into one ``<testcase>`` per logical test.
+
+    For each group of ``<testcase>`` sharing the same (classname, canonical name):
+        - If any attempt has no failure/error child → keep one PASSED testcase
+          (strip any failure/error children from the kept entry).
+        - Else → keep the last testcase (most recent failure).
+
+    Updates the parent ``<testsuite>`` aggregate counts.
+    """
+    if not xmlpath or not os.path.exists(xmlpath):
+        return
+    try:
+        tree = ET.parse(xmlpath)
+    except ET.ParseError:
+        log.warning(f"JUnit XML at {xmlpath} could not be parsed; skipping retry aggregation rewrite")
+        return
+    root = tree.getroot()
+
+    for testsuite in root.iter('testsuite'):
+        testcases = list(testsuite.findall('testcase'))
+        groups = {}
+        order = []
+        for tc in testcases:
+            key = (tc.get('classname', ''), canonical_id(tc.get('name', '')))
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(tc)
+
+        for key in order:
+            tcs = groups[key]
+            if len(tcs) == 1:
+                tcs[0].set('name', key[1])
+                continue
+            has_pass = any(
+                not tc.findall('failure')
+                and not tc.findall('error')
+                and not tc.findall('skipped')
+                for tc in tcs
+            )
+            if has_pass:
+                keep = next(
+                    (tc for tc in tcs
+                     if not tc.findall('failure') and not tc.findall('error')),
+                    tcs[-1],
+                )
+                for child in list(keep):
+                    if child.tag in ('failure', 'error'):
+                        keep.remove(child)
+            else:
+                keep = tcs[-1]
+            keep.set('name', key[1])
+            for tc in tcs:
+                if tc is not keep:
+                    testsuite.remove(tc)
+
+        remaining = list(testsuite.findall('testcase'))
+        testsuite.set('tests', str(len(remaining)))
+        testsuite.set('failures', str(sum(1 for tc in remaining if tc.findall('failure'))))
+        testsuite.set('errors', str(sum(1 for tc in remaining if tc.findall('error'))))
+        testsuite.set('skipped', str(sum(1 for tc in remaining if tc.findall('skipped'))))
+
+    tree.write(xmlpath, encoding='utf-8', xml_declaration=True)

--- a/unit-tests/py/rspy/pytest/retry_aggregation.py
+++ b/unit-tests/py/rspy/pytest/retry_aggregation.py
@@ -47,12 +47,22 @@ _call_reports = {}
 # in TerminalReporter.stats). Same key/shape as _call_reports.
 _error_reports = {}
 
+# Module-scoped retry tracking. Set to True per (module_path, step) when ANY
+# phase report for the module's tests at that step is failed. Used by the
+# skip-if-clean optimisation - if step N had no failures, step N+1 doesn't
+# need to run for that module.
+_module_pass_had_failure = {}
+
 # Activated by conftest.py when --retries is in use. While inactive, record_report
 # is a no-op so the buffers don't accumulate TestReport objects across a long
 # session that never asked for retries.
 _enabled = False
 
 _STEP_SUFFIX_RE = re.compile(r'\[([^\]]*)\]$')
+
+# Conftest's skip-if-clean optimisation calls pytest.skip() with this exact prefix.
+# We detect those reports here so they can be suppressed from per-line output and stats.
+_RETRY_SKIP_PREFIX = "Module retry skipped"
 
 
 def enable():
@@ -65,6 +75,50 @@ def reset():
     """Clear state (for tests that re-enter pytest_configure within one process)."""
     _call_reports.clear()
     _error_reports.clear()
+    _module_pass_had_failure.clear()
+
+
+def record_module_failure(mod_path, step):
+    """Mark that the module's ``step`` had at least one failed report.
+
+    Drives the skip-if-clean optimisation: a clean module pass means the next
+    pass doesn't need to run.
+    """
+    _module_pass_had_failure[(mod_path, step)] = True
+
+
+def should_skip_if_clean(item):
+    """True if this item is a retry pass (step > 0) and the previous pass was clean.
+
+    Called from both the protocol-bypass hook and conftest's pytest_runtest_protocol
+    hookwrapper so the latter doesn't open a per-test log file for items that won't run.
+    """
+    if not getattr(item.config, '_module_retry_mode', False):
+        return False
+    callspec = getattr(item, 'callspec', None)
+    if not callspec:
+        return False
+    step = callspec.params.get('__pytest_repeat_step_number', 0)
+    if step <= 0:
+        return False
+    mod = item.module.__file__
+    return not _module_pass_had_failure.get((mod, step - 1), False)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Bypass the default protocol entirely for retry-skip-if-clean items.
+
+    Returning True signals pytest we handled this item, which prevents the
+    default protocol from running pytest_runtest_logstart (which would print
+    a location line to the terminal), the setup/call/teardown phases, and
+    pytest_runtest_logfinish. The item disappears completely from the per-line
+    output and from the test count - exactly what we want for the
+    skip-if-clean optimisation.
+    """
+    if _enabled and should_skip_if_clean(item):
+        return True
+    return None
 
 
 def canonical_id(nodeid_or_name):
@@ -110,6 +164,23 @@ def _step_from_nodeid(nodeid):
     return step_val
 
 
+def is_retry_skip_if_clean(report):
+    """True if this report is the skip-if-clean optimisation's SKIPPED, not a real test skip.
+
+    The conftest emits ``pytest.skip("Module retry skipped — no failures …")`` from
+    ``pytest_runtest_setup`` when step > 0 and the previous module pass was clean.
+    Those entries are pure UX noise — the test didn't run and isn't a real skip.
+    """
+    if not (report.skipped and report.when == 'setup'):
+        return False
+    longrepr = getattr(report, 'longrepr', None)
+    if longrepr is None:
+        return False
+    if isinstance(longrepr, tuple) and len(longrepr) >= 3:
+        return _RETRY_SKIP_PREFIX in str(longrepr[2])
+    return _RETRY_SKIP_PREFIX in str(longrepr)
+
+
 def record_report(report):
     """Buffer report keyed by canonical id.
 
@@ -119,8 +190,11 @@ def record_report(report):
     'call' phase reports are tracked for pass/fail aggregation. Failed
     'setup'/'teardown' reports (which surface as 'error' in the terminal stats)
     are tracked separately so a later successful call attempt can rescue them.
+    Skip-if-clean reports are ignored (they're optimisation noise, not test results).
     """
     if not _enabled:
+        return
+    if is_retry_skip_if_clean(report):
         return
     cid = canonical_id(report.nodeid)
     step = _step_from_nodeid(report.nodeid) or 0


### PR DESCRIPTION
**TL;DR**: When ``--retries N`` is used, the *aggregate* report (summary line, JUnit XML, exit code) now reflects one outcome per logical test - a test rescued by retry counts as a single PASS and the job exits green. Per-line output during the run is unchanged: every attempt still prints its true PASSED/FAILED, so flakes remain visible.

## Why

Today ``--retries N`` is implemented via ``pytest-repeat`` with ``count = N+1`` and module-scoped repeat. Each test appears as N+1 separate parametrized cases (``[…-1-2]``, ``[…-2-2]``). When attempt-1 of a flaky test fails and the retry passes, pytest still reports the original FAILED, the job goes red in Jenkins, and someone has to investigate noise. We added a retry mechanism specifically so transient flakes wouldn't fail the job - this PR makes the aggregate surfaces match that intent.

## What changed

- **New module** ``unit-tests/py/rspy/pytest/retry_aggregation.py``
  - ``canonical_id()`` strips pytest-repeat's ``-<step>-<count>`` suffix from nodeids and JUnit names.
  - ``record_report()`` buffers ``call``-phase reports (and failed ``setup``/``teardown`` reports) keyed by logical test id.
  - ``reconcile_terminal_stats()`` drops rescued failures, rescued setup errors, and duplicate passes from ``TerminalReporter.stats`` so the standard ``=== N failed, M passed ===`` line and pytest's short-test-summary reflect logical-test counts.
  - ``adjust_session_exitstatus()`` recomputes ``session.testsfailed`` from the cleaned stats and flips ``session.exitstatus`` to ``OK`` when no logical failures remain - drives the process return code, which drives Jenkins job status.
  - ``print_retry_summary()`` emits a clearly-marked ``retry summary`` section listing ``RETRY-RESCUED`` (yellow) and ``RETRY-FAIL`` (red) entries so retried tests are still visible without being a job failure.
  - ``rewrite_junit_xml()`` post-processes ``--junit-xml`` output: per (classname, canonical name) it keeps a single ``<testcase>`` - PASSED if any attempt passed, else the most recent failure - and updates the parent ``<testsuite>`` aggregate counts.

- **``unit-tests/conftest.py``** wires the new module in:
  - ``pytest_runtest_logreport`` -> buffer reports (cheap no-op when ``_module_retry_mode`` is off).
  - ``pytest_sessionfinish`` (hookwrapper, ``tryfirst``): pre-yield reconciles stats and adjusts exit status before the terminal summary and exit-code path read them; post-yield rewrites the JUnit XML after the ``junitxml`` plugin has written it.
  - ``pytest_terminal_summary`` (``tryfirst``): prints the Jenkins-friendly summary and the rescue/fail listing using the already-reconciled stats.

- **Tests**
  - ``unit-tests/infra-tests/e2e/pytest-retry.py`` expanded to cover all three logical outcomes (always-pass, rescued, hard-fail).
  - New ``unit-tests/infra-tests/e2e/pytest-retry-rescued.py`` exercises the all-rescued path.
  - ``test_retries`` assertions updated to the new aggregated semantics (``passed=2, failed=1, rc != 0, RETRY-RESCUED in out``).
  - New ``test_retries_all_recovered`` asserts ``rc == 0`` and ``RETRY-RESCUED`` shows up when every failure is rescued.
  - ``test_retries_on_setup_error`` updated to match the new behaviour: a setup ERROR rescued by a retry now contributes a single PASS, ``rc == 0``.

## Behaviour matrix

| Scenario                              | Per-attempt console        | Aggregate (summary/JUnit/rc) |
|---------------------------------------|----------------------------|------------------------------|
| Attempt 1 PASS                        | PASS                       | 1 PASS                       |
| Attempt 1 FAIL, attempt 2 PASS        | FAIL then PASS             | 1 PASS, RETRY-RESCUED note   |
| Attempt 1 FAIL, attempt 2 FAIL        | FAIL then FAIL             | 1 FAIL, RETRY-FAIL note      |
| Attempt 1 setup ERROR, attempt 2 PASS | ERROR then PASS            | 1 PASS, RETRY-RESCUED note   |

## What is *not* changed

- The per-line console output during the run - every attempt still prints its true status, so transient failures stay visible for investigation.
- ``--repeat N``: intentional repetition still reports each repetition independently.
- The existing module-scoped retry recycling logic (device recycled between passes; skip-if-clean optimisation when a module had no failures).

## Test plan

- [x] ``unit-tests/infra-tests/`` full suite green (119/119).
- [x] ``test_retries`` covers always-pass / rescued / hard-fail in one module.
- [x] ``test_retries_all_recovered`` asserts ``rc == 0`` and ``RETRY-RESCUED`` listing.
- [x] ``test_retries_on_setup_error`` asserts ``rc == 0`` and rescue when ``setup`` errors.
- [x] JUnit XML inspected: ``<testcase>`` entries collapsed to canonical names, no ``<failure>`` for rescued tests, parent ``<testsuite>`` counts updated.
- [ ] Jenkins libci run to confirm full pipeline still parses the new output and reports green on a flaky-then-rescued module.

## Follow-up (separate PR to ``librealsense-deploy``, not in this change)

- Optional Jenkins Groovy enhancement: parse the ``retry summary`` section to surface ``RETRY-RESCUED`` tests in the build description as a non-red badge, and skip generating ``FAILED`` log-file links for tests later rescued.