### PR TITLE
Add MIPI RGB controls (saturation, sharpness, white balance, power line fr…

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -11,6 +11,8 @@
 #include "d400-info.h"
 #include <src/backend.h>
 #include <src/platform/platform-utils.h>
+#include <src/platform/uvc-option.h>
+#include <src/option.h>
 
 #include <src/ds/features/auto-exposure-roi-feature.h>
 
@@ -188,11 +190,35 @@ namespace librealsense
                     { 2.f, "60Hz" },
                     { 3.f, "Auto" }, }));
         }
+        else
+        {
+            // MIPI RGB controls exposed once the FW/kernel driver support them (RSDEV-5918),
+            // bringing the MIPI color sensor to parity with the USB D45x/D41x RGB controls.
+            auto raw_color_ep = get_raw_color_sensor();
+
+            color_ep.register_pu(RS2_OPTION_SATURATION);
+            color_ep.register_pu(RS2_OPTION_SHARPNESS);
+
+            auto white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_WHITE_BALANCE);
+            auto auto_white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
+            color_ep.register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, auto_white_balance_option);
+            color_ep.register_option(RS2_OPTION_WHITE_BALANCE,
+                std::make_shared<auto_disabling_control>(
+                    white_balance_option,
+                    auto_white_balance_option));
+
+            color_ep.register_option(RS2_OPTION_POWER_LINE_FREQUENCY,
+                std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_POWER_LINE_FREQUENCY,
+                    std::map<float, std::string>{ { 0.f, "Disabled"},
+                    { 1.f, "50Hz" },
+                    { 2.f, "60Hz" },
+                    { 3.f, "Auto" }, }));
+        }
 
         if (_separate_color)
         {
-            // Currently disabled for certain sensors
-            if (!_is_mipi_device)
+            // Auto exposure priority is supported on all RGB sensors except D401/GMSL
+            if (!_is_mipi_device || _pid != ds::RS401_GMSL_PID)
             {
                 color_ep.register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
             }

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -192,8 +192,9 @@ namespace librealsense
         }
         else
         {
-            // MIPI RGB controls exposed once the FW/kernel driver support them (RSDEV-5918),
-            // bringing the MIPI color sensor to parity with the USB D45x/D41x RGB controls.
+            // RGB controls registered for USB but not yet for MIPI (no FW/kernel support):
+            //   RS2_OPTION_BRIGHTNESS, RS2_OPTION_CONTRAST, RS2_OPTION_GAMMA,
+            //   RS2_OPTION_BACKLIGHT_COMPENSATION, RS2_OPTION_HUE
             auto raw_color_ep = get_raw_color_sensor();
 
             color_ep.register_pu(RS2_OPTION_SATURATION);

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -11,8 +11,6 @@
 #include "d400-info.h"
 #include <src/backend.h>
 #include <src/platform/platform-utils.h>
-#include <src/platform/uvc-option.h>
-#include <src/option.h>
 
 #include <src/ds/features/auto-exposure-roi-feature.h>
 

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -175,6 +175,12 @@ namespace librealsense
     {
         auto& color_ep = get_color_sensor();
 
+        // MIPI RGB controls require FW >= 5.17.3.15 and d4xx kernel driver >= 1.0.3.15.
+        const bool mipi_rgb_controls_supported = _is_mipi_device
+            && _fw_version >= firmware_version("5.17.3.15")
+            && supports_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)
+            && rsutils::version(get_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)) >= rsutils::version("1.0.3.15");
+
         if (!_is_mipi_device)
         {
             _ds_color_common->register_color_options();
@@ -188,7 +194,7 @@ namespace librealsense
                     { 2.f, "60Hz" },
                     { 3.f, "Auto" }, }));
         }
-        else
+        else if (mipi_rgb_controls_supported)
         {
             // RGB controls registered for USB but not yet for MIPI (no FW/kernel support):
             //   RS2_OPTION_BRIGHTNESS, RS2_OPTION_CONTRAST, RS2_OPTION_GAMMA,
@@ -217,7 +223,7 @@ namespace librealsense
         if (_separate_color)
         {
             // Auto exposure priority is supported on all RGB sensors except D401/GMSL
-            if (!_is_mipi_device || _pid != ds::RS401_GMSL_PID)
+            if (!_is_mipi_device || (mipi_rgb_controls_supported && _pid != ds::RS401_GMSL_PID))
             {
                 color_ep.register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
             }

--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -37,7 +37,6 @@ namespace librealsense
         _color_ep.register_pu(RS2_OPTION_SHARPNESS);
 
         auto white_balance_option = std::make_shared<uvc_pu_option>(_raw_color_ep, RS2_OPTION_WHITE_BALANCE);
-        _color_ep.register_option(RS2_OPTION_WHITE_BALANCE, white_balance_option);
         auto auto_white_balance_option = std::make_shared<uvc_pu_option>(_raw_color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
         _color_ep.register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, auto_white_balance_option);
         _color_ep.register_option(RS2_OPTION_WHITE_BALANCE,

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -3174,13 +3174,13 @@ namespace librealsense
                 case RS2_OPTION_HUE: return V4L2_CID_HUE;
                 case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
                 case RS2_OPTION_EMITTER_ENABLED: return V4L2_CID_EXPOSURE_AUTO;
-//            case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;
-//            case RS2_OPTION_SHARPNESS: return V4L2_CID_SHARPNESS;
-//            case RS2_OPTION_WHITE_BALANCE: return V4L2_CID_WHITE_BALANCE_TEMPERATURE;
+                case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;
+                case RS2_OPTION_SHARPNESS: return V4L2_CID_SHARPNESS;
+                case RS2_OPTION_WHITE_BALANCE: return V4L2_CID_WHITE_BALANCE_TEMPERATURE;
                 case RS2_OPTION_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; // Automatic gain/exposure control
-//            case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return V4L2_CID_AUTO_WHITE_BALANCE;
-//            case RS2_OPTION_POWER_LINE_FREQUENCY : return V4L2_CID_POWER_LINE_FREQUENCY;
-//            case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return V4L2_CID_EXPOSURE_AUTO_PRIORITY;
+                case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return V4L2_CID_AUTO_WHITE_BALANCE;
+                case RS2_OPTION_POWER_LINE_FREQUENCY : return V4L2_CID_POWER_LINE_FREQUENCY;
+                case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return V4L2_CID_EXPOSURE_AUTO_PRIORITY;
                 default: throw linux_backend_exception(rsutils::string::from() << "no v4l2 mipi mapping cid for option " << option);
             }
         }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -3171,6 +3171,7 @@ namespace librealsense
                 case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE; // Is this actually valid? I'm getting a lot of VIDIOC error 22s...
                 case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903; // v4l2-ctl --list-ctrls -d /dev/video0
                 case RS2_OPTION_GAMMA: return V4L2_CID_GAMMA;
+                // case RS2_OPTION_HUE: return V4L2_CID_HUE;
                 case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
                 case RS2_OPTION_EMITTER_ENABLED: return V4L2_CID_EXPOSURE_AUTO;
                 case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -3171,7 +3171,6 @@ namespace librealsense
                 case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE; // Is this actually valid? I'm getting a lot of VIDIOC error 22s...
                 case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903; // v4l2-ctl --list-ctrls -d /dev/video0
                 case RS2_OPTION_GAMMA: return V4L2_CID_GAMMA;
-                case RS2_OPTION_HUE: return V4L2_CID_HUE;
                 case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
                 case RS2_OPTION_EMITTER_ENABLED: return V4L2_CID_EXPOSURE_AUTO;
                 case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;


### PR DESCRIPTION
**Overview:** Exposes saturation, sharpness, white balance (with auto-WB linkage), power-line frequency, and auto-exposure-priority on the D45x MIPI color sensor - bringing it closer to the USB D45x/D41x feature set.

Tracked on [RSDEV-5919]

## Summary
- `src/ds/d400/d400-color.cpp` - in the MIPI branch of `d400_color::register_options`, register `SATURATION`, `SHARPNESS`, `WHITE_BALANCE` + `ENABLE_AUTO_WHITE_BALANCE` (wrapped via `auto_disabling_control`), and `POWER_LINE_FREQUENCY` with the standard `{Disabled, 50Hz, 60Hz, Auto}` map.
- `src/ds/d400/d400-color.cpp` - `RS2_OPTION_AUTO_EXPOSURE_PRIORITY` is now also registered on MIPI separate-color devices (still excluded for D401/GMSL); old comment "Currently disabled for certain sensors" replaced with an accurate one.
- `src/linux/backend-v4l2.cpp` - uncomment the v4l2 CID mappings for `SATURATION`, `SHARPNESS`, `WHITE_BALANCE`, `ENABLE_AUTO_WHITE_BALANCE`, `POWER_LINE_FREQUENCY`, `AUTO_EXPOSURE_PRIORITY` in `v4l_mipi_device::get_cid` so the newly-registered options can resolve.
- `src/ds/ds-color-common.cpp` - drop the redundant first `register_option(RS2_OPTION_WHITE_BALANCE, .)` call in the USB path; the subsequent `auto_disabling_control`-wrapped registration overwrites it via the same key, so the first was dead code.

Controls registered for USB but not yet wired for MIPI (no FW/kernel support today): `BRIGHTNESS`, `CONTRAST`, `GAMMA`, `BACKLIGHT_COMPENSATION`, `HUE`.

## Why
The kernel/FW for the MIPI color sensor now exposes these UVC controls, but librealsense was still ignoring them - the v4l2 CID mappings were commented out and the d400 color sensor only registered them on the non-MIPI path. As a result D45x MIPI users had no way to adjust WB, saturation, sharpness, PLF, or AE-priority from the SDK / viewer. This PR closes that gap and aligns the MIPI surface with what the hardware supports.

## Test plan
- [ ] Build on Linux with MIPI backend enabled (`-DBUILD_WITH_TM2=OFF -DFORCE_RSUSB_BACKEND=OFF`).
- [ ] On a D45x MIPI unit, open `realsense-viewer` and confirm the RGB Camera sensor exposes the five new sliders (Saturation, Sharpness, White Balance, Power Line Frequency, Auto Exposure Priority).
- [ ] Toggle Enable Auto White Balance ON ? White Balance slider becomes read-only; toggle OFF ? becomes writable (auto-disabling-control linkage works).
- [ ] Set Power Line Frequency through all four values (Disabled / 50Hz / 60Hz / Auto) and verify GET returns the SET value.
- [ ] Sanity-run an existing USB D45x to confirm the dropped USB WB registration causes no behavior change (auto-WB toggle still gates the WB slider).
- [ ] CI: all required Win/U22/U24/Mac/Android/ROS2 jobs green.