### PR TITLE
Skip multi-device streaming PHASE 2 (with color) pending HW investigation

### DIFF
--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -346,6 +346,7 @@ def test_multi_stream_operation(test_devices, request):
             pytest.fail(f"At least 2 non-color streams needed for phase 1, but found {len(no_color_configs)}")
 
         run_phase("PHASE 1 (no color)", device_list, no_color_configs)
+        #run_phase("PHASE 2 (with color)", device_list, all_stream_configs)
         log.warning("PHASE 2 (with color) skipped until the hardware issue is understood and solved")
     finally:
         rs.reset_logger()

--- a/unit-tests/live/multi_devices/pytest-devices-streaming.py
+++ b/unit-tests/live/multi_devices/pytest-devices-streaming.py
@@ -346,6 +346,6 @@ def test_multi_stream_operation(test_devices, request):
             pytest.fail(f"At least 2 non-color streams needed for phase 1, but found {len(no_color_configs)}")
 
         run_phase("PHASE 1 (no color)", device_list, no_color_configs)
-        run_phase("PHASE 2 (with color)", device_list, all_stream_configs)
+        log.warning("PHASE 2 (with color) skipped until the hardware issue is understood and solved")
     finally:
         rs.reset_logger()


### PR DESCRIPTION
Tracked by: RSDSO-21360

**Overview:** Skip the *PHASE 2 (with color)* run in `test_multi_stream_operation` until the hardware issue contributing to color-stream frame drops is understood and solved. PHASE 1 (depth + IR, no color) still runs.

## Summary
- In `unit-tests/live/multi_devices/pytest-devices-streaming.py`, replace the second `run_phase(...)` call with a `log.warning(...)` notice so the skip is visible in test output.
- Restore the `run_phase("PHASE 2 (with color)", ...)` call once the HW issue is resolved.

## Why
PHASE 2 streams depth + IR + color simultaneously across two D400 devices. While the HW behavior under that combination is being investigated, the color phase produces unreliable frame-drop results and is not useful as a regression gate. Keeping PHASE 1 active preserves depth + IR coverage on multi-device streaming so the rest of the signal is not lost.

## Test plan
- [ ] Run the test on a 2x D400 setup: confirm PHASE 1 still executes and asserts as before, and that PHASE 2 is skipped with the warning visible in the log.
- [ ] Confirm no other tests in `unit-tests/live/multi_devices/` are affected.