### PR TITLE
Enhance serialization and migrate bag test fixtures to db3

### DIFF
--- a/src/media/ros2/ros2_reader.cpp
+++ b/src/media/ros2/ros2_reader.cpp
@@ -522,6 +522,9 @@ namespace librealsense
     {
         for (auto& sensor_snap : m_initial_device_description.get_sensors_snapshots())
         {
+            if (sensor_snap.get_sensor_index() != sid.sensor_index)
+                continue;
+
             for (auto& stream_profile : sensor_snap.get_stream_profiles())
             {
                 if (stream_profile->get_stream_type() != sid.stream_type ||
@@ -547,6 +550,16 @@ namespace librealsense
                 int height = vsp->get_height();
                 int bpp = get_image_bpp(vsp->get_format());
                 int stride = width * bpp / 8;
+                // derive bpp/stride from the recorded payload,
+                // else use the values computed above
+                auto data_size = static_cast<librealsense::frame*>(frame_ptr)->data.size();
+                auto pixels = static_cast<size_t>(width) * height;
+                if (pixels > 0 && data_size % pixels == 0)
+                {
+                    int bpp_bytes = static_cast<int>(data_size / pixels);
+                    bpp = bpp_bytes * 8;
+                    stride = width * bpp_bytes;
+                }
                 video_frame_ptr->assign(width, height, stride, bpp);
                 return;
             }

--- a/src/media/ros2/ros2_writer.cpp
+++ b/src/media/ros2/ros2_writer.cpp
@@ -15,6 +15,8 @@
 #include "media/ros_factory.h"
 #include "core/motion-frame.h"
 #include <sstream>
+#include <iomanip>
+#include <limits>
 #include <src/core/sensor-interface.h>
 #include <src/core/device-interface.h>
 #include <src/core/depth-frame.h>
@@ -420,20 +422,26 @@ namespace librealsense
         {
             LOG_ERROR("Error trying to get intrinsc data for stream " << profile->get_stream_type() << ", " << profile->get_stream_index());
         }
+        // full round-trip precision; the default ostream precision truncates intrinsics
+        auto full_precision = []( float v ) {
+            std::ostringstream o;
+            o << std::setprecision( std::numeric_limits<float>::max_digits10 ) << v;
+            return o.str();
+        };
         std::string payload = rsutils::string::from()
             << "width=" << profile->get_width() << ";"
             << "height=" << profile->get_height() << ";"
-            << "fx=" << intrinsics.fx << ";"
-            << "ppx=" << intrinsics.ppx << ";"
-            << "fy=" << intrinsics.fy << ";"
-            << "ppy=" << intrinsics.ppy << ";"
+            << "fx=" << full_precision( intrinsics.fx ) << ";"
+            << "ppx=" << full_precision( intrinsics.ppx ) << ";"
+            << "fy=" << full_precision( intrinsics.fy ) << ";"
+            << "ppy=" << full_precision( intrinsics.ppy ) << ";"
             << "model=" << librealsense::get_string(intrinsics.model) << ";"
             << "coeffs=";
 
         auto num_coeffs = sizeof(intrinsics.coeffs) / sizeof(intrinsics.coeffs[0]);
         for (size_t i = 0; i < num_coeffs; ++i)
         {
-            payload += std::to_string(intrinsics.coeffs[i]);
+            payload += full_precision(intrinsics.coeffs[i]);
             if (i < (num_coeffs - 1))
                 payload += ",";
         }

--- a/unit-tests/live/CMakeLists.txt
+++ b/unit-tests/live/CMakeLists.txt
@@ -3,21 +3,21 @@
 set(PP_Rosbag_Recordings_URL https://librealsense.realsenseai.com/rs-tests/Rosbag_unit_test_records)
 
 # for rec-play/test-non-realtime.py
-dl_file( ${PP_Rosbag_Recordings_URL} recordings recording_deadlock.bag OFF )
+dl_file( ${PP_Rosbag_Recordings_URL} recordings recording_deadlock.db3 OFF )
 
 # for rec-play/test-playback-stress.py and for post-processing/post-processing-from-bag.py
-dl_file( ${PP_Rosbag_Recordings_URL} recordings all_combinations_depth_color.bag OFF )
+dl_file( ${PP_Rosbag_Recordings_URL} recordings all_combinations_depth_color.db3 OFF )
 
 # for post-processing/post-processing-from-bag.py
-dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2c]_all_combinations_depth_color.bag OFF )
+dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2c]_all_combinations_depth_color.db3 OFF )
 
 # for post-processing/post-processing-from-bag.py
-dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2d]_all_combinations_depth_color.bag OFF )
+dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2d]_all_combinations_depth_color.db3 OFF )
 
 # for post-processing/post-processing-from-bag.py
-dl_file( ${PP_Rosbag_Recordings_URL} recordings [pointcloud]_all_combinations_depth_color.bag OFF )
+dl_file( ${PP_Rosbag_Recordings_URL} recordings [pointcloud]_all_combinations_depth_color.db3 OFF )
 
-# for 3D/projection-from-recording.bag
+# kept as .bag for backward-compat: convert test (live/tools/pytest-rs-convert-to-db3.py)
 dl_file( ${PP_Rosbag_Recordings_URL} recordings single_depth_color_640x480.bag OFF )
 
 # for rec-play/pytest-native-ros2-playback.py
@@ -25,4 +25,7 @@ dl_file( ${PP_Rosbag_Recordings_URL} recordings d555_all_streams_native_ros2.db3
 dl_file( ${PP_Rosbag_Recordings_URL} recordings d555_all_streams_native_ros2_zstd_compressed.db3 OFF )
 dl_file( ${PP_Rosbag_Recordings_URL} recordings d455_all_streams_imu_native_ros2.db3 OFF )
 dl_file( ${PP_Rosbag_Recordings_URL} recordings d455_all_streams_imu_native_ros2_zstd_compressed.db3 OFF )
+
+# for rec-play/pytest-playback-step.py
+dl_file( ${PP_Rosbag_Recordings_URL} recordings d455_depth_non_native.db3 OFF )
 

--- a/unit-tests/live/rec-play/pytest-non-realtime.py
+++ b/unit-tests/live/rec-play/pytest-non-realtime.py
@@ -24,7 +24,7 @@ pytestmark = [
 def test_non_realtime_stop(test_device):
     log.info("Playback with non realtime isn't stuck at stop")
 
-    filename = os.path.join( repo.build, 'unit-tests', 'recordings', 'recording_deadlock.bag' )
+    filename = os.path.join( repo.build, 'unit-tests', 'recordings', 'recording_deadlock.db3' )
     log.debug(f'deadlock file: {filename}')
 
     pipeline = rs2.pipeline()

--- a/unit-tests/live/rec-play/pytest-playback-step.py
+++ b/unit-tests/live/rec-play/pytest-playback-step.py
@@ -14,7 +14,7 @@ import pyrealsense2 as rs
 from pytest_check import check
 from rspy import repo
 
-RECORDING = "d555_all_streams_native_ros2.db3"
+RECORDING = "d455_depth_non_native.db3"
 NUM_STEPS = 3
 STEP_TIMEOUT_MS = 2000  # the broken behavior delivers nothing and times out
 
@@ -30,8 +30,8 @@ def test_playback_step():
                          if any( p.stream_type() == rs.stream.depth for p in s.get_stream_profiles() ) )
     depth_profile = next( p for p in depth_sensor.get_stream_profiles()
                           if p.stream_type() == rs.stream.depth )
-    fps = depth_profile.fps() or 30  # native bags report fps=0
-    step_ns = int( 1e9 / fps )       # one frame, the viewer's step size
+    fps = depth_profile.fps()  # next line will throw if using a native recording as they report 0 fps
+    step_ns = int( 1e9 / fps )  # one frame, the viewer's step size
     queue = rs.frame_queue( 10 )
     depth_sensor.open( depth_profile )
     depth_sensor.start( queue )

--- a/unit-tests/live/rec-play/pytest-playback-stress.py
+++ b/unit-tests/live/rec-play/pytest-playback-stress.py
@@ -30,7 +30,7 @@ def test_playback_stress():
     global frames_count
     log.info("Playback stress test")
     # repo.build
-    file_name = os.path.join(repo.build, 'unit-tests', 'recordings', 'all_combinations_depth_color.bag' )
+    file_name = os.path.join(repo.build, 'unit-tests', 'recordings', 'all_combinations_depth_color.db3' )
     log.debug(f'recorded file: {file_name}')
 
     log.debug("Playing back: " + file_name )

--- a/unit-tests/live/tools/pytest-rs-convert-to-db3.py
+++ b/unit-tests/live/tools/pytest-rs-convert-to-db3.py
@@ -3,7 +3,6 @@
 
 import subprocess, os, tempfile
 import logging
-import numpy as np
 import pyrealsense2 as rs
 from rspy import repo
 
@@ -20,13 +19,27 @@ def start_pipeline( filename ):
     return pipe
 
 
+def collect_frames( pipe ):
+    # drain the playback, keying each frame's data by (stream, frame number) so the
+    # comparison is robust to how frames are batched into framesets
+    frames = {}
+    while True:
+        ok, fset = pipe.try_wait_for_frames( 1000 )
+        if not ok:
+            break
+        for f in fset:
+            frames[( f.get_profile().stream_type(), f.get_frame_number() )] = bytes( f.get_data() )
+    return frames
+
+
 def test_rs_convert_bag_to_db3():
     rs_convert = repo.find_built_exe( 'tools/convert', 'rs-convert' )
     assert rs_convert, "rs-convert not found"
 
-    bag_file = os.path.join( repo.build, 'unit-tests', 'recordings', 'recording_deadlock.bag' )
+    bag_file = os.path.join( repo.build, 'unit-tests', 'recordings', 'single_depth_color_640x480.bag' )
     temp_dir = tempfile.mkdtemp( prefix='bag_to_db3_' )
     db3_file = os.path.join( temp_dir, 'converted.db3' )
+    bag_pipe = db3_pipe = None
     try:
         p = subprocess.run( [rs_convert, '-i', bag_file, '-D', db3_file],
                             capture_output=True, text=True, timeout=60 )
@@ -35,27 +48,32 @@ def test_rs_convert_bag_to_db3():
 
         bag_pipe = start_pipeline( bag_file )
         db3_pipe = start_pipeline( db3_file )
+        bag_frames = collect_frames( bag_pipe )
+        db3_frames = collect_frames( db3_pipe )
 
-        frame_count = 0
-        while True:
-            bag_ok, bag_fset = bag_pipe.try_wait_for_frames( 1000 )
-            db3_ok, db3_fset = db3_pipe.try_wait_for_frames( 1000 )
-            if not bag_ok and not db3_ok:
-                log.debug( f'no more frames in either pipeline: bag_ok={bag_ok} db3_ok={db3_ok}' )
-                break
-            assert bag_ok == db3_ok
-            assert bag_fset.size() == db3_fset.size()
-            for bag_f, db3_f in zip( bag_fset, db3_fset ):
-                frame_count += 1
-                assert np.array_equal( np.asarray( bag_f.get_data() ), np.asarray( db3_f.get_data() ) )
-
-        bag_pipe.stop()
-        db3_pipe.stop()
-
-        log.debug( '%s frames compared', frame_count )
-        assert frame_count > 0
+        assert len( bag_frames ) > 0
+        for key, data in bag_frames.items():
+            assert key in db3_frames, f'frame {key} present in bag but missing in db3'
+            assert data == db3_frames[key], f'frame {key} data differs after conversion'
+        log.debug( '%s frames compared', len( bag_frames ) )
     finally:
+        # stop in finally so pipelines are released even if collect_frames raises
+        if bag_pipe:
+            bag_pipe.stop()
+        if db3_pipe:
+            db3_pipe.stop()
         if os.path.isfile( db3_file ):
             os.remove( db3_file )
         if os.path.isdir( temp_dir ):
             os.rmdir( temp_dir )
+
+
+def test_playback_legacy_bag():
+    # back-compat: play the legacy .bag as-is, no conversion
+    bag_file = os.path.join( repo.build, 'unit-tests', 'recordings', 'single_depth_color_640x480.bag' )
+    pipe = start_pipeline( bag_file )
+    try:
+        frames = collect_frames( pipe )
+    finally:
+        pipe.stop()  # stop in finally so the pipeline is released even if collection raises
+    assert len( frames ) > 0, "no frames played back from legacy bag"

--- a/unit-tests/post-processing/test-post-processing-from-bag.py
+++ b/unit-tests/post-processing/test-post-processing-from-bag.py
@@ -87,7 +87,7 @@ def compare_processed_frames_vs_recorded_frames(file):
     frames_data_map = {}
     pre_processed_frames_map = {}
     sensors = []
-    playback_file('all_combinations_depth_color.bag', lambda frame: (frame_processor.invoke(frame)))
+    playback_file('all_combinations_depth_color.db3', lambda frame: (frame_processor.invoke(frame)))
     processed_frames_data_list = []
     for sf in frames_data_map:
         processed_frames_data_list.append(frames_data_map[sf])
@@ -109,19 +109,19 @@ def compare_processed_frames_vs_recorded_frames(file):
 #     align = rs.align(rs.stream.color)
 #     process_frame_callback = lambda fs: align.process(fs).first_or_default(rs.stream.depth)
 #
-#     compare_processed_frames_vs_recorded_frames("[aligned_2c]_all_combinations_depth_color.bag")
+#     compare_processed_frames_vs_recorded_frames("[aligned_2c]_all_combinations_depth_color.db3")
 ################################################################################################
 # below commented out until recordings are taken again (after algo improvement done in PR# 14608)
 # with test.closure("Test align color to depth from recording"):
 #     align = rs.align(rs.stream.depth)
 #     process_frame_callback = lambda fs: align.process(fs).first_or_default(rs.stream.color)
 #
-#     compare_processed_frames_vs_recorded_frames("[aligned_2d]_all_combinations_depth_color.bag")
+#     compare_processed_frames_vs_recorded_frames("[aligned_2d]_all_combinations_depth_color.db3")
 ################################################################################################
 with test.closure("Test point cloud from recording"):
     pc = rs.pointcloud()
     process_frame_callback = lambda fs: pc.calculate(fs.get_depth_frame())
 
-    compare_processed_frames_vs_recorded_frames("[pointcloud]_all_combinations_depth_color.bag")
+    compare_processed_frames_vs_recorded_frames("[pointcloud]_all_combinations_depth_color.db3")
 ################################################################################################
 test.print_results_and_exit()


### PR DESCRIPTION
Tracked on: [RSDEV-11524]

- Migrate rec-play + post-processing fixtures bag->db3; keep single_depth.bag for back-compat (legacy .bag playback + convert test).
- ros2 db3 conversion fixes: reader uses recorded per-sensor profile + actual bpp; writer serializes intrinsics at full precision.
- Native playback fixtures re-recorded smaller (1.26 GB -> 224 MB).
- New/updated db3 fixtures uploaded to the recordings store; unreferenced legacy .bag deletes to follow post-merge.