### PR TITLE
Detect device connection state change on react viewer

### DIFF
--- a/wrappers/rest-api/app/services/metadata_socket_server.py
+++ b/wrappers/rest-api/app/services/metadata_socket_server.py
@@ -124,11 +124,14 @@ class MetadataSocketServer:
 
     def start_broadcast(self, device_id: str):
         """Starts the metadata broadcast loop as a background thread."""
-        if self._is_broadcasting:
-            return
-
         if not device_id:
             raise ValueError("A target device_id must be provided.")
+
+        # If already broadcasting for a different device, switch targets gracefully.
+        if self._is_broadcasting:
+            if self._target_device_id == device_id:
+                return
+            self.stop_broadcast()
 
         self._target_device_id = device_id
         self._is_broadcasting = True

--- a/wrappers/rest-api/app/services/rs_manager.py
+++ b/wrappers/rest-api/app/services/rs_manager.py
@@ -101,6 +101,45 @@ class RealSenseManager:
         # Initialize devices
         self.refresh_devices()
 
+        # Refresh devices when one is plugged in or out.
+        self.ctx.set_devices_changed_callback(self._on_devices_changed)
+
+    def _on_devices_changed(self, info) -> None:
+        """rs.context devices-changed callback. Runs on a pyrealsense2 internal thread."""
+        added: List[str] = []
+        for dev in info.get_new_devices():
+            if dev.supports(rs.camera_info.serial_number):
+                added.append(dev.get_info(rs.camera_info.serial_number))
+
+        removed: List[str] = []
+        with self.lock:
+            for serial, dev in list(self.devices.items()):
+                if info.was_removed(dev):
+                    removed.append(serial)
+            # Drop cached devices so the next /devices call re-enumerates.
+            self.device_infos.clear()
+            for serial in removed:
+                self._remove_device(serial)
+            self._supported_md_by_profile.clear()
+
+        if removed and self.metadata_socket_server._target_device_id in removed:
+            self.metadata_socket_server.stop_broadcast()
+
+        if added or removed:
+            logging.info("devices_changed: +%s -%s", added, removed)
+        self._emit_socket_event("devices_changed", {"added": added, "removed": removed})
+
+    def _remove_device(self, serial: str) -> None:
+        assert self.lock.locked(), "_remove_device called without self.lock held"
+        self.pipelines.pop(serial, None)
+        self.configs.pop(serial, None)
+        self.active_streams.pop(serial, None)
+        self.frame_queues.pop(serial, None)
+        self.metadata_queues.pop(serial, None)
+        self.depth_frames.pop(serial, None)
+        self.devices.pop(serial, None)
+        self.streaming_mode.pop(serial, None)
+
     def _emit_socket_event(self, event: str, payload: Dict[str, Any]) -> None:
         """Emit a Socket.IO event from sync contexts using the main FastAPI event loop."""
         loop = RealSenseManager._main_loop

--- a/wrappers/rest-api/tools/react-viewer/src/api/socket.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/socket.ts
@@ -32,6 +32,8 @@ class SocketService {
       if (import.meta.env.DEV) console.log('Socket.IO connected:', this.socket?.id)
       this.isConnecting = false
       useAppStore.getState().setConnected(true)
+      // Refresh devices in case any were plugged in/out while disconnected.
+      useAppStore.getState().fetchDevices()
     })
 
     this.socket.on('disconnect', (reason) => {
@@ -46,6 +48,12 @@ class SocketService {
 
     this.socket.on('metadata_update', (data: MetadataUpdate) => {
       useAppStore.getState().updateMetadata(data)
+    })
+
+    this.socket.on('devices_changed', (data: { added?: string[]; removed?: string[] }) => {
+      if (import.meta.env.DEV) console.log('Socket.IO devices_changed:', data)
+      // Refresh device list. fetchDevices itself handles first-load auto-activate.
+      useAppStore.getState().fetchDevices()
     })
 
     this.socket.on('welcome', (data) => {

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -19,7 +19,6 @@ export function DevicePanel() {
     resetDevice,
     error,
     clearError,
-    isAnyDeviceStreaming,
     updateStreamConfig,
     updateSensorConfig,
     setOption,
@@ -30,16 +29,9 @@ export function DevicePanel() {
 
   const [toasts, setToasts] = useState<Toast[]>([])
 
-  const isStreaming = isAnyDeviceStreaming()
-
   useEffect(() => {
     fetchDevices()
-    // Only poll for device changes when NOT streaming (polling causes frame hiccups)
-    if (!isStreaming) {
-      const interval = setInterval(fetchDevices, 5000)
-      return () => clearInterval(interval)
-    }
-  }, [fetchDevices, isStreaming])
+  }, [fetchDevices])
 
   const addToast = (type: ToastType, message: string) => {
     const id = Date.now().toString()


### PR DESCRIPTION
- Register `ctx.set_devices_changed_callback` in RealSenseManager; emits a Socket.IO `devices_changed` event on plug/unplug so the UI refreshes without manual Refresh.

- Stop MetadataSocketServer's per-device broadcast loop when its target device disappears (no more "Error getting stream status" spam after unplug).

- Drop the 5-second `fetchDevices` polling from DevicePanel; refresh is now event-driven.