### PR TITLE
Clean up temp recordings left in OS temp dir by rec-play tests

### DIFF
--- a/.github/skills/pytest-infra.md
+++ b/.github/skills/pytest-infra.md
@@ -137,6 +137,16 @@ When migrating a legacy `test-*.py` to `pytest-*.py`:
       ```
     - **Expected exceptions** (legacy `try/except RuntimeError: test.check_exception(...)`) → migrate to `with pytest.raises(RuntimeError, match="..."):` (see `unit-tests/syncer/pytest-ts-same-fps.py:63` for the pattern).
 
+15. **Write test-created files to pytest's `tmp_path`, never a bare `mkdtemp`**: Any file a test writes to disk — recordings (`.db3`/`.bag`), point clouds, PNGs, logs, XML — must go under the `tmp_path` fixture. pytest places it inside the OS temp dir but auto-prunes all but the last 3 runs, so there is **no teardown to write** and nothing accumulates. A bare `tempfile.mkdtemp()` / `mkstemp()` leaks its directory into the OS temp dir permanently (most visible on Windows, which never auto-cleans `%TEMP%`).
+
+    ```python
+    def test_record(test_device, tmp_path):       # add tmp_path to the signature
+        file_name = str(tmp_path / "recording.db3")
+        ...
+    ```
+
+    Legacy flat `test-*.py` scripts run outside pytest and have no fixtures, so `tmp_path` is unavailable. There, wrap the work in `tempfile.TemporaryDirectory()` (auto-cleans on context exit) or add `try/finally: shutil.rmtree(temp_dir, ignore_errors=True)` so the directory is removed even when the test fails. See `unit-tests/live/rec-play/pytest-record-and-stream.py` (tmp_path) and `test-record-software-device.py` (try/finally) for the two patterns.
+
 ## Handling `on_fail=test.ABORT`
 
 The legacy framework supported `with test.closure('Name', on_fail=test.ABORT):` — if that closure failed, all subsequent closures were skipped. In pytest, use a **module-level state dict** with `pytest.skip()`.
@@ -203,6 +213,8 @@ The `pytest-check` plugin is available for soft assertions (non-stopping checks)
 Import: `from pytest_check import check`
 
 ## Writing a New Pytest Test
+
+> **Files on disk → `tmp_path`.** If the test records, exports, or otherwise writes a file, take the `tmp_path` fixture and build paths under it (`str(tmp_path / "name.db3")`). pytest auto-cleans it — never `tempfile.mkdtemp()` without teardown. See migration-checklist item 15 for details and the legacy-script fallback.
 
 ### Fixture chain
 

--- a/unit-tests/live/rec-play/pytest-record-and-stream.py
+++ b/unit-tests/live/rec-play/pytest-record-and-stream.py
@@ -4,7 +4,7 @@
 #The test flow is a result of a fixed bug - viewer crashed when starting stream after finishing record session
 
 import pytest
-import pyrealsense2 as rs, os, time, tempfile
+import pyrealsense2 as rs, time
 from pytest_check import check
 import logging
 
@@ -73,11 +73,10 @@ def play_recording(file_name, default_profile):
 
     check.is_true(frame_queue.poll_for_frame())
 ################################################################################################
-def test_record_and_stream(test_device):
+def test_record_and_stream(test_device, tmp_path):
     global dev, ctx, depth_sensor
     log.info("Record, stream and playback using sensor interface with frame queue")
-    temp_dir = tempfile.mkdtemp()
-    file_name = os.path.join(temp_dir, "recording.db3")
+    file_name = str(tmp_path / "recording.db3")
 
     dev, ctx = test_device
     depth_sensor = dev.first_depth_sensor()

--- a/unit-tests/live/rec-play/test-record-software-device.py
+++ b/unit-tests/live/rec-play/test-record-software-device.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2023 RealSense, Inc. All Rights Reserved.
 
 import os.path
+import shutil
 import tempfile
 import numpy as np
 import pyrealsense2 as rs
@@ -164,8 +165,11 @@ stream_profiles = [depth_stream_profile, motion_stream_profile]
 video_frame = prepare_depth_frame(pixels, BPP, depth_stream_profile)
 motion_frame = prepare_motion_frame(motion_frame_data, motion_stream_profile)
 
-record_frames(filename, sd, sync, video_frame, motion_frame, sensor, stream_profiles)
-play_frames(filename)
+try:
+    record_frames(filename, sd, sync, video_frame, motion_frame, sensor, stream_profiles)
+    play_frames(filename)
+finally:
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
 test.finish()
 ################################################################################################


### PR DESCRIPTION
**Overview:** Two rec-play unit tests created a recording under a `tempfile.mkdtemp()` directory in the OS temp dir and never deleted it, so the folders accumulated in `%TEMP%` on Windows across runs. This switches them to auto-cleaned temp handling and documents the rule.

Tracked on [RSDSO-21593]

## Summary
- `unit-tests/live/rec-play/pytest-record-and-stream.py` — use pytest's `tmp_path` fixture (auto-cleaned, self-pruning) instead of `tempfile.mkdtemp()`; drop now-unused `os`/`tempfile` imports.
- `unit-tests/live/rec-play/test-record-software-device.py` — legacy flat script (no pytest fixtures): wrap record/play in `try/finally` with `shutil.rmtree(temp_dir, ignore_errors=True)` so the temp dir is removed even when the test fails.
- `.github/skills/pytest-infra.md` — add migration-checklist item 15 + a "Writing a New Pytest Test" callout teaching the `tmp_path` rule (and the legacy-script fallback) so new/migrated tests don't reintroduce the leak.

## Why
`tempfile.mkdtemp()` without cleanup leaks its directory into the OS temp dir permanently; Windows never auto-prunes `%TEMP%`, so these recording folders piled up on CI/dev machines.

## Test plan
- [x] `python -m py_compile` on both edited test files.
- [x] `pytest-record-and-stream.py` — `PASSED [D455-114222251272]`; recording lands under pytest's auto-pruned temp base.
- [x] `test-record-software-device.py` — passes; with `%TEMP%` redirected to an empty sandbox, 0 leftover entries after the run.
