### PR TITLE
Cherry-pick #15197 to r/2.58.2: enhanced-depth README apt note

### DIFF
--- a/examples/enhanced-depth-range/README.md
+++ b/examples/enhanced-depth-range/README.md
@@ -59,6 +59,8 @@ Everything installs to `/opt/librealsense2-enhanced-depth/`. No venv needed — 
 The deb depends on `librealsense2` (≥ matching version) — install both from the
 same Artifactory / apt source so the SONAMEs line up.
 
+> Stay tuned: Details about how to get the package will be shared soon.
+
 ---
 
 ## RealSense Viewer: Improved Close Range Depth Post-Processing Filter


### PR DESCRIPTION
**Overview:** Cherry-picks the enhanced-depth example README "stay tuned" apt-availability note (PR #15197) onto the `r/2.58.2` release branch.

Cherry-pick of #15197 (merged to `development`).

## Summary
- Adds a `> Stay tuned:` note in the Installation section of `examples/enhanced-depth-range/README.md` indicating that the Debian package will be uploaded to the RealSense apt repo and details on how to get it will be shared soon.

## Test plan
- [ ] Docs-only change; verify the note renders correctly on GitHub.
