### PR TITLE
multidev streaming test: enable rs debug log file

### DIFF
--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -15,6 +15,7 @@ import pytest
 import pyrealsense2 as rs
 from pytest_check import check
 from rspy.pytest.device_helpers import is_jetson_platform
+import os
 import time
 from collections import defaultdict
 import logging
@@ -312,14 +313,18 @@ def run_phase(phase_label, device_list, stream_configs):
 
 
 @pytest.mark.skip(reason="Multi-stream test skipped until depth-drops issue on Windows is stable")
-def test_multi_stream_operation(test_devices):
+def test_multi_stream_operation(test_devices, request):
     """Simultaneous multi-stream operation on multiple devices.
 
     Runs in two phases to isolate whether color streaming contributes to depth drops:
       Phase 1: depth + IR only (no color)
       Phase 2: depth + IR + color
     """
-    rs.log_to_file(rs.log_severity.debug, f"multi_dev_streaming_log_{time.strftime('%Y%m%d_%H%M%S')}.txt")
+    # Write rs debug log into pytest's per-test log directory so Jenkins archives it
+    # alongside the standard per-test logs (workspace is wiped at the start of each job).
+    logdir = getattr(request.config, '_test_logdir', os.getcwd())
+    log_filename = os.path.join(logdir, f"pytest-live-multi_devices-devices-streaming-rs-debug_{time.strftime('%Y%m%d_%H%M%S')}.log")
+    rs.log_to_file(rs.log_severity.debug, log_filename)
     try:
         device_list, ctx = test_devices
 

--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -319,25 +319,29 @@ def test_multi_stream_operation(test_devices):
       Phase 1: depth + IR only (no color)
       Phase 2: depth + IR + color
     """
-    device_list, ctx = test_devices
+    rs.log_to_file(rs.log_severity.debug, f"multi_dev_streaming_log_{time.strftime('%Y%m%d_%H%M%S')}.txt")
+    try:
+        device_list, ctx = test_devices
 
-    log.info("=" * 80)
-    log.info(f"Testing multi-stream operation on {len(device_list)} devices:")
-    for i, dev in enumerate(device_list, 1):
-        sn = dev.get_info(rs.camera_info.serial_number)
-        name = dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else "Unknown"
-        log.info(f"  Device {i}: {name} (SN: {sn})")
-    log.info("=" * 80)
+        log.info("=" * 80)
+        log.info(f"Testing multi-stream operation on {len(device_list)} devices:")
+        for i, dev in enumerate(device_list, 1):
+            sn = dev.get_info(rs.camera_info.serial_number)
+            name = dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else "Unknown"
+            log.info(f"  Device {i}: {name} (SN: {sn})")
+        log.info("=" * 80)
 
-    log.info("Finding common multi-stream configuration...")
-    all_stream_configs = get_common_multi_stream_config(*device_list)
+        log.info("Finding common multi-stream configuration...")
+        all_stream_configs = get_common_multi_stream_config(*device_list)
 
-    if len(all_stream_configs) < 2:
-        pytest.fail(f"At least 2 stream types needed for multi-stream test, but found {len(all_stream_configs)}")
+        if len(all_stream_configs) < 2:
+            pytest.fail(f"At least 2 stream types needed for multi-stream test, but found {len(all_stream_configs)}")
 
-    no_color_configs = [c for c in all_stream_configs if c[0] != rs.stream.color]
-    if len(no_color_configs) < 2:
-        pytest.fail(f"At least 2 non-color streams needed for phase 1, but found {len(no_color_configs)}")
+        no_color_configs = [c for c in all_stream_configs if c[0] != rs.stream.color]
+        if len(no_color_configs) < 2:
+            pytest.fail(f"At least 2 non-color streams needed for phase 1, but found {len(no_color_configs)}")
 
-    run_phase("PHASE 1 (no color)", device_list, no_color_configs)
-    run_phase("PHASE 2 (with color)", device_list, all_stream_configs)
+        run_phase("PHASE 1 (no color)", device_list, no_color_configs)
+        run_phase("PHASE 2 (with color)", device_list, all_stream_configs)
+    finally:
+        rs.reset_logger()

--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -312,7 +312,6 @@ def run_phase(phase_label, device_list, stream_configs):
         f"{phase_label}: All streams should receive frames independently without interference")
 
 
-@pytest.mark.skip(reason="Multi-stream test skipped until depth-drops issue on Windows is stable")
 def test_multi_stream_operation(test_devices, request):
     """Simultaneous multi-stream operation on multiple devices.
 


### PR DESCRIPTION
Adds `rs.log_to_file(rs.log_severity.debug, ...)` at the start of `test_multi_stream_operation` to capture the SDK's internal debug logs during the multidev streaming test.

Details:
- Log file name is timestamped (`multi_dev_streaming_log_YYYYMMDD_HHMMSS.txt`) so successive runs do not overwrite each other.
- The test body is wrapped in `try / finally`: `rs.reset_logger()` is called on exit so log capture stops at the end of this test and does not leak into subsequent tests in the same pytest session.
- `log_to_file` was chosen over `log_to_console` because console output added too much latency on the streaming hot path.

Goal: capture SDK-internal events on `rsdsk254` where multi_devices-devices-streaming reproducibly fails with 78-93% depth drops in phase 2 (with color) on D435+D455 - looking specifically for `Dropped frame. alloc_frame(...) returned nullptr` host-queue-saturation signatures.