### PR TITLE
Add apt repo note and install link to enhanced-depth README

### DIFF
--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -60,8 +60,7 @@ Everything installs to `/opt/librealsense2-enhanced-depth/`. No venv needed — 
 The deb depends on `librealsense2` (≥ matching version) — install both from the
 same Artifactory / apt source so the SONAMEs line up.
 
-> Note: The Debian package will be uploaded to the RealSense Debian apt repository soon.
-> Details about how to get the package will be shared soon.
+> Stay tuned: Details about how to get the package will be shared soon.
 
 ---
 

--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -60,6 +60,10 @@ Everything installs to `/opt/librealsense2-enhanced-depth/`. No venv needed — 
 The deb depends on `librealsense2` (≥ matching version) — install both from the
 same Artifactory / apt source so the SONAMEs line up.
 
+The Debian package will be uploaded to the RealSense Debian apt repository soon.
+See [Installing the packages](../../doc/distribution_linux.md#installing-the-packages)
+for instructions on how to install our Debians.
+
 ---
 
 ## RealSense Viewer: Improved Close Range Depth Post-Processing Filter

--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -61,8 +61,7 @@ The deb depends on `librealsense2` (≥ matching version) — install both from 
 same Artifactory / apt source so the SONAMEs line up.
 
 > Note: The Debian package will be uploaded to the RealSense Debian apt repository soon.
-See [Installing the packages](../../doc/distribution_linux.md#installing-the-packages)
-for instructions on how to install our Debians.
+> Details about how to get the package will be shared soon.
 
 ---
 

--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -60,7 +60,7 @@ Everything installs to `/opt/librealsense2-enhanced-depth/`. No venv needed — 
 The deb depends on `librealsense2` (≥ matching version) — install both from the
 same Artifactory / apt source so the SONAMEs line up.
 
-The Debian package will be uploaded to the RealSense Debian apt repository soon.
+> Note: The Debian package will be uploaded to the RealSense Debian apt repository soon.
 See [Installing the packages](../../doc/distribution_linux.md#installing-the-packages)
 for instructions on how to install our Debians.
 


### PR DESCRIPTION
**Overview:** Adds a note to the enhanced-depth example README that the Debian package will be uploaded to the RealSense apt repository soon, with details on how to get the package coming soon.

## Summary
- Added a short `> Note:` callout in the Installation section of `examples/enhanced-depth-range/README.md` stating the deb will be uploaded to the RealSense Debian apt repo soon and that details on how to get the package will be shared soon.

## Why
Users currently have no in-README pointer about availability of the Debian package.

## Test plan
- [ ] Docs-only change; verify the note renders correctly on GitHub.
