### PR TITLE
Fix D500 recovery FW update: add D500 recovery PIDs and abort on failed recovery switch

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -355,6 +355,8 @@ namespace rs2
                 log("Requesting to switch to recovery mode");
 
                 switch_device_to_recovery_mode(upd, serial, dfu, cleanup);
+                if (failed())
+                    return; // do not fall through to the unsigned update path
             }
         }
         else

--- a/src/fw-update/fw-update-factory.cpp
+++ b/src/fw-update/fw-update-factory.cpp
@@ -27,6 +27,10 @@ namespace librealsense
             return RS2_PRODUCT_LINE_D500;
         if( ds::D585S_RECOVERY_PID == usb_info.pid )
             return RS2_PRODUCT_LINE_D500;
+        if( ds::D500_RECOVERY_PID == usb_info.pid )
+            return RS2_PRODUCT_LINE_D500;
+        if( ds::D500_USB2_RECOVERY_PID == usb_info.pid )
+            return RS2_PRODUCT_LINE_D500;
         return 0;
     }
 
@@ -78,6 +82,8 @@ namespace librealsense
                             return std::make_shared< ds_d400_update_device >(shared_from_this(), usb);
                         case ds::D555_RECOVERY_PID:
                         case ds::D585S_RECOVERY_PID:
+                        case ds::D500_RECOVERY_PID:
+                        case ds::D500_USB2_RECOVERY_PID:
                             return std::make_shared< ds_d500_update_device >(shared_from_this(), usb);
                         default:
                             // Do nothing


### PR DESCRIPTION
**Overview:** Fixes signed firmware update for D500 devices in recovery mode — the new shared D500-family recovery PIDs (`0x0CFD`, `0x0CFE`) are now recognized, and a failed recovery-mode switch no longer falls through to the (unsupported) unsigned update path.

## Summary
- **`src/fw-update/fw-update-factory.cpp`**
  - `get_product_line()` now maps `D500_RECOVERY_PID` and `D500_USB2_RECOVERY_PID` to `RS2_PRODUCT_LINE_D500`.
  - `create_device()` now handles those two PIDs in its `switch`, constructing a `ds_d500_update_device`.
- **`common/fw-update-helper.cpp`**
  - After a signed update calls `switch_device_to_recovery_mode()`, the flow now returns early if it `failed()`, instead of falling through to `update_unsigned()`.

## Why
Two bugs in the same D500 signed-update flow:

1. **Recovery PID not recognized.** Only `D555_RECOVERY_PID` / `D585S_RECOVERY_PID` were handled. A D500 re-enumerating in recovery as `0x0CFD`/`0x0CFE` was never surfaced as an `update_device`, so the 60s recovery poll timed out ("Recovery device did not connect in time!"). The PID constants and display names already exist in `src/ds/d500/d500-private.h`; the factory was the only gap (no enumerator VID whitelist blocks them).
2. **Fall-through to unsigned.** `fail()` only sets a flag — it does not stop execution. So after the recovery timeout, control fell into the `else` branch and called `update_unsigned()`, which D500 rejects with "D500 device does not support unsigned FW update" — a misleading second error overwriting the real one.

The guard is scoped to the signed path (`if (_is_signed)`) only: D400 signed-success and all unsigned-API updates are unchanged; the only behavioral change is that a failed *signed* recovery switch now aborts cleanly instead of attempting an invalid signed-image-through-unsigned-path flash.

## Test plan
- [x] Builds clean (`realsense2` target, MSVC x64).
- [ ] Manual: put a D500 into recovery mode and confirm `rs-fw-update` / viewer detects and signed-flashes it.
- [ ] Manual: confirm a failed recovery switch surfaces only "Recovery device did not connect in time!" (no unsigned error).

🤖 Generated by AI
