### PR TITLE
close-range USB: don't force enable state at SDK init

### DIFF
--- a/src/ds/d500/d500-close-range-embedded-filter.cpp
+++ b/src/ds/d500/d500-close-range-embedded-filter.cpp
@@ -114,17 +114,6 @@ d500_close_range_embedded_filter::d500_close_range_embedded_filter( std::weak_pt
     auto opt = std::make_shared< close_range_xu_option >( raw_depth_ep );
     register_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED, opt );
     _options_watcher.register_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED, opt );
-
-    // Default-on at the SDK level: send SET_CUR(1) so the FW state matches what we report,
-    // independent of whatever the device's persisted state was.
-    try
-    {
-        opt->set( 1.f );
-    }
-    catch( std::exception const & e )
-    {
-        LOG_WARNING( "Could not enable Improved Close Range Depth by default: " << e.what() );
-    }
 }
 
 }  // namespace librealsense

--- a/unit-tests/live/d500/pytest-close-range.py
+++ b/unit-tests/live/d500/pytest-close-range.py
@@ -26,8 +26,8 @@ pytestmark = [
 # DPP Filter Bitmask bit 5 = "Improved Close Range Depth merge applied"
 CLOSE_RANGE_METADATA_BIT = 1 << 5
 
-# Spec defaults. Enable is forced ON at SDK level (close_range filter ctor sends SET_CUR(1)).
-ENABLE_DEFAULT     = 1.0
+# Spec defaults for the option-specific (DDS-only) sections. The Enable default is
+# device/FW-driven on USB so we don't pin it here.
 RATIO_INDEX_DEFAULT = 1.0    # choices ["1","2","4"], default "2" -> index 1
 SHIFT_DEFAULT      = 0.0
 THRESHOLD_DEFAULT  = 550.0
@@ -81,11 +81,6 @@ def test_close_range_filter_present( test_device ):
     assert rs.option.embedded_filter_enabled in options
 
     log.info( f"close-range exposes {len(options)} option(s): {[str(o) for o in options]}" )
-
-
-def test_close_range_enable_default( test_device ):
-    _, embedded_filter = _get_close_range_filter( test_device )
-    assert embedded_filter.get_option( rs.option.embedded_filter_enabled ) == ENABLE_DEFAULT
 
 
 def test_close_range_enable_round_trip( test_device ):


### PR DESCRIPTION
**Overview:** Removed the SDK-level `SET_CUR(1)` that the D5xx USB close-range filter sent at registration time, so the Improved Close Range Depth toggle now reflects whatever the firmware reports rather than being forced ON by the host.

## Summary
- `src/ds/d500/d500-close-range-embedded-filter.cpp`: dropped the `try { opt->set(1.f); }` block in `d500_close_range_embedded_filter`'s ctor. No host-side default is written; FW state is the source of truth.
- `unit-tests/live/d500/pytest-close-range.py`: removed `test_close_range_enable_default`, dropped the now-unused `ENABLE_DEFAULT` constant, and updated the stale comment that claimed Enable is forced ON at SDK level.

## Why
The SDK shouldn't be the source of truth for an option's default state — that belongs to firmware. Forcing `SET_CUR(1)` at registration masked FW persistence behavior and created a second place where the default had to be kept in sync. The accompanying pytest pinned `1.0` as the default purely because the SDK was writing it; with the host-side write gone, that assertion no longer reflects anything meaningful.

## Test plan
- [ ] `unit-tests/live/d500/pytest-close-range.py` on D555 / D585 over USB — `test_close_range_filter_present`, `test_close_range_enable_round_trip`, `test_close_range_enable_invalid_value_rejected` still pass; DDS-only option tests skip on USB as before.
- [ ] DDS path unchanged: `unit-tests/live/d500/test-dds-embedded-filters.py` still green on a DDS D555.
- [ ] Manual viewer check: connect D555 over USB, open the Embedded Filters panel — Improved Close Range Depth toggle reflects FW state on attach (not forced ON).