### PR TITLE
Cherry-pick MinZ GMSL fixes to 2.58.2

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -65,6 +65,7 @@ set(COMMON_SRC
     "${CMAKE_CURRENT_LIST_DIR}/min-z-depth-improver.h"
     "${CMAKE_CURRENT_LIST_DIR}/min-z-depth-improver.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/minz-filter.h"
+    "${CMAKE_CURRENT_LIST_DIR}/rs-depth-range-loader.h"
     "${CMAKE_CURRENT_LIST_DIR}/labeled-point-cloud-utilities.h"
     "${CMAKE_CURRENT_LIST_DIR}/labeled-point-cloud-utilities.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/dds-model.h"

--- a/common/min-z-depth-improver.cpp
+++ b/common/min-z-depth-improver.cpp
@@ -4,10 +4,7 @@
 #include "min-z-depth-improver.h"
 
 #ifdef BUILD_WITH_MINZ
-#include <rs_depth_calibration.hpp>
-#include <rs_depth_range.hpp>
-#include <rsutils/easylogging/easyloggingpp.h>
-#include <cstring>
+#include "rs-depth-range-loader.h"  // pulls in calibration headers + easylogging
 #include <cmath>
 #include <limits>
 #endif
@@ -18,6 +15,9 @@ min_z_depth_improver::~min_z_depth_improver() = default;
 rs2::frame min_z_depth_improver::apply( rs2::frame f, rs2::frame_source const & src )
 {
 #ifdef BUILD_WITH_MINZ
+    if( _library_absent )
+        return f;
+
     auto fs = f.as< rs2::frameset >();
     if( ! fs )
         return f;
@@ -62,9 +62,15 @@ bool min_z_depth_improver::init( rs2::video_frame const & ir_left,
 
     auto cal = rs_depth::Calibration::from_sdk( intrin, extrin );
 
+    if( ! get_rs_depth_range_loader().is_loaded() )
+    {
+        _library_absent = true;
+        return false;
+    }
+
     try
     {
-        _impl.reset( new rs_depth::DepthRangeImprover( cal ) );
+        _impl.reset( new rs_depth_range_impl( cal ) );
     }
     catch( std::exception const & e )
     {

--- a/common/min-z-depth-improver.h
+++ b/common/min-z-depth-improver.h
@@ -8,16 +8,16 @@
 #include <vector>
 
 #ifdef BUILD_WITH_MINZ
-// Forward-declare so the enhanced-depth headers stay out of this file.
-namespace rs_depth {
-    class DepthRangeImprover;
-}
+// Forward-declare — full definition lives in rs-depth-range-loader.h (included by the .cpp).
+class rs_depth_range_impl;
 #endif
 
-// Viewer-side adapter for rs_depth::DepthRangeImprover (librealsense2-enhanced-depth package).
-// Lazily initialises from camera calibration on the first frameset that
+// Viewer-side adapter for the librealsense2-enhanced-depth MinZ library.
+// Loads librs_depth_range.so at runtime via dlopen (see rs-depth-range-loader.h);
+// lazily initialises from camera calibration on the first frameset that
 // contains IR left, IR right, and depth together.
-// When BUILD_WITH_MINZ is not defined apply() is a no-op pass-through.
+// When BUILD_WITH_MINZ is not defined, or when the library is absent at runtime,
+// apply() is a no-op pass-through.
 //
 // Threading: apply() must be called from a single thread (the viewer render loop).
 // The scratch buffers (_depth_mm_buf, _replace_buf) are not protected by a mutex;
@@ -48,10 +48,11 @@ private:
                               rs2::frame            new_depth,
                               rs2::frame_source const & src );
 
-    std::unique_ptr< rs_depth::DepthRangeImprover > _impl;
+    std::unique_ptr< rs_depth_range_impl > _impl;
     std::vector< uint16_t >  _depth_mm_buf;
     std::vector< rs2::frame > _replace_buf;
-    int _init_width  = 0;
-    int _init_height = 0;
+    int  _init_width    = 0;
+    int  _init_height   = 0;
+    bool _library_absent = false;  // set on first failed init(); stops per-frame retry
 #endif
 };

--- a/common/rs-depth-range-loader.h
+++ b/common/rs-depth-range-loader.h
@@ -1,0 +1,139 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+#ifdef BUILD_WITH_MINZ
+
+#include <rs_depth_calibration.hpp>
+#include <rs_depth_range.hpp>  // FrameMetadata and extern "C" function declarations
+#include <rsutils/easylogging/easyloggingpp.h>
+
+#include <cstdint>
+#include <dlfcn.h>
+#include <stdexcept>
+
+// Runtime loader for librs_depth_range.so.
+// Wraps dlopen so the viewer starts even when the library is absent;
+// callers check is_loaded() before use.  The singleton is initialised once
+// on first access and lives for the process lifetime.
+class rs_depth_range_loader
+{
+public:
+    // Derive types directly from the extern "C" declarations in rs_depth_range.hpp
+    // so the compiler validates our casts instead of accepting hand-typed signatures.
+    using fn_create     = decltype( &rs_depth_range_create );
+    using fn_destroy    = decltype( &rs_depth_range_destroy );
+    using fn_process    = decltype( &rs_depth_range_process );
+    using fn_last_error = decltype( &rs_depth_range_last_error );
+
+    rs_depth_range_loader()
+    {
+        _handle = ::dlopen( "librs_depth_range.so", RTLD_LAZY | RTLD_LOCAL );
+        if( ! _handle )
+            _handle = ::dlopen( "/opt/librealsense2-enhanced-depth/lib/librs_depth_range.so",
+                                RTLD_LAZY | RTLD_LOCAL );
+        if( ! _handle )
+        {
+            LOG_WARNING( "MinZ: dlopen(librs_depth_range.so) failed: " << ::dlerror() );
+            return;
+        }
+
+        _create     = reinterpret_cast< fn_create >(
+                          ::dlsym( _handle, "rs_depth_range_create" ) );
+        _destroy    = reinterpret_cast< fn_destroy >(
+                          ::dlsym( _handle, "rs_depth_range_destroy" ) );
+        _process    = reinterpret_cast< fn_process >(
+                          ::dlsym( _handle, "rs_depth_range_process" ) );
+        _last_error = reinterpret_cast< fn_last_error >(
+                          ::dlsym( _handle, "rs_depth_range_last_error" ) );
+
+        if( ! _create || ! _destroy || ! _process || ! _last_error )
+        {
+            LOG_WARNING( "MinZ: missing symbols in librs_depth_range.so: " << ::dlerror() );
+            ::dlclose( _handle );
+            _handle     = nullptr;
+            _create     = nullptr;
+            _destroy    = nullptr;
+            _process    = nullptr;
+            _last_error = nullptr;
+        }
+    }
+
+    // Do NOT dlclose: the singleton outlives all rs_depth_range_impl objects only if
+    // static-destruction order is guaranteed, which it is not.  The OS reclaims the
+    // mapping on process exit without our help.
+    ~rs_depth_range_loader() = default;
+
+    rs_depth_range_loader( const rs_depth_range_loader & ) = delete;
+    rs_depth_range_loader & operator=( const rs_depth_range_loader & ) = delete;
+
+    bool is_loaded() const { return _handle != nullptr; }
+
+    fn_create     create()     const { return _create; }
+    fn_destroy    destroy()    const { return _destroy; }
+    fn_process    process()    const { return _process; }
+    fn_last_error last_error() const { return _last_error; }
+
+private:
+    void *        _handle     = nullptr;
+    fn_create     _create     = nullptr;
+    fn_destroy    _destroy    = nullptr;
+    fn_process    _process    = nullptr;
+    fn_last_error _last_error = nullptr;
+};
+
+inline rs_depth_range_loader & get_rs_depth_range_loader()
+{
+    static rs_depth_range_loader s_loader;
+    return s_loader;
+}
+
+// RAII wrapper around the opaque library handle.
+// Mirrors the rs_depth::DepthRangeImprover interface so call sites change minimally.
+class rs_depth_range_impl
+{
+public:
+    explicit rs_depth_range_impl( const rs_depth::Calibration & cal )
+    {
+        rs_depth_range_loader & ldr = get_rs_depth_range_loader();
+        _handle = ldr.create()(
+            cal.focal_length_px,
+            cal.baseline_m,
+            cal.min_z_threshold_mm(),
+            0.35f,       // scale_factor — matches DepthRangeImprover default
+            -1, -1, -1, -1  // no crop region
+        );
+        if( ! _handle )
+        {
+            const char * err = ldr.last_error()( nullptr );
+            throw std::runtime_error( err ? err : "rs_depth_range_create failed" );
+        }
+    }
+
+    ~rs_depth_range_impl()
+    {
+        if( _handle )
+            get_rs_depth_range_loader().destroy()( _handle );
+    }
+
+    rs_depth_range_impl( const rs_depth_range_impl & ) = delete;
+    rs_depth_range_impl & operator=( const rs_depth_range_impl & ) = delete;
+
+    void process( const uint8_t * ir_l, const uint8_t * ir_r,
+                  const uint16_t * depth_in, uint16_t * depth_out,
+                  const FrameMetadata & meta )
+    {
+        rs_depth_range_loader & ldr = get_rs_depth_range_loader();
+        int ret = ldr.process()( _handle, ir_l, ir_r, depth_in, depth_out, &meta );
+        if( ret != 0 )
+        {
+            const char * err = ldr.last_error()( _handle );
+            throw std::runtime_error( err ? err : "rs_depth_range_process failed" );
+        }
+    }
+
+private:
+    void * _handle = nullptr;
+};
+
+#endif  // BUILD_WITH_MINZ

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -5,6 +5,7 @@
 #include "post-processing-block-model.h"
 #ifdef BUILD_WITH_MINZ
 #include "minz-filter.h"
+#include "rs-depth-range-loader.h"
 #endif
 #include <imgui_internal.h>
 #include <realsense_imgui.h>
@@ -130,7 +131,12 @@ namespace rs2
                 [block]( rs2::frame f ) { return block->process( f ); },
                 error_message, false );
 
-            if( !rsutils::rs2_is_cuda_available() )
+            if( ! get_rs_depth_range_loader().is_loaded() )
+            {
+                model->available = []() { return false; };
+                model->unavailable_tooltip = "MinZ library not found; install librealsense2-enhanced-depth package";
+            }
+            else if( !rsutils::rs2_is_cuda_available() )
             {
                 model->available = []() { return false; };
                 model->unavailable_tooltip = "MinZ requires CUDA (not detected on this system)";

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -937,13 +937,10 @@ namespace librealsense
                 }
             }
 
-            if (!_is_mipi_device)
-            {
-                depth_sensor.register_option( RS2_OPTION_STEREO_BASELINE,
-                                              std::make_shared< const_value_option >(
-                                                  "Distance in mm between the stereo imagers",
-                                                  rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
-            }
+            depth_sensor.register_option( RS2_OPTION_STEREO_BASELINE,
+                                          std::make_shared< const_value_option >(
+                                              "Distance in mm between the stereo imagers",
+                                              rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
 
             _depth_units_register_action = [this]()
             {

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -197,12 +197,9 @@ endif()
 set(RS_VIEWER_LIBS ${GTK3_LIBRARIES} Threads::Threads realsense2-gl)
 
 if(BUILD_WITH_MINZ)
-    # NOTE: librs_depth_range.so is hard-linked into the viewer binary.
-    # The librealsense2-enhanced-depth package MUST be installed on every system
-    # that runs this binary — if the library is absent the viewer will fail to start.
-    # Do not distribute a BUILD_WITH_MINZ=ON binary to systems without the package.
-    #
-    # Installed by: sudo dpkg -i librealsense2-enhanced-depth-*.deb
+    # librs_depth_range.so is loaded at runtime via dlopen (see rs-depth-range-loader.h);
+    # the binary starts normally when the library is absent — the MinZ toggle is greyed out.
+    # Install the library with: sudo dpkg -i librealsense2-enhanced-depth-*.deb
     set(MINZ_ROOT "/opt/librealsense2-enhanced-depth" CACHE PATH
         "Root of the librealsense2-enhanced-depth installation (default: /opt/librealsense2-enhanced-depth)")
 
@@ -217,32 +214,20 @@ if(BUILD_WITH_MINZ)
         PATHS "${MINZ_ROOT}/include"
         NO_DEFAULT_PATH
     )
-    find_library(MINZ_LIBRARY
-        NAMES rs_depth_range
-        PATHS "${MINZ_ROOT}/lib"
-        NO_DEFAULT_PATH
-    )
 
     if(NOT MINZ_INCLUDE_DIR)
         message(FATAL_ERROR "rs_depth_range.hpp not found under ${MINZ_ROOT}/include -- "
-            "install librealsense2-enhanced-depth library or set MINZ_ROOT")
+            "install librealsense2-enhanced-depth or set MINZ_ROOT")
     endif()
     if(NOT MINZ_CALIBRATION_HEADER)
         message(FATAL_ERROR "rs_depth_calibration.hpp not found under ${MINZ_ROOT}/include -- "
-            "install librealsense2-enhanced-depth library or set MINZ_ROOT")
-    endif()
-    if(NOT MINZ_LIBRARY)
-        message(FATAL_ERROR "librs_depth_range not found under ${MINZ_ROOT}/lib -- "
-            "install librealsense2-enhanced-depth library or set MINZ_ROOT")
+            "install librealsense2-enhanced-depth or set MINZ_ROOT")
     endif()
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE BUILD_WITH_MINZ)
     target_include_directories(${PROJECT_NAME} PRIVATE "${MINZ_INCLUDE_DIR}")
-    # DEPENDENCIES is consumed by tools_target_config() in tools_common.cmake via target_link_libraries
-    list(APPEND DEPENDENCIES ${MINZ_LIBRARY})
-    message(STATUS "MinZ depth improvement enabled")
+    message(STATUS "MinZ depth improvement enabled (runtime dlopen)")
     message(STATUS "  include : ${MINZ_INCLUDE_DIR}")
-    message(STATUS "  library : ${MINZ_LIBRARY}")
 endif()
 
 include(../tools_common.cmake)


### PR DESCRIPTION
**Overview:** Cherry-pick the two MinZ-on-GMSL fixes from `development` into 2.58.2 — register `RS2_OPTION_STEREO_BASELINE` on MIPI devices, and load `librs_depth_range.so` at runtime via dlopen.

Tracked on [RSDSO-21585], [RSDSO-21586]

## Summary
- Cherry-pick of #15139 (net change): remove the `!_is_mipi_device` guard around `RS2_OPTION_STEREO_BASELINE` registration so the viewer's MinZ gate covers GMSL SKUs (#15079 and its revert cancel out and are skipped — `r/2.58.2` predates both)
- Cherry-pick of #15143: dlopen-based loading of the enhanced-depth library — required because signed/released `librealsense2-enhanced-depth` debs are UPX-encrypted and cannot be link-time resolved; also lets the viewer start without the package (MinZ greys out)

## Why
Without these, 2.58.2 ships MinZ blocked on GMSL (D401/D457) and a viewer that fails to link against (or start without) released enhanced-depth packages.

## Test plan
- [x] `BUILD_WITH_MINZ=ON` build on Jetson Orin links against signed deb setup (dlopen verified on rs-ci-orin-04 with encrypted 1.0.43)
- [x] MinZ available on D401/D457 GMSL in viewer
- [ ] LibCI