### PR TITLE
test-fw-update: pre-recover D400 devices stuck in DFU with gold signed FW + FWID fallback in find_first_device_or_exit

### DIFF
--- a/unit-tests/infra-tests/test_find_first_device.py
+++ b/unit-tests/infra-tests/test_find_first_device.py
@@ -1,0 +1,155 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests for rspy.test.find_first_device_or_exit.
+
+The harness (run-unit-tests.py / rspy.devices) registers each connected device
+by `camera_info.serial_number` when available, and by `camera_info.firmware_update_id`
+when the device is in DFU/recovery mode and the regular serial number isn't exposed.
+find_first_device_or_exit has to match against either, otherwise a SN derived from a
+recovery-mode device fails the lookup -- which is what test-fw-update.py hit when
+two devices were left in recovery on a multi-device rig.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+rs = pytest.importorskip("pyrealsense2")
+
+from rspy import test as rspy_test
+
+
+class FakePyrsDevice:
+    """Minimal stand-in for pyrealsense2.device: supports() + get_info() only.
+
+    The two camera_info keys we care about for matching are wired up via the
+    sn / fwid kwargs. Pass either or both; absent ones return False from supports().
+    """
+    def __init__(self, sn=None, fwid=None):
+        self._sn = sn
+        self._fwid = fwid
+
+    def supports(self, info):
+        if info == rs.camera_info.serial_number:
+            return self._sn is not None
+        if info == rs.camera_info.firmware_update_id:
+            return self._fwid is not None
+        return False
+
+    def get_info(self, info):
+        if info == rs.camera_info.serial_number:
+            return self._sn
+        if info == rs.camera_info.firmware_update_id:
+            return self._fwid
+        return None
+
+
+class FakeContext:
+    """Minimal stand-in for rs.context(): exposes devices as both list and .size()."""
+    def __init__(self, devs):
+        self._devs = devs
+
+    @property
+    def devices(self):
+        return _DeviceList(self._devs)
+
+
+class _DeviceList(list):
+    """list with rs-style .size() method."""
+    def size(self):
+        return len(self)
+
+
+@pytest.fixture
+def _patch_context(monkeypatch):
+    """Replace rs.context with a factory that returns whatever FakeContext we set up."""
+    holder = {"ctx": None}
+
+    def _ctx_factory(*args, **kwargs):
+        return holder["ctx"]
+
+    monkeypatch.setattr(rs, "context", _ctx_factory)
+    return holder
+
+
+@pytest.fixture
+def _silence_log_f(monkeypatch):
+    """log.f normally exits. Replace with a raising stub so tests can assert on it."""
+    class _LogF(Exception):
+        pass
+
+    def _raise(*args, **kwargs):
+        raise _LogF(" ".join(str(a) for a in args))
+
+    monkeypatch.setattr(rspy_test.log, "f", _raise)
+    return _LogF
+
+
+class TestFindFirstDeviceOrExit:
+
+    def test_no_serial_returns_first_device(self, _patch_context):
+        """Without a serial_number arg, returns devices[0]."""
+        d0, d1 = FakePyrsDevice(sn="111"), FakePyrsDevice(sn="222")
+        _patch_context["ctx"] = FakeContext([d0, d1])
+
+        dev, ctx = rspy_test.find_first_device_or_exit()
+        assert dev is d0
+
+    def test_matches_by_serial_number(self, _patch_context):
+        """When serial_number is supplied and a device exposes it, return that device."""
+        d_match = FakePyrsDevice(sn="222")
+        d_other = FakePyrsDevice(sn="111")
+        _patch_context["ctx"] = FakeContext([d_other, d_match])
+
+        dev, _ = rspy_test.find_first_device_or_exit(serial_number="222")
+        assert dev is d_match
+
+    def test_matches_by_firmware_update_id_when_serial_not_exposed(self, _patch_context):
+        """Recovery-mode case: device doesn't expose camera_info.serial_number, so
+        the lookup must fall back to camera_info.firmware_update_id."""
+        d_recovery = FakePyrsDevice(sn=None, fwid="204423060494")
+        _patch_context["ctx"] = FakeContext([d_recovery])
+
+        dev, _ = rspy_test.find_first_device_or_exit(serial_number="204423060494")
+        assert dev is d_recovery
+
+    def test_mixed_recovery_and_normal_devices_each_resolvable(self, _patch_context):
+        """Two devices, one normal and one in recovery -- each should resolve from its own ID."""
+        d_normal = FakePyrsDevice(sn="111")
+        d_recovery = FakePyrsDevice(sn=None, fwid="222-fwid")
+        _patch_context["ctx"] = FakeContext([d_normal, d_recovery])
+
+        dev_a, _ = rspy_test.find_first_device_or_exit(serial_number="111")
+        assert dev_a is d_normal
+
+        dev_b, _ = rspy_test.find_first_device_or_exit(serial_number="222-fwid")
+        assert dev_b is d_recovery
+
+    def test_serial_takes_precedence_over_firmware_update_id(self, _patch_context):
+        """A device that exposes BOTH should match against serial_number first."""
+        d = FakePyrsDevice(sn="sn-value", fwid="fwid-value")
+        _patch_context["ctx"] = FakeContext([d])
+
+        dev, _ = rspy_test.find_first_device_or_exit(serial_number="sn-value")
+        assert dev is d
+
+        # And the same device should NOT match by its fwid when its sn is exposed
+        # (otherwise we'd risk matching collisions in mixed setups).
+
+    def test_no_match_calls_log_f(self, _patch_context, _silence_log_f):
+        """No device with the requested SN or fwid -> log.f (test fail)."""
+        d = FakePyrsDevice(sn="111", fwid="aaa")
+        _patch_context["ctx"] = FakeContext([d])
+
+        with pytest.raises(_silence_log_f) as exc_info:
+            rspy_test.find_first_device_or_exit(serial_number="999")
+        assert "999" in str(exc_info.value)
+
+    def test_empty_context_calls_log_f(self, _patch_context, _silence_log_f):
+        """No devices visible at all -> log.f ('No device found')."""
+        _patch_context["ctx"] = FakeContext([])
+
+        with pytest.raises(_silence_log_f) as exc_info:
+            rspy_test.find_first_device_or_exit()
+        assert "No device found" in str(exc_info.value)

--- a/unit-tests/infra-tests/test_find_first_device.py
+++ b/unit-tests/infra-tests/test_find_first_device.py
@@ -13,7 +13,6 @@ two devices were left in recovery on a multi-device rig.
 """
 
 import pytest
-from unittest.mock import MagicMock
 
 rs = pytest.importorskip("pyrealsense2")
 
@@ -126,16 +125,21 @@ class TestFindFirstDeviceOrExit:
         dev_b, _ = rspy_test.find_first_device_or_exit(serial_number="222-fwid")
         assert dev_b is d_recovery
 
-    def test_serial_takes_precedence_over_firmware_update_id(self, _patch_context):
-        """A device that exposes BOTH should match against serial_number first."""
+    def test_serial_takes_precedence_over_firmware_update_id(self, _patch_context, _silence_log_f):
+        """A device that exposes BOTH should match against serial_number, and must NOT
+        also be matchable via its firmware_update_id value -- otherwise a SN that happens
+        to collide with another device's fwid would resolve to the wrong handle."""
         d = FakePyrsDevice(sn="sn-value", fwid="fwid-value")
         _patch_context["ctx"] = FakeContext([d])
 
+        # Positive: matches via serial_number.
         dev, _ = rspy_test.find_first_device_or_exit(serial_number="sn-value")
         assert dev is d
 
-        # And the same device should NOT match by its fwid when its sn is exposed
-        # (otherwise we'd risk matching collisions in mixed setups).
+        # Negative: searching by the fwid value must NOT find the device, because the
+        # SN-exposed branch wins and returns "sn-value", not "fwid-value".
+        with pytest.raises(_silence_log_f):
+            rspy_test.find_first_device_or_exit(serial_number="fwid-value")
 
     def test_no_match_calls_log_f(self, _patch_context, _silence_log_f):
         """No device with the requested SN or fwid -> log.f (test fail)."""

--- a/unit-tests/py/rspy/fw_compat.py
+++ b/unit-tests/py/rspy/fw_compat.py
@@ -33,31 +33,19 @@ _FALLBACK_JSON = os.path.join( os.path.dirname( __file__ ), 'fw_fallback.json' )
 # test-data downloads, e.g. unit-tests/post-processing/test-filters.py). Used as a
 # recovery image for any D400 device that's in DFU mode -- rs-fw-update's recovery (-r)
 # path only accepts signed FW, so we can't reuse the unsigned --custom-fw-d400 path.
-_GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
+GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
 
 
-def _looks_d400_recovery(d):
-    """True if d is a D400-series device currently in DFU/recovery mode."""
-    import pyrealsense2 as rs
-    if not d.is_in_recovery_mode():
-        return False
-    if d.supports(rs.camera_info.product_line) and d.get_info(rs.camera_info.product_line) == 'D400':
-        return True
-    if d.supports(rs.camera_info.name) and 'D4' in d.get_info(rs.camera_info.name):
-        return True
-    return False
-
-
-def _download_gold_d400_fw():
+def download_gold_d400_fw():
     """Download the D4XX gold signed FW (5.17.0.10) to a per-process temp cache.
     Returns the local path, or None on failure."""
-    dest = os.path.join(tempfile.gettempdir(), os.path.basename(_GOLD_D400_FW_URL))
+    dest = os.path.join(tempfile.gettempdir(), os.path.basename(GOLD_D400_FW_URL))
     if os.path.isfile(dest):
         log.d(f"gold D400 FW already cached: {dest}")
         return dest
-    log.d(f"downloading gold D400 FW from {_GOLD_D400_FW_URL}")
+    log.d(f"downloading gold D400 FW from {GOLD_D400_FW_URL}")
     try:
-        with urllib.request.urlopen(_GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
+        with urllib.request.urlopen(GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
             out_file.write(response.read())
     except Exception as e:
         log.w(f"failed to download gold D400 FW from S3: {e}")
@@ -66,7 +54,7 @@ def _download_gold_d400_fw():
     return dest
 
 
-def _reload_d4xx_driver_on_jetson(context):
+def reload_d4xx_driver_on_jetson(context):
     """On Jetson, the d4xx MIPI driver must be reloaded after a recovery flash so the
     re-enumerated device shows up. No-op (with a warning) if sudo requires a password
     or if we're not running under the 'jetson' context."""
@@ -84,50 +72,6 @@ def _reload_d4xx_driver_on_jetson(context):
                   f"returncode={ld.returncode}, stderr={ld.stderr}")
     except Exception as e:
         log.w("Could not reload d4xx driver (passwordless sudo may not be configured):", e)
-
-
-def recover_d400_devices_in_dfu(fw_updater_exe, context=None):
-    """Pre-test step: find any D400 devices currently in DFU/recovery mode and recover
-    them with a gold signed FW pulled from the RealSense releases S3.
-
-    Intended to be called by the harness (run-unit-tests.py) before `enable_only` and
-    before each retry of `test-fw-update`. A previous mid-flash failure can leave the
-    device in DFU; without this pre-step, every subsequent run sees a device that
-    exposes only `firmware_update_id` and the harness/test can't recover it cleanly.
-
-    rs-fw-update's recovery (-r) path only accepts signed FW images, so the unsigned
-    --custom-fw-d400 used elsewhere in CI won't work here.
-
-    No-op when no D400 is in DFU. Best-effort -- logs a warning and returns on any
-    failure rather than raising, so the surrounding test still gets a chance to run.
-    """
-    import pyrealsense2 as rs
-
-    ctx = rs.context()
-    recovery_devs = [d for d in ctx.devices if _looks_d400_recovery(d)]
-    if not recovery_devs:
-        return
-
-    log.i(f"Found {len(recovery_devs)} D400 device(s) in DFU; recovering with gold signed FW")
-    gold_fw = _download_gold_d400_fw()
-    if gold_fw is None:
-        log.w("No gold FW available; skipping pre-test recovery")
-        return
-
-    for d in recovery_devs:
-        fwid = d.get_info(rs.camera_info.firmware_update_id)
-        cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', fwid]
-        log.d(f"[pre-test-fw-recovery] running: {cmd}")
-        try:
-            result = subprocess.run(cmd)
-        except Exception as e:
-            log.w(f"[pre-test-fw-recovery] subprocess.run raised for {fwid}: {e}")
-            continue
-        if result.returncode != 0:
-            log.w(f"[pre-test-fw-recovery] rs-fw-update -r returned {result.returncode} for {fwid}; continuing")
-            continue
-        _reload_d4xx_driver_on_jetson(context)
-        time.sleep(5)  # let device settle in normal mode before subsequent enable_only
 
 
 def _load_fallback_map():

--- a/unit-tests/py/rspy/fw_compat.py
+++ b/unit-tests/py/rspy/fw_compat.py
@@ -19,38 +19,60 @@ import json
 import os
 import re
 import subprocess
-import tempfile
-import time
 import urllib.request
 
-from rspy import log
+from rspy import log, libci
 
 
 _FALLBACK_JSON = os.path.join( os.path.dirname( __file__ ), 'fw_fallback.json' )
 
 
-# Gold signed D400 FW pulled from the RealSense releases S3 (same host pattern as other
-# test-data downloads, e.g. unit-tests/post-processing/test-filters.py). Used as a
-# recovery image for any D400 device that's in DFU mode -- rs-fw-update's recovery (-r)
-# path only accepts signed FW, so we can't reuse the unsigned --custom-fw-d400 path.
-GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
+def _load_gold_recovery_fw_map():
+    """Read fw_fallback.json -> dict[product_line -> URL]. Returns {} on any error.
+    Gold recovery images live in a `gold_recovery_fw` section alongside `fallbacks`."""
+    try:
+        with open( _FALLBACK_JSON, 'r' ) as f:
+            data = json.load( f )
+    except (FileNotFoundError, ValueError, OSError) as e:
+        log.w( f'[fw-gate] could not load {_FALLBACK_JSON}: {e}' )
+        return {}
+    return data.get( 'gold_recovery_fw', {} )
 
 
 def download_gold_d400_fw():
-    """Download the D4XX gold signed FW (5.17.0.10) to a per-process temp cache.
-    Returns the local path, or None on failure."""
-    dest = os.path.join(tempfile.gettempdir(), os.path.basename(GOLD_D400_FW_URL))
-    if os.path.isfile(dest):
-        log.d(f"gold D400 FW already cached: {dest}")
-        return dest
-    log.d(f"downloading gold D400 FW from {GOLD_D400_FW_URL}")
-    try:
-        with urllib.request.urlopen(GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
-            out_file.write(response.read())
-    except Exception as e:
-        log.w(f"failed to download gold D400 FW from S3: {e}")
+    """Return a local path to the D400 gold signed FW image.
+
+    Used as a recovery image for any D400 device in DFU mode; rs-fw-update's
+    recovery (-r) path only accepts signed FW, so we can't reuse the unsigned
+    --custom-fw-d400 path. The URL is configured in fw_fallback.json under
+    `gold_recovery_fw.D400` so it can be updated without touching code.
+
+    The image is cached under libci.home (persistent across reboots) and only
+    re-downloaded if missing on disk. Returns the local path, or None on failure.
+    """
+    url = _load_gold_recovery_fw_map().get( 'D400' )
+    if not url:
+        log.w( "fw_fallback.json has no gold_recovery_fw.D400 entry" )
         return None
-    log.d(f"saved gold D400 FW to: {dest}")
+    # Co-locate with the D400 fallback signed images, under libci.home.
+    cache_dir = os.path.join( libci.home, 'data', 'FW', 'D400' )
+    dest = os.path.join( cache_dir, os.path.basename( url ) )
+    if os.path.isfile( dest ):
+        log.d( f"gold D400 FW already cached: {dest}" )
+        return dest
+    try:
+        os.makedirs( cache_dir, exist_ok=True )
+    except OSError as e:
+        log.w( f"could not create cache directory {cache_dir}: {e}" )
+        return None
+    log.d( f"downloading gold D400 FW from {url}" )
+    try:
+        with urllib.request.urlopen( url ) as response, open( dest, 'wb' ) as out_file:
+            out_file.write( response.read() )
+    except Exception as e:
+        log.w( f"failed to download gold D400 FW from S3: {e}" )
+        return None
+    log.d( f"saved gold D400 FW to: {dest}" )
     return dest
 
 

--- a/unit-tests/py/rspy/fw_compat.py
+++ b/unit-tests/py/rspy/fw_compat.py
@@ -18,11 +18,116 @@ runners should import these helpers rather than re-implementing the logic.
 import json
 import os
 import re
+import subprocess
+import tempfile
+import time
+import urllib.request
 
 from rspy import log
 
 
 _FALLBACK_JSON = os.path.join( os.path.dirname( __file__ ), 'fw_fallback.json' )
+
+
+# Gold signed D400 FW pulled from the RealSense releases S3 (same host pattern as other
+# test-data downloads, e.g. unit-tests/post-processing/test-filters.py). Used as a
+# recovery image for any D400 device that's in DFU mode -- rs-fw-update's recovery (-r)
+# path only accepts signed FW, so we can't reuse the unsigned --custom-fw-d400 path.
+_GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
+
+
+def _looks_d400_recovery(d):
+    """True if d is a D400-series device currently in DFU/recovery mode."""
+    import pyrealsense2 as rs
+    if not d.is_in_recovery_mode():
+        return False
+    if d.supports(rs.camera_info.product_line) and d.get_info(rs.camera_info.product_line) == 'D400':
+        return True
+    if d.supports(rs.camera_info.name) and 'D4' in d.get_info(rs.camera_info.name):
+        return True
+    return False
+
+
+def _download_gold_d400_fw():
+    """Download the D4XX gold signed FW (5.17.0.10) to a per-process temp cache.
+    Returns the local path, or None on failure."""
+    dest = os.path.join(tempfile.gettempdir(), os.path.basename(_GOLD_D400_FW_URL))
+    if os.path.isfile(dest):
+        log.d(f"gold D400 FW already cached: {dest}")
+        return dest
+    log.d(f"downloading gold D400 FW from {_GOLD_D400_FW_URL}")
+    try:
+        with urllib.request.urlopen(_GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
+            out_file.write(response.read())
+    except Exception as e:
+        log.w(f"failed to download gold D400 FW from S3: {e}")
+        return None
+    log.d(f"saved gold D400 FW to: {dest}")
+    return dest
+
+
+def _reload_d4xx_driver_on_jetson(context):
+    """On Jetson, the d4xx MIPI driver must be reloaded after a recovery flash so the
+    re-enumerated device shows up. No-op (with a warning) if sudo requires a password
+    or if we're not running under the 'jetson' context."""
+    if 'jetson' not in (context or []):
+        return
+    log.d("Reloading d4xx driver on Jetson...")
+    try:
+        rm = subprocess.run(['sudo', '-n', 'modprobe', '-r', 'd4xx'], capture_output=True, text=True)
+        if rm.returncode != 0:
+            log.e("Failed to remove d4xx module (may require passwordless sudo):", rm.stderr)
+            return
+        ld = subprocess.run(['sudo', '-n', 'modprobe', 'd4xx'], capture_output=True, text=True, check=False)
+        if ld.returncode != 0:
+            log.e("Failed to load d4xx module (may require passwordless sudo):",
+                  f"returncode={ld.returncode}, stderr={ld.stderr}")
+    except Exception as e:
+        log.w("Could not reload d4xx driver (passwordless sudo may not be configured):", e)
+
+
+def recover_d400_devices_in_dfu(fw_updater_exe, context=None):
+    """Pre-test step: find any D400 devices currently in DFU/recovery mode and recover
+    them with a gold signed FW pulled from the RealSense releases S3.
+
+    Intended to be called by the harness (run-unit-tests.py) before `enable_only` and
+    before each retry of `test-fw-update`. A previous mid-flash failure can leave the
+    device in DFU; without this pre-step, every subsequent run sees a device that
+    exposes only `firmware_update_id` and the harness/test can't recover it cleanly.
+
+    rs-fw-update's recovery (-r) path only accepts signed FW images, so the unsigned
+    --custom-fw-d400 used elsewhere in CI won't work here.
+
+    No-op when no D400 is in DFU. Best-effort -- logs a warning and returns on any
+    failure rather than raising, so the surrounding test still gets a chance to run.
+    """
+    import pyrealsense2 as rs
+
+    ctx = rs.context()
+    recovery_devs = [d for d in ctx.devices if _looks_d400_recovery(d)]
+    if not recovery_devs:
+        return
+
+    log.i(f"Found {len(recovery_devs)} D400 device(s) in DFU; recovering with gold signed FW")
+    gold_fw = _download_gold_d400_fw()
+    if gold_fw is None:
+        log.w("No gold FW available; skipping pre-test recovery")
+        return
+
+    for d in recovery_devs:
+        fwid = d.get_info(rs.camera_info.firmware_update_id)
+        cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', fwid]
+        log.d(f"[pre-test-fw-recovery] running: {cmd}")
+        try:
+            result = subprocess.run(cmd)
+        except Exception as e:
+            log.w(f"[pre-test-fw-recovery] subprocess.run raised for {fwid}: {e}")
+            continue
+        if result.returncode != 0:
+            log.w(f"[pre-test-fw-recovery] rs-fw-update -r returned {result.returncode} for {fwid}; continuing")
+            continue
+        _reload_d4xx_driver_on_jetson(context)
+        time.sleep(5)  # let device settle in normal mode before subsequent enable_only
 
 
 def _load_fallback_map():

--- a/unit-tests/py/rspy/fw_fallback.json
+++ b/unit-tests/py/rspy/fw_fallback.json
@@ -1,6 +1,9 @@
 {
-    "_comment": "Per-device FW image fallbacks used when the bundled FW is below the device's minimum supported FW. Keys are device names as exposed by rspy.devices.Device (with the 'Intel RealSense ' or 'RealSense ' prefix stripped). Paths are relative to libci.home so they resolve on both Linux (/usr/local/lib/ci) and Windows (C:\\LibCI). Add an entry per device as needed.",
+    "_comment": "Per-device FW images consumed by rspy.fw_compat. Paths are relative to libci.home so they resolve on both Linux (/usr/local/lib/ci) and Windows (C:\\LibCI). 'fallbacks' keys are device names as exposed by rspy.devices.Device (with the 'Intel RealSense ' or 'RealSense ' prefix stripped). 'gold_recovery_fw' keys are product lines; the URL is downloaded once and cached under libci.home for reuse across runs.",
     "fallbacks": {
         "D436": "data/FW/D400/Signed_Image_UVC_5_17_3_10.bin"
+    },
+    "gold_recovery_fw": {
+        "D400": "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
     }
 }

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -157,7 +157,7 @@ def find_first_device_or_exit( serial_number=None ):
                 log.d( 'found', d )
                 log.d( 'in', rs )
                 return d, c
-        log.f( f"No device matches serial number / firmware_update_id {serial_number}" )
+        log.f( f"No device with serial number / firmware-update ID '{serial_number}' is visible" )
     dev = c.devices[0]
     log.d( 'found', dev )
     log.d( 'in', rs )

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -132,9 +132,14 @@ def find_first_device_or_exit( serial_number=None ):
     :return: the first device that was found, if no device is found the test is skipped. That way we can still run
         the unit-tests when no device is connected and not fail the tests that check a connected device
 
-    If serial_number is provided, the device with the matching serial number is returned instead
+    If serial_number is provided, the device with the matching identifier is returned instead
     of the positional "first" pick. The harness passes this for test-fw-update on multi-device
     rigs (e.g. Jetson with a GMSL camera alongside the USB one being flashed).
+
+    The match is done against `camera_info.serial_number` when available, and falls back to
+    `camera_info.firmware_update_id` for devices in DFU/recovery mode (where serial_number
+    isn't exposed). This mirrors how rspy.devices registers devices on discovery, so a SN
+    that the harness derived from a recovery-mode device still resolves here.
     """
     import pyrealsense2 as rs
     c = rs.context()
@@ -142,13 +147,17 @@ def find_first_device_or_exit( serial_number=None ):
         log.f("No device found")
     if serial_number:
         for d in c.devices:
-            if not d.supports( rs.camera_info.serial_number ):
+            if d.supports( rs.camera_info.serial_number ):
+                d_sn = d.get_info( rs.camera_info.serial_number )
+            elif d.supports( rs.camera_info.firmware_update_id ):
+                d_sn = d.get_info( rs.camera_info.firmware_update_id )
+            else:
                 continue
-            if d.get_info( rs.camera_info.serial_number ) == serial_number:
+            if d_sn == serial_number:
                 log.d( 'found', d )
                 log.d( 'in', rs )
                 return d, c
-        log.f( f"No device with serial number {serial_number}" )
+        log.f( f"No device matches serial number / firmware_update_id {serial_number}" )
     dev = c.devices[0]
     log.d( 'found', dev )
     log.d( 'in', rs )

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -466,6 +466,38 @@ def devices_by_test_config( test, exceptions ):
             continue
 
 
+# Lazy-discovered path to the rs-fw-update binary; cached on first need.
+_FW_UPDATER_EXE_CACHE = None
+
+
+def _find_fw_updater_exe():
+    """Locate the built rs-fw-update binary inside repo.build. Returns None if not found."""
+    regex = r'(^|/)rs-fw-update'
+    if platform.system() == 'Windows':
+        regex += r'\.exe'
+    regex += '$'
+    for tool in file.find( repo.build, regex ):
+        return os.path.join( repo.build, tool )
+    return None
+
+
+def _pre_test_fw_recovery_if_needed( test ):
+    """Before invoking test-fw-update (initial attempt or retry), recover any D400 in
+    DFU mode with the gold signed FW. No-op for other tests."""
+    if test.name != 'test-fw-update':
+        return
+    global _FW_UPDATER_EXE_CACHE
+    if _FW_UPDATER_EXE_CACHE is None:
+        _FW_UPDATER_EXE_CACHE = _find_fw_updater_exe()
+        if _FW_UPDATER_EXE_CACHE is None:
+            log.w( '[pre-test-fw-recovery] rs-fw-update binary not found; skipping' )
+            return
+    try:
+        fw_compat.recover_d400_devices_in_dfu( _FW_UPDATER_EXE_CACHE, context=context )
+    except Exception as e:
+        log.w( f'[pre-test-fw-recovery] unexpected error: {e}' )
+
+
 def test_wrapper_( test, configuration=None, repetition=1, curr_retry=0, max_retry = 0, sns=None, custom_fw_d400_override=None ):
     global rslog
     #
@@ -527,6 +559,10 @@ def test_wrapper( test, configuration=None, repetition=1, serial_numbers=None, c
             if no_reset or not serial_numbers:
                 time.sleep(1)  # small pause between tries
             else:
+                # If we're about to retry test-fw-update and the device entered DFU during
+                # the previous attempt, recover it before enable_only times out trying to
+                # find the original SN.
+                _pre_test_fw_recovery_if_needed( test )
                 devices.enable_only( serial_numbers, recycle=True )
         if test_wrapper_( test, configuration, repetition, retry, retry_count, serial_numbers,
                           custom_fw_d400_override=custom_fw_d400_override ):
@@ -732,6 +768,9 @@ try:
                         log.d( 'configuration:', configuration_str( configuration, repetition, sns=serial_numbers ) )
                         log.debug_indent()
                         should_reset = not no_reset
+                        # For test-fw-update: recover any D400 that's currently in DFU
+                        # before enable_only, so the hub-recycle finds the device by SN.
+                        _pre_test_fw_recovery_if_needed( test )
                         devices.enable_only( serial_numbers, recycle=should_reset )
                     except (RuntimeError, TimeoutError, OSError) as e:
                         log.w( log.red + test.name + log.reset + ': ' + str( e ) )

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -466,38 +466,6 @@ def devices_by_test_config( test, exceptions ):
             continue
 
 
-# Lazy-discovered path to the rs-fw-update binary; cached on first need.
-_FW_UPDATER_EXE_CACHE = None
-
-
-def _find_fw_updater_exe():
-    """Locate the built rs-fw-update binary inside repo.build. Returns None if not found."""
-    regex = r'(^|/)rs-fw-update'
-    if platform.system() == 'Windows':
-        regex += r'\.exe'
-    regex += '$'
-    for tool in file.find( repo.build, regex ):
-        return os.path.join( repo.build, tool )
-    return None
-
-
-def _pre_test_fw_recovery_if_needed( test ):
-    """Before invoking test-fw-update (initial attempt or retry), recover any D400 in
-    DFU mode with the gold signed FW. No-op for other tests."""
-    if test.name != 'test-fw-update':
-        return
-    global _FW_UPDATER_EXE_CACHE
-    if _FW_UPDATER_EXE_CACHE is None:
-        _FW_UPDATER_EXE_CACHE = _find_fw_updater_exe()
-        if _FW_UPDATER_EXE_CACHE is None:
-            log.w( '[pre-test-fw-recovery] rs-fw-update binary not found; skipping' )
-            return
-    try:
-        fw_compat.recover_d400_devices_in_dfu( _FW_UPDATER_EXE_CACHE, context=context )
-    except Exception as e:
-        log.w( f'[pre-test-fw-recovery] unexpected error: {e}' )
-
-
 def test_wrapper_( test, configuration=None, repetition=1, curr_retry=0, max_retry = 0, sns=None, custom_fw_d400_override=None ):
     global rslog
     #
@@ -559,10 +527,6 @@ def test_wrapper( test, configuration=None, repetition=1, serial_numbers=None, c
             if no_reset or not serial_numbers:
                 time.sleep(1)  # small pause between tries
             else:
-                # If we're about to retry test-fw-update and the device entered DFU during
-                # the previous attempt, recover it before enable_only times out trying to
-                # find the original SN.
-                _pre_test_fw_recovery_if_needed( test )
                 devices.enable_only( serial_numbers, recycle=True )
         if test_wrapper_( test, configuration, repetition, retry, retry_count, serial_numbers,
                           custom_fw_d400_override=custom_fw_d400_override ):
@@ -768,9 +732,6 @@ try:
                         log.d( 'configuration:', configuration_str( configuration, repetition, sns=serial_numbers ) )
                         log.debug_indent()
                         should_reset = not no_reset
-                        # For test-fw-update: recover any D400 that's currently in DFU
-                        # before enable_only, so the hub-recycle finds the device by SN.
-                        _pre_test_fw_recovery_if_needed( test )
                         devices.enable_only( serial_numbers, recycle=should_reset )
                     except (RuntimeError, TimeoutError, OSError) as e:
                         log.w( log.red + test.name + log.reset + ': ' + str( e ) )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -16,7 +16,9 @@ import platform
 import pyrealsense2 as rs
 import pyrsutils as rsutils
 from rspy import log, test, file, repo
+import tempfile
 import time
+import urllib.request
 import argparse
 
 # Parse command-line arguments
@@ -123,6 +125,114 @@ for tool in file.find( repo.build, fw_updater_exe_regex ):
     fw_updater_exe = os.path.join( repo.build, tool )
 if not fw_updater_exe:
     log.f( "Could not find the update tool file (rs-fw-update.exe)" )
+
+
+# Gold signed FW used to recover any D400 device that is in DFU/recovery mode at the
+# start of the test. rs-fw-update's recovery (-r) path only accepts signed FW; using the
+# unsigned --custom-fw-d400 image here would fail with "Unsupported firmware binary image
+# provided - <size> bytes". Fetched from the RealSense releases S3 (same host used by
+# other test-data downloads, e.g. unit-tests/post-processing/test-filters.py).
+_GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
+
+
+def _looks_d400_recovery(d):
+    """True if d is a D400-series device currently in DFU/recovery mode."""
+    if not d.is_in_recovery_mode():
+        return False
+    if d.supports(rs.camera_info.product_line) and d.get_info(rs.camera_info.product_line) == 'D400':
+        return True
+    if d.supports(rs.camera_info.name) and 'D4' in d.get_info(rs.camera_info.name):
+        return True
+    return False
+
+
+def _download_gold_d400_fw():
+    """Download D4XX gold signed FW (5.17.0.10) to a per-process temp cache.
+    Returns the local path, or None on failure."""
+    dest = os.path.join(tempfile.gettempdir(), os.path.basename(_GOLD_D400_FW_URL))
+    if os.path.isfile(dest):
+        log.d(f"gold D400 FW already cached: {dest}")
+        return dest
+    log.d(f"downloading gold D400 FW from {_GOLD_D400_FW_URL}")
+    try:
+        with urllib.request.urlopen(_GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
+            out_file.write(response.read())
+    except Exception as e:
+        log.w(f"failed to download gold D400 FW from S3: {e}")
+        return None
+    log.d(f"saved gold D400 FW to: {dest}")
+    return dest
+
+
+def _reload_d4xx_driver_on_jetson():
+    """On Jetson, the d4xx MIPI driver must be reloaded after a recovery flash so the
+    re-enumerated device shows up. No-op (with a warning) if sudo requires a password."""
+    if 'jetson' not in test.context:
+        return
+    log.d("Reloading d4xx driver on Jetson...")
+    try:
+        rm = subprocess.run(['sudo', '-n', 'modprobe', '-r', 'd4xx'], capture_output=True, text=True)
+        if rm.returncode != 0:
+            log.e("Failed to remove d4xx module (may require passwordless sudo):", rm.stderr)
+            return
+        ld = subprocess.run(['sudo', '-n', 'modprobe', 'd4xx'], capture_output=True, text=True, check=False)
+        if ld.returncode != 0:
+            log.e("Failed to load d4xx module (may require passwordless sudo):",
+                  f"returncode={ld.returncode}, stderr={ld.stderr}")
+    except Exception as e:
+        log.w("Could not reload d4xx driver (passwordless sudo may not be configured):", e)
+
+
+def recover_d400_devices_in_dfu():
+    """Find any D400 devices currently in DFU mode and recover them with the gold signed
+    FW so subsequent test logic can proceed against normal-mode devices.
+
+    Returns a {firmware_update_id: new_serial_number} map for devices we recovered, so
+    the caller can re-pin args.serial when it referred to a now-recovered device.
+    """
+    ctx = rs.context()
+    recovery_devs = [d for d in ctx.devices if _looks_d400_recovery(d)]
+    if not recovery_devs:
+        return {}
+
+    log.i(f"Found {len(recovery_devs)} D400 device(s) in DFU; recovering with gold signed FW")
+    gold_fw = _download_gold_d400_fw()
+    if gold_fw is None:
+        log.w("No gold FW available; skipping upfront recovery")
+        return {}
+
+    fwid_to_sn = {}
+    for d in recovery_devs:
+        fwid = d.get_info(rs.camera_info.firmware_update_id)
+        cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', fwid]
+        log.d('running:', cmd)
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            log.w(f"Failed to recover D400 device {fwid} with gold FW; continuing")
+            continue
+        _reload_d4xx_driver_on_jetson()
+        # Give the device time to re-enumerate in normal mode before we query it.
+        time.sleep(5)
+        # asic_serial (firmware_update_id) is stable across DFU<->normal, so we can find
+        # the now-normal device by the same FWID we used during DFU.
+        for d2 in rs.context().devices:
+            if d2.supports(rs.camera_info.firmware_update_id) \
+               and d2.get_info(rs.camera_info.firmware_update_id) == fwid \
+               and d2.supports(rs.camera_info.serial_number):
+                fwid_to_sn[fwid] = d2.get_info(rs.camera_info.serial_number)
+                log.d(f"D400 recovered: FWID {fwid} -> SN {fwid_to_sn[fwid]}")
+                break
+    return fwid_to_sn
+
+
+# Run the upfront gold-FW recovery so any DFU-mode D400 is back in normal mode before
+# the test proper starts. Re-pin args.serial if it referenced a now-recovered device
+# (the harness passes the FWID in that case; after recovery the device's
+# serial_number identifier is different).
+_recovered_fwid_to_sn = recover_d400_devices_in_dfu()
+if args.serial in _recovered_fwid_to_sn:
+    log.d(f"re-pinning args.serial: {args.serial} (FWID) -> {_recovered_fwid_to_sn[args.serial]} (SN)")
+    args.serial = _recovered_fwid_to_sn[args.serial]
 
 device, ctx = test.find_first_device_or_exit( args.serial )
 product_line = device.get_info( rs.camera_info.product_line )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -16,9 +16,7 @@ import platform
 import pyrealsense2 as rs
 import pyrsutils as rsutils
 from rspy import log, test, file, repo
-import tempfile
 import time
-import urllib.request
 import argparse
 
 # Parse command-line arguments
@@ -125,114 +123,6 @@ for tool in file.find( repo.build, fw_updater_exe_regex ):
     fw_updater_exe = os.path.join( repo.build, tool )
 if not fw_updater_exe:
     log.f( "Could not find the update tool file (rs-fw-update.exe)" )
-
-
-# Gold signed FW used to recover any D400 device that is in DFU/recovery mode at the
-# start of the test. rs-fw-update's recovery (-r) path only accepts signed FW; using the
-# unsigned --custom-fw-d400 image here would fail with "Unsupported firmware binary image
-# provided - <size> bytes". Fetched from the RealSense releases S3 (same host used by
-# other test-data downloads, e.g. unit-tests/post-processing/test-filters.py).
-_GOLD_D400_FW_URL = "https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin"
-
-
-def _looks_d400_recovery(d):
-    """True if d is a D400-series device currently in DFU/recovery mode."""
-    if not d.is_in_recovery_mode():
-        return False
-    if d.supports(rs.camera_info.product_line) and d.get_info(rs.camera_info.product_line) == 'D400':
-        return True
-    if d.supports(rs.camera_info.name) and 'D4' in d.get_info(rs.camera_info.name):
-        return True
-    return False
-
-
-def _download_gold_d400_fw():
-    """Download D4XX gold signed FW (5.17.0.10) to a per-process temp cache.
-    Returns the local path, or None on failure."""
-    dest = os.path.join(tempfile.gettempdir(), os.path.basename(_GOLD_D400_FW_URL))
-    if os.path.isfile(dest):
-        log.d(f"gold D400 FW already cached: {dest}")
-        return dest
-    log.d(f"downloading gold D400 FW from {_GOLD_D400_FW_URL}")
-    try:
-        with urllib.request.urlopen(_GOLD_D400_FW_URL) as response, open(dest, 'wb') as out_file:
-            out_file.write(response.read())
-    except Exception as e:
-        log.w(f"failed to download gold D400 FW from S3: {e}")
-        return None
-    log.d(f"saved gold D400 FW to: {dest}")
-    return dest
-
-
-def _reload_d4xx_driver_on_jetson():
-    """On Jetson, the d4xx MIPI driver must be reloaded after a recovery flash so the
-    re-enumerated device shows up. No-op (with a warning) if sudo requires a password."""
-    if 'jetson' not in test.context:
-        return
-    log.d("Reloading d4xx driver on Jetson...")
-    try:
-        rm = subprocess.run(['sudo', '-n', 'modprobe', '-r', 'd4xx'], capture_output=True, text=True)
-        if rm.returncode != 0:
-            log.e("Failed to remove d4xx module (may require passwordless sudo):", rm.stderr)
-            return
-        ld = subprocess.run(['sudo', '-n', 'modprobe', 'd4xx'], capture_output=True, text=True, check=False)
-        if ld.returncode != 0:
-            log.e("Failed to load d4xx module (may require passwordless sudo):",
-                  f"returncode={ld.returncode}, stderr={ld.stderr}")
-    except Exception as e:
-        log.w("Could not reload d4xx driver (passwordless sudo may not be configured):", e)
-
-
-def recover_d400_devices_in_dfu():
-    """Find any D400 devices currently in DFU mode and recover them with the gold signed
-    FW so subsequent test logic can proceed against normal-mode devices.
-
-    Returns a {firmware_update_id: new_serial_number} map for devices we recovered, so
-    the caller can re-pin args.serial when it referred to a now-recovered device.
-    """
-    ctx = rs.context()
-    recovery_devs = [d for d in ctx.devices if _looks_d400_recovery(d)]
-    if not recovery_devs:
-        return {}
-
-    log.i(f"Found {len(recovery_devs)} D400 device(s) in DFU; recovering with gold signed FW")
-    gold_fw = _download_gold_d400_fw()
-    if gold_fw is None:
-        log.w("No gold FW available; skipping upfront recovery")
-        return {}
-
-    fwid_to_sn = {}
-    for d in recovery_devs:
-        fwid = d.get_info(rs.camera_info.firmware_update_id)
-        cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', fwid]
-        log.d('running:', cmd)
-        result = subprocess.run(cmd)
-        if result.returncode != 0:
-            log.w(f"Failed to recover D400 device {fwid} with gold FW; continuing")
-            continue
-        _reload_d4xx_driver_on_jetson()
-        # Give the device time to re-enumerate in normal mode before we query it.
-        time.sleep(5)
-        # asic_serial (firmware_update_id) is stable across DFU<->normal, so we can find
-        # the now-normal device by the same FWID we used during DFU.
-        for d2 in rs.context().devices:
-            if d2.supports(rs.camera_info.firmware_update_id) \
-               and d2.get_info(rs.camera_info.firmware_update_id) == fwid \
-               and d2.supports(rs.camera_info.serial_number):
-                fwid_to_sn[fwid] = d2.get_info(rs.camera_info.serial_number)
-                log.d(f"D400 recovered: FWID {fwid} -> SN {fwid_to_sn[fwid]}")
-                break
-    return fwid_to_sn
-
-
-# Run the upfront gold-FW recovery so any DFU-mode D400 is back in normal mode before
-# the test proper starts. Re-pin args.serial if it referenced a now-recovered device
-# (the harness passes the FWID in that case; after recovery the device's
-# serial_number identifier is different).
-_recovered_fwid_to_sn = recover_d400_devices_in_dfu()
-if args.serial in _recovered_fwid_to_sn:
-    log.d(f"re-pinning args.serial: {args.serial} (FWID) -> {_recovered_fwid_to_sn[args.serial]} (SN)")
-    args.serial = _recovered_fwid_to_sn[args.serial]
 
 device, ctx = test.find_first_device_or_exit( args.serial )
 product_line = device.get_info( rs.camera_info.product_line )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -245,15 +245,18 @@ log.d( 'running:', cmd )
 sys.stdout.flush()
 result = subprocess.run( cmd )   # may throw
 
+# Wait for the camera to finish rebooting before doing anything else, REGARDLESS of
+# rs-fw-update's exit code. A non-zero exit doesn't necessarily mean no flash started:
+# rs-fw-update may have begun a section flash before erroring out, leaving the device
+# mid-reboot. The test exit flow may cut USB power (hub port disable), so we must not
+# exit while the device is still rebooting.
+wait_for_reboot( same_version )
+
 if result.returncode != 0:
     log.e( 'rs-fw-update returned exit code', result.returncode )
     test.check( False, description='rs-fw-update should return exit code 0' )
     test.finish()
     test.print_results_and_exit()
-
-# Wait for the camera to finish rebooting before doing anything else;
-# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
-wait_for_reboot( same_version )
 
 # make sure update worked and check FW version and update counter
 device, ctx = test.find_first_device_or_exit( args.serial )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -16,6 +16,7 @@ import platform
 import pyrealsense2 as rs
 import pyrsutils as rsutils
 from rspy import log, test, file, repo, fw_compat
+from rspy.timer import Timer
 import time
 import argparse
 
@@ -177,9 +178,10 @@ if device.is_in_recovery_mode():
         # harness was tracking. Poll for the device to re-enumerate in normal mode
         # (a fresh rs.context() needs time after rs-fw-update exits) -- up to 60s.
         log.d( "waiting for recovered device to re-enumerate in normal mode..." )
-        deadline = time.time() + 60
         recovered_device = None
-        while time.time() < deadline:
+        timer = Timer( 60 )
+        timer.start()
+        while not timer.has_expired():
             for d in rs.context().devices:
                 if d.supports( rs.camera_info.firmware_update_id ) \
                    and d.get_info( rs.camera_info.firmware_update_id ) == args.serial \
@@ -191,7 +193,7 @@ if device.is_in_recovery_mode():
             time.sleep( 2 )
         if recovered_device is None:
             log.f( f"Recovered device with firmware_update_id '{args.serial}' did not "
-                   f"re-enumerate within 60s after gold FW flash" )
+                   f"re-enumerate within {timer.get_timeout()}s after gold FW flash" )
         # Re-pin args.serial to the device's normal-mode SN so downstream
         # rs-fw-update -s <sn> finds the device (rs-fw-update.cpp:480 uses SN when supported).
         if recovered_device.supports( rs.camera_info.serial_number ):

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -167,8 +167,6 @@ if device.is_in_recovery_mode():
         subprocess.run( cmd )
         recovered = True
         fw_compat.reload_d4xx_driver_on_jetson( test.context )
-        # Give the device time to re-enumerate in normal mode.
-        time.sleep( 5 )
     except Exception as e:
         test.unexpected_exception()
         log.f( "Unexpected error while trying to recover device:", e )
@@ -176,15 +174,32 @@ if device.is_in_recovery_mode():
         # The device's identity changed: in DFU it exposed firmware_update_id only,
         # now in normal mode it exposes its real serial_number (optic_serial). The
         # firmware_update_id (asic_serial) is still exposed and matches what the
-        # harness was tracking, so find_first_device_or_exit(args.serial) resolves
-        # via the FWID fallback. We then re-pin args.serial to the real SN so the
-        # downstream rs-fw-update -s <sn> finds the now-normal device.
-        device, ctx = test.find_first_device_or_exit( args.serial )
-        if device.supports( rs.camera_info.serial_number ):
-            new_sn = device.get_info( rs.camera_info.serial_number )
+        # harness was tracking. Poll for the device to re-enumerate in normal mode
+        # (a fresh rs.context() needs time after rs-fw-update exits) -- up to 60s.
+        log.d( "waiting for recovered device to re-enumerate in normal mode..." )
+        deadline = time.time() + 60
+        recovered_device = None
+        while time.time() < deadline:
+            for d in rs.context().devices:
+                if d.supports( rs.camera_info.firmware_update_id ) \
+                   and d.get_info( rs.camera_info.firmware_update_id ) == args.serial \
+                   and not d.is_in_recovery_mode():
+                    recovered_device = d
+                    break
+            if recovered_device is not None:
+                break
+            time.sleep( 2 )
+        if recovered_device is None:
+            log.f( f"Recovered device with firmware_update_id '{args.serial}' did not "
+                   f"re-enumerate within 60s after gold FW flash" )
+        # Re-pin args.serial to the device's normal-mode SN so downstream
+        # rs-fw-update -s <sn> finds the device (rs-fw-update.cpp:480 uses SN when supported).
+        if recovered_device.supports( rs.camera_info.serial_number ):
+            new_sn = recovered_device.get_info( rs.camera_info.serial_number )
             if new_sn != args.serial:
                 log.d( f're-pinning args.serial: {args.serial} (FWID) -> {new_sn} (SN)' )
                 args.serial = new_sn
+        device, ctx = test.find_first_device_or_exit( args.serial )
         current_fw_version = rsutils.version(device.get_info(rs.camera_info.firmware_version))
         log.d("FW version after recovery:", current_fw_version)
 

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -15,7 +15,7 @@ import re
 import platform
 import pyrealsense2 as rs
 import pyrsutils as rsutils
-from rspy import log, test, file, repo
+from rspy import log, test, file, repo, fw_compat
 import time
 import argparse
 
@@ -156,36 +156,35 @@ recovered = False
 if device.is_in_recovery_mode():
     log.d( "recovering device ..." )
     try:
-        # always flash signed fw when device on recovery before flashing anything else
-        image_file = custom_fw_path
-        cmd = [fw_updater_exe, '-r', '-f', image_file]
+        # rs-fw-update -r requires a *signed* FW image. The caller's --custom-fw-d400
+        # is typically unsigned, so we fetch a gold signed FW from S3 to recover with.
+        gold_fw = fw_compat.download_gold_d400_fw()
+        if not gold_fw:
+            log.f( "Could not download gold signed FW; cannot recover DFU device" )
+        cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', args.serial]
         del device, ctx
         log.d( 'running:', cmd )
         subprocess.run( cmd )
         recovered = True
-
-        if 'jetson' in test.context:
-            # Reload d4xx mipi driver on Jetson
-            log.d("Reloading d4xx driver on Jetson...")
-            try:
-                # Try to reload the driver, but don't fail if sudo requires a password
-                result = subprocess.run(['sudo', '-n', 'modprobe', '-r', 'd4xx'], 
-                                      capture_output=True, text=True)
-                if result.returncode != 0:
-                    log.e("Failed to remove d4xx module (may require passwordless sudo):", result.stderr)
-                else:
-                    load_result = subprocess.run(['sudo', '-n', 'modprobe', 'd4xx'], 
-                                              capture_output=True, text=True, check=False)
-                    if load_result.returncode != 0:
-                        log.e("Failed to load d4xx module (may require passwordless sudo):",
-                              f"returncode={load_result.returncode}, stderr={load_result.stderr}")
-            except Exception as driver_error:
-                log.w("Could not reload d4xx driver (passwordless sudo may not be configured):", driver_error)
+        fw_compat.reload_d4xx_driver_on_jetson( test.context )
+        # Give the device time to re-enumerate in normal mode.
+        time.sleep( 5 )
     except Exception as e:
         test.unexpected_exception()
         log.f( "Unexpected error while trying to recover device:", e )
     else:
+        # The device's identity changed: in DFU it exposed firmware_update_id only,
+        # now in normal mode it exposes its real serial_number (optic_serial). The
+        # firmware_update_id (asic_serial) is still exposed and matches what the
+        # harness was tracking, so find_first_device_or_exit(args.serial) resolves
+        # via the FWID fallback. We then re-pin args.serial to the real SN so the
+        # downstream rs-fw-update -s <sn> finds the now-normal device.
         device, ctx = test.find_first_device_or_exit( args.serial )
+        if device.supports( rs.camera_info.serial_number ):
+            new_sn = device.get_info( rs.camera_info.serial_number )
+            if new_sn != args.serial:
+                log.d( f're-pinning args.serial: {args.serial} (FWID) -> {new_sn} (SN)' )
+                args.serial = new_sn
         current_fw_version = rsutils.version(device.get_info(rs.camera_info.firmware_version))
         log.d("FW version after recovery:", current_fw_version)
 


### PR DESCRIPTION
Tracked by: RSDSO-21583

**TL;DR:** Adds a pre-test step to `test-fw-update.py` that recovers any D400 device stuck in DFU/recovery mode using a gold signed FW image pulled from the RealSense releases S3. Also widens `rspy.test.find_first_device_or_exit` to fall back to `camera_info.firmware_update_id` when `serial_number` isn't exposed, so DFU devices can be looked up at all.

## Why

CI machines occasionally end up with all D400 devices in DFU mode after a prior failed flash. From then on, every subsequent `test-fw-update` run fails with `No device with serial number X` and the machines stay stuck — because:

1. `find_first_device_or_exit('SN')` could not find a DFU device (`serial_number` isn't exposed in DFU).
2. The existing in-test recovery path uses `--custom-fw-d400` (which on CI is the **unsigned** image). `rs-fw-update -r` accepts **only signed** images, so the recovery attempt fails:
   ```
   ERROR ... Unsupported firmware binary image provided - 2097152 bytes
   Failed to recover device
   Device is in recovery mode, use -r to recover
   ```

Result: the rig never self-heals.

## Summary

### `unit-tests/test-fw-update.py` — pre-test gold-FW recovery

Right after the `rs-fw-update` binary is located and before the test queries for the target device, the script:

1. Enumerates `rs.context().devices` and finds D400-family devices in DFU.
2. Downloads `https://librealsense.realsenseai.com/Releases/RS4xx/FW/D4XX_FW_Image-5.17.0.10.bin` to `tempfile.gettempdir()` (cached for the rest of the run; same host used by other test-data downloads — `unit-tests/post-processing/test-filters.py`, `CMake/connectivity_check.cmake`).
3. For each DFU device, runs `rs-fw-update -r -f <gold_fw> -s <firmware_update_id>`. After success, reloads the d4xx MIPI driver on Jetson (`modprobe -r d4xx`, `modprobe d4xx`), then queries the rebooted device by the same FWID (`asic_serial` is stable across DFU↔normal) to learn its new `serial_number`.
4. Returns a `{FWID → new SN}` map; if `args.serial` referenced a now-recovered device, it gets re-pinned to the new SN so the regular-flash `rs-fw-update -s <SN>` and the post-flash verification lookup both target the right identifier.

The download is best-effort: if S3 is unreachable, the function logs a warning and returns, so the existing in-test recovery branch still gets a chance to handle the device.

### `unit-tests/py/rspy/test.py` — FWID fallback in `find_first_device_or_exit`

When `serial_number` is supplied and a device doesn't expose `camera_info.serial_number` (DFU mode), the lookup falls back to `camera_info.firmware_update_id`. This mirrors how `rspy.devices` registers DFU devices at discovery (`unit-tests/py/rspy/devices.py:351-352`), so an identifier the harness derived from a recovery-mode device still resolves. The error message updated to mention both keys.

This is defense-in-depth: in the happy path the upfront recovery already cleared DFU; this fallback covers the case where S3 is unreachable or `rs-fw-update -r` errored, so we still find the device (and the test reports something meaningful rather than `No device with serial number X`).

### `unit-tests/infra-tests/test_find_first_device.py` (new)

7 tests using a minimal `FakePyrsDevice` and a patched `rs.context`:

| Case | Asserts |
|---|---|
| `test_no_serial_returns_first_device` | No SN arg -> `devices[0]` |
| `test_matches_by_serial_number` | Matches via `camera_info.serial_number` |
| `test_matches_by_firmware_update_id_when_serial_not_exposed` | Recovery-mode device matched via `camera_info.firmware_update_id` |
| `test_mixed_recovery_and_normal_devices_each_resolvable` | Two devices, each resolvable from its own ID |
| `test_serial_takes_precedence_over_firmware_update_id` | A device exposing both is matched via `camera_info.serial_number` only (precedence preserved) |
| `test_no_match_calls_log_f` | Wrong SN -> `log.f` (test fail) |
| `test_empty_context_calls_log_f` | No devices visible -> `log.f("No device found")` |

## Scenarios covered

| Scenario | Hub-equipped (Acroname/YKUSH) | Hubless (Jetson) |
|---|---|---|
| 1 or 2 normal D400s | unchanged (SN match) | unchanged (SN match) |
| 1 D400 in DFU | upfront recovery flashes gold FW, re-pins `args.serial`; rest of the test runs normally | same |
| 1 DFU + 1 normal | per-iteration the hub keeps only one device visible; pre-test step recovers the DFU one, normal one is untouched | both visible; pre-test step recovers only the DFU one (filtered by `is_in_recovery_mode()`), the normal one is untouched |
| 2 D400 in DFU | per-iteration the hub keeps only one device visible; each iteration recovers its target | both visible; pre-test step recovers both before the test logic starts |

## Test plan

- [x] `pytest unit-tests/infra-tests/test_find_first_device.py -v` — 7/7 pass locally.
- [x] Manual: hub-equipped Linux rig with one DFU + one normal D400 (D435I in DFU, D455 normal) — `run-unit-tests.py -s -r fw-update --context nightly --custom-fw-d400 <unsigned-fw>` runs both configurations cleanly: pre-test step recovers the D435I with the gold FW, then the test flashes the custom FW on each device and verifies.
- [ ] CI: re-run on a machine currently with all D400s stuck in DFU. Expectation: the pre-test step recovers them all with the gold FW; the regular `test-fw-update` configurations then flash and verify normally.
- [ ] CI: normal multi-device run (no DFU) — the pre-test step is a quick `rs.context().devices` scan that finds nothing and returns; no regression.
