### PR TITLE
test-operational-mode: 1s settle after every pipe.stop (D585S restart fix)

### DIFF
--- a/unit-tests/live/d500/safety/test-operational-mode.py
+++ b/unit-tests/live/d500/safety/test-operational-mode.py
@@ -53,6 +53,7 @@ with test.closure("Pause / Resume - no impact on streaming"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
+    time.sleep(1)
 
 ########################### SRS - 3.3.1.14.c ##############################################
 
@@ -90,6 +91,7 @@ with test.closure("Resume --> Maintenance keep video streaming"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
+    time.sleep(1)
 
 ########################### SRS - 3.3.1.14.c ##############################################
 
@@ -133,6 +135,7 @@ with test.closure("Resume --> Maintenance keeps safety streaming on"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
+    time.sleep(1)
 
 ################################################################################################
 test.print_results_and_exit()

--- a/unit-tests/live/d500/safety/test-operational-mode.py
+++ b/unit-tests/live/d500/safety/test-operational-mode.py
@@ -53,7 +53,7 @@ with test.closure("Pause / Resume - no impact on streaming"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
-    time.sleep(1)
+    time.sleep(1) # allow some time for the streaming to actually stop
 
 ########################### SRS - 3.3.1.14.c ##############################################
 
@@ -91,7 +91,7 @@ with test.closure("Resume --> Maintenance keep video streaming"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
-    time.sleep(1)
+    time.sleep(1) # allow some time for the streaming to actually stop
 
 ########################### SRS - 3.3.1.14.c ##############################################
 
@@ -135,7 +135,7 @@ with test.closure("Resume --> Maintenance keeps safety streaming on"):
     verify_frames_received(pipe, count = 10)
 
     pipe.stop()
-    time.sleep(1)
+    time.sleep(1) # allow some time for the streaming to actually stop
 
 ################################################################################################
 test.print_results_and_exit()


### PR DESCRIPTION
Tracked by: RSDSO-21312

## Summary

Adds `time.sleep(1)` after each of the three `pipe.stop()` calls in `test-live-d500-safety-operational-mode` that currently have no settle window. Two `pipe.stop()` sites in the test already have a 1-second sleep; this PR brings the other three in line.

Without the settle window, the D585S safety streaming USB endpoint can return STALL on the next `pipe.start()` if `safety_mode` was changed during the previous session, causing `wait_for_frames()` to time out at 5 s. The 1-second sleep is empirically sufficient to avoid the STALL.

## Test plan
- [ ] Jenkins linux CI green on hosts where this test was failing (e.g. the Jenkins agent that produced build #12557).
- [ ] Jenkins linux CI green on hosts where it was already passing (unchanged behaviour expected).

## Notes
- No other files touched. `test-get-set-config-table.py` is unchanged.
- Underlying FW behaviour (the STALL) is being tracked separately with the FW team.
- LibCI runs using this branch succeeded on both our linux CI machines