### PR TITLE
Skip close-range embedded-filters metadata test pending FW fix

### DIFF
--- a/unit-tests/live/d500/test-dds-close-range.py
+++ b/unit-tests/live/d500/test-dds-close-range.py
@@ -137,16 +137,25 @@ if test_close_range_filter:
         close_range_filter.set_option(rs.option.embedded_filter_enabled, 0.0)
         test.check_equal(close_range_filter.get_option(rs.option.embedded_filter_enabled), 0.0)
 
-    with test.closure("Improved Close Range Depth embedded filter metadata member"):
-        disable_close_range_filter()
-        close_range_enabled = False
-        stream_and_check_close_range_filter()
-        time.sleep(1)
-        enable_close_range_filter()
-        close_range_enabled = True
-        stream_and_check_close_range_filter()
-        time.sleep(1)
-        disable_close_range_filter()
+    # Skipped due to known FW issue: the close-range bit (1 << 5) of the embedded_filters
+    # metadata is not set on depth frames even when the filter is enabled. Re-enable once
+    # the FW fix is available.
+    SKIP_METADATA_BIT_TEST_FW_ISSUE = True
+
+    if not SKIP_METADATA_BIT_TEST_FW_ISSUE:
+        with test.closure("Improved Close Range Depth embedded filter metadata member"):
+            disable_close_range_filter()
+            close_range_enabled = False
+            stream_and_check_close_range_filter()
+            time.sleep(1)
+            enable_close_range_filter()
+            close_range_enabled = True
+            stream_and_check_close_range_filter()
+            time.sleep(1)
+            disable_close_range_filter()
+    else:
+        log.w("Skipping 'Improved Close Range Depth embedded filter metadata member' "
+              "- known FW issue (metadata bit not set)")
 else:
     print("Improved Close Range Depth Embedded Filter not tested")
 

--- a/unit-tests/live/d500/test-dds-close-range.py
+++ b/unit-tests/live/d500/test-dds-close-range.py
@@ -137,9 +137,9 @@ if test_close_range_filter:
         close_range_filter.set_option(rs.option.embedded_filter_enabled, 0.0)
         test.check_equal(close_range_filter.get_option(rs.option.embedded_filter_enabled), 0.0)
 
-    # Skipped due to known FW issue: the close-range bit (1 << 5) of the embedded_filters
-    # metadata is not set on depth frames even when the filter is enabled. Re-enable once
-    # the FW fix is available.
+    # Skipped due to known FW issue [RSDEV-12008]: the close-range bit (1 << 5) of the
+    # embedded_filters metadata is not set on depth frames even when the filter is enabled.
+    # Re-enable once the FW fix is available.
     SKIP_METADATA_BIT_TEST_FW_ISSUE = True
 
     if not SKIP_METADATA_BIT_TEST_FW_ISSUE:


### PR DESCRIPTION
**Overview:** Skip the failing *Improved Close Range Depth embedded filter metadata member* closure in `test-live-d500-dds-close-range` until the FW fix is available. The other four closures in the file still run.

Tracked on [RSDEV-12008]

## Summary
- Gate the metadata-bit closure in `unit-tests/live/d500/test-dds-close-range.py` behind a `SKIP_METADATA_BIT_TEST_FW_ISSUE` flag (currently `True`).
- Emit a `log.w(...)` notice so the skip is visible in test output.
- Reference RSDEV-12008 in the in-source comment so the FW bug is discoverable from the code.
- Flip the flag back to `False` once the FW fix lands.

## Why
The closure asserts that bit 5 (`1 << 5`) of the `embedded_filters` metadata is set on depth frames while the Improved Close Range Depth filter is enabled. The FW currently does not set that bit, so the assertion fails: `(md_val & CLOSE_RANGE_METADATA_BIT)` returns `0` instead of the expected `32`, repeating across 8 frame callbacks. Tracked as RSDEV-12008.

Jenkins failure: rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/13482/artifact/x86_64/static/Release/unit-tests/test-live-d500-dds-close-range.log

## Test plan
- [ ] CI run on `LRS_linux_compile_lib_ci` shows `test-live-d500-dds-close-range` passing with the closure skipped (warning visible in the log).
- [ ] Confirm the remaining four closures (option discovery, defaults, set/get, invalid-ratio rejection) still execute and pass.