### PR TITLE
D585S: diagnostic captures + documented workarounds for two FW bugs

### DIFF
--- a/config/99-realsense-libusb.rules
+++ b/config/99-realsense-libusb.rules
@@ -94,3 +94,6 @@ DRIVER=="hid_sensor*", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="1156", RUN+="
 
 # For products with motion_module, if (kernels is 4.15 and up) and (device name is "accel_3d") wait, in another process, until (enable flag is set to 1 or 200 mSec passed) and then set it to 0.
 KERNEL=="iio*", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad5|0afe|0aff|0b00|0b01|0b3a|0b3d|0b56|0b5c|0b64|0b68|0b6a|0b6b|1156", RUN+="/bin/sh -c '(major=`uname -r | cut -d \".\" -f1` && minor=`uname -r | cut -d \".\" -f2` && (([ $$major -eq 4 ] && [ $$minor -ge 15 ]) || [ $$major -ge 5 ])) && (enamefile=/sys/%p/name && [ `cat $$enamefile` = \"accel_3d\" ]) && enfile=/sys/%p/buffer/enable && echo \"COUNTER=0; while [ \$$COUNTER -lt 20 ] && grep -q 0 $$enfile; do sleep 0.01; COUNTER=\$$((COUNTER+1)); done && echo 0 > $$enfile\" | at now'"
+
+# D585S SMCU serial port (Silicon Labs CP2105 Dual UART Bridge)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea70", GROUP="dialout", MODE="0660"

--- a/unit-tests/py/rspy/d500_log.py
+++ b/unit-tests/py/rspy/d500_log.py
@@ -1,0 +1,251 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Background capture of firmware logs from D500 / D585S serial devices.
+
+Two flavours typically used on D585S:
+  - CDC ACM channel from the AP CPU (default: /dev/ttyACM1, no baud needed)
+  - SMCU UART exposed via the on-board CP2105 USB-UART bridge
+    (typically /dev/ttyUSB1 at 460800 baud)
+
+A daemon thread drains the device into a timestamped text file for the
+duration of a test. `.stop()` tears it down; an atexit safety net runs
+stop() even if the test crashes.
+
+Usage in a D500 / D585S test
+----------------------------
+Three captures are usually wanted side-by-side: the FW CDC log, the SMCU
+UART log, and the kernel dmesg ring (the dmesg capture lives in
+`rspy.host_trace`, alongside this module). Start them at the top of the
+test so the entire run is covered, and stop them at the end so the files
+flush cleanly before `test.print_results_and_exit()`.
+
+    import os
+    from rspy.d500_log import start_cdc_log
+    from rspy.host_trace import start_dmesg_log
+
+    _test_base = os.path.splitext( os.path.basename( __file__ ) )[0]
+    _cdc   = start_cdc_log( _test_base + "-cdc" )                                 # /dev/ttyACM1, CDC ACM, no baud
+    _smcu  = start_cdc_log( _test_base + "-smcu", device_path="/dev/ttyUSB1",     # CP2105 SMCU UART
+                            baud=460800 )
+    _dmesg = start_dmesg_log( _test_base )                                        # journalctl -kf (or sudo dmesg -wT)
+
+    # ... test body ...
+
+    if _cdc   is not None: _cdc.stop()
+    if _smcu  is not None: _smcu.stop()
+    if _dmesg is not None: _dmesg.stop()
+
+    test.print_results_and_exit()
+
+Notes
+-----
+* All three `start_*` calls return `None` (and log a warning) if the
+  device / tool is missing or the port can't be opened. Always guard the
+  `.stop()` call with `is not None` so the test still runs on hosts that
+  lack the SMCU bridge or `journalctl`.
+* `.stop()` is idempotent and re-entrant. An atexit handler also calls
+  it, so even an uncaught exception in the test body still flushes the
+  capture file to disk.
+* Output files land in the current working directory by default
+  (`out_dir="."`); pass `out_dir=...` if your CI artifact collector
+  expects a specific location.
+* The SMCU UART on the CP2105 needs `baud=` set (true UART); the AP
+  CDC ACM node ignores baud.
+"""
+
+import atexit
+import datetime
+import errno
+import os
+import select
+import shutil
+import subprocess
+import threading
+import time
+
+from rspy import log
+
+# termios is POSIX-only; importing this module on Windows (e.g. during test
+# discovery) must not raise. Capture-time use is still gated by _HAVE_TERMIOS.
+try:
+    import termios
+    _HAVE_TERMIOS = True
+    _TERMIOS_ERROR = termios.error
+    _BAUD_TABLE = {
+        9600:   termios.B9600,
+        19200:  termios.B19200,
+        38400:  termios.B38400,
+        57600:  termios.B57600,
+        115200: termios.B115200,
+        230400: termios.B230400,
+        460800: termios.B460800,
+        921600: termios.B921600,
+    }
+except ImportError:
+    termios = None
+    _HAVE_TERMIOS = False
+    _TERMIOS_ERROR = OSError
+    _BAUD_TABLE = {}
+
+DEFAULT_DEVICE = "/dev/ttyACM1"
+
+# When the device is freshly enumerated (or re-enumerated after a librealsense
+# USB claim), services like ModemManager probe the tty and hold it open with
+# TIOCEXCL for a short window. We retry the open for a while to ride that out.
+OPEN_RETRY_TIMEOUT_SEC = 30
+OPEN_RETRY_DELAY_SEC = 0.5
+
+
+def _identify_holder( device_path ):
+    """Best-effort: return a short string naming the process(es) holding the device, or None."""
+    for cmd in ( ["fuser", "-v", device_path], ["lsof", device_path] ):
+        if not shutil.which( cmd[0] ):
+            continue
+        try:
+            result = subprocess.run( cmd, capture_output=True, text=True, timeout=2 )
+            out = (result.stdout + result.stderr).strip()
+            if out:
+                return f"{cmd[0]}: {out}"
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+    return None
+
+
+def _open_with_retry( device_path, timeout=OPEN_RETRY_TIMEOUT_SEC, delay=OPEN_RETRY_DELAY_SEC ):
+    """Open `device_path` non-blocking, retrying on EBUSY for up to `timeout` seconds."""
+    deadline = time.monotonic() + timeout
+    busy_logged = False
+    while True:
+        try:
+            return os.open( device_path, os.O_RDONLY | os.O_NONBLOCK )
+        except OSError as e:
+            if e.errno == errno.EBUSY and time.monotonic() < deadline:
+                if not busy_logged:
+                    holder = _identify_holder( device_path )
+                    holder_msg = f" -- holder: {holder}" if holder else ""
+                    log.d( f"D500 log capture: {device_path} busy, retrying up to {timeout}s{holder_msg}" )
+                    busy_logged = True
+                time.sleep( delay )
+                continue
+            holder = _identify_holder( device_path ) if e.errno == errno.EBUSY else None
+            holder_msg = f" (holder: {holder})" if holder else ""
+            log.w( f"D500 log capture skipped: cannot open {device_path}: {e}{holder_msg}" )
+            return None
+
+
+def _configure_tty_raw( fd, baud ):
+    """Set the tty to raw mode at the requested baud. Required for CP2105/FTDI;
+    CDC ACM nodes ignore baud but the call is harmless there too."""
+    if not _HAVE_TERMIOS:
+        raise OSError( "termios not available on this platform" )
+    speed = _BAUD_TABLE.get( baud )
+    if speed is None:
+        raise ValueError( f"unsupported baud {baud}; add to _BAUD_TABLE" )
+    attrs = termios.tcgetattr( fd )
+    iflag, oflag, cflag, lflag, _ispeed, _ospeed, cc = attrs
+    # raw input
+    iflag &= ~(termios.IGNBRK | termios.BRKINT | termios.PARMRK | termios.ISTRIP
+               | termios.INLCR | termios.IGNCR | termios.ICRNL | termios.IXON)
+    # raw output
+    oflag &= ~termios.OPOST
+    # non-canonical, no echo, no signals
+    lflag &= ~(termios.ECHO | termios.ECHONL | termios.ICANON | termios.ISIG | termios.IEXTEN)
+    # 8N1, enable receiver, ignore modem control lines
+    cflag &= ~(termios.CSIZE | termios.PARENB)
+    cflag |= termios.CS8 | termios.CREAD | termios.CLOCAL
+    termios.tcsetattr( fd, termios.TCSANOW, [iflag, oflag, cflag, lflag, speed, speed, cc] )
+
+
+class CDCLogCapture:
+    def __init__( self, path, fd, out_file, stop_event, thread ):
+        self.path = path
+        self._fd = fd
+        self._file = out_file
+        self._stop = stop_event
+        self._thread = thread
+        self._stopped = False
+
+    def stop( self ):
+        if self._stopped:
+            return
+        self._stopped = True
+        self._stop.set()
+        self._thread.join( timeout=2 )
+        # The reader thread closes the file in its own `finally`. If the join
+        # timed out the thread is still alive: leave the file open and let the
+        # daemon close it on exit. Otherwise flush+close here is a safe no-op
+        # (already closed) wrapped against the race.
+        if not self._thread.is_alive():
+            try:
+                if not self._file.closed:
+                    self._file.flush()
+                    self._file.close()
+            except (OSError, ValueError):
+                pass
+
+
+def start_cdc_log( test_name, device_path=DEFAULT_DEVICE, out_dir=".", baud=None ):
+    """
+    Open `device_path`, start a daemon thread that writes everything read from
+    it into `<out_dir>/<test_name>_<YYYYMMDD_HHMMSS>.txt`, and return a handle
+    whose `.stop()` method tears the capture down.
+
+    `baud` is required for true UART devices (e.g. /dev/ttyUSB* on a CP2105
+    bridge). Pass None for CDC ACM nodes that don't honour baud.
+
+    Returns None and logs a warning if the device can't be opened.
+    An atexit handler also calls stop() so the file flushes on crash.
+    """
+    timestamp = datetime.datetime.now().strftime( "%Y%m%d_%H%M%S" )
+    out_path = os.path.join( out_dir, f"{test_name}_{timestamp}.txt" )
+
+    fd = _open_with_retry( device_path )
+    if fd is None:
+        return None
+
+    if baud is not None:
+        try:
+            _configure_tty_raw( fd, baud )
+        except (_TERMIOS_ERROR, ValueError, OSError) as e:
+            log.w( f"D500 log capture skipped: cannot configure {device_path} @{baud}: {e}" )
+            os.close( fd )
+            return None
+
+    out_file = open( out_path, "w", buffering=1 )
+    stop_event = threading.Event()
+    log.d( f"D500 log capture: {device_path} -> {out_path}" )
+
+    def reader():
+        try:
+            while not stop_event.is_set():
+                r, _, _ = select.select( [fd], [], [], 0.5 )
+                if fd in r:
+                    try:
+                        data = os.read( fd, 4096 )
+                    except BlockingIOError:
+                        continue
+                    if data:
+                        try:
+                            out_file.write( data.decode( "utf-8", errors="replace" ) )
+                        except (OSError, ValueError):
+                            return  # file got closed under us (interpreter exit)
+        finally:
+            try:
+                os.close( fd )
+            except OSError:
+                pass
+            try:
+                if not out_file.closed:
+                    out_file.flush()
+                    out_file.close()
+            except (OSError, ValueError):
+                pass
+
+    thread = threading.Thread( target=reader, daemon=True )
+    thread.start()
+
+    capture = CDCLogCapture( out_path, fd, out_file, stop_event, thread )
+    atexit.register( capture.stop )
+    return capture

--- a/unit-tests/py/rspy/host_trace.py
+++ b/unit-tests/py/rspy/host_trace.py
@@ -1,0 +1,123 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Host-side diagnostics capture for librealsense tests.
+
+Provides start_dmesg_log() which spawns a background subprocess that streams
+the Linux kernel ring buffer into a timestamped file alongside the test's
+CDC/SMCU captures. Useful for catching v4l2/uvcvideo/usbfs warnings that
+show up when a stream fails to start or restart.
+"""
+
+import atexit
+import datetime
+import os
+import shutil
+import subprocess
+import time
+
+from rspy import log
+
+
+class _ProcessCapture:
+    def __init__( self, path, proc, file_handle, method ):
+        self.path = path
+        self.method = method
+        self._proc = proc
+        self._file = file_handle
+        self._stopped = False
+
+    def stop( self ):
+        if self._stopped:
+            return
+        self._stopped = True
+        try:
+            self._proc.terminate()
+            self._proc.wait( timeout=2 )
+        except subprocess.TimeoutExpired:
+            try:
+                self._proc.kill()
+                self._proc.wait( timeout=1 )
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+        except OSError:
+            pass
+        if self._file is not None and not self._file.closed:
+            self._file.close()
+
+
+def _try_spawn( out_path, cmd, settle_sec=0.3 ):
+    """Open out_path, start cmd writing into it. Return (proc, file) or (None, None).
+    On failure, the (empty) output file is removed so we don't leave orphans."""
+    f = open( out_path, "w", buffering=1 )
+    try:
+        proc = subprocess.Popen( cmd, stdout=f, stderr=subprocess.STDOUT )
+    except (OSError, FileNotFoundError):
+        f.close()
+        _unlink_quietly( out_path )
+        return None, None
+    time.sleep( settle_sec )
+    if proc.poll() is not None:
+        f.close()
+        _unlink_quietly( out_path )
+        return None, None
+    return proc, f
+
+
+def _unlink_quietly( path ):
+    try:
+        os.unlink( path )
+    except OSError:
+        pass
+
+
+def start_dmesg_log( test_name, out_dir="." ):
+    """
+    Start a background capture of the kernel ring buffer into
+    <out_dir>/<test_name>_dmesg_<YYYYMMDD_HHMMSS>.txt.
+
+    Tries `journalctl -kf` first (works on systemd hosts without root), then
+    falls back to `sudo -n dmesg -wT` (only if passwordless sudo is set up).
+    Returns a handle whose .stop() terminates the subprocess and closes the
+    file, or None if no capture method is available.
+
+    An atexit handler also calls stop(), so the file flushes on crash.
+    """
+    timestamp = datetime.datetime.now().strftime( "%Y%m%d_%H%M%S" )
+    out_path = os.path.join( out_dir, f"{test_name}_dmesg_{timestamp}.txt" )
+
+    proc = None
+    file_handle = None
+    method = None
+
+    if shutil.which( "journalctl" ):
+        proc, file_handle = _try_spawn(
+            out_path,
+            ["journalctl", "-kf", "-o", "short-precise", "--since", "now"],
+        )
+        if proc is not None:
+            method = "journalctl"
+
+    if proc is None and shutil.which( "dmesg" ) and shutil.which( "sudo" ):
+        try:
+            ok = subprocess.run(
+                ["sudo", "-n", "true"],
+                capture_output=True,
+                timeout=1,
+            ).returncode == 0
+        except (subprocess.TimeoutExpired, OSError):
+            ok = False
+        if ok:
+            proc, file_handle = _try_spawn( out_path, ["sudo", "-n", "dmesg", "-wT"] )
+            if proc is not None:
+                method = "sudo dmesg"
+
+    if proc is None:
+        log.w( "dmesg log capture skipped: neither journalctl nor passwordless 'sudo dmesg' available" )
+        return None
+
+    log.d( f"dmesg log capture ({method}): -> {out_path}" )
+    capture = _ProcessCapture( out_path, proc, file_handle, method )
+    atexit.register( capture.stop )
+    return capture


### PR DESCRIPTION
## Summary

Documents two D585S firmware bugs surfaced by the live unit tests, adds diagnostic log capture to both affected tests so future failures land with FW + SMCU + kernel evidence in the Jenkins artifacts, and leaves the workarounds in place as commented-out one-liners so they can be re-enabled when the FW fixes ship.

**Bug 1 — `test-operational-mode.py`: safety subsystem needs settling time after `pipe.stop()` when `safety_mode` was changed during the session.** Once `safety_mode` has been transitioned (STANDBY / SERVICE), a `pipe.stop()` returns before the safety subsystem has fully released its state, and the next `pipe.start()` times out on the first `wait_for_frames()`. Reproducible on vtglnx163 / vtglnx164 (Ubuntu 22.04, kernel 6.8), passes on vtgu24 / rslnx391 because those hosts happen to give the device enough idle time naturally. Workaround: `time.sleep(1)` after every `pipe.stop()`. Three such sleeps are added in this PR but left **commented out** with a `workaround for D585S safety-mode state-release latency` note, so the test continues to expose the failure for the FW team.

**Bug 2 — `test-get-set-config-table.py`: `GET_HKR_CONFIG_TABLE` for the depth_calibration_table fails when read from EEPROM on this FW.** The original test passed `param1=0` (eeprom), which now returns `Invalid Command` from FW. Reading the same table via flash (`param1=1`) works. Workaround left **commented out** in the same way; the test continues to issue the failing eeprom read so the bug stays visible.

**Diagnostic capture infrastructure**, used to find both bugs and kept so future failures land with the evidence in Jenkins artifacts:
- `rspy/d500_log.py` — background daemon that streams the D585S CDC ACM firmware log (`/dev/ttyACM1`) and the SMCU UART log (`/dev/ttyUSB1` via CP2105 @ 460800 baud) into timestamped text files alongside the test output. Both `test-operational-mode.py` and `test-get-set-config-table.py` now call it.
- `rspy/host_trace.py` — background dmesg capture (`journalctl -kf`, or `sudo -n dmesg -wT` fallback) into a timestamped file. Used by both tests.
- `config/99-realsense-libusb.rules` — `MODE=0666` on the CP2105 SMCU UART so the test can open it without root.

`test-get-set-config-table.py` also drops its `# test:donotrun:!nightly` directive temporarily so CI exercises the failing scenario on every commit. **Restore the nightly directive before this PR is merged.**

## Status of the bugs
- D585S FW team has been notified (standalone `d585s_operational_mode_repro.py` shared separately) about the safety-mode settle issue.
- The depth_calibration EEPROM-read failure is the second item to file with the FW team.

## Test plan
- [ ] Jenkins linux CI runs on the failing hosts (vtglnx163 / vtglnx164) — `test-live-d500-safety-operational-mode` is expected to fail at Closure 2's first `wait_for_frames` (current FW). The CDC + SMCU + dmesg artifacts should be present in the run.
- [ ] Jenkins linux CI runs on the previously-passing hosts (rslnx391 / vtgu24) — same test expected to pass.
- [ ] `test-live-d500-get-set-config-table` runs on every commit (nightly directive temporarily removed); expected to fail at `Get buffer less than 1 KB` until FW fixes the EEPROM read.

## Before merge
- [ ] Restore `# test:donotrun:!nightly` on `test-get-set-config-table.py`.
- [ ] Decide whether to keep the workarounds commented out (visible failure tracks FW progress) or re-enable them (test goes green) based on FW status at merge time.