### PR TITLE
Adapt D585S safety tests to flash 0.95 spec tables

### DIFF
--- a/unit-tests/live/d500/safety/test-interface-config-get-set.py
+++ b/unit-tests/live/d500/safety/test-interface-config-get-set.py
@@ -131,7 +131,7 @@ valid_sic_table_as_json_str = """
             "l_2_total_threshold": 10,
             "hkr_stl_timeout": 15,
             "mcu_stl_timeout": 10,
-            "sustained_aicv_frame_drops": 95,
+            "sustained_aicv_frame_drops": 90,
             "ossd_self_test_pulse_width": 23
         },
         "crypto_signature": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/unit-tests/live/d500/safety/test-preset-get-set.py
+++ b/unit-tests/live/d500/safety/test-preset-get-set.py
@@ -60,8 +60,8 @@ valid_sp_json_str = """
                 "zone_polygon":
                 {
                     "p0": {"x": 0.5, "y":  0.1},
-                    "p1": {"x": 0.8, "y":  0.1},
-                    "p2": {"x": 0.8, "y": -0.1},
+                    "p1": {"x": 1.2, "y":  0.1},
+                    "p2": {"x": 1.2, "y": -0.1},
                     "p3": {"x": 0.5, "y": -0.1}
                 },
                 "safety_trigger_confidence": 3,
@@ -71,10 +71,10 @@ valid_sp_json_str = """
             {
                 "zone_polygon":
                 {
-                    "p0": {"x": 0.8, "y":  0.1},
-                    "p1": {"x": 1.2, "y":  0.1},
-                    "p2": {"x": 1.2, "y": -0.1},
-                    "p3": {"x": 0.8, "y": -0.1}
+                    "p0": {"x": 0.3, "y":  0.1},
+                    "p1": {"x": 0.5, "y":  0.1},
+                    "p2": {"x": 0.5, "y": -0.1},
+                    "p3": {"x": 0.3, "y": -0.1}
                 },
                 "safety_trigger_confidence": 3,
                 "reserved": [0, 0, 0, 0, 0, 0, 0]
@@ -169,7 +169,7 @@ valid_sp_json_str = """
             "7":
             {
                 "attributes": 0,
-                "minimal_range": 0,
+                "minimal_range": 0.5,
                 "region_of_interests":
                 {
                     "vertex_0": [0, 0],


### PR DESCRIPTION
## Summary
- Align inline JSON in `test-interface-config-get-set.py` and `test-preset-get-set.py` with the flash 0.95 `d585s_tables.json` defaults (`sustained_aicv_frame_drops`, danger/warning-zone polygons, masking zone 7 `minimal_range`).
- Save the original SIC table at the start of `test-interface-config-get-set.py` and restore it at the end.
- Save all 64 original safety presets at the start of `test-preset-get-set.py` and restore all of them at the end.

## Why
The two inline JSONs previously differed from `d585s_tables.json` and the tests left the device in a modified state - the SIC test never restored its modifications (which then persisted across HW reset), and the preset test overwrote all 64 indexes but only restored a single random index. Running these tests after `flash-tables-update.py` therefore drifted flash away from the 0.95 spec.

## Test plan
- [x] Run `test-interface-config-get-set.py` on a D585S and verify flash SIC table is unchanged after the test completes.
- [x] Run `test-preset-get-set.py` on a D585S and verify all 64 safety presets are restored to their pre-test values.
- [ ] Confirm both tests still pass their existing assertions (modified-config writeback, HW-reset persistence, ram/flash equality, random-index mutation).