### PR TITLE
Skip image-quality 60fps tests on D436 (color stream FW bug)

### DIFF
--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -7,6 +7,7 @@ from pytest_check import check
 import numpy as np
 import cv2
 import logging
+import re
 from iq_helper import find_roi_location, get_roi_from_frame, is_color_close, save_failure_snapshot, WIDTH, HEIGHT
 
 log = logging.getLogger(__name__)
@@ -176,7 +177,10 @@ def test_basic_color(test_device, test_context_var):
     # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).
     # Restrict to <=30 fps until the FW issue is fixed.
     product_name = dev.get_info(rs.camera_info.name)
-    if "D436" in product_name:
+    if re.search(r'\bD436\b', product_name):
+        skipped = [c for c in configurations if c[1] > 30]
+        if skipped:
+            log.warning(f"D436 FW color-stream bug: skipping color configs fps>30: {skipped}")
         configurations = [c for c in configurations if c[1] <= 30]
 
     for resolution, fps in configurations:

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -172,5 +172,12 @@ def test_basic_color(test_device, test_context_var):
             ((1280,720), 15),
         ]
 
+    # D436 color stream returns near-black frames at >30 fps with Auto-Exposure ON
+    # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).
+    # Restrict to <=30 fps until the FW issue is fixed.
+    product_name = dev.get_info(rs.camera_info.name)
+    if "D436" in product_name:
+        configurations = [c for c in configurations if c[1] <= 30]
+
     for resolution, fps in configurations:
         run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-texture-mapping.py
+++ b/unit-tests/live/image-quality/pytest-texture-mapping.py
@@ -263,6 +263,13 @@ def test_texture_mapping(test_device, test_context_var):
             ((1280, 720), 15),
         ]
 
+    # D436 color stream returns near-black frames at >30 fps with Auto-Exposure ON
+    # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).
+    # Restrict to <=30 fps until the FW issue is fixed.
+    product_name = dev.get_info(rs.camera_info.name)
+    if "D436" in product_name:
+        configurations = [c for c in configurations if c[1] <= 30]
+
     for (depth_resolution, depth_fps) in configurations:
         for (color_resolution, color_fps) in configurations:
             if "weekly" not in test_context_var:

--- a/unit-tests/live/image-quality/pytest-texture-mapping.py
+++ b/unit-tests/live/image-quality/pytest-texture-mapping.py
@@ -14,6 +14,7 @@ from pytest_check import check
 import numpy as np
 import cv2
 import logging
+import re
 from iq_helper import (find_roi_location, get_roi_from_frame, is_color_close,
                        get_median_depth_from_region, sample_bg_depth,
                        get_median_color_from_region, sample_bg_color,
@@ -265,13 +266,18 @@ def test_texture_mapping(test_device, test_context_var):
 
     # D436 color stream returns near-black frames at >30 fps with Auto-Exposure ON
     # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).
-    # Restrict to <=30 fps until the FW issue is fixed.
+    # The FW issue is on the color stream only -- filter just the color dimension
+    # so the depth-only combinations are still exercised in weekly.
     product_name = dev.get_info(rs.camera_info.name)
-    if "D436" in product_name:
-        configurations = [c for c in configurations if c[1] <= 30]
+    color_configurations = configurations
+    if re.search(r'\bD436\b', product_name):
+        skipped = [c for c in configurations if c[1] > 30]
+        if skipped:
+            log.warning(f"D436 FW color-stream bug: skipping color configs fps>30: {skipped}")
+        color_configurations = [c for c in configurations if c[1] <= 30]
 
     for (depth_resolution, depth_fps) in configurations:
-        for (color_resolution, color_fps) in configurations:
+        for (color_resolution, color_fps) in color_configurations:
             if "weekly" not in test_context_var:
                 # in nightly we test only matching resolutions and fps
                 if depth_resolution != color_resolution or depth_fps != color_fps:


### PR DESCRIPTION
**Overview:** Skip the `image-quality-texture-mapping` and `image-quality-basic-color` nightly/weekly configurations at fps > 30 on D436, where the color stream returns near-black frames due to a firmware bug.

Tracked on [RSDSO-21605]

## Summary
- In `pytest-texture-mapping.py` and `pytest-basic-color.py`, filter the `configurations` list to keep only fps <= 30 when the device name contains "D436".
- All other devices and all <=30 fps D436 configurations are unaffected.

## Why
D436 color streaming at fps > 30 (640x480@60, 848x480@60) returns near-black frames when Auto-Exposure is ON. Reproduced on FW 5.17.3.10 and 5.17.3.21, in both the librealsense pytest IQ suite (Jenkins LRS_libci_pipeline #16559 / #16560) and in realsense-viewer. The CI tests fail because:
- On FW 5.17.3.10 the ArUco detection on the lab page returns "Page not found" (near-black color frame -> no markers).
- On FW 5.17.3.21 the color frames pass ArUco detection but the depth-difference validation collapses (0/100 frames) because the color frames are still too dark to align reliably.

This is a FW issue tracked on RSDSO-21605 - the test gating keeps CI green until the FW fix lands. Once the FW issue is closed, revert the D436 filter in both files.

## Test plan
- [ ] Run pytest on a D436 unit: confirm the 60fps configs are skipped and the <=30fps configs still execute.
- [ ] Run pytest on a non-D436 D400 unit (e.g. D455): confirm all configurations still execute as before.
- [ ] Verify Jenkins LRS_libci_pipeline run on the branch completes without the D436 IQ failures.