### PR TITLE
Advanced OCC tests uses fill rate (not average depth)

### DIFF
--- a/unit-tests/live/calib/calibrations_common.py
+++ b/unit-tests/live/calib/calibrations_common.py
@@ -222,6 +222,78 @@ def measure_average_depth(config, pipe, width=640, height=480, fps=30, frames=10
         return None
 
 
+def measure_depth_fill_rate(config, pipe, width=640, height=480, fps=30, frames=10, timeout_s=12, enable_emitter=True, center_fraction=1.0, depth_range_mm=None):
+    """Measure the average depth fill rate (fraction of valid pixels) across a series of frames.
+
+    Valid depth pixels are > 0 (raw units). Fill rate per frame = valid_pixels / total_pixels.
+
+    Args: same as measure_average_depth.
+
+    Returns:
+        float | None: Mean fill rate in [0.0, 1.0] over collected frames, or None if no data.
+    """
+    try:
+        import numpy as np
+
+        conf = pipe.start(config)
+        try:
+            depth_sensor = conf.get_device().first_depth_sensor()
+            if enable_emitter and depth_sensor.supports(rs.option.emitter_enabled):
+                depth_sensor.set_option(rs.option.emitter_enabled, 1)
+            if depth_sensor.supports(rs.option.thermal_compensation):
+                depth_sensor.set_option(rs.option.thermal_compensation, 0)
+            depth_scale = depth_sensor.get_depth_scale()
+        except Exception:
+            depth_scale = 0.001
+
+        start = time.time()
+        collected = 0
+        fill_rate_sum = 0.0
+        fill_rate_count = 0
+
+        while collected < frames and (time.time() - start) < timeout_s:
+            try:
+                fs = pipe.wait_for_frames(3000)
+            except Exception:
+                continue
+            depth = fs.get_depth_frame()
+            if not depth:
+                continue
+            data = np.asanyarray(depth.get_data())
+            if data.size == 0:
+                continue
+            if center_fraction < 1.0:
+                h, w = data.shape
+                y0 = int(h * (1.0 - center_fraction) / 2)
+                y1 = h - y0
+                x0 = int(w * (1.0 - center_fraction) / 2)
+                x1 = w - x0
+                data = data[y0:y1, x0:x1]
+            valid_mask = data > 0
+            if depth_range_mm is not None:
+                min_raw = int(depth_range_mm[0] / (depth_scale * 1000.0))
+                max_raw = int(depth_range_mm[1] / (depth_scale * 1000.0))
+                valid_mask = valid_mask & (data >= min_raw) & (data <= max_raw)
+            fill_rate_sum += float(valid_mask.sum()) / float(data.size)
+            fill_rate_count += 1
+            collected += 1
+            if collected >= 5 and (time.time() - start) > 1.5:
+                break
+
+        pipe.stop()
+        if fill_rate_count == 0:
+            return None
+        return fill_rate_sum / fill_rate_count
+    except Exception as e:
+        log.warning(f"measure_depth_fill_rate failed: {e}")
+        try:
+            if pipe:
+                pipe.stop()
+        except Exception:
+            pass
+        return None
+
+
 def is_mipi_device():
     ctx = rs.context()
     device = ctx.query_devices()[0]

--- a/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
@@ -35,6 +35,7 @@ EPSILON = 0.5         # half of PIXEL_CORRECTION tolerance
 DIFF_THRESHOLD = 0.001  # minimum change expected after OCC calibration
 HEALTH_FACTOR_THRESHOLD_AFTER_MODIFICATION = 3.0
 FILL_RATE_CONVERGENCE_TOLERANCE = 0.02  # 2% slack for frame-to-frame fill rate noise
+
 def on_chip_calibration_json(occ_json_file, host_assistance):
     occ_json = None
     if occ_json_file is not None:
@@ -166,7 +167,7 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
         dist_from_modified = abs(final_axis_val - modified_axis_val)
         log.info(f"  ppy distances: from_base={dist_from_original:.6f} from_modified={dist_from_modified:.6f}")
 
-        # Measure average depth after OCC correction
+        # Measure depth fill rate after OCC correction
         post_fill_rate = measure_depth_fill_rate(config, pipeline, width=image_width, height=image_height, fps=fps)
         if post_fill_rate is not None:
             log.info(f"Fill rate after OCC: {post_fill_rate*100:.1f}%")
@@ -174,17 +175,14 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
             log.error("Fill rate after OCC unavailable")
             pytest.fail()
 
-        # Fill rate convergence assertion: post-OCC fill rate must be closer to baseline than modified fill rate was
+        # Fill rate assertion: post-OCC fill rate must be at least as good as the perturbed fill rate
         if (baseline_fill_rate is not None and modified_fill_rate is not None and post_fill_rate is not None):
-            dist_post = abs(post_fill_rate - baseline_fill_rate)
-            dist_modified = abs(modified_fill_rate - baseline_fill_rate)
-            log.info(f"Fill rate distance to baseline: modified={dist_modified*100:.1f}% post={dist_post*100:.1f}% (baseline={baseline_fill_rate*100:.1f}%)")
-            if dist_post > dist_modified + FILL_RATE_CONVERGENCE_TOLERANCE:
-                log.error("Post-OCC fill rate did not converge toward baseline fill rate")
+            log.info(f"Fill rates: baseline={baseline_fill_rate*100:.1f}% modified={modified_fill_rate*100:.1f}% post={post_fill_rate*100:.1f}%")
+            if post_fill_rate - FILL_RATE_CONVERGENCE_TOLERANCE <= modified_fill_rate:
+                log.error("Post-OCC fill rate did not improve over perturbed fill rate")
                 pytest.fail()
             else:
-                improvement = dist_modified - dist_post
-                log.info(f"Fill rate converged toward baseline (improvement={improvement*100:.1f}%)")
+                log.info(f"Fill rate improved after OCC (improvement={( post_fill_rate - modified_fill_rate)*100:.1f}%)")
 
         if abs(final_axis_val - modified_axis_val) <= DIFF_THRESHOLD:
             log.error(f"OCC left ppy unchanged (within DIFF_THRESHOLD={DIFF_THRESHOLD}); failing")            

--- a/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
@@ -15,7 +15,7 @@ from calibrations_common import (
     save_calibration_table,
     restore_calibration_table,
     write_calibration_table_with_crc,
-    measure_average_depth,
+    measure_depth_fill_rate,
     is_d555
 )
 
@@ -34,8 +34,7 @@ SHORT_DISTANCE_PIXEL_CORRECTION = -3.0
 EPSILON = 0.5         # half of PIXEL_CORRECTION tolerance
 DIFF_THRESHOLD = 0.001  # minimum change expected after OCC calibration
 HEALTH_FACTOR_THRESHOLD_AFTER_MODIFICATION = 3.0
-DEPTH_MODIF_THRESHOLD_MM = 100.0  # 10 cm minimum depth change after modification to consider convergence
-DEPTH_CONVERGENCE_TOLERANCE_MM = 50.0  # 5 cm tolerance for depth convergence toward ground truth
+FILL_RATE_CONVERGENCE_TOLERANCE = 0.02  # 2% slack for frame-to-frame fill rate noise
 def on_chip_calibration_json(occ_json_file, host_assistance):
     occ_json = None
     if occ_json_file is not None:
@@ -61,7 +60,7 @@ def on_chip_calibration_json(occ_json_file, host_assistance):
                    '}'
     return occ_json
 
-def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True, ground_truth_mm=None):
+def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True):
     """Run advanced OCC calibration test with calibration table modifications.
 
         Flow:
@@ -92,24 +91,15 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
 
         base_axis_val = base_right_pp[1]
 
-        # 2. Baseline average depth (before perturbation)
-        baseline_avg_depth_m = measure_average_depth(config, pipeline, width=image_width, height=image_height, fps=fps)
-        if baseline_avg_depth_m is not None:
-            baseline_mm = baseline_avg_depth_m * 1000.0
-            log.info(f"Baseline average depth (pre-modification): {baseline_mm:.1f} mm")
-            # If caller did not supply ground_truth_mm, derive it from baseline
-            if ground_truth_mm is None:
-                ground_truth_mm = baseline_mm
-                log.info(f"Ground truth depth set from baseline: {ground_truth_mm:.1f} mm")
-            else:
-                log.info(f"Ground truth depth provided: {ground_truth_mm:.1f} mm")
+        # 2. Baseline fill rate (before perturbation)
+        baseline_fill_rate = measure_depth_fill_rate(config, pipeline, width=image_width, height=image_height, fps=fps)
+        if baseline_fill_rate is not None:
+            log.info(f"Baseline fill rate (pre-modification): {baseline_fill_rate*100:.1f}%")
         else:
-            log.warning("Baseline average depth unavailable; depth convergence assertion will be skipped")
+            log.warning("Baseline fill rate unavailable; fill rate convergence assertion will be skipped")
         
         # 3. Apply perturbation
         pixel_correction = PIXEL_CORRECTION
-        if ground_truth_mm < 1300.0:
-            pixel_correction = SHORT_DISTANCE_PIXEL_CORRECTION
         log.info(f"Applying manual raw intrinsic correction: delta={pixel_correction:+.3f} px")
         modification_success, _modified_table_bytes, modified_ppx, modified_ppy = modify_intrinsic_calibration(
             calib_dev, pixel_correction, modify_ppy=modify_ppy)
@@ -129,12 +119,12 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
             log.error(f"Modification mismatch for ppy. Expected {returned_modified_axis_val:.6f} got {modified_axis_val:.6f}")
             pytest.fail()
 
-        # 5. Measure average depth after modification, before OCC correction (modified baseline)
-        modified_avg_depth_m = measure_average_depth(config, pipeline, width=image_width, height=image_height, fps=fps)
-        if modified_avg_depth_m is not None:
-            log.info(f"Average depth after modification (pre-OCC): {modified_avg_depth_m*1000:.1f} mm")
+        # 5. Measure fill rate after modification, before OCC correction (modified baseline)
+        modified_fill_rate = measure_depth_fill_rate(config, pipeline, width=image_width, height=image_height, fps=fps)
+        if modified_fill_rate is not None:
+            log.info(f"Fill rate after modification (pre-OCC): {modified_fill_rate*100:.1f}%")
         else:
-            log.error("Average depth after modification unavailable")
+            log.error("Fill rate after modification unavailable")
             pytest.fail()
         
         # 6. Run OCC
@@ -177,27 +167,24 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
         log.info(f"  ppy distances: from_base={dist_from_original:.6f} from_modified={dist_from_modified:.6f}")
 
         # Measure average depth after OCC correction
-        post_avg_depth_m = measure_average_depth(config, pipeline, width=image_width, height=image_height, fps=fps)
-        if post_avg_depth_m is not None:
-            log.info(f"Average depth after OCC: {post_avg_depth_m*1000:.1f} mm")
+        post_fill_rate = measure_depth_fill_rate(config, pipeline, width=image_width, height=image_height, fps=fps)
+        if post_fill_rate is not None:
+            log.info(f"Fill rate after OCC: {post_fill_rate*100:.1f}%")
         else:
-            log.error("Average depth after OCC unavailable")
+            log.error("Fill rate after OCC unavailable")
             pytest.fail()
 
-        # Depth convergence assertion relative to ground truth: ensure post depth is closer to ground truth than modified depth
-        if (ground_truth_mm is not None and
-            modified_avg_depth_m is not None and
-            post_avg_depth_m is not None):
-            dist_post_gt_mm = abs(post_avg_depth_m * 1000.0 - ground_truth_mm)
-            dist_modified_gt_mm = abs(modified_avg_depth_m * 1000.0 - ground_truth_mm)
-            log.info(f"Depth to ground truth (mm): modified={dist_modified_gt_mm:.1f} post={dist_post_gt_mm:.1f} (ground truth={ground_truth_mm:.1f} mm)")
-            # verify convergence toward ground truth, allow tolerance in case of too small modification in depth due to small distance change
-            if dist_post_gt_mm > dist_modified_gt_mm + DEPTH_CONVERGENCE_TOLERANCE_MM:
-                log.error("Post-calibration average depth did not converge toward ground truth")
+        # Fill rate convergence assertion: post-OCC fill rate must be closer to baseline than modified fill rate was
+        if (baseline_fill_rate is not None and modified_fill_rate is not None and post_fill_rate is not None):
+            dist_post = abs(post_fill_rate - baseline_fill_rate)
+            dist_modified = abs(modified_fill_rate - baseline_fill_rate)
+            log.info(f"Fill rate distance to baseline: modified={dist_modified*100:.1f}% post={dist_post*100:.1f}% (baseline={baseline_fill_rate*100:.1f}%)")
+            if dist_post > dist_modified + FILL_RATE_CONVERGENCE_TOLERANCE:
+                log.error("Post-OCC fill rate did not converge toward baseline fill rate")
                 pytest.fail()
             else:
-                improvement = dist_modified_gt_mm - dist_post_gt_mm
-                log.info(f"Post-calibration average depth converged toward ground truth (improvement={improvement:.1f} mm)")
+                improvement = dist_modified - dist_post
+                log.info(f"Fill rate converged toward baseline (improvement={improvement*100:.1f}%)")
 
         if abs(final_axis_val - modified_axis_val) <= DIFF_THRESHOLD:
             log.error(f"OCC left ppy unchanged (within DIFF_THRESHOLD={DIFF_THRESHOLD}); failing")            
@@ -225,10 +212,9 @@ def test_advanced_occ_calibration(test_device):
     try:
         host_assistance = False
         image_width, image_height, fps = (256, 144, 90)
-        ground_truth_mm = None  # Example ground-truth depth (mm); adjust if known
         config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
         restore_calibration_table(calib_dev, None)
-        calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True, ground_truth_mm=ground_truth_mm)
+        calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True)
     except Exception as e:
         log.error(f"OCC calibration with principal point modification failed: {e}")
         raise
@@ -248,10 +234,9 @@ def test_advanced_occ_calibration_with_host_assistance(test_device):
     try:
         host_assistance = True
         image_width, image_height, fps = (1280, 720, 30)
-        ground_truth_mm = None  # Example ground-truth depth (mm); adjust if known
         config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
         restore_calibration_table(calib_dev, None)
-        calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True, ground_truth_mm=ground_truth_mm)
+        calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True)
     except Exception as e:
         log.error(f"OCC calibration with principal point modification failed: {e}")
         raise


### PR DESCRIPTION
using depth fill rate check for advanced occ tests.
OCC improves depth fill rate (previously checked depth accuracy) while Tare calibrations supposed to improve depth accuracy (no change).