### PR TITLE
pytest-pipeline-start-stop: 1s settle after pipe.stop (D585S restart fix)

### DIFF
--- a/unit-tests/live/frames/pytest-pipeline-start-stop.py
+++ b/unit-tests/live/frames/pytest-pipeline-start-stop.py
@@ -8,6 +8,8 @@ and verifies frames arrive each time.
 On D455 and other units with IMU it takes ~4 seconds per iteration.
 """
 
+import time
+
 import pytest
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
@@ -43,6 +45,7 @@ def test_pipeline_start_stop(test_device):
         delay = start_call_stopwatch.get_elapsed()
         log.info(f"After {delay:.3f} [sec] got first frame of {f}")
         pipe.stop()
+        time.sleep(1) # allow some time for the streaming to actually stop
 
         iteration_time = iteration_stopwatch.get_elapsed()
         log.info(f"Iteration took {iteration_time:.3f} [sec]")


### PR DESCRIPTION
Tracked by: RSDSO-21312

## Summary

Adds `time.sleep(1)` after `pipe.stop()` in `pytest-pipeline-start-stop`, matching the workaround applied in #15163 for `test-operational-mode`.

Without the settle window, the D585S safety streaming USB endpoint can return STALL on the next `pipe.start()`, causing `wait_for_frames()` to time out at 5 s on the following iteration. The 1-second sleep is empirically sufficient to avoid the STALL.

Observed failure (Jenkins): iteration #2 ends with `pipe.stop()` at `15:51:47.256`; iteration #3 calls `pipe.start()` immediately and `wait_for_frames()` raises `RuntimeError: Frame didn't arrive within 5000` at `15:51:52.308`. Reproduced on the same device after a recycle. Same D585S STALL signature as #15163.

## Test plan
- [ ] Jenkins linux CI green on hosts where this test was failing on D585S.
- [ ] Jenkins linux CI green on other devices (D400*, D500* non-D585S) — adds 3s per run, no other behaviour change expected.

## Notes
- Underlying FW behaviour (the STALL) is being tracked separately with the FW team.
- Consistent with #15163: unconditional sleep, no device-specific gating.

After several tests, it indeed solves the failure of pytest-live-frames-pipeline-start-stop.