### PR TITLE
Re-apply manual exposure on Linux when disabling color sensor auto-exposure

### DIFF
--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -25,38 +25,24 @@ namespace librealsense
 
     void uvc_pu_auto_exposure_option::set( float value )
     {
-        // Capture the current exposure BEFORE switching AE off so the value is preserved
-        // across the transition (the underlying backend may otherwise leave the device at
-        // an arbitrary value once AE is turned off).
-        float saved_exposure = 0;
-        auto exposure = _exposure_option.lock();
-        bool reapply = ( value == 0 ) && exposure;
-        if( reapply )
-        {
-            try
-            {
-                saved_exposure = exposure->query();
-            }
-            catch( const std::exception & e )
-            {
-                LOG_WARNING( "Query exposure before AE disable failed: " << e.what() );
-                reapply = false;
-            }
-        }
-
         uvc_pu_option::set( value );
 
-        if( reapply )
+        if( value != 0 )
+            return;
+
+        auto exposure = _exposure_option.lock();
+        if( ! exposure )
+            return;
+
+        try
         {
-            try
-            {
-                LOG_DEBUG( "Re-applying exposure " << saved_exposure << " after AE disable" );
-                exposure->set( saved_exposure );
-            }
-            catch( const std::exception & e )
-            {
-                LOG_WARNING( "Re-applying exposure after AE disable failed: " << e.what() );
-            }
+            float def_exposure = exposure->get_range().def;
+            LOG_DEBUG( "Applying default exposure " << def_exposure << " after AE disable" );
+            exposure->set( def_exposure );
+        }
+        catch( const std::exception & e )
+        {
+            LOG_WARNING( "Applying default exposure after AE disable failed: " << e.what() );
         }
     }
 

--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -27,6 +27,9 @@ namespace librealsense
     {
         uvc_pu_option::set( value );
 
+        // When AE is turned off, the device may keep streaming with the last
+        // auto-computed exposure. Re-write the default exposure to force the
+        // device to apply a known manual value.
         if( value != 0 )
             return;
 

--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -15,6 +15,51 @@ namespace librealsense
 {
     using namespace ds;
 
+    uvc_pu_auto_exposure_option::uvc_pu_auto_exposure_option(
+        const std::weak_ptr< uvc_sensor > & ep,
+        const std::weak_ptr< option > & exposure_option )
+        : uvc_pu_option( ep, RS2_OPTION_ENABLE_AUTO_EXPOSURE )
+        , _exposure_option( exposure_option )
+    {
+    }
+
+    void uvc_pu_auto_exposure_option::set( float value )
+    {
+        // Capture the current exposure BEFORE switching AE off so the value is preserved
+        // across the transition (the underlying backend may otherwise leave the device at
+        // an arbitrary value once AE is turned off).
+        float saved_exposure = 0;
+        auto exposure = _exposure_option.lock();
+        bool reapply = ( value == 0 ) && exposure;
+        if( reapply )
+        {
+            try
+            {
+                saved_exposure = exposure->query();
+            }
+            catch( const std::exception & e )
+            {
+                LOG_WARNING( "Query exposure before AE disable failed: " << e.what() );
+                reapply = false;
+            }
+        }
+
+        uvc_pu_option::set( value );
+
+        if( reapply )
+        {
+            try
+            {
+                LOG_DEBUG( "Re-applying exposure " << saved_exposure << " after AE disable" );
+                exposure->set( saved_exposure );
+            }
+            catch( const std::exception & e )
+            {
+                LOG_WARNING( "Re-applying exposure after AE disable failed: " << e.what() );
+            }
+        }
+    }
+
     ds_color_common::ds_color_common( const std::shared_ptr< uvc_sensor > & raw_color_ep,
                                       synthetic_sensor & color_ep,
                                       firmware_version fw_version,
@@ -50,7 +95,7 @@ namespace librealsense
     {
         auto gain_option = std::make_shared<uvc_pu_option>(_raw_color_ep, RS2_OPTION_GAIN);
         auto exposure_option = std::make_shared<uvc_pu_option>(_raw_color_ep, RS2_OPTION_EXPOSURE);
-        auto auto_exposure_option = std::make_shared<uvc_pu_option>(_raw_color_ep, RS2_OPTION_ENABLE_AUTO_EXPOSURE);
+        auto auto_exposure_option = std::make_shared<uvc_pu_auto_exposure_option>(_raw_color_ep, exposure_option);
         _color_ep.register_option(RS2_OPTION_GAIN, gain_option);
         _color_ep.register_option(RS2_OPTION_EXPOSURE, exposure_option);
         _color_ep.register_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, auto_exposure_option);

--- a/src/ds/ds-color-common.h
+++ b/src/ds/ds-color-common.h
@@ -7,8 +7,28 @@
 #include "core/video.h"
 #include "ds-device-common.h"
 
+#include <src/platform/uvc-option.h>
+
 namespace librealsense
 {
+    // UVC PU auto-exposure control that preserves the current exposure value across
+    // the AE-off transition. Switching the UVC AE control from auto to manual does not,
+    // by itself, guarantee that the device re-applies a sensible exposure to the sensor:
+    // on some backends the stream brightness can jump or the device keeps the last
+    // auto-computed exposure even though the reported value differs. Capturing the
+    // exposure before disabling AE and re-writing it after forces the device to apply it.
+    class uvc_pu_auto_exposure_option : public uvc_pu_option
+    {
+    public:
+        uvc_pu_auto_exposure_option( const std::weak_ptr< uvc_sensor > & ep,
+                                     const std::weak_ptr< option > & exposure_option );
+
+        void set( float value ) override;
+
+    private:
+        std::weak_ptr< option > _exposure_option;
+    };
+
     class ds_color_common
     {
     public:

--- a/src/ds/ds-color-common.h
+++ b/src/ds/ds-color-common.h
@@ -11,12 +11,11 @@
 
 namespace librealsense
 {
-    // UVC PU auto-exposure control that preserves the current exposure value across
-    // the AE-off transition. Switching the UVC AE control from auto to manual does not,
-    // by itself, guarantee that the device re-applies a sensible exposure to the sensor:
-    // on some backends the stream brightness can jump or the device keeps the last
-    // auto-computed exposure even though the reported value differs. Capturing the
-    // exposure before disabling AE and re-writing it after forces the device to apply it.
+    // UVC PU auto-exposure control that writes the default exposure value after AE is
+    // disabled. Switching the UVC AE control from auto to manual does not, by itself,
+    // make the device re-apply a manual exposure value: on some backends it keeps the
+    // last auto-computed exposure even though the reported value differs. Writing the
+    // default exposure forces the device to apply a known manual value.
     class uvc_pu_auto_exposure_option : public uvc_pu_option
     {
     public:

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2332,6 +2332,18 @@ namespace librealsense
             if (!pend_for_ctrl_status_event())
                 return false;
 
+            // Switching the UVC exposure control from auto to manual mode does not, by itself, make the
+            // device re-apply the manual exposure value to the sensor: it keeps streaming with the last
+            // auto-computed exposure even though V4L2_CID_EXPOSURE_ABSOLUTE (and the frame metadata) still
+            // report the manually-set value. Re-write the current exposure value to force the device to
+            // apply it, so the stream brightness matches the reported exposure (as done on Windows).
+            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
+            {
+                int32_t exposure = 0;
+                if (get_pu(RS2_OPTION_EXPOSURE, exposure))
+                    set_pu(RS2_OPTION_EXPOSURE, exposure);
+            }
+
             return true;
         }
 
@@ -3038,6 +3050,18 @@ namespace librealsense
                 throw linux_backend_exception(rsutils::string::from()
                                               << "xioctl(VIDIOC_S_EXT_CTRLS) failed on option " << rs2_option_to_string(opt)
                                               << ", value=" << value << ", errno=" << errno );
+            }
+
+            // Switching the exposure control from auto to manual mode does not, by itself, make the
+            // device re-apply the manual exposure value to the sensor: it keeps streaming with the last
+            // auto-computed exposure even though the control (and the frame metadata) still report the
+            // manually-set value. Re-write the current exposure value to force the device to apply it,
+            // so the stream brightness matches the reported exposure (as done on Windows).
+            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
+            {
+                int32_t exposure = 0;
+                if (get_pu(RS2_OPTION_EXPOSURE, exposure))
+                    set_pu(RS2_OPTION_EXPOSURE, exposure);
             }
 
             return true;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2332,24 +2332,6 @@ namespace librealsense
             if (!pend_for_ctrl_status_event())
                 return false;
 
-            // Switching the UVC exposure control from auto to manual mode does not, by itself, make the
-            // device re-apply the manual exposure value to the sensor: it keeps streaming with the last
-            // auto-computed exposure even though V4L2_CID_EXPOSURE_ABSOLUTE (and the frame metadata) still
-            // report the manually-set value. Re-write the current exposure value to force the device to
-            // apply it, so the stream brightness matches the reported exposure (as done on Windows).
-            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
-            {
-                int32_t exposure = 0;
-                if (get_pu(RS2_OPTION_EXPOSURE, exposure))
-                {
-                    LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_uvc_device)");
-                    if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
-                    {
-                        LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_uvc_device)");
-                    }
-                }
-            }
-
             return true;
         }
 
@@ -3056,24 +3038,6 @@ namespace librealsense
                 throw linux_backend_exception(rsutils::string::from()
                                               << "xioctl(VIDIOC_S_EXT_CTRLS) failed on option " << rs2_option_to_string(opt)
                                               << ", value=" << value << ", errno=" << errno );
-            }
-
-            // Switching the exposure control from auto to manual mode does not, by itself, make the
-            // device re-apply the manual exposure value to the sensor: it keeps streaming with the last
-            // auto-computed exposure even though the control (and the frame metadata) still report the
-            // manually-set value. Re-write the current exposure value to force the device to apply it,
-            // so the stream brightness matches the reported exposure (as done on Windows).
-            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
-            {
-                int32_t exposure = 0;
-                if (get_pu(RS2_OPTION_EXPOSURE, exposure))
-                {
-                    LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_mipi_device)");
-                    if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
-                    {
-                        LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_mipi_device)");
-                    }
-                }
             }
 
             return true;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2339,9 +2339,15 @@ namespace librealsense
             // apply it, so the stream brightness matches the reported exposure (as done on Windows).
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
             {
+                LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_uvc_device)");
                 int32_t exposure = 0;
                 if (get_pu(RS2_OPTION_EXPOSURE, exposure))
-                    set_pu(RS2_OPTION_EXPOSURE, exposure);
+                {
+                    if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
+                    {
+                        LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_uvc_device)");
+                    }
+                }
             }
 
             return true;
@@ -3059,9 +3065,15 @@ namespace librealsense
             // so the stream brightness matches the reported exposure (as done on Windows).
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
             {
+                LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_mipi_device)");
                 int32_t exposure = 0;
                 if (get_pu(RS2_OPTION_EXPOSURE, exposure))
-                    set_pu(RS2_OPTION_EXPOSURE, exposure);
+                {
+                    if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
+                    {
+                        LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_mipi_device)");
+                    }
+                }
             }
 
             return true;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2339,10 +2339,10 @@ namespace librealsense
             // apply it, so the stream brightness matches the reported exposure (as done on Windows).
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
             {
-                LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_uvc_device)");
                 int32_t exposure = 0;
                 if (get_pu(RS2_OPTION_EXPOSURE, exposure))
                 {
+                    LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_uvc_device)");
                     if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
                     {
                         LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_uvc_device)");
@@ -3065,10 +3065,10 @@ namespace librealsense
             // so the stream brightness matches the reported exposure (as done on Windows).
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && value == 0)
             {
-                LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_mipi_device)");
                 int32_t exposure = 0;
                 if (get_pu(RS2_OPTION_EXPOSURE, exposure))
                 {
+                    LOG_DEBUG("Re-applying manual exposure " << exposure << " after AE disable (v4l_mipi_device)");
                     if (!set_pu(RS2_OPTION_EXPOSURE, exposure))
                     {
                         LOG_WARNING("Re-applying manual exposure after AE disable failed (v4l_mipi_device)");

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -562,29 +562,15 @@ namespace librealsense
             }
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
             {
-                if (value)
-                {
-                    auto hr = get_camera_control()->Set(CameraControl_Exposure, 0, CameraControl_Flags_Auto);
-                    if (hr == DEVICE_NOT_READY_ERROR)
-                        return false;
+                // The exposure value passed here is intentionally 0 - when switching to
+                // Manual, uvc_pu_auto_exposure_option re-applies the saved exposure right
+                // after this call, so the value written here is overwritten immediately.
+                auto flags = value ? CameraControl_Flags_Auto : CameraControl_Flags_Manual;
+                auto hr = get_camera_control()->Set(CameraControl_Exposure, 0, flags);
+                if (hr == DEVICE_NOT_READY_ERROR)
+                    return false;
 
-                    CHECK_HR(hr);
-                }
-                else
-                {
-                    long min, max, step, def, caps;
-                    auto hr = get_camera_control()->GetRange(CameraControl_Exposure, &min, &max, &step, &def, &caps);
-                    if (hr == DEVICE_NOT_READY_ERROR)
-                        return false;
-
-                    CHECK_HR(hr);
-
-                    hr = get_camera_control()->Set(CameraControl_Exposure, def, CameraControl_Flags_Manual);
-                    if (hr == DEVICE_NOT_READY_ERROR)
-                        return false;
-
-                    CHECK_HR(hr);
-                }
+                CHECK_HR(hr);
                 return true;
             }
 


### PR DESCRIPTION
Tracked by: RSDSO-21416

**TL;DR:** On Linux, disabling the color sensor's auto-exposure now re-applies the manual exposure value so the stream brightness matches the reported exposure, fixing a metadata/brightness mismatch that did not occur on Windows.

## Summary
- In `v4l_uvc_device::set_pu` and `v4l_mipi_device::set_pu`, when auto-exposure is disabled (`RS2_OPTION_ENABLE_AUTO_EXPOSURE` set to 0), re-write the current exposure value after switching the UVC control to `V4L2_EXPOSURE_MANUAL`.

## Why
Switching the UVC exposure control from auto to manual mode does not, by itself, make the device re-apply the manual exposure to the sensor: it keeps streaming with the last auto-computed exposure, even though `V4L2_CID_EXPOSURE_ABSOLUTE` (and the frame metadata) still report the manually-set value. This produced a Linux-only bug where, after setting a manual exposure → enabling AE → disabling AE, the metadata reported the manual value but the stream brightness stayed at the AE level. The Windows MF backend already forces a manual exposure write when disabling AE; this aligns the Linux behavior.

## Test plan
- [x] Manual: color sensor — set high exposure, enable AE, disable AE; verify stream brightness matches the reported `RS2_FRAME_METADATA_ACTUAL_EXPOSURE` metadata.
- [ ] CI: existing live color/exposure tests pass on Linux.
