### PR TITLE
mf-uvc: retry ReadSample on MF_E_NOTACCEPTING to keep stream alive

### DIFF
--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -168,6 +168,45 @@ namespace librealsense
             return count;
         }
 
+        // Runs on a Win32 thread-pool worker. The MF source reader returned
+        // MF_E_NOTACCEPTING on the only ReadSample request for this pin, so the
+        // pin would never call OnReadSample again unless we re-issue the request.
+        // Retry with short exponential backoff (~30 ms total) and give up if the
+        // pin stays backpressured.
+        VOID CALLBACK source_reader_callback::read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context)
+        {
+            std::unique_ptr<read_sample_retry_context> ctx(static_cast<read_sample_retry_context*>(context));
+            DWORD sleep_ms = 1;
+            for (int attempts = 0; attempts < 6; ++attempts)
+            {
+                Sleep(sleep_ms);
+                sleep_ms = std::min<DWORD>(sleep_ms * 2, 16);
+
+                auto owner = ctx->owner.lock();
+                if (!owner || !owner->_reader || !owner->_is_started)
+                    return;
+
+                HRESULT hr = owner->_reader->ReadSample(ctx->stream_index, 0, nullptr, nullptr, nullptr, nullptr);
+                if (hr != MF_E_NOTACCEPTING)
+                {
+                    if (FAILED(hr))
+                        LOG_HR(hr);
+                    return;
+                }
+            }
+            LOG_WARNING("MF_E_NOTACCEPTING persisted on stream " << ctx->stream_index << " after retries; sample stream may be stalled");
+        }
+
+        void source_reader_callback::schedule_read_sample_retry(std::weak_ptr<wmf_uvc_device> owner, DWORD stream_index)
+        {
+            auto ctx = std::make_unique<read_sample_retry_context>();
+            ctx->owner = std::move(owner);
+            ctx->stream_index = stream_index;
+            if (TrySubmitThreadpoolCallback(read_sample_retry_work, ctx.get(), nullptr))
+                ctx.release();
+            else
+                LOG_WARNING("Failed to schedule MF ReadSample retry on stream " << stream_index);
+        }
 
         STDMETHODIMP source_reader_callback::OnReadSample(HRESULT hrStatus,
             DWORD dwStreamIndex,
@@ -189,7 +228,18 @@ namespace librealsense
                 }
                 owner->_has_started.set();
 
-                LOG_HR(owner->_reader->ReadSample(dwStreamIndex, 0, nullptr, nullptr, nullptr, nullptr));
+                HRESULT hr_read = owner->_reader->ReadSample(dwStreamIndex, 0, nullptr, nullptr, nullptr, nullptr);
+                if (hr_read == MF_E_NOTACCEPTING)
+                {
+                    // Without a retry the source reader will never call us again on
+                    // this pin and the stream effectively dies. Schedule a deferred
+                    // retry on the thread pool so we don't block the MF callback.
+                    schedule_read_sample_retry(_owner, dwStreamIndex);
+                }
+                else if (FAILED(hr_read))
+                {
+                    LOG_HR(hr_read);
+                }
 
                 if (!owner->_is_started)
                     return S_OK;

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -168,33 +168,90 @@ namespace librealsense
             return count;
         }
 
-        // Runs on a Win32 thread-pool worker. The MF source reader returned
-        // MF_E_NOTACCEPTING on the only ReadSample request for this pin, so the
-        // pin would never call OnReadSample again unless we re-issue the request.
-        // Retry with short exponential backoff (~30 ms total) and give up if the
-        // pin stays backpressured.
-        VOID CALLBACK source_reader_callback::read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context)
+        namespace
         {
-            std::unique_ptr<read_sample_retry_context> ctx(static_cast<read_sample_retry_context*>(context));
-            DWORD sleep_ms = 1;
-            for (int attempts = 0; attempts < 6; ++attempts)
+            constexpr int   k_max_readsample_retries = 6;   // 1+2+4+8+16+16 ms ≈ 47 ms worst case
+            constexpr DWORD k_max_retry_sleep_ms     = 16;
+        }
+
+        // Re-issues ReadSample after MF returned MF_E_NOTACCEPTING.
+        //
+        // Uses a thread-pool *timer* (not Sleep + thread-pool work item) so we never
+        // hold a worker thread across the backoff interval — under sustained
+        // backpressure on multiple pins, blocking workers would starve the MF pipeline
+        // itself (which shares the default thread pool). The callback re-arms the
+        // timer for each subsequent attempt and exits immediately.
+        //
+        // Backoff: 1, 2, 4, 8, 16, 16 ms (k_max_readsample_retries attempts, worst-case
+        // ~47 ms total) — longer than a frame interval at 30 fps so we comfortably
+        // outlast transient hiccups; short enough not to leak resources if the pin
+        // is genuinely dead.
+        //
+        // On the standard MF source reader, MF_E_NOTACCEPTING means "a ReadSample is
+        // already pending for this stream". In the symptom this PR addresses, the
+        // pending request never completes (the pin is stuck) — without a retry there
+        // is no further OnReadSample, so the stream dies. If the pending request
+        // does eventually complete in parallel with our retry, MF returns
+        // MF_E_NOTACCEPTING to whichever ReadSample finds an in-flight one, and the
+        // pipeline self-stabilizes back to a single in-flight request within a few
+        // callback cycles.
+        VOID CALLBACK source_reader_callback::read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context, PTP_TIMER /*timer*/)
+        {
+            auto* ctx = static_cast<read_sample_retry_context*>(context);
+            bool done = false;
+
+            if (auto owner = ctx->owner.lock())
             {
-                Sleep(sleep_ms);
-                sleep_ms = std::min<DWORD>(sleep_ms * 2, 16);
-
-                auto owner = ctx->owner.lock();
-                if (!owner || !owner->_reader || !owner->_is_started)
-                    return;
-
-                HRESULT hr = owner->_reader->ReadSample(ctx->stream_index, 0, nullptr, nullptr, nullptr, nullptr);
-                if (hr != MF_E_NOTACCEPTING)
+                if (owner->_is_started)
                 {
-                    if (FAILED(hr))
-                        LOG_HR(hr);
-                    return;
+                    // Snapshot the reader so a concurrent close()/flush() that
+                    // resets owner->_reader can't invalidate it between our
+                    // null-check and the ReadSample call.
+                    CComPtr<IMFSourceReader> reader = owner->_reader;
+                    if (reader)
+                    {
+                        HRESULT hr = reader->ReadSample(ctx->stream_index, 0, nullptr, nullptr, nullptr, nullptr);
+                        if (hr != MF_E_NOTACCEPTING)
+                        {
+                            if (SUCCEEDED(hr))
+                                LOG_DEBUG("MF ReadSample retry succeeded on stream " << ctx->stream_index
+                                          << " after attempt " << (ctx->attempts + 1));
+                            else
+                                LOG_HR(hr);
+                            done = true;
+                        }
+                    }
+                    else
+                    {
+                        done = true;
+                    }
+                }
+                else
+                {
+                    done = true;
                 }
             }
-            LOG_WARNING("MF_E_NOTACCEPTING persisted on stream " << ctx->stream_index << " after retries; sample stream may be stalled");
+            else
+            {
+                done = true;
+            }
+
+            if (!done && ++ctx->attempts < k_max_readsample_retries)
+            {
+                ctx->next_sleep_ms = std::min<DWORD>(ctx->next_sleep_ms * 2, k_max_retry_sleep_ms);
+                LARGE_INTEGER due;
+                due.QuadPart = -static_cast<LONGLONG>(ctx->next_sleep_ms) * 10000; // -ve = relative, 100-ns units
+                FILETIME due_ft = { due.LowPart, static_cast<DWORD>(due.HighPart) };
+                SetThreadpoolTimer(ctx->timer, &due_ft, 0, 0);
+                return;
+            }
+
+            if (!done)
+                LOG_WARNING("MF_E_NOTACCEPTING persisted on stream " << ctx->stream_index
+                            << " after " << k_max_readsample_retries << " retries; sample stream may be stalled");
+
+            CloseThreadpoolTimer(ctx->timer);
+            delete ctx;
         }
 
         void source_reader_callback::schedule_read_sample_retry(std::weak_ptr<wmf_uvc_device> owner, DWORD stream_index)
@@ -202,10 +259,19 @@ namespace librealsense
             auto ctx = std::make_unique<read_sample_retry_context>();
             ctx->owner = std::move(owner);
             ctx->stream_index = stream_index;
-            if (TrySubmitThreadpoolCallback(read_sample_retry_work, ctx.get(), nullptr))
-                ctx.release();
-            else
-                LOG_WARNING("Failed to schedule MF ReadSample retry on stream " << stream_index);
+
+            ctx->timer = CreateThreadpoolTimer(read_sample_retry_work, ctx.get(), nullptr);
+            if (!ctx->timer)
+            {
+                LOG_WARNING("Failed to create thread-pool timer for MF ReadSample retry on stream " << stream_index);
+                return; // ctx auto-freed via unique_ptr
+            }
+
+            LARGE_INTEGER due;
+            due.QuadPart = -static_cast<LONGLONG>(ctx->next_sleep_ms) * 10000;
+            FILETIME due_ft = { due.LowPart, static_cast<DWORD>(due.HighPart) };
+            SetThreadpoolTimer(ctx->timer, &due_ft, 0, 0);
+            ctx.release(); // ownership transferred to the timer callback
         }
 
         STDMETHODIMP source_reader_callback::OnReadSample(HRESULT hrStatus,

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -169,9 +169,12 @@ namespace librealsense
             struct read_sample_retry_context
             {
                 std::weak_ptr<wmf_uvc_device> owner;
-                DWORD stream_index;
+                DWORD stream_index = 0;
+                PTP_TIMER timer = nullptr;
+                int attempts = 0;
+                DWORD next_sleep_ms = 1;
             };
-            static VOID CALLBACK read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context);
+            static VOID CALLBACK read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context, PTP_TIMER timer);
             static void schedule_read_sample_retry(std::weak_ptr<wmf_uvc_device> owner, DWORD stream_index);
 
             std::weak_ptr<wmf_uvc_device> _owner;

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -166,6 +166,14 @@ namespace librealsense
             STDMETHODIMP OnEvent(DWORD /*sidx*/, IMFMediaEvent* /*event*/) override;
             STDMETHODIMP OnFlush(DWORD) override;
         private:
+            struct read_sample_retry_context
+            {
+                std::weak_ptr<wmf_uvc_device> owner;
+                DWORD stream_index;
+            };
+            static VOID CALLBACK read_sample_retry_work(PTP_CALLBACK_INSTANCE, PVOID context);
+            static void schedule_read_sample_retry(std::weak_ptr<wmf_uvc_device> owner, DWORD stream_index);
+
             std::weak_ptr<wmf_uvc_device> _owner;
             long _refCount = 0;
         };


### PR DESCRIPTION
## Problem

In `source_reader_callback::OnReadSample` (`src/mf/mf-uvc.cpp`), the next `ReadSample` request is issued with a bare `LOG_HR`. If that call returns `MF_E_NOTACCEPTING` (HResult `0xc00d36b5` - the MF source reader is transiently backpressured), the failure is logged but no retry is scheduled. Since OnReadSample is the only place a new ReadSample is issued for that pin, a single transient backpressure event silently kills the stream for the rest of the session.

This is the root cause of the catastrophic depth-frame loss observed on D435 + D455 multidev streaming on Windows (rsdsk254): when color is added on top of depth + IR, the depth pin's MF source-reader hits `MF_E_NOTACCEPTING` and never recovers, producing the 78-93% depth-loss pattern seen in nightly #15914 / #15935 / #16029 and reproduced locally with `rs.log_to_file(rs.log_severity.debug, ...)` (PR #15131). SDK debug logs show only ~179 `FrameAccepted` events for depth across 16 s of Phase 2 streaming - depth frames never even reach the SDK after the backpressure event.

## Fix

Detect `MF_E_NOTACCEPTING` at the ReadSample call site and schedule a deferred retry on a Win32 thread-pool worker (`TrySubmitThreadpoolCallback`). The worker retries with short exponential backoff (1, 2, 4, 8, 16, 16 ms - 6 attempts, ~47 ms total max wait), re-checks `weak_ptr.lock()` + `_is_started` between attempts so it exits cleanly on device shutdown, and gives up with a single `LOG_WARNING` if the pin stays backpressured (same outcome as today, but at least the stall is surfaced).

Other `ReadSample` failure paths preserve the existing `LOG_HR` behavior. The success path is unchanged.

## Scope

- Addresses *Mode A* (catastrophic): depth frames don't reach the SDK because the source reader is dead.
- Does *not* address *Mode B*: 16-17% residual depth loss from publish-queue / callback pressure observed in the second local-repro run; that needs a separate change to move user-callback processing off the MF callback thread.

## Testing

- Builds clean on Windows (`cmake --build ... --target realsense2 --config Release`).
- Not yet run on rsdsk254 - waiting for a CI run on this branch (test from PR #15131 is in place to surface the impact in Jenkins logs).

## References

- PR #15084 - multidev streaming test Phase 1 / Phase 2 split
- PR #15131 - rs debug log capture into pytest log dir (Jenkins-archived)
- Nightly failures: #15914 (2026-05-20), #15935 (2026-05-22), #16029 (2026-05-26) - all on rsdsk254 (Windows)