### PR TITLE
cli: accept --eth/--no-eth/--eth-only/--domain-id in non-DDS builds

### DIFF
--- a/common/cli.h
+++ b/common/cli.h
@@ -202,12 +202,12 @@ public:
         , no_eth_arg( "no-eth", "Do not detect DDS devices, even if enabled in the configuration" )
         , domain_id_arg( "domain-id", "0-232", 0, "Domain ID to use with DDS devices" )
     {
-#ifdef BUILD_WITH_DDS
+        // Register these flags unconditionally so non-DDS builds still accept (and ignore) them;
+        // build_cli_settings() applies their effect only when BUILD_WITH_DDS is defined.
         add( eth_arg );
         add( eth_only_arg );
         add( no_eth_arg );
         add( domain_id_arg );
-#endif
     }
     cli( std::string const & tool_name )
         : cli( tool_name, RS2_API_FULL_VERSION_STR ) {}


### PR DESCRIPTION
**Overview:** Register the `--eth`, `--eth-only`, `--no-eth`, and `--domain-id` flags in `common/cli.h` unconditionally so tools built without `BUILD_WITH_DDS` (e.g. the Jetson static Release pipeline) no longer reject these arguments with a TCLAP parse error.

## Summary
- Move the `add( eth_arg / eth_only_arg / no_eth_arg / domain_id_arg )` calls out of the `#ifdef BUILD_WITH_DDS` block in `common/cli.h`.
- The flag-effect logic in `build_cli_settings()` stays under `#ifdef BUILD_WITH_DDS`, so non-DDS builds parse the flags but ignore them (the right semantics - "do not look for DDS devices" is trivially satisfied when DDS is not compiled in).

## Why
`unit-tests/live/tools/pytest-enumerate-devices.py::test_rs_enumerate_devices` started failing on the Jetson `arm64/static/Release` build after commit `865e48cb8` switched the test from `--no-dds` to `--no-eth`. The old `--no-dds` was registered unconditionally; `--no-eth` is only registered when `BUILD_WITH_DDS` is defined. The Jetson static build has `BUILD_WITH_DDS=OFF`, so TCLAP rejects the unknown argument and `rs-enumerate-devices` exits 1 before any enumeration, causing `assert p.returncode == 0` to fail.

Example failure (D457 GMSL on Jetson):
```
06:04:16.653 -E- call failed: AssertionError: assert 1 == 0
 +  where 1 = CompletedProcess(args=['.../rs-enumerate-devices', '--no-eth'], returncode=1).returncode
```

## Test plan
- [ ] Jetson `arm64/static/Release` (BUILD_WITH_DDS=OFF) - `pytest-enumerate-devices` passes on D400*/D500*
- [ ] Any DDS-enabled build - `--no-eth` / `--eth` / `--eth-only` / `--domain-id` behavior unchanged
- [ ] `--help` output on non-DDS builds now lists the eth/domain-id flags (cosmetic - matches the prior `--no-dds` behavior of always being shown)