### PR TITLE
close-range: pytest fixes (FW gate + skip metadata-bit pending RSDEV-12008)

### DIFF
--- a/unit-tests/live/d500/pytest-close-range.py
+++ b/unit-tests/live/d500/pytest-close-range.py
@@ -11,6 +11,7 @@ import time
 
 import pytest
 import pyrealsense2 as rs
+import pyrsutils as rsutils
 from pytest_check import check
 import logging
 log = logging.getLogger(__name__)
@@ -31,12 +32,31 @@ RATIO_INDEX_DEFAULT = 1.0    # choices ["1","2","4"], default "2" -> index 1
 SHIFT_DEFAULT      = 0.0
 THRESHOLD_DEFAULT  = 550.0
 
+# Minimum FW that registers the close-range feature on each device, mirroring
+# src/ds/d500/d500-factory.cpp. Below the gate the feature is not registered and
+# get_embedded_filter() throws rather than returning a falsy value, so we skip up front.
+MIN_FW_BY_DEVICE = {
+    "D555": "7.58.39807.10573",
+    "D585": "7.58.39807.10574",
+}
+
 # Pick a depth profile that the close-range merge actually exercises on D555/D585.
 DEPTH_W, DEPTH_H, DEPTH_FPS = 640, 360, 30
 
 
+def _skip_if_fw_below_minimum( dev ):
+    name = dev.get_info( rs.camera_info.name ) if dev.supports( rs.camera_info.name ) else ""
+    min_fw = next( ( v for k, v in MIN_FW_BY_DEVICE.items() if k in name ), None )
+    if min_fw is None:
+        return
+    fw = dev.get_info( rs.camera_info.firmware_version )
+    if rsutils.version( fw ) < rsutils.version( min_fw ):
+        pytest.skip( f"FW {fw} below minimum {min_fw} for Improved Close Range Depth on {name}" )
+
+
 def _get_close_range_filter( test_device ):
     dev, _ = test_device
+    _skip_if_fw_below_minimum( dev )
     depth_sensor = dev.first_depth_sensor()
     f = depth_sensor.get_embedded_filter( rs.embedded_filter_type.improved_close_range_depth )
     if not f:

--- a/unit-tests/live/d500/pytest-close-range.py
+++ b/unit-tests/live/d500/pytest-close-range.py
@@ -158,6 +158,11 @@ def _find_depth_profile( depth_sensor ):
 
 @pytest.mark.parametrize( "enable_value, expected_bit", [( 0.0, 0 ), ( 1.0, CLOSE_RANGE_METADATA_BIT )] )
 def test_close_range_metadata_bit( test_device, enable_value, expected_bit ):
+    # FW does not yet populate the embedded_filters metadata key for the close-range bit, so
+    # frames arrive without it and the test times out. Restore once RSDEV-12008 is resolved.
+    log.warning( "Skipping test_close_range_metadata_bit due to FW bug - restore after RSDEV-12008 is solved" )
+    pytest.skip( "FW bug tracked by RSDEV-12008" )
+
     depth_sensor, embedded_filter = _get_close_range_filter( test_device )
     profile = _find_depth_profile( depth_sensor )
     if profile is None:


### PR DESCRIPTION
Tracked by: RSDEV-11827

## Overview
Two fixes to `unit-tests/live/d500/pytest-close-range.py` so the close-range nightly run is clean on D555/D585.

### 1. Gate the test on minimum FW (matches the factory)
The test was erroring on devices whose FW is below the factory gate, instead of skipping cleanly.

`src/ds/d500/d500-factory.cpp` only registers the close-range filter feature when FW is at or above:
- D555: `7.58.39807.10573` (`d500-factory.cpp:345`)
- D585: `7.58.39807.10574` (`d500-factory.cpp:167`)

The test's only safety net was:
```python
f = depth_sensor.get_embedded_filter( rs.embedded_filter_type.improved_close_range_depth )
if not f:
    pytest.skip( ... )
```
But `sensor::get_embedded_filter<T>()` in `include/librealsense2/hpp/rs_sensor.hpp:324-332` **throws** `rs2::error("Could not find requested embedded filter type!")` when the feature isn't registered - it never returns a falsy value. So on older FW the test errored out instead of skipping.

**Change:** add a `MIN_FW_BY_DEVICE` map mirroring the factory gates (with a comment noting they must stay in sync), and a `_skip_if_fw_below_minimum(dev)` helper that resolves the minimum from `camera_info.name`, compares against `camera_info.firmware_version` via `pyrsutils.version()`, and `pytest.skip(...)` if below. Called at the top of `_get_close_range_filter`, before `get_embedded_filter()`. Same FW-gating pattern as the sibling `unit-tests/live/d500/test-dds-embedded-filters.py`.

### 2. Skip `test_close_range_metadata_bit` pending RSDEV-12008
FW does not yet populate the `embedded_filters` metadata key for the close-range bit, so frames arrive without it and the test times out after 10s. Skip with a warning log so it's visible in CI. Restore once RSDEV-12008 is resolved.

## Test plan
- [x] Local run against fresh build: `test_close_range_metadata_bit` now reports SKIPPED (`FW bug tracked by RSDEV-12008`), other tests still execute.
- [ ] LibCI nightly: confirm `pytest-close-range.py` skips (not errors) on D555/D585 setups running FW below the gate.
- [ ] LibCI nightly: confirm the test still executes on D555/D585 setups running FW at or above the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

LibCI aborted and reran with nightly on failing test: https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/16674/