### PR TITLE
Show person detection distance up to 5m only

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3610,7 +3610,11 @@ namespace rs2
                 ++hits;
             }
         }
-        return hits > 0 ? total / hits : 0.f;
+
+        float val = hits > 0 ? total / hits : 0.f;
+        if( val > 5.0f ) // Above 5 meters not accurate, prefer to not show.
+            val = 0.f;
+        return val;
     }
 
     void viewer_model::process_object_detection_frames( std::map< int, rs2::frame > & last_frames )


### PR DESCRIPTION
Trained on data set mostly up to 5 meters. For now, don't print calculated depth above this.