### PR TITLE
Register RS2_OPTION_STEREO_BASELINE for MIPI devices

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,8 @@ Detailed how-to guides for common tasks are maintained as skill files under `.gi
 | `.github/skills/build.md` | Building the project (CMake configure, compile, flags) |
 | `.github/skills/testing.md` | Running, filtering, and debugging unit tests |
 | `.github/skills/pytest-infra.md` | Migrating tests to pytest, modifying pytest/hub infrastructure, verifying Jenkins CI results |
-| `.github/skills/pr-review.md` | Opening a pull request, updating its description, replying to review comments |
+| `.github/skills/pr-create.md` | Opening a pull request, pushing commits to it, updating its description |
+| `.github/skills/pr-review.md` | Replying to review comments on a pull request |
 
 If a skill file exists for the task at hand, follow its instructions precisely. New skills may be added to this folder over time — check its contents before assuming none applies.
 

--- a/.github/skills/pr-create.md
+++ b/.github/skills/pr-create.md
@@ -1,0 +1,41 @@
+# PR Creation & Update Workflow
+
+## When to Use This Skill
+
+Opening a PR, pushing new commits to one, or updating its description on `realsenseai/librealsense`.
+
+## Tracking Ticket — Required
+
+Every PR requires a tracking Jira ticket.
+
+- If you **know** the ticket (the user told you, or you opened the ticket yourself this session), add a `Tracked on [RSDEV-1234]` line right after the Overview — bare text, no link.
+- If you are **not sure** which ticket is relevant, **ask the user before creating the PR**. Tell them each PR requires a ticket, and let them either provide one or explicitly approve creating the PR without it.
+- Never guess a ticket. Only omit the `Tracked on` line when the user explicitly says it's OK without one.
+
+## Description Format
+
+Every PR description starts with an Overview (1–2 sentences stating the user-visible change), then the body:
+
+```markdown
+**Overview:** <1-2 sentences>
+
+Tracked on [RSDEV-1234]
+
+## Summary
+- <what changed and why>
+
+## Why
+<bug, regression, or capability gap>
+
+## Test plan
+- [ ] <unit/pytest entries, marker/context/iteration counts>
+- [ ] <manual or CI verification>
+```
+
+Keep the Overview jargon-free. Put tables (behavior change, latency, benchmarks) in the body, never in the Overview.
+
+## Before Every Push — Description Audit
+
+Re-read the PR description before `git push`. If any concrete detail in the description (iteration counts, timeouts, file paths, marker lists, behavior tables, referenced PR numbers) no longer matches what's actually on the branch, update the description in the same push (`gh pr edit <num> --body ...`).
+
+The description and the diff must stay in sync.

--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -1,44 +1,10 @@
-# Pull Request Workflow
+# PR Review Workflow
 
 ## When to Use This Skill
 
-Opening a PR, pushing new commits to one, or replying to review comments on `realsenseai/librealsense`.
+Replying to review comments (human or bot) on a `realsenseai/librealsense` pull request.
 
-## Description Format
-
-Every PR description starts with a TL;DR (1–2 sentences stating the user-visible change), then the body:
-
-```markdown
-**TL;DR:** <1-2 sentences>
-
-## Summary
-- <what changed and why>
-
-## Why
-<bug, regression, or capability gap>
-
-## Test plan
-- [ ] <unit/pytest entries, marker/context/iteration counts>
-- [ ] <manual or CI verification>
-```
-
-Keep the TL;DR jargon-free. Put tables (behavior change, latency, benchmarks) in the body, never in the TL;DR.
-
-If you **know** which Jira ticket the PR is tracking (the user told you, or you opened the ticket yourself this session), append a `Tracked on [RSDEV-1234]` line right after the TL;DR — bare text, no link:
-
-```markdown
-**TL;DR:** <1-2 sentences>
-
-Tracked on [RSDEV-1234]
-```
-
-Only add this line when you are sure. If you only suspect a ticket is related, ask the user before adding it — never guess.
-
-## Before Every Push — Description Audit
-
-Re-read the PR description before `git push`. If any concrete detail in the description (iteration counts, timeouts, file paths, marker lists, behavior tables, referenced PR numbers) no longer matches what's actually on the branch, update the description in the same push (`gh pr edit <num> --body ...`).
-
-The description and the diff must stay in sync.
+For opening a PR, pushing commits to one, or updating its description, see `.github/skills/pr-create.md`.
 
 ## Responding to Review Comments
 

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -122,12 +122,7 @@ namespace rs2
         // Decimation halves depth resolution while leaving IR unchanged; the mismatch would
         // trigger the resolution guard in min_z_depth_improver::apply() and silently skip MinZ.
 #ifdef BUILD_WITH_MINZ
-        std::string device_pid = s->get_info(RS2_CAMERA_INFO_PRODUCT_ID);
-        if( !is_rgb_camera && (s->supports( RS2_OPTION_STEREO_BASELINE ) ||
-                                            device_pid == "ABCC" || //D401 GMSL
-                                            device_pid == "ABCD" || //D457 GMSL
-                                            device_pid == "ABCE" || //D430 GMSL
-                                            device_pid == "ABCF"))  //D415 GMSL
+        if( !is_rgb_camera && s->supports( RS2_OPTION_STEREO_BASELINE ) )
         {
             auto block = std::make_shared< minz_filter >();
             auto model = std::make_shared< processing_block_model >(

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -949,13 +949,10 @@ namespace librealsense
                 }
             }
 
-            if (!_is_mipi_device)
-            {
-                depth_sensor.register_option( RS2_OPTION_STEREO_BASELINE,
-                                              std::make_shared< const_value_option >(
-                                                  "Distance in mm between the stereo imagers",
-                                                  rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
-            }
+            depth_sensor.register_option( RS2_OPTION_STEREO_BASELINE,
+                                          std::make_shared< const_value_option >(
+                                              "Distance in mm between the stereo imagers",
+                                              rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
 
             _depth_units_register_action = [this]()
             {


### PR DESCRIPTION
**Overview:** Replace the PID-based GMSL MinZ whitelist (PR #15079) with the proper fix — register `RS2_OPTION_STEREO_BASELINE` on MIPI devices, same as all other D400 devices. Also restructures the agent PR skills.

## Summary
- Revert #15079's PID-based GMSL check in `common/subdevice-model.cpp`
- Remove the `!_is_mipi_device` guard around `RS2_OPTION_STEREO_BASELINE` registration in `src/ds/d400/d400-device.cpp` — the existing `supports(RS2_OPTION_STEREO_BASELINE)` MinZ condition now covers GMSL naturally
- Split `.github/skills/pr-review.md` into `pr-create.md` (opening/updating PRs: **Overview** description format, mandatory tracking ticket with explicit user override, pre-push description audit) and `pr-review.md` (replying to review comments and bots); updated the skills table in `copilot-instructions.md`

## Why
MinZ was blocked on GMSL because the viewer gates it on `RS2_OPTION_STEREO_BASELINE` support, which MIPI devices never registered. The exclusion traces back to initial RS457 bringup with no recorded reason. The option's getter reads the coefficients calibration table via hw_monitor — a path MIPI already uses today for left↔right extrinsics and the spatial/disparity post-processing filters, so registering the option adds no new risk.

## Test plan
- [x] Verify `Stereo Baseline` option is exposed and MinZ filter is available on a GMSL device (D457/D401)
- [ ] LibCI