### PR TITLE
Cherry Pick PR #15194: Replace PR #15177 with PR #15175 to fix OD viewer toggle stall

### DIFF
--- a/src/core/matcher-factory.cpp
+++ b/src/core/matcher-factory.cpp
@@ -39,22 +39,43 @@ std::shared_ptr< matcher > matcher_factory::create( rs2_matchers matcher,
 
 std::shared_ptr< matcher > matcher_factory::create_DLR_C_matcher( std::vector< stream_interface * > const & profiles )
 {
-    auto color = get_color_profiles( profiles );
+    auto infer = get_inference_profiles( profiles );
+
+    std::vector< stream_interface * > synchronized_profiles;
+    synchronized_profiles.reserve( profiles.size() );
+    for( auto & profile : profiles )
+    {
+        if( profile->get_stream_type() != RS2_STREAM_OBJECT_DETECTION )
+            synchronized_profiles.push_back( profile );
+    }
+
+    auto color = get_color_profiles( synchronized_profiles );
     if( color.empty() )
     {
         LOG_DEBUG( "Created default matcher" );
-        return create_timestamp_matcher( profiles );
+        auto sync_matcher = create_timestamp_matcher( synchronized_profiles );
+        if( infer.empty() )
+            return sync_matcher;
+
+        std::vector< std::shared_ptr< matcher > > matchers;
+        if( ! synchronized_profiles.empty() )
+            matchers.push_back( sync_matcher );
+        for( auto & profile : infer )
+            matchers.push_back( create_identity_matcher( profile ) );
+
+        return std::make_shared< composite_identity_matcher >( matchers );
     }
 
-    auto infer = get_inference_profiles( profiles );
-    if( ! infer.empty() )
-    {
-        return create_timestamp_composite_matcher( { create_DLR_matcher( profiles ),
-                                                     create_color_composite_matcher( color ),
-                                                     create_identity_matcher( infer ) } );
-    }
+    auto sync_matcher = create_timestamp_composite_matcher(
+        { create_DLR_matcher( synchronized_profiles ), create_color_composite_matcher( color ) } );
+    if( infer.empty() )
+        return sync_matcher;
 
-    return create_timestamp_composite_matcher( { create_DLR_matcher( profiles ), create_color_composite_matcher( color ) } );
+    std::vector< std::shared_ptr< matcher > > matchers = { sync_matcher };
+    for( auto & profile : infer )
+        matchers.push_back( create_identity_matcher( profile ) );
+
+    return std::make_shared< composite_identity_matcher >( matchers );
 }
 
 
@@ -104,11 +125,11 @@ std::shared_ptr< matcher > matcher_factory::create_DIC_matcher( std::vector< str
 {
     std::vector< std::shared_ptr< matcher > > matchers;
     if( auto depth = find_profile( RS2_STREAM_DEPTH, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( { depth } ) );
+        matchers.push_back( create_identity_matcher( depth ) );
     if( auto ir = find_profile( RS2_STREAM_INFRARED, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( { ir } ) );
+        matchers.push_back( create_identity_matcher( ir ) );
     if( auto confidence = find_profile( RS2_STREAM_CONFIDENCE, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( { confidence } ) );
+        matchers.push_back( create_identity_matcher( confidence ) );
 
     if( matchers.empty() )
     {
@@ -154,14 +175,9 @@ matcher_factory::create_timestamp_matcher( std::vector< stream_interface * > con
 }
 
 
-std::shared_ptr< matcher >
-matcher_factory::create_identity_matcher( std::vector< stream_interface * > const & profiles )
+std::shared_ptr< matcher > matcher_factory::create_identity_matcher( stream_interface * profile )
 {
-    std::vector< std::shared_ptr< matcher > > matchers;
-    for( auto & p : profiles )
-        matchers.push_back( std::make_shared< identity_matcher >( p->get_unique_id(), p->get_stream_type() ) );
-
-    return std::make_shared< composite_identity_matcher >( matchers );
+    return std::make_shared< identity_matcher >( profile->get_unique_id(), profile->get_stream_type() );
 }
 
 std::shared_ptr< matcher >

--- a/src/core/matcher-factory.h
+++ b/src/core/matcher-factory.h
@@ -30,7 +30,7 @@ private:
     static std::shared_ptr< matcher > create_DIC_matcher( std::vector< stream_interface * > const & profiles );
     static std::shared_ptr< matcher > create_DIC_C_matcher( std::vector< stream_interface * > const & profiles );
 
-    static std::shared_ptr< matcher > create_identity_matcher( std::vector< stream_interface * > const & profiles );
+    static std::shared_ptr< matcher > create_identity_matcher( stream_interface * profiles );
     static std::shared_ptr< matcher > create_frame_number_matcher( std::vector< stream_interface * > const & profiles );
     static std::shared_ptr< matcher > create_timestamp_matcher( std::vector< stream_interface * > const & profiles );
 


### PR DESCRIPTION
**TL;DR:** Cherry-pick of PR #15194 (merged to `development` as `ae763eae7`) onto `r/2.58.2`. Reverts the existing PR #15177 cherry-pick (`b05b08204`) and applies PR #15175 instead.

Tracked on [RSDEV-11961]

## Summary
- Cherry-pick `6cad0a2f6` — revert of "Fix matcher for inference" (undoes PR #15177's content on `r/2.58.2`).
- Cherry-pick `35048b5f0` — re-apply Hu Gang's PR #15175 patch on `src/core/matcher-factory.cpp` (`create_DLR_C_matcher`): outer wrapper becomes `composite_identity_matcher`, with an inner `timestamp_composite_matcher` syncing only Color and Depth/IR; OD becomes a structural sibling.

## Why
The PR #15177 cherry-pick currently on `r/2.58.2` (RC4 build #10626 = `c7943690e`) fixed the inner OD timestamp queue but left the outer `timestamp_composite_matcher` with OD as a sync member. Reproduction on RC4 still shows the viewer-goes-dark symptom after many rapid OD toggles. PR #15175's reshape removes the outer stall surface entirely.

See PR #15194 for the full discussion and tree-shape comparison.

## Test plan
- [ ] Build with `-DBUILD_GRAPHICAL_EXAMPLES=ON`; run `realsense-viewer` against a D555 over DDS.
- [ ] Rapidly toggle Object Detection on/off (≥ ~100 cycles) and confirm Depth + Color streams keep flowing.
- [ ] Repeat with `RS2_LOG_LEVEL=DEBUG`; confirm absence of `missing (TS: ...)` / `publish(...) failed` lines from the matcher under OD toggling.
- [ ] Existing unit tests on `src/core/matcher-factory.cpp`-touched matcher selection paths still pass.