### PR TITLE
Pre-install ROS 2 apt source in GHA to avoid setup-ros rate-limit failures

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -42,6 +42,25 @@ jobs:
       image: ${{ matrix.docker_image }}
     steps:
 
+      - name: install ROS 2 apt source
+        # Workaround: setup-ros resolves the ros-apt-source version via an
+        # unauthenticated GitHub API call (60 req/hour per IP, shared across
+        # hosted runners), which intermittently gets rate-limited and fails the
+        # job with a 404. Pre-installing the package here makes setup-ros skip
+        # that step. The version is resolved from the releases/latest web
+        # redirect, which is not subject to the API rate limit.
+        # Remove once fixed upstream (ros-tooling/setup-ros).
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+          VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 5 --retry-delay 5 \
+            https://github.com/ros-infrastructure/ros-apt-source/releases/latest | sed 's|.*/||')
+          codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+          curl -fsSL --retry 5 --retry-delay 5 -o /tmp/ros2-apt-source.deb \
+            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/ros2-apt-source_${VERSION}.${codename}_all.deb"
+          dpkg -i /tmp/ros2-apt-source.deb
+
       - name: setup ROS environment
         uses: ros-tooling/setup-ros@77bcad67a6cb15f6192d61464d99bbab658e4ca9 #v0.7.18
         with:

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -54,10 +54,11 @@ jobs:
         run: |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-          VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 5 --retry-delay 5 \
+          VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 5 --retry-delay 5 --retry-all-errors \
             https://github.com/ros-infrastructure/ros-apt-source/releases/latest | sed 's|.*/||')
+          [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]] || { echo "ERROR: could not resolve ros-apt-source version (got: '${VERSION}')"; exit 1; }
           codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
-          curl -fsSL --retry 5 --retry-delay 5 -o /tmp/ros2-apt-source.deb \
+          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
             "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/ros2-apt-source_${VERSION}.${codename}_all.deb"
           dpkg -i /tmp/ros2-apt-source.deb
 


### PR DESCRIPTION
**TL;DR:** Fixes the intermittent `build_lrs_ROS2_package` CI failures (curl 404 in `setup ROS environment`) by pre-installing the ROS 2 apt source before `setup-ros` runs.

Tracked on [RSDSO-21587]

## Summary
- Add an `install ROS 2 apt source` step before `ros-tooling/setup-ros` in `build-ROS2-package-CI.yaml`
- The step resolves the latest `ros-apt-source` version from the `releases/latest` web redirect (not subject to the GitHub API rate limit), downloads the deb with retries, and installs it
- `setup-ros` (≥ v0.7.16) detects the ROS apt repo is already configured and skips its own fragile install path
- No hardcoded versions; the step is purely additive and can be removed once fixed upstream in ros-tooling/setup-ros

## Why
`setup-ros` resolves the `ros-apt-source` version via an **unauthenticated** GitHub API call with no retry (60 req/hour per IP). GitHub-hosted runners share IP pools, so every few days a job lands on a rate-limited IP: the version resolves empty, the download URL is malformed, and the job fails with `curl: (22) The requested URL returned error: 404`. Reproduced on setup-ros v0.7.18 (latest) — the flaw still exists upstream on master, so bumping the action does not help.

## Test plan
- [x] All 4 matrix jobs (humble/jammy, kilted, rolling, jazzy on noble) pass on this PR — the new step logs the resolved version and `setup-ros` skips its apt-source install
- [x] Version-resolution redirect and deb download URL verified locally (resolves `1.2.0`, HTTP 200)

