### PR TITLE
conftest + iq_helper: per-device fixture + per-device failure snapshots

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -60,7 +60,12 @@ from rspy.pytest.logging_setup import (
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
 from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
-from rspy.pytest.device_helpers import resolve_device_each_serials, _MISSING_SENTINEL_PREFIX, _SKIP_SENTINEL_PREFIX
+from rspy.pytest.device_helpers import (
+    resolve_device_each_serials,
+    select_target_device,
+    _MISSING_SENTINEL_PREFIX,
+    _SKIP_SENTINEL_PREFIX,
+)
 from rspy.pytest.collection import filter_and_sort_items
 from rspy.pytest.plugins import check_required_plugins
 
@@ -590,35 +595,6 @@ def test_context(module_device_setup):
     return ctx
 
 
-def _select_target_device(devices_list, module_device_setup):
-    """
-    Return the device matching the SN yielded by module_device_setup. Falls back to
-    devices_list[0] only when the test has no device parametrization (e.g. tests
-    without a device() marker). On CI rigs without a hub -- e.g. Jetson with D457 on
-    MIPI and D436 on USB -- both devices stay visible regardless of which one was
-    "enabled", so the fixture must filter by SN rather than pick devices_list[0].
-    """
-    if isinstance(module_device_setup, list):
-        # Multi-device marker (e.g. device("D400*", "D400*")) -- the test should use
-        # the test_devices (plural) fixture, not test_device. Falling back to the first
-        # device to preserve pre-PR behavior, but warn so the misuse is visible in CI.
-        log.warning(
-            "test_device/function_scoped_device fixture invoked with a multi-device marker; "
-            "use test_devices instead. Falling back to devices_list[0]."
-        )
-        return devices_list[0]
-    target_sn = module_device_setup if isinstance(module_device_setup, str) else None
-    if target_sn:
-        for d in devices_list:
-            if d.supports(rs.camera_info.serial_number) \
-               and d.get_info(rs.camera_info.serial_number) == target_sn:
-                return d
-        visible = [d.get_info(rs.camera_info.serial_number)
-                   for d in devices_list if d.supports(rs.camera_info.serial_number)]
-        pytest.fail(f"Target device {target_sn} not visible in context (visible: {visible})")
-    return devices_list[0]
-
-
 @pytest.fixture(scope="module")
 def test_device(test_context, module_device_setup):
     """Return (device, context) for the test's target device, or fail if none found."""
@@ -626,7 +602,7 @@ def test_device(test_context, module_device_setup):
     if not devices_list:
         pytest.fail("No device available for test")
 
-    dev = _select_target_device(devices_list, module_device_setup)
+    dev = select_target_device(devices_list, module_device_setup)
     log.debug(f"Test using device: {dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
 
     return dev, test_context
@@ -648,7 +624,7 @@ def function_scoped_device(test_context, module_device_setup):
     if not devices_list:
         pytest.fail("No device available for test")
 
-    dev = _select_target_device(devices_list, module_device_setup)
+    dev = select_target_device(devices_list, module_device_setup)
     log.debug(f"Test using fresh device handle: {dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
 
     return dev

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -590,23 +590,43 @@ def test_context(module_device_setup):
     return ctx
 
 
+def _select_target_device(devices_list, module_device_setup):
+    """
+    Return the device matching the SN yielded by module_device_setup. Falls back to
+    devices_list[0] only when the test has no device parametrization (e.g. tests
+    without a device() marker). On CI rigs without a hub -- e.g. Jetson with D457 on
+    MIPI and D436 on USB -- both devices stay visible regardless of which one was
+    "enabled", so the fixture must filter by SN rather than pick devices_list[0].
+    """
+    target_sn = module_device_setup if isinstance(module_device_setup, str) else None
+    if target_sn:
+        for d in devices_list:
+            if d.supports(rs.camera_info.serial_number) \
+               and d.get_info(rs.camera_info.serial_number) == target_sn:
+                return d
+        visible = [d.get_info(rs.camera_info.serial_number)
+                   for d in devices_list if d.supports(rs.camera_info.serial_number)]
+        pytest.fail(f"Target device {target_sn} not visible in context (visible: {visible})")
+    return devices_list[0]
+
+
 @pytest.fixture(scope="module")
-def test_device(test_context):
-    """Return (device, context) for the first visible device, or fail if none found."""
+def test_device(test_context, module_device_setup):
+    """Return (device, context) for the test's target device, or fail if none found."""
     devices_list = list(test_context.devices)
     if not devices_list:
         pytest.fail("No device available for test")
 
-    dev = devices_list[0]
+    dev = _select_target_device(devices_list, module_device_setup)
     log.debug(f"Test using device: {dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
 
     return dev, test_context
 
 
 @pytest.fixture
-def function_scoped_device(test_context):
+def function_scoped_device(test_context, module_device_setup):
     """Function-scoped: re-query the module-scoped ``test_context`` and return a
-    *fresh* device wrapper for the first visible device.  Use this in tests that
+    *fresh* device wrapper for the test's target device.  Use this in tests that
     mutate persistent device state (e.g. HDR sequencer overrides in
     ``pytest-hdr-long.py``) and need each test to start from a new device object,
     even though the underlying ``rs.context()`` is shared across the module.
@@ -619,7 +639,7 @@ def function_scoped_device(test_context):
     if not devices_list:
         pytest.fail("No device available for test")
 
-    dev = devices_list[0]
+    dev = _select_target_device(devices_list, module_device_setup)
     log.debug(f"Test using fresh device handle: " f"{dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
 
     return dev

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -598,6 +598,15 @@ def _select_target_device(devices_list, module_device_setup):
     MIPI and D436 on USB -- both devices stay visible regardless of which one was
     "enabled", so the fixture must filter by SN rather than pick devices_list[0].
     """
+    if isinstance(module_device_setup, list):
+        # Multi-device marker (e.g. device("D400*", "D400*")) -- the test should use
+        # the test_devices (plural) fixture, not test_device. Falling back to the first
+        # device to preserve pre-PR behavior, but warn so the misuse is visible in CI.
+        log.warning(
+            "test_device/function_scoped_device fixture invoked with a multi-device marker; "
+            "use test_devices instead. Falling back to devices_list[0]."
+        )
+        return devices_list[0]
     target_sn = module_device_setup if isinstance(module_device_setup, str) else None
     if target_sn:
         for d in devices_list:
@@ -640,7 +649,7 @@ def function_scoped_device(test_context, module_device_setup):
         pytest.fail("No device available for test")
 
     dev = _select_target_device(devices_list, module_device_setup)
-    log.debug(f"Test using fresh device handle: " f"{dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
+    log.debug(f"Test using fresh device handle: {dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else 'Unknown'}")
 
     return dev
 

--- a/unit-tests/infra-tests/test_iq_snapshot_dedup.py
+++ b/unit-tests/infra-tests/test_iq_snapshot_dedup.py
@@ -16,13 +16,11 @@ import sys
 import pytest
 from unittest.mock import MagicMock
 
-# Skip the whole module if either cv2 or pyrealsense2 isn't importable in this
-# environment. iq_helper imports both at module load, so they're required.
-try:
-    import cv2  # noqa: F401
-    import pyrealsense2 as rs  # noqa: F401
-except ImportError as e:
-    pytestmark = pytest.mark.skip(reason=f"{e.name} not available")
+# iq_helper imports cv2, pyrealsense2, and rspy at module load. If any of them
+# isn't available, skip the whole file cleanly (importorskip raises Skipped at
+# module level, which pytest handles as a module skip rather than a collection error).
+pytest.importorskip("cv2")
+pytest.importorskip("pyrealsense2")
 
 # iq_helper lives outside the standard rspy import path; add its directory.
 _IQ_DIR = os.path.normpath(os.path.join(
@@ -30,7 +28,7 @@ _IQ_DIR = os.path.normpath(os.path.join(
 if _IQ_DIR not in sys.path:
     sys.path.insert(0, _IQ_DIR)
 
-import iq_helper  # noqa: E402
+iq_helper = pytest.importorskip("iq_helper")
 
 
 def _make_pipeline(device_full_name):

--- a/unit-tests/infra-tests/test_iq_snapshot_dedup.py
+++ b/unit-tests/infra-tests/test_iq_snapshot_dedup.py
@@ -16,16 +16,13 @@ import sys
 import pytest
 from unittest.mock import MagicMock
 
+# Skip the whole module if either cv2 or pyrealsense2 isn't importable in this
+# environment. iq_helper imports both at module load, so they're required.
 try:
-    import pyrealsense2 as rs
-except ImportError:
-    pytestmark = pytest.mark.skip(reason="pyrealsense2 not available")
-    rs = None
-
-# cv2 may not be installed in the infra-test environment; stub it out before
-# iq_helper imports it. cv2.imwrite calls become recordable MagicMock calls.
-_cv2_mock = MagicMock()
-sys.modules['cv2'] = _cv2_mock
+    import cv2  # noqa: F401
+    import pyrealsense2 as rs  # noqa: F401
+except ImportError as e:
+    pytestmark = pytest.mark.skip(reason=f"{e.name} not available")
 
 # iq_helper lives outside the standard rspy import path; add its directory.
 _IQ_DIR = os.path.normpath(os.path.join(
@@ -51,14 +48,17 @@ def _make_image():
 class TestSaveFailureSnapshotDedup:
 
     @pytest.fixture(autouse=True)
-    def _reset_state(self):
-        """Each test starts with an empty dedup set and a fresh cv2.imwrite mock."""
+    def imwrite_mock(self, monkeypatch):
+        """Mock only iq_helper's cv2.imwrite for the duration of each test, and reset the
+        module-level dedup state. Using monkeypatch (rather than mutating sys.modules['cv2'])
+        keeps the real cv2 intact for any other test in the same pytest session."""
         iq_helper._snapshot_saved.clear()
-        _cv2_mock.imwrite.reset_mock()
-        yield
+        mock = MagicMock()
+        monkeypatch.setattr(iq_helper.cv2, 'imwrite', mock)
+        yield mock
         iq_helper._snapshot_saved.clear()
 
-    def test_same_test_different_devices_both_saved(self):
+    def test_same_test_different_devices_both_saved(self, imwrite_mock):
         """The Jetson scenario: D457 and D436 both fail same test -> two snapshots."""
         iq_helper.save_failure_snapshot(
             'test_basic_color.py',
@@ -69,12 +69,12 @@ class TestSaveFailureSnapshotDedup:
             _make_pipeline('Intel RealSense D436'),
             annotated_image=_make_image())
 
-        saved_paths = [c.args[0] for c in _cv2_mock.imwrite.call_args_list]
+        saved_paths = [c.args[0] for c in imwrite_mock.call_args_list]
         assert len(saved_paths) == 2, f"expected 2 snapshots, got: {saved_paths}"
         assert any('D457' in os.path.basename(p) for p in saved_paths), saved_paths
         assert any('D436' in os.path.basename(p) for p in saved_paths), saved_paths
 
-    def test_same_test_same_device_deduped(self):
+    def test_same_test_same_device_deduped(self, imwrite_mock):
         """Repeated failure on the same (test, device) pair only saves once."""
         iq_helper.save_failure_snapshot(
             'test_basic_color.py',
@@ -85,9 +85,9 @@ class TestSaveFailureSnapshotDedup:
             _make_pipeline('Intel RealSense D457'),
             annotated_image=_make_image())
 
-        assert _cv2_mock.imwrite.call_count == 1
+        assert imwrite_mock.call_count == 1
 
-    def test_different_tests_independent_dedup(self):
+    def test_different_tests_independent_dedup(self, imwrite_mock):
         """Different test files dedupe independently even when sharing a device."""
         iq_helper.save_failure_snapshot(
             'test_basic_color.py',
@@ -98,9 +98,9 @@ class TestSaveFailureSnapshotDedup:
             _make_pipeline('Intel RealSense D436'),
             annotated_image=_make_image())
 
-        assert _cv2_mock.imwrite.call_count == 2
+        assert imwrite_mock.call_count == 2
 
-    def test_no_device_name_falls_back_to_test_name(self):
+    def test_no_device_name_falls_back_to_test_name(self, imwrite_mock):
         """When pipeline can't yield a device name, filename omits the device suffix."""
         bad_pipeline = MagicMock()
         bad_pipeline.get_active_profile.side_effect = RuntimeError("no profile")
@@ -108,8 +108,8 @@ class TestSaveFailureSnapshotDedup:
         iq_helper.save_failure_snapshot(
             'test_basic_color.py', bad_pipeline, annotated_image=_make_image())
 
-        assert _cv2_mock.imwrite.call_count == 1
-        saved_path = _cv2_mock.imwrite.call_args.args[0]
+        assert imwrite_mock.call_count == 1
+        saved_path = imwrite_mock.call_args.args[0]
         basename = os.path.basename(saved_path)
         assert basename == 'test_basic_color.png', \
             f"expected device-less filename, got: {basename}"

--- a/unit-tests/infra-tests/test_iq_snapshot_dedup.py
+++ b/unit-tests/infra-tests/test_iq_snapshot_dedup.py
@@ -1,0 +1,115 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests for save_failure_snapshot dedup in unit-tests/live/image-quality/iq_helper.py.
+
+On hub-less multi-device rigs (e.g. Jetson with D457 on MIPI + D436 on USB), the
+same image-quality test runs once per parametrized device. The dedup that
+prevents repeated snapshots for the same failing test must key on (test_file,
+device_name) so that both devices' failures still produce their own snapshot --
+not just the first one to fail.
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+try:
+    import pyrealsense2 as rs
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="pyrealsense2 not available")
+    rs = None
+
+# cv2 may not be installed in the infra-test environment; stub it out before
+# iq_helper imports it. cv2.imwrite calls become recordable MagicMock calls.
+_cv2_mock = MagicMock()
+sys.modules['cv2'] = _cv2_mock
+
+# iq_helper lives outside the standard rspy import path; add its directory.
+_IQ_DIR = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', 'live', 'image-quality'))
+if _IQ_DIR not in sys.path:
+    sys.path.insert(0, _IQ_DIR)
+
+import iq_helper  # noqa: E402
+
+
+def _make_pipeline(device_full_name):
+    """Build a MagicMock that mimics the pipeline.get_active_profile().get_device().get_info() chain."""
+    pipeline = MagicMock()
+    pipeline.get_active_profile.return_value.get_device.return_value.get_info.return_value = device_full_name
+    return pipeline
+
+
+def _make_image():
+    """A non-None stand-in for the annotated image; the helper only checks it's not None."""
+    return MagicMock(name="annotated_image")
+
+
+class TestSaveFailureSnapshotDedup:
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self):
+        """Each test starts with an empty dedup set and a fresh cv2.imwrite mock."""
+        iq_helper._snapshot_saved.clear()
+        _cv2_mock.imwrite.reset_mock()
+        yield
+        iq_helper._snapshot_saved.clear()
+
+    def test_same_test_different_devices_both_saved(self):
+        """The Jetson scenario: D457 and D436 both fail same test -> two snapshots."""
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py',
+            _make_pipeline('Intel RealSense D457'),
+            annotated_image=_make_image())
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py',
+            _make_pipeline('Intel RealSense D436'),
+            annotated_image=_make_image())
+
+        saved_paths = [c.args[0] for c in _cv2_mock.imwrite.call_args_list]
+        assert len(saved_paths) == 2, f"expected 2 snapshots, got: {saved_paths}"
+        assert any('D457' in os.path.basename(p) for p in saved_paths), saved_paths
+        assert any('D436' in os.path.basename(p) for p in saved_paths), saved_paths
+
+    def test_same_test_same_device_deduped(self):
+        """Repeated failure on the same (test, device) pair only saves once."""
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py',
+            _make_pipeline('Intel RealSense D457'),
+            annotated_image=_make_image())
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py',
+            _make_pipeline('Intel RealSense D457'),
+            annotated_image=_make_image())
+
+        assert _cv2_mock.imwrite.call_count == 1
+
+    def test_different_tests_independent_dedup(self):
+        """Different test files dedupe independently even when sharing a device."""
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py',
+            _make_pipeline('Intel RealSense D436'),
+            annotated_image=_make_image())
+        iq_helper.save_failure_snapshot(
+            'test_basic_depth.py',
+            _make_pipeline('Intel RealSense D436'),
+            annotated_image=_make_image())
+
+        assert _cv2_mock.imwrite.call_count == 2
+
+    def test_no_device_name_falls_back_to_test_name(self):
+        """When pipeline can't yield a device name, filename omits the device suffix."""
+        bad_pipeline = MagicMock()
+        bad_pipeline.get_active_profile.side_effect = RuntimeError("no profile")
+
+        iq_helper.save_failure_snapshot(
+            'test_basic_color.py', bad_pipeline, annotated_image=_make_image())
+
+        assert _cv2_mock.imwrite.call_count == 1
+        saved_path = _cv2_mock.imwrite.call_args.args[0]
+        basename = os.path.basename(saved_path)
+        assert basename == 'test_basic_color.png', \
+            f"expected device-less filename, got: {basename}"

--- a/unit-tests/infra-tests/test_select_target_device.py
+++ b/unit-tests/infra-tests/test_select_target_device.py
@@ -1,0 +1,96 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests for select_target_device (rspy/pytest/device_helpers.py).
+
+select_target_device is the per-test device picker used by the test_device and
+function_scoped_device fixtures in unit-tests/conftest.py. It exists so that on
+hub-less multi-device CI rigs (e.g. Jetson with D457 on MIPI and D436 on USB,
+both always visible), a test parametrized for one device doesn't silently end
+up running against the other one because of enumeration order.
+
+Covered:
+- str setup: returns the device whose SN matches.
+- None setup: no device parametrization -> falls back to devices_list[0].
+- str setup, SN not present in devices_list -> pytest.fail with a useful message.
+- list setup (multi-device marker misuse): warns and falls back to devices_list[0].
+"""
+
+import pytest
+
+try:
+    import pyrealsense2 as rs
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="pyrealsense2 not available")
+    rs = None
+
+from rspy.pytest.device_helpers import select_target_device
+
+
+class FakePyrsDevice:
+    """Minimal stand-in for pyrealsense2.device.
+
+    Only implements supports()/get_info() for camera_info.serial_number (the only
+    attribute select_target_device queries). Pass has_sn=False to simulate a device
+    that doesn't expose its serial number.
+    """
+    def __init__(self, sn, has_sn=True):
+        self._sn = sn
+        self._has_sn = has_sn
+
+    def supports(self, info):
+        return info == rs.camera_info.serial_number and self._has_sn
+
+    def get_info(self, info):
+        if info == rs.camera_info.serial_number and self._has_sn:
+            return self._sn
+        return None
+
+
+class TestSelectTargetDevice:
+
+    def test_picks_matching_sn(self):
+        """str setup: the device with the matching SN is returned, regardless of position."""
+        d0 = FakePyrsDevice('111')
+        d1 = FakePyrsDevice('222')
+        d2 = FakePyrsDevice('333')
+        assert select_target_device([d0, d1, d2], '222') is d1
+
+    def test_picks_matching_sn_when_not_first(self):
+        """str setup: the last device in the list still gets picked when its SN matches."""
+        d0 = FakePyrsDevice('111')
+        d1 = FakePyrsDevice('222')
+        assert select_target_device([d0, d1], '222') is d1
+
+    def test_no_parametrization_falls_back_to_first(self):
+        """None setup (no device() marker) -> devices_list[0]."""
+        d0 = FakePyrsDevice('111')
+        d1 = FakePyrsDevice('222')
+        assert select_target_device([d0, d1], None) is d0
+
+    def test_missing_sn_calls_pytest_fail(self):
+        """str setup, target SN absent -> pytest.fail with both the missing SN and the visible SNs."""
+        d0 = FakePyrsDevice('111')
+        d1 = FakePyrsDevice('222')
+        with pytest.raises(pytest.fail.Exception) as exc_info:
+            select_target_device([d0, d1], '999')
+        msg = str(exc_info.value)
+        assert '999' in msg, f"missing target SN not surfaced in message: {msg!r}"
+        assert '111' in msg and '222' in msg, f"visible SNs not listed in message: {msg!r}"
+
+    def test_devices_without_sn_skipped_during_match(self):
+        """str setup: a device that doesn't expose its SN is skipped, not matched."""
+        d_no_sn = FakePyrsDevice('111', has_sn=False)
+        d_target = FakePyrsDevice('222')
+        assert select_target_device([d_no_sn, d_target], '222') is d_target
+
+    def test_list_setup_warns_and_returns_first(self, caplog):
+        """list setup means a multi-device marker was used -> warn + fallback to devices_list[0]."""
+        d0 = FakePyrsDevice('111')
+        d1 = FakePyrsDevice('222')
+        with caplog.at_level('WARNING', logger='librealsense'):
+            result = select_target_device([d0, d1], ['111', '222'])
+        assert result is d0
+        assert any('multi-device marker' in r.message for r in caplog.records), \
+            f"expected a 'multi-device marker' warning, got: {[r.message for r in caplog.records]}"

--- a/unit-tests/live/calib/calibrations_common.py
+++ b/unit-tests/live/calib/calibrations_common.py
@@ -29,22 +29,27 @@ def on_calib_cb(progress):
     pp = int(progress)
     log.debug( f"Calibration at {progress}%" )
 
-def get_calibration_device(image_width, image_height, fps):
+def get_calibration_device(image_width, image_height, fps, dev=None):
     """
     Setup and configure the calibration device.
-    
+
     Args:
         image_width (int): Image width
         image_height (int): Image height
         fps (int): Frames per second
-        
+        dev: optional pyrealsense2 device handle. When provided, the pipeline is
+            bound to its serial number; required on hubless multi-device rigs
+            (e.g. Jetson with D457 + D436) where the context sees both devices.
+
     Returns:
         tuple: (pipeline, auto_calibrated_device)
     """
     config = rs.config()
     pipeline = rs.pipeline()
     pipeline_wrapper = rs.pipeline_wrapper(pipeline)
-    config.enable_stream(rs.stream.depth, image_width, image_height, rs.format.z16, fps)            
+    if dev is not None:
+        config.enable_device(dev.get_info(rs.camera_info.serial_number))
+    config.enable_stream(rs.stream.depth, image_width, image_height, rs.format.z16, fps)
 
     pipeline_profile = config.resolve(pipeline_wrapper)
     auto_calibrated_device = rs.auto_calibrated_device(pipeline_profile.get_device())

--- a/unit-tests/live/calib/calibrations_common.py
+++ b/unit-tests/live/calib/calibrations_common.py
@@ -299,16 +299,27 @@ def measure_depth_fill_rate(config, pipe, width=640, height=480, fps=30, frames=
         return None
 
 
-def is_mipi_device():
-    ctx = rs.context()
-    device = ctx.query_devices()[0]
+def is_mipi_device(device=None):
+    """True if *device* is on a GMSL (MIPI) connection.
+
+    *device* should be the pyrealsense2 handle returned by the test_device fixture.
+    Without it, this function reads ctx.query_devices()[0] -- on hubless multi-device
+    rigs (e.g. Jetson with D457 + D436) that returns whichever device pyrealsense2
+    enumerated first, not the one the test is parametrized for. Always pass *device*
+    when called from a parametrized test.
+    """
+    if device is None:
+        ctx = rs.context()
+        device = ctx.query_devices()[0]
     return device.supports(rs.camera_info.connection_type) and device.get_info(rs.camera_info.connection_type) == "GMSL"
 
-def is_d555():
+def is_d555(device=None):
+    """True if *device* is a D555. See is_mipi_device for why *device* should be passed."""
     try:
-        ctx = rs.context()
-        dev = ctx.query_devices()[0]
-        name = dev.get_info(rs.camera_info.name) if dev.supports(rs.camera_info.name) else ""
+        if device is None:
+            ctx = rs.context()
+            device = ctx.query_devices()[0]
+        name = device.get_info(rs.camera_info.name) if device.supports(rs.camera_info.name) else ""
         return ("D555" in name)
     except Exception:
         return False

--- a/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
@@ -199,9 +199,10 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
     return calib_dev, saved_table
 
 def test_advanced_occ_calibration(test_device):
+    dev, _ = test_device
     # mipi devices do not support OCC calibration without host assistance; D555 excluded separately
     # (D555 needs different parsing of calibration tables, SRC and more).
-    if is_mipi_device() or is_d555():
+    if is_mipi_device(dev) or is_d555(dev):
         pytest.skip("Non-mipi non-D555 only — see test_advanced_occ_calibration_with_host_assistance for mipi")
 
     calib_dev = None
@@ -210,7 +211,7 @@ def test_advanced_occ_calibration(test_device):
     try:
         host_assistance = False
         image_width, image_height, fps = (256, 144, 90)
-        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
         restore_calibration_table(calib_dev, None)
         calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True)
     except Exception as e:
@@ -223,7 +224,8 @@ def test_advanced_occ_calibration(test_device):
 
 
 def test_advanced_occ_calibration_with_host_assistance(test_device):
-    if not is_mipi_device() or is_d555():
+    dev, _ = test_device
+    if not is_mipi_device(dev) or is_d555(dev):
         pytest.skip("Host-assistance OCC calibration only on mipi/GMSL non-D555 devices")
 
     calib_dev = None
@@ -232,7 +234,7 @@ def test_advanced_occ_calibration_with_host_assistance(test_device):
     try:
         host_assistance = True
         image_width, image_height, fps = (1280, 720, 30)
-        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
         restore_calibration_table(calib_dev, None)
         calib_dev, saved_table = run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_dev, image_width, image_height, fps, modify_ppy=True)
     except Exception as e:

--- a/unit-tests/live/calib/pytest-advanced-tare-calibrations.py
+++ b/unit-tests/live/calib/pytest-advanced-tare-calibrations.py
@@ -249,9 +249,10 @@ def run_advanced_tare_calibration_test(host_assistance, config, pipeline, calib_
 
 
 def test_advanced_tare_calibration(test_device):
+    dev, _ = test_device
     # mipi devices do not support OCC calibration without host assistance; D555 excluded separately
     # (D555 needs different parsing of calibration tables, SRC and more).
-    if is_mipi_device() or is_d555():
+    if is_mipi_device(dev) or is_d555(dev):
         pytest.skip("Non-mipi non-D555 only")
 
     global _target_z
@@ -265,7 +266,7 @@ def test_advanced_tare_calibration(test_device):
             except Exception as e:
                 log.warning(f"calculate_target_z failed ({e}); will measure average depth as fallback baseline")
         image_width, image_height, fps = (256, 144, 90)
-        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
         restore_calibration_table(calib_dev, None)
         if _target_z is None:
             baseline_m = measure_average_depth(config, pipeline, width=image_width, height=image_height, fps=fps, center_fraction=0.3)

--- a/unit-tests/live/calib/pytest-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-occ-calibrations.py
@@ -48,6 +48,7 @@ NUM_ITERATIONS = 1
 
 
 def test_occ_calibration(test_device):
+    dev, _ = test_device
     # mipi devices do not support OCC calibration without host assistance
     if is_mipi_device():
         pytest.skip("MIPI/GMSL devices require host assistance — covered by test_occ_calibration_with_host_assistance")
@@ -57,7 +58,7 @@ def test_occ_calibration(test_device):
             host_assistance = False
             occ_json = on_chip_calibration_json(None, host_assistance)
             image_width, image_height, fps = 256, 144, 90
-            config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+            config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
             health_factor, new_calib_bytes = calibration_main(config, pipeline, calib_dev, True, occ_json, None, return_table=True)
             assert abs(health_factor) < HEALTH_FACTOR_THRESHOLD or new_calib_bytes is None
             log.info(f"Completed OCC calibration iteration {iteration}/{NUM_ITERATIONS} - Health factor: {health_factor}")
@@ -67,6 +68,7 @@ def test_occ_calibration(test_device):
 
 
 def test_occ_calibration_with_host_assistance(test_device):
+    dev, _ = test_device
     if not is_mipi_device():
         pytest.skip("Host-assistance OCC calibration is only run on MIPI/GMSL devices")
     for iteration in range(1, NUM_ITERATIONS + 1):
@@ -75,7 +77,7 @@ def test_occ_calibration_with_host_assistance(test_device):
             host_assistance = True
             image_width, image_height, fps = 1280, 720, 30
             occ_json = on_chip_calibration_json(None, host_assistance)
-            config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+            config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
             health_factor, new_calib_bytes = calibration_main(config, pipeline, calib_dev, True, occ_json, None, host_assistance=host_assistance, return_table=True)
             assert abs(health_factor) < HEALTH_FACTOR_THRESHOLD or new_calib_bytes is None
             log.info(f"Completed OCC calibration iteration {iteration}/{NUM_ITERATIONS} - Health factor: {health_factor}")

--- a/unit-tests/live/calib/pytest-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-occ-calibrations.py
@@ -50,7 +50,7 @@ NUM_ITERATIONS = 1
 def test_occ_calibration(test_device):
     dev, _ = test_device
     # mipi devices do not support OCC calibration without host assistance
-    if is_mipi_device():
+    if is_mipi_device(dev):
         pytest.skip("MIPI/GMSL devices require host assistance — covered by test_occ_calibration_with_host_assistance")
     for iteration in range(1, NUM_ITERATIONS + 1):
         try:
@@ -69,7 +69,7 @@ def test_occ_calibration(test_device):
 
 def test_occ_calibration_with_host_assistance(test_device):
     dev, _ = test_device
-    if not is_mipi_device():
+    if not is_mipi_device(dev):
         pytest.skip("Host-assistance OCC calibration is only run on MIPI/GMSL devices")
     for iteration in range(1, NUM_ITERATIONS + 1):
         try:

--- a/unit-tests/live/calib/pytest-tare-calibrations.py
+++ b/unit-tests/live/calib/pytest-tare-calibrations.py
@@ -119,8 +119,9 @@ def test_tare_calibration_with_host_assistance(test_device):
 
 
 def test_tare_calibration(test_device):
+    dev, _ = test_device
     # mipi devices do not support OCC calibration without host assistance
-    if is_mipi_device():
+    if is_mipi_device(dev):
         pytest.skip("MIPI/GMSL devices require host assistance for tare calibration")
     global _target_z
     try:
@@ -134,7 +135,7 @@ def test_tare_calibration(test_device):
 
         tare_json = tare_calibration_json(None, host_assistance)
         image_width, image_height, fps = 256, 144, 90
-        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps)
+        config, pipeline, calib_dev = get_calibration_device(image_width, image_height, fps, dev=dev)
         if _target_z is None:
             baseline_m = measure_average_depth(config, pipeline, width=image_width, height=image_height, fps=fps, center_fraction=0.3)
             if baseline_m is not None:

--- a/unit-tests/live/d400/pytest-auto-limits.py
+++ b/unit-tests/live/d400/pytest-auto-limits.py
@@ -66,16 +66,23 @@ def test_auto_exposure_toggle_one_device(test_device):
 
 
 def test_auto_exposure_two_devices(test_device):
-    _, ctx = test_device
+    dev, ctx = test_device
+    sn = dev.get_info(rs.camera_info.serial_number)
 
     # Scenario 2: 2 device instances (s1 and s2) pointing to the same physical sensor.
     # Each instance has its own independent SW cache for the limit value.
     # The exposure limit value is cached in SW and is only applied to HW when the toggle
     # is turned ON. Reading the limit while the toggle is OFF returns the current HW value,
     # not the SW cached value.
-    device1 = ctx.query_devices().front()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; find the parametrized one by SN rather than using .front().
+    def _find_by_sn():
+        return next(d for d in ctx.query_devices()
+                    if d.supports(rs.camera_info.serial_number)
+                    and d.get_info(rs.camera_info.serial_number) == sn)
+    device1 = _find_by_sn()
     s1 = device1.first_depth_sensor()
-    device2 = ctx.query_devices().front()
+    device2 = _find_by_sn()
     s2 = device2.first_depth_sensor()
 
     option_range = s1.get_option_range(rs.option.auto_exposure_limit)  # same range for both instances
@@ -121,16 +128,23 @@ def test_gain_toggle_one_device(test_device):
 
 
 def test_gain_toggle_two_devices(test_device):
-    _, ctx = test_device
+    dev, ctx = test_device
+    sn = dev.get_info(rs.camera_info.serial_number)
 
     # Scenario 2: 2 device instances (s1 and s2) pointing to the same physical sensor.
     # Each instance has its own independent SW cache for the limit value.
     # The gain limit value is cached in SW and is only applied to HW when the toggle
     # is turned ON. Reading the limit while the toggle is OFF returns the current HW value,
     # not the SW cached value.
-    device1 = ctx.query_devices().front()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; find the parametrized one by SN rather than using .front().
+    def _find_by_sn():
+        return next(d for d in ctx.query_devices()
+                    if d.supports(rs.camera_info.serial_number)
+                    and d.get_info(rs.camera_info.serial_number) == sn)
+    device1 = _find_by_sn()
     s1 = device1.first_depth_sensor()
-    device2 = ctx.query_devices().front()
+    device2 = _find_by_sn()
     s2 = device2.first_depth_sensor()
 
     option_range = s1.get_option_range(rs.option.auto_gain_limit)  # same range for both instances

--- a/unit-tests/live/d400/pytest-auto-limits.py
+++ b/unit-tests/live/d400/pytest-auto-limits.py
@@ -15,6 +15,18 @@ pytestmark = [pytest.mark.device("D400*")]
 _depth_sensor = None
 
 
+def _find_device_by_sn(ctx, sn):
+    """Look up a fresh rs.device instance in *ctx* matching *sn*.
+
+    Used by the two-instance tests below where we need a second device handle
+    pointing at the same physical sensor as test_device's `dev`. On hubless
+    multi-device rigs the context sees every connected device, so we filter
+    by SN rather than using ctx.query_devices().front()."""
+    return next(d for d in ctx.query_devices()
+                if d.supports(rs.camera_info.serial_number)
+                and d.get_info(rs.camera_info.serial_number) == sn)
+
+
 @pytest.fixture(autouse=True)
 def _require_auto_limit_support(test_device):
     global _depth_sensor
@@ -74,15 +86,9 @@ def test_auto_exposure_two_devices(test_device):
     # The exposure limit value is cached in SW and is only applied to HW when the toggle
     # is turned ON. Reading the limit while the toggle is OFF returns the current HW value,
     # not the SW cached value.
-    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
-    # connected device; find the parametrized one by SN rather than using .front().
-    def _find_by_sn():
-        return next(d for d in ctx.query_devices()
-                    if d.supports(rs.camera_info.serial_number)
-                    and d.get_info(rs.camera_info.serial_number) == sn)
-    device1 = _find_by_sn()
+    device1 = _find_device_by_sn(ctx, sn)
     s1 = device1.first_depth_sensor()
-    device2 = _find_by_sn()
+    device2 = _find_device_by_sn(ctx, sn)
     s2 = device2.first_depth_sensor()
 
     option_range = s1.get_option_range(rs.option.auto_exposure_limit)  # same range for both instances
@@ -136,15 +142,9 @@ def test_gain_toggle_two_devices(test_device):
     # The gain limit value is cached in SW and is only applied to HW when the toggle
     # is turned ON. Reading the limit while the toggle is OFF returns the current HW value,
     # not the SW cached value.
-    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
-    # connected device; find the parametrized one by SN rather than using .front().
-    def _find_by_sn():
-        return next(d for d in ctx.query_devices()
-                    if d.supports(rs.camera_info.serial_number)
-                    and d.get_info(rs.camera_info.serial_number) == sn)
-    device1 = _find_by_sn()
+    device1 = _find_device_by_sn(ctx, sn)
     s1 = device1.first_depth_sensor()
-    device2 = _find_by_sn()
+    device2 = _find_device_by_sn(ctx, sn)
     s2 = device2.first_depth_sensor()
 
     option_range = s1.get_option_range(rs.option.auto_gain_limit)  # same range for both instances

--- a/unit-tests/live/d400/pytest-hdr-long.py
+++ b/unit-tests/live/d400/pytest-hdr-long.py
@@ -105,6 +105,9 @@ def _hdr_streaming_default_config(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     cfg.enable_stream(rs.stream.infrared, 1)
     pipe = rs.pipeline(ctx)
@@ -139,6 +142,9 @@ def test_hdr_streaming_default_config(function_scoped_device, test_context):
 def _hdr_running_restart_hdr_at_restream(dev, ctx):
     depth_sensor = dev.first_depth_sensor()
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)
@@ -231,6 +237,9 @@ def _hdr_running_hdr_merge_after_hdr_restart(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)
@@ -324,6 +333,9 @@ def _check_sequence_id(pipe):
 def _hdr_streaming_checking_sequence_id(dev, ctx):
     depth_sensor = dev.first_depth_sensor()
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     cfg.enable_stream(rs.stream.infrared, 1)
     pipe = rs.pipeline(ctx)
@@ -352,6 +364,9 @@ def _emitter_on_off_check_sequence_id(dev, ctx):
     if not (depth_sensor and depth_sensor.supports(rs.option.emitter_on_off)):
         pytest.skip("Emitter on/off option not supported on this device")
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     cfg.enable_stream(rs.stream.infrared, 1)
     pipe = rs.pipeline(ctx)
@@ -380,6 +395,9 @@ def _hdr_merge_discard_merged_frame(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     pipe = rs.pipeline(ctx)
 
@@ -454,6 +472,9 @@ def _hdr_start_stop_recover_manual_exposure_and_gain(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)
@@ -554,6 +575,9 @@ def _hdr_streaming_set_locked_options(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)
@@ -594,6 +618,9 @@ def _hdr_streaming_enable_runtime_exposure_update(dev, ctx):
     assert depth_sensor.get_option(rs.option.hdr_enabled) == 1
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     cfg.enable_stream(rs.stream.infrared, 1)
     pipe = rs.pipeline(ctx)

--- a/unit-tests/live/d400/pytest-hdr-sanity.py
+++ b/unit-tests/live/d400/pytest-hdr-sanity.py
@@ -50,6 +50,9 @@ def test_hdr_streaming_custom_config(test_device):
     check.is_true(depth_sensor.get_option(rs.option.hdr_enabled) == 1)
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
     cfg.enable_stream(rs.stream.infrared, 1)
     pipe = rs.pipeline(ctx)

--- a/unit-tests/live/frames/pytest-color_frame_drops.py
+++ b/unit-tests/live/frames/pytest-color_frame_drops.py
@@ -50,6 +50,9 @@ def test_color_frame_drops(test_device):
         hw_ts.clear()
 
         cfg = rs.config()
+        # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+        # connected device; without enable_device(sn) the pipeline picks the first match.
+        cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
         cfg.enable_stream(rs.stream.color, WIDTH, HEIGHT, FORMAT, FPS)
         pipe.start(cfg, lrs_fq.lrs_queue)
         time.sleep(SLEEP_PER_ITERATION)

--- a/unit-tests/live/frames/pytest-t2ff-pipeline.py
+++ b/unit-tests/live/frames/pytest-t2ff-pipeline.py
@@ -58,6 +58,9 @@ def test_pipeline_first_depth_frame_delay(pipeline_device):
     log.info(f"Testing pipeline first depth frame delay on {product_name} device - {os_name} OS")
 
     depth_cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    depth_cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     depth_cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
 
     frame_delay = time_to_first_frame(ctx, depth_cfg)
@@ -85,6 +88,9 @@ def test_pipeline_first_color_frame_delay(pipeline_device):
     log.info(f"Testing pipeline first color frame delay on {product_name} device - {os_name} OS")
 
     color_cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    color_cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     color_cfg.enable_stream(rs.stream.color, rs.format.rgb8, 30)
 
     frame_delay = time_to_first_frame(ctx, color_cfg)

--- a/unit-tests/live/fw/pytest-fw-errors.py
+++ b/unit-tests/live/fw/pytest-fw-errors.py
@@ -145,9 +145,13 @@ def test_firmware_error_monitoring(test_device):
 
     # Start streaming
     pipe = rs.pipeline(ctx)
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg = rs.config()
+    cfg.enable_device(device_serial)
 
     try:
-        pipe.start()
+        pipe.start(cfg)
         log.info("Started streaming, monitoring for firmware errors for %d seconds...", STREAMING_DURATION_SECONDS)
 
         stopwatch = Stopwatch()

--- a/unit-tests/live/hdr/hdr_helper.py
+++ b/unit-tests/live/hdr/hdr_helper.py
@@ -97,6 +97,9 @@ def perform_manual_hdr_test(hdr_config, test_title, resolution=(640, 480)):
         expected_iterations[idx] = int(item["iterations"])
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(device.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth, resolution[0], resolution[1], rs.format.z16, 30)
     seq_id_counts = {}
     pipe.start(cfg)
@@ -152,6 +155,9 @@ def perform_auto_hdr_test(hdr_config, test_title, resolution=(640, 480)):
 
     seq_id_counts = {}
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(device.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth, resolution[0], resolution[1], rs.format.z16, 30)
     pipe.start(cfg)
     log.debug("Batch size: %s", batch_size)

--- a/unit-tests/live/hdr/pytest-hdr-configurations.py
+++ b/unit-tests/live/hdr/pytest-hdr-configurations.py
@@ -64,6 +64,9 @@ def test_disable_auto_hdr(test_device):
     check.equal(sensor.get_option(rs.option.hdr_enabled), 0)
 
     # Verify we're back to default single-frame behavior
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(hdr_helper.device.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
     pipe.start(cfg)
 

--- a/unit-tests/live/image-quality/iq_helper.py
+++ b/unit-tests/live/image-quality/iq_helper.py
@@ -256,8 +256,10 @@ _snapshot_saved = set()
 
 def save_failure_snapshot( test_file, pipeline, annotated_image=None ):
     """
-    Save one failure snapshot per test file (first call per test wins). When
-    multiple IQ tests fail in the same run, each gets its own snapshot.
+    Save one failure snapshot per (test file, device) pair. When the same test
+    runs against multiple devices on a multi-device rig (e.g. Jetson with D457
+    on MIPI and D436 on USB), each device's failure produces its own snapshot.
+    Repeated failures for the same (test, device) pair are deduped.
     If *annotated_image* is provided it is saved directly; otherwise a raw
     frame is grabbed from the still-running *pipeline* as a fallback
     (useful for page-detection failures).
@@ -267,7 +269,14 @@ def save_failure_snapshot( test_file, pipeline, annotated_image=None ):
     :param annotated_image:  optional pre-built debug image (numpy array)
     """
     name = os.path.basename( test_file ).replace( '.py', '' )
-    if name in _snapshot_saved:
+    # Resolve the device name up front so dedup keys (test, device) together.
+    try:
+        dev_name = pipeline.get_active_profile().get_device().get_info( rs.camera_info.name ).split()[-1]
+    except:
+        dev_name = None
+
+    key = (name, dev_name)
+    if key in _snapshot_saved:
         return
 
     image = annotated_image
@@ -280,14 +289,10 @@ def save_failure_snapshot( test_file, pipeline, annotated_image=None ):
     if image is None:
         return
 
-    try:
-        dev_name = pipeline.get_active_profile().get_device().get_info( rs.camera_info.name ).split()[-1]
-        filename = f"{name}_{dev_name}.png"
-    except:
-        filename = f"{name}.png"
+    filename = f"{name}_{dev_name}.png" if dev_name else f"{name}.png"
     logdir = os.path.join( os.path.dirname( rs.__file__ ), 'unit-tests' )
     if os.path.isdir( logdir ):
         filename = os.path.join( logdir, filename )
     cv2.imwrite( filename, image )
     log.i( f"Saved failure snapshot: {filename}" )
-    _snapshot_saved.add( name )
+    _snapshot_saved.add( key )

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -79,12 +79,15 @@ def draw_debug(frame_bgr, a4_page_bgr):
     return np.hstack([left, right])
 
 
-def run_test(ctx, resolution, fps):
+def run_test(dev, ctx, resolution, fps):
     log.info(f"Basic Color Image Quality Test: {resolution[0]}x{resolution[1]} @ {fps}fps")
     color_match_count = {color: 0 for color in expected_colors.keys()}
     color_sums = {color: np.zeros(3, dtype=int) for color in expected_colors.keys()}
     pipeline = rs.pipeline(ctx)
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.color, resolution[0], resolution[1], rs.format.bgr8, fps)
     if not cfg.can_resolve(pipeline):
         log.info(f"Configuration {resolution[0]}x{resolution[1]}@{fps}fps is not supported by the device")
@@ -170,4 +173,4 @@ def test_basic_color(test_device, test_context_var):
         ]
 
     for resolution, fps in configurations:
-        run_test(ctx, resolution, fps)
+        run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-basic-depth.py
+++ b/unit-tests/live/image-quality/pytest-basic-depth.py
@@ -101,6 +101,9 @@ def run_test(dev, ctx, resolution, fps):
     profile = None
     try:
         cfg = rs.config()
+        # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+        # connected device; without enable_device(sn) the pipeline picks the first match.
+        cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
         cfg.enable_stream(rs.stream.depth, resolution[0], resolution[1], rs.format.z16, fps)
         cfg.enable_stream(rs.stream.infrared, 1, resolution[0], resolution[1], rs.format.y8,
                           fps)  # needed for finding the ArUco markers

--- a/unit-tests/live/image-quality/pytest-has-depth.py
+++ b/unit-tests/live/image-quality/pytest-has-depth.py
@@ -67,6 +67,9 @@ def test_depth_laser_on(test_device_wrapped):
     product_name = dev.get_info(rs.camera_info.name)
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
 
     pipeline = rs.pipeline(ctx)

--- a/unit-tests/live/image-quality/pytest-texture-mapping.py
+++ b/unit-tests/live/image-quality/pytest-texture-mapping.py
@@ -103,6 +103,9 @@ def run_test(dev, ctx, depth_resolution, depth_fps, color_resolution, color_fps)
     try:
         pipeline = rs.pipeline(ctx)
         cfg = rs.config()
+        # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+        # connected device; without enable_device(sn) the pipeline picks the first match.
+        cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
         cfg.enable_stream(rs.stream.depth, depth_resolution[0], depth_resolution[1], rs.format.z16, depth_fps)
         cfg.enable_stream(rs.stream.color, color_resolution[0], color_resolution[1], rs.format.bgr8, color_fps)
         if not cfg.can_resolve(pipeline):

--- a/unit-tests/live/metadata/pytest-depth-unit.py
+++ b/unit-tests/live/metadata/pytest-depth-unit.py
@@ -20,6 +20,9 @@ def test_depth_units_metadata(test_device):
 
     pipeline = rs.pipeline(ctx)
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
 
     try:
         pipeline_profile = pipeline.start(cfg)

--- a/unit-tests/live/metadata/pytest-sync.py
+++ b/unit-tests/live/metadata/pytest-sync.py
@@ -58,6 +58,9 @@ def run_test(device, ctx, resolution, fps):
     """Run timestamp synchronization test for a specific resolution and FPS"""
     pipeline = rs.pipeline(ctx)
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(device.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth, resolution[0], resolution[1], rs.format.z16, fps)
     cfg.enable_stream(rs.stream.infrared, 1, resolution[0], resolution[1], rs.format.y8, fps)
     cfg.enable_stream(rs.stream.infrared, 2, resolution[0], resolution[1], rs.format.y8, fps)

--- a/unit-tests/live/options/pytest-rgb-ae-metadata.py
+++ b/unit-tests/live/options/pytest-rgb-ae-metadata.py
@@ -17,6 +17,9 @@ def test_rgb_ae_metadata(test_device):
                   if any(p.stream_type() == rs.stream.color for p in s.profiles))
 
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.color)
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)

--- a/unit-tests/live/rec-play/pytest-got-playback-frames.py
+++ b/unit-tests/live/rec-play/pytest-got-playback-frames.py
@@ -143,6 +143,9 @@ def test_pipeline_interface(test_device):
         # creating a pipeline and recording to a file
         pipeline = rs.pipeline(ctx)
         cfg = rs.config()
+        # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+        # connected device; without enable_device(sn) the pipeline picks the first match.
+        cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
         cfg.enable_record_to_file( file_name )
         pipeline.start( cfg )
         time.sleep(3)

--- a/unit-tests/live/rec-play/pytest-pause-playback-frames.py
+++ b/unit-tests/live/rec-play/pytest-pause-playback-frames.py
@@ -29,10 +29,14 @@ STREAMING_DURATION = 3
 TIMEOUT_BUFFER = 3  # [sec] extra time to the expected playback time for not failing on runtime hiccups..
 
 
-def record_with_pause( file_name, iterations, pause_delay=0, resume_delay=0 ):
+def record_with_pause( file_name, iterations, pause_delay=0, resume_delay=0, dev=None ):
     # creating a pipeline and recording to a file
     pipeline = rs.pipeline()
     cfg = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    if dev is not None:
+        cfg.enable_device( dev.get_info( rs.camera_info.serial_number ) )
     cfg.enable_record_to_file( file_name )
     pipeline_record_profile = pipeline.start( cfg )
     device = pipeline_record_profile.get_device()
@@ -82,6 +86,7 @@ def calc_playback_timeout( iterations, pause_delay ):
 
 
 def test_pause_playback_frames(test_device):
+    dev, _ = test_device
     # create temporary folder to record to that will be deleted automatically at the end of the script
     # (requires that no files are being held open inside this directory. Important to not keep any handle open to a file
     # in this directory, any handle as such must be set to None)
@@ -94,7 +99,7 @@ def test_pause_playback_frames(test_device):
     # probably pause & resume will occur before recording base time is set.
 
     try:
-        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 0, resume_delay = 0 )
+        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 0, resume_delay = 0, dev = dev )
         pipeline = rs.pipeline()
         device_playback = playback( pipeline, file_name )
         psv = PlaybackStatusVerifier( device_playback );
@@ -112,7 +117,7 @@ def test_pause_playback_frames(test_device):
 
     # Pause time should be lower than recording base time and resume time higher
     try:
-        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 0, resume_delay = 5 )
+        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 0, resume_delay = 5, dev = dev )
         pipeline = rs.pipeline()
         device_playback = playback( pipeline, file_name )
         psv = PlaybackStatusVerifier( device_playback );
@@ -129,7 +134,7 @@ def test_pause_playback_frames(test_device):
     log.info("delayed pause & delayed resume test")
     # Pause & resume will occur after recording base time is set
     try:
-        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 3, resume_delay = 2 )
+        timeout = record_with_pause( file_name, iterations = 1, pause_delay = 3, resume_delay = 2, dev = dev )
         pipeline = rs.pipeline()
         device_playback = playback( pipeline, file_name )
         psv = PlaybackStatusVerifier( device_playback );
@@ -147,7 +152,7 @@ def test_pause_playback_frames(test_device):
     # Combination of some of the previous tests, testing accumulated recording capture time
 
     try:
-        timeout = record_with_pause( file_name, iterations = 2, pause_delay = 0, resume_delay = 2 )
+        timeout = record_with_pause( file_name, iterations = 2, pause_delay = 0, resume_delay = 2, dev = dev )
         pipeline = rs.pipeline()
         device_playback = playback( pipeline, file_name )
         psv = PlaybackStatusVerifier( device_playback );

--- a/unit-tests/live/streaming/pytest-jpeg-compressed-format.py
+++ b/unit-tests/live/streaming/pytest-jpeg-compressed-format.py
@@ -20,7 +20,20 @@ def test_jpeg_format_support(module_device_setup):
     """Prerequisite: device must support JPEG streaming."""
     global _jpeg_profile
     ctx = rs.context({"format-conversion": "raw"})
-    color_sensor = ctx.query_devices()[0].first_color_sensor()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; find the parametrized one by SN rather than picking index 0.
+    target_sn = module_device_setup if isinstance(module_device_setup, str) else None
+    if target_sn:
+        target_dev = next(
+            (d for d in ctx.query_devices()
+             if d.supports(rs.camera_info.serial_number)
+             and d.get_info(rs.camera_info.serial_number) == target_sn),
+            None)
+        if target_dev is None:
+            pytest.fail(f"Target device {target_sn} not visible in context")
+    else:
+        target_dev = ctx.query_devices()[0]
+    color_sensor = target_dev.first_color_sensor()
     _jpeg_profile = next(
         (p for p in color_sensor.profiles
          if p.stream_type() == rs.stream.color and p.format() == rs.format.mjpeg),
@@ -38,6 +51,10 @@ def test_jpeg_streaming_conversion(module_device_setup):
     """Stream JPEG color and verify conversion to RGB8 succeeds for 10 frames."""
     pipeline = rs.pipeline()
     config = rs.config()
+    # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
+    # connected device; without enable_device(sn) the pipeline picks the first match.
+    if isinstance(module_device_setup, str):
+        config.enable_device(module_device_setup)
     vp = _jpeg_profile.as_video_stream_profile()
     config.enable_stream(rs.stream.color, vp.stream_index(), vp.width(), vp.height(), rs.format.rgb8, vp.fps()) # JPEG is converted to RGB8
     pipeline.start(config)

--- a/unit-tests/py/rspy/pytest/device_helpers.py
+++ b/unit-tests/py/rspy/pytest/device_helpers.py
@@ -356,3 +356,41 @@ def require_min_fw_version(dev, min_version, feature_name="", inclusive=True):
         feature_str = f" ({feature_name})" if feature_name else ""
         pytest.skip(f"FW version {fw_version} does not meet minimum {op} {min_version}{feature_str}, skipping test...")
     _fw_version_cache[key] = True
+
+
+def select_target_device(devices_list, module_device_setup):
+    """
+    Pick the right pyrealsense2 device from `devices_list` for the current test.
+
+    `module_device_setup` is whatever the `module_device_setup` fixture yielded:
+      - str  -- a single parametrized serial number; pick the device with that SN
+                or raise `pytest.fail` if it isn't visible in `devices_list`.
+      - list -- a multi-device marker was used; this caller should be using the
+                `test_devices` (plural) fixture instead. Log a warning and fall
+                back to `devices_list[0]` to preserve pre-existing behavior.
+      - None -- no device parametrization (test without a device() marker);
+                pick `devices_list[0]`.
+
+    On CI rigs without a hub -- e.g. Jetson with D457 on MIPI and D436 on USB --
+    every device stays enumerated regardless of which one was "enabled" for the
+    test, so the fixture must filter by SN rather than blindly pick index 0.
+    """
+    import pytest
+    import pyrealsense2 as rs
+
+    if isinstance(module_device_setup, list):
+        log.warning(
+            "test_device/function_scoped_device fixture invoked with a multi-device marker; "
+            "use test_devices instead. Falling back to devices_list[0]."
+        )
+        return devices_list[0]
+    target_sn = module_device_setup if isinstance(module_device_setup, str) else None
+    if target_sn:
+        for d in devices_list:
+            if d.supports(rs.camera_info.serial_number) \
+               and d.get_info(rs.camera_info.serial_number) == target_sn:
+                return d
+        visible = [d.get_info(rs.camera_info.serial_number)
+                   for d in devices_list if d.supports(rs.camera_info.serial_number)]
+        pytest.fail(f"Target device {target_sn} not visible in context (visible: {visible})")
+    return devices_list[0]


### PR DESCRIPTION
Tracked by: RSDSO-21099 (second PR)

**TL;DR:** Two related fixes for multi-device CI rigs (Jetson with D457 on MIPI + D436 on USB always visible): the `test_device` / `function_scoped_device` pytest fixtures now select the parametrized device by serial number instead of `devices[0]`, and `iq_helper.save_failure_snapshot` now dedups by `(test, device)` so each device's failure produces its own snapshot.

## Summary

### 1. Fixture device selection (`unit-tests/conftest.py` + `rspy/pytest/device_helpers.py`)

- New `select_target_device(devices_list, module_device_setup)` helper in `rspy.pytest.device_helpers`. Returns the device whose serial number matches the one yielded by `module_device_setup`, falling back to `devices_list[0]` only when the test has no device parametrization.
- `test_device` (module-scoped) and `function_scoped_device` (function-scoped) both depend on `module_device_setup` and call the new helper.
- If the target SN isn't visible in the context: `pytest.fail` with the missing SN and the list of visible SNs (clearer than silently picking the wrong device).
- Multi-device marker misuse (`module_device_setup` is a `list`): warn and fall back to `devices_list[0]` to preserve pre-PR behavior, but make the misuse visible in CI logs.
- `test_devices` (plural) is unchanged — it already filtered by SN correctly.

### 2. Per-device failure snapshots (`unit-tests/live/image-quality/iq_helper.py`)

- `save_failure_snapshot` now keys its dedup set by `(test_file, device_name)` instead of just `test_file`.
- Previously, the same test running against multiple parametrized devices would only ever save the *first* device's snapshot — the rest were short-circuited by the dedup. On the Jetson rig, this combined with fix #1 above to mean every snapshot was named `_D436` regardless of which device the test was actually parametrized for.
- Device name is now resolved up front so the dedup decision still short-circuits before pulling a frame from the pipeline.

## Why

Observed in CI logs (`pytest-unit-tests.15498.log`):

```
-D- Test using parametrized device: 220422303069
-I- Configuration: D457 [220422303069]
-D- Recycling device via hub...
-D- device removed: 220422303069
-D- device added: 220422303069 <pyrealsense2.device: D457 ...>
-D- Device enabled and ready
-D- Test using device: Intel RealSense D436     <-- wrong device!
```

And in the artifact list for the same run, every image-quality snapshot was `_D436`:

```
pytest-basic-color_D436.png
pytest-basic-depth_D436.png
```

Even though four parametrizations failed per test (D457×2 + D436×2), only one snapshot landed per test, all showing D436.

Root causes:

1. `test_device` returned `devices_list[0]` regardless of parametrization. On the Jetson rig:
   - D457 is GMSL → `rspy.devices.Device.port == None`
   - D436 is USB
   - No hub → `enable_only([D457_sn], recycle=True)` falls through to `hw_reset([D457_sn])`; D436 stays enumerated
   - `rs.context().devices` returns both, `[0]` lands on D436

2. `save_failure_snapshot`'s dedup was keyed by `test_file` only, so the second parametrization of the same test got short-circuited even though it could have produced a snapshot for the other device.

## Test plan

- [x] Local pytest: 10/10 new unit tests pass.
  ```
  unit-tests/infra-tests/test_select_target_device.py    6 passed
  unit-tests/infra-tests/test_iq_snapshot_dedup.py       4 passed
  ```
- [ ] CI on Jetson rig (D457 MIPI + D436 USB): tests parametrized for D457 should log `Test using device: Intel RealSense D457` (not D436), and the image-quality artifact set should contain both `pytest-basic-color_D457.png` and `pytest-basic-color_D436.png` when both parametrizations fail.
- [ ] CI on single-device or non-parametrized tests: no behavior change.
- [ ] CI: multi-device tests using `test_devices` (plural) unaffected — fixture untouched.

## Files

- `unit-tests/py/rspy/pytest/device_helpers.py` — new `select_target_device` helper.
- `unit-tests/conftest.py` — `test_device` and `function_scoped_device` use the helper.
- `unit-tests/live/image-quality/iq_helper.py` — `save_failure_snapshot` dedup keys on `(test, device)`.
- `unit-tests/infra-tests/test_select_target_device.py` — 6 unit tests for the device picker.
- `unit-tests/infra-tests/test_iq_snapshot_dedup.py` — 4 unit tests for the snapshot dedup.
