### PR TITLE
Bump brainstem to 2.12.4 to stop locked BrainStemLog.txt blocking workspace cleanup

### DIFF
--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -2,7 +2,7 @@
 yepkit-pykush==0.3.5; platform_machine != "aarch64"
 
 # Acroname hub (not used on Jetson/aarch64)
-brainstem==2.12.4; platform_machine != "aarch64"  # 2.11.1 wrote a locked BrainStemLog.txt into CWD on import, blocking Jenkins workspace cleanup
+brainstem==2.12.4; platform_machine != "aarch64"
 
 # Unifi hub (not used on Jetson/aarch64)
 paramiko==3.5.1; platform_machine != "aarch64"

--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -2,7 +2,7 @@
 yepkit-pykush==0.3.5; platform_machine != "aarch64"
 
 # Acroname hub (not used on Jetson/aarch64)
-brainstem==2.11.1; platform_machine != "aarch64"
+brainstem==2.12.4; platform_machine != "aarch64"  # 2.11.1 wrote a locked BrainStemLog.txt into CWD on import, blocking Jenkins workspace cleanup
 
 # Unifi hub (not used on Jetson/aarch64)
 paramiko==3.5.1; platform_machine != "aarch64"


### PR DESCRIPTION
**TL;DR:** Bumps the `brainstem` (Acroname hub) pin from 2.11.1 to 2.12.4 so importing it no longer creates a locked `BrainStemLog.txt` in the Jenkins workspace, which intermittently blocks workspace cleanup on Windows agents.

Tracked on [RSDSO-21584]

## Summary
- `unit-tests/requirements.txt`: `brainstem==2.11.1` → `brainstem==2.12.4`

## Why
brainstem 2.11.1's `BrainStem2_CCA.dll` opens `BrainStemLog.txt` in the process CWD at `DLL_PROCESS_ATTACH` (i.e. on `import brainstem`) and holds an exclusive handle for the process lifetime. There is no way to disable or redirect it (no env var, no API — verified by binary inspection). When a stale python process survives a build on a Windows agent, the locked file makes the next build fail in Checkout SCM with `Failed to clean the workspace` (e.g. LRS_windows_compile_pipeline #113689 on rsdsk254).

Acroname removed this attach-time logging entirely in 2.12.x.

## Test plan
- [x] Verified locally: 2.11.1 import creates + exclusively locks `BrainStemLog.txt` in CWD; 2.12.4 import creates no file
- [x] Verified the API surface used by `acroname.py` is intact in 2.12.4 (`USBHub3p`, `brainstem.result.Result`, `version.get_version_string`)
- [x] Verified the 2.12.4 wheel bundles Linux x86_64 libs (Ubuntu 18/20/22) and they are equally free of the log write
- [ ] Gated libci run on this PR exercises real Acroname port enable/disable on the rigs with 2.12.4
