### PR TITLE
Skip D457/D455 FPS tests failing on FW 5.17.3.14 (RSDSO-21568)

### DIFF
--- a/unit-tests/live/frames/pytest-fps-performance.py
+++ b/unit-tests/live/frames/pytest-fps-performance.py
@@ -1571,6 +1571,7 @@ def settled_device(test_device):
 # ============================================================================
 
 @pytest.mark.timeout(14400)
+@pytest.mark.device_exclude("D457")  # RSDSO-21568: skip pending FW 5.17.3.14 FPS regression fix
 def test_depth_configurations(settled_device):
     """Test depth FPS accuracy for all supported configurations"""
     dev, ctx = settled_device
@@ -1636,6 +1637,8 @@ def test_ir_configurations(settled_device):
 
 
 @pytest.mark.timeout(14400)
+@pytest.mark.device_exclude("D457")  # RSDSO-21568: FW 5.17.3.14 FPS regression
+@pytest.mark.device_exclude("D455")  # RSDSO-21568: FW 5.17.3.14 multistream 90fps regression
 def test_multistream_configurations(settled_device):
     """Test depth + color multi-stream FPS accuracy for all supported configurations"""
     dev, ctx = settled_device
@@ -1696,6 +1699,7 @@ def test_color_fps_rates(settled_device):
 
 
 @pytest.mark.timeout(14400)
+@pytest.mark.device_exclude("D457")  # RSDSO-21568: skip pending FW 5.17.3.14 FPS regression fix
 def test_ir_fps_rates(settled_device):
     """Test IR FPS accuracy for all supported frame rates"""
     dev, ctx = settled_device

--- a/unit-tests/live/frames/pytest-fps-single-stream.py
+++ b/unit-tests/live/frames/pytest-fps-single-stream.py
@@ -27,6 +27,7 @@ TIME_TO_TEST_FPS =    [8,  8,  5,  4,  3,  2]
 fps_helper.TIME_FOR_STEADY_STATE = 1.2  # t2ff KPI is 1 second + some extra
 
 
+@pytest.mark.device_exclude("D457")  # RSDSO-21568: skip pending FW 5.17.3.14 FPS regression fix
 def test_depth_fps(test_device):
     dev, ctx = test_device
     product_line = dev.get_info(rs.camera_info.product_line)


### PR DESCRIPTION
## TL;DR
Temporarily skip the D400 FPS/streaming tests that regressed on FW **5.17.3.14** (D457/JP5 + D455/Linux), tracked in **RSDSO-21568**. Markers only — revert once the FW team ships a fix.

## Background
Two consecutive LibCI nightlies (2026-05-30 #204, 2026-05-31 #205) show a D400-family streaming/FPS regression introduced in the FW **5.17.3.10 → 5.17.3.14** delta. The same physical hardware (D457 S/N 220422303069 on `vtg-librs-jetson01`, same d4xx 1.0.3.12, same SDK) **passes on golden FW 5.17.3.10** and **fails on latest FW 5.17.3.14** — a textbook FW regression. Filed as **RSDSO-21568** (FW team owns the fix).

Symptoms: zero IR frames @90fps, `Insufficient color measurements: 0`, `stop_streaming() failed. UVC device is not streaming!`, and `hwmon command 0x2c (response -110)` ETIMEDOUT opening high-fps profiles; plus a D455/Linux multistream 90fps shortfall (71.7 fps).

## Change
Added `@pytest.mark.device_exclude(...)` markers (no test-logic changes) to skip the failing instances:

| File | Test | Excluded |
|------|------|----------|
| `pytest-fps-single-stream.py` | `test_depth_fps` | D457 |
| `pytest-fps-performance.py` | `test_depth_configurations` | D457 |
| `pytest-fps-performance.py` | `test_ir_fps_rates` | D457 |
| `pytest-fps-performance.py` | `test_multistream_configurations` | D457, D455 |

Every marker is tagged `# RSDSO-21568` for an easy grep-and-remove revert.

## Note
This also pauses golden-FW 5.17.3.10 coverage on these tests until revert — accepted as a temporary trade-off to keep the nightly green.

## Revert criteria
Once the FW team fixes the 5.17.3.14 regression (RSDSO-21568), revert this PR (remove the 5 tagged markers).
