### PR TITLE
viewer: add Dual-RGB / Dedicated-RGB mode toggle in More menu

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1316,7 +1316,10 @@ namespace rs2
                     const bool is_c8 = (current_pid == "0C08");
                     if (is_c7 || is_c8)
                     {
-                        if (ImGui::Selectable("Toggle Device PID"))
+                        const std::string toggle_label = is_c7
+                            ? "Switch to Dedicated-RGB Mode"
+                            : "Switch to Dual-RGB Mode";
+                        if (ImGui::Selectable(toggle_label.c_str()))
                         {
                             try
                             {

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1308,15 +1308,18 @@ namespace rs2
                     }
                 }
 
-                // Prototype PID toggle for D585 2C/3C (0x0C07 <-> 0x0C08).
+                // PID toggle between Dual-RGB (2C) and Dedicated-RGB (3C) variants:
+                //   D535:       0x0C01 <-> 0x0C02
+                //   D585:       0x0C04 <-> 0x0C05
+                //   D585 Proto: 0x0C07 <-> 0x0C08
                 if (dev.supports(RS2_CAMERA_INFO_PRODUCT_ID) && dev.is<debug_protocol>())
                 {
                     std::string current_pid = dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
-                    const bool is_c7 = (current_pid == "0C07");
-                    const bool is_c8 = (current_pid == "0C08");
-                    if (is_c7 || is_c8)
+                    const bool is_dual_rgb      = (current_pid == "0C01") || (current_pid == "0C04") || (current_pid == "0C07");
+                    const bool is_dedicated_rgb = (current_pid == "0C02") || (current_pid == "0C05") || (current_pid == "0C08");
+                    if (is_dual_rgb || is_dedicated_rgb)
                     {
-                        const std::string toggle_label = is_c7
+                        const std::string toggle_label = is_dual_rgb
                             ? "Switch to Dedicated-RGB Mode"
                             : "Switch to Dual-RGB Mode";
                         if (ImGui::Selectable(toggle_label.c_str()))
@@ -1326,7 +1329,7 @@ namespace rs2
                                 const uint32_t mwd_opcode = 0x02;
                                 const uint32_t addr_start = 0x80000064;
                                 const uint32_t addr_end   = 0x80000068;
-                                const uint32_t value = is_c7 ? 0u : 1u;
+                                const uint32_t value = is_dual_rgb ? 0u : 1u;
                                 const std::vector<uint8_t> data = {
                                     static_cast<uint8_t>( value         & 0xFF),
                                     static_cast<uint8_t>((value >>  8 ) & 0xFF),
@@ -1351,11 +1354,7 @@ namespace rs2
                         }
                         if (ImGui::IsItemHovered())
                         {
-                            std::string current_name = dev.supports(RS2_CAMERA_INFO_NAME)
-                                ? dev.get_info(RS2_CAMERA_INFO_NAME) : "this device";
-                            std::string tooltip = rsutils::string::from()
-                                << "Switch " << current_name << " to its alternate PID variant and reset";
-                            RsImGui::CustomTooltip("%s", tooltip.c_str());
+                            RsImGui::CustomTooltip("%s", "Switch Dual-RGB / Dedicated Color Sensor Mode");
                         }
                     }
                 }

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1308,6 +1308,55 @@ namespace rs2
                     }
                 }
 
+                // Prototype PID toggle for D585 2C/3C (0x0C07 <-> 0x0C08).
+                if (dev.supports(RS2_CAMERA_INFO_PRODUCT_ID) && dev.is<debug_protocol>())
+                {
+                    std::string current_pid = dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
+                    const bool is_c7 = (current_pid == "0C07");
+                    const bool is_c8 = (current_pid == "0C08");
+                    if (is_c7 || is_c8)
+                    {
+                        if (ImGui::Selectable("Toggle Device PID"))
+                        {
+                            try
+                            {
+                                const uint32_t mwd_opcode = 0x02;
+                                const uint32_t addr_start = 0x80000064;
+                                const uint32_t addr_end   = 0x80000068;
+                                const uint32_t value = is_c7 ? 0u : 1u;
+                                const std::vector<uint8_t> data = {
+                                    static_cast<uint8_t>( value         & 0xFF),
+                                    static_cast<uint8_t>((value >>  8 ) & 0xFF),
+                                    static_cast<uint8_t>((value >> 16 ) & 0xFF),
+                                    static_cast<uint8_t>((value >> 24 ) & 0xFF) };
+
+                                auto dp = dev.as<debug_protocol>();
+                                auto cmd = dp.build_command(mwd_opcode, addr_start, addr_end, 0, 0, data);
+
+                                dp.send_and_receive_raw_data(cmd);
+                                restarting_device_info = get_device_info(dev, false);
+                                dev.hardware_reset();
+                            }
+                            catch (const error& e)
+                            {
+                                error_message = error_to_string(e);
+                            }
+                            catch (const std::exception& e)
+                            {
+                                error_message = e.what();
+                            }
+                        }
+                        if (ImGui::IsItemHovered())
+                        {
+                            std::string current_name = dev.supports(RS2_CAMERA_INFO_NAME)
+                                ? dev.get_info(RS2_CAMERA_INFO_NAME) : "this device";
+                            std::string tooltip = rsutils::string::from()
+                                << "Switch " << current_name << " to its alternate PID variant and reset";
+                            RsImGui::CustomTooltip("%s", tooltip.c_str());
+                        }
+                    }
+                }
+
                 // fw update disabled when any sensor is streaming
                 ImGuiSelectableFlags updateFwFlags = (is_streaming) ? ImGuiSelectableFlags_Disabled : 0;
 

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -1314,6 +1314,12 @@ namespace rs2
                 //   D585 Proto: 0x0C07 <-> 0x0C08
                 if (dev.supports(RS2_CAMERA_INFO_PRODUCT_ID) && dev.is<debug_protocol>())
                 {
+                    static constexpr uint32_t MWD_OPCODE          = 0x02U;
+                    static constexpr uint32_t MODE_REG_START_ADDR = 0x80000064U;
+                    static constexpr uint32_t MODE_REG_END_ADDR   = 0x80000068U;
+                    static constexpr uint32_t MODE_DEDICATED_RGB  = 0U;
+                    static constexpr uint32_t MODE_DUAL_RGB       = 1U;
+
                     std::string current_pid = dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
                     const bool is_dual_rgb      = (current_pid == "0C01") || (current_pid == "0C04") || (current_pid == "0C07");
                     const bool is_dedicated_rgb = (current_pid == "0C02") || (current_pid == "0C05") || (current_pid == "0C08");
@@ -1322,14 +1328,13 @@ namespace rs2
                         const std::string toggle_label = is_dual_rgb
                             ? "Switch to Dedicated-RGB Mode"
                             : "Switch to Dual-RGB Mode";
-                        if (ImGui::Selectable(toggle_label.c_str()))
+                        const ImGuiSelectableFlags toggle_flags = is_streaming
+                            ? ImGuiSelectableFlags_Disabled : ImGuiSelectableFlags_None;
+                        if (ImGui::Selectable(toggle_label.c_str(), false, toggle_flags))
                         {
                             try
                             {
-                                const uint32_t mwd_opcode = 0x02;
-                                const uint32_t addr_start = 0x80000064;
-                                const uint32_t addr_end   = 0x80000068;
-                                const uint32_t value = is_dual_rgb ? 0u : 1u;
+                                const uint32_t value = is_dual_rgb ? MODE_DEDICATED_RGB : MODE_DUAL_RGB;
                                 const std::vector<uint8_t> data = {
                                     static_cast<uint8_t>( value         & 0xFF),
                                     static_cast<uint8_t>((value >>  8 ) & 0xFF),
@@ -1337,7 +1342,7 @@ namespace rs2
                                     static_cast<uint8_t>((value >> 24 ) & 0xFF) };
 
                                 auto dp = dev.as<debug_protocol>();
-                                auto cmd = dp.build_command(mwd_opcode, addr_start, addr_end, 0, 0, data);
+                                auto cmd = dp.build_command(MWD_OPCODE, MODE_REG_START_ADDR, MODE_REG_END_ADDR, 0, 0, data);
 
                                 dp.send_and_receive_raw_data(cmd);
                                 restarting_device_info = get_device_info(dev, false);
@@ -1354,7 +1359,10 @@ namespace rs2
                         }
                         if (ImGui::IsItemHovered())
                         {
-                            RsImGui::CustomTooltip("%s", "Switch Dual-RGB / Dedicated Color Sensor Mode");
+                            std::string tooltip = rsutils::string::from()
+                                << "Switch Dual-RGB / Dedicated Color Sensor Mode"
+                                << (is_streaming ? " (Disabled while streaming)" : "");
+                            RsImGui::CustomTooltip("%s", tooltip.c_str());
                         }
                     }
                 }


### PR DESCRIPTION
**Overview:** Adds a "Switch to Dual-RGB Mode" / "Switch to Dedicated-RGB Mode" entry in the realsense-viewer More menu that flips D535, D585 and D585 prototype devices between their Dual-RGB (2C) and Dedicated-RGB (3C) variants, then resets the device.

## Summary
- New per-device More-menu item, shown only when the current PID is one of the toggleable variants and the device exposes `debug_protocol`.
- Supported PID pairs:
  - D535:       `0x0C01` (Dual-RGB) <-> `0x0C02` (Dedicated-RGB)
  - D585:       `0x0C04` (Dual-RGB) <-> `0x0C05` (Dedicated-RGB)
  - D585 Proto: `0x0C07` (Dual-RGB) <-> `0x0C08` (Dedicated-RGB)
- Label is direction-aware: from a Dual-RGB PID it reads "Switch to Dedicated-RGB Mode", and from a Dedicated-RGB PID it reads "Switch to Dual-RGB Mode".
- On click, sends `MWD 0x80000064 0x80000068 <0|1>` via `rs2::debug_protocol::build_command` + `send_and_receive_raw_data`, then calls `hardware_reset()`. Value `0` switches Dual-RGB -> Dedicated-RGB, value `1` switches Dedicated-RGB -> Dual-RGB.
- Tooltip: "Switch Dual-RGB / Dedicated Color Sensor Mode".

## Why
The D535, D585, and D585 prototype devices ship as either the Dual-RGB or Dedicated-RGB variant. Previously toggling required `rs-terminal` plus a manual hardware reset; this exposes the flow directly in the viewer.

## Test plan
- [ ] For each Dual-RGB PID (`0x0C01`, `0x0C04`, `0x0C07`): open viewer, More -> "Switch to Dedicated-RGB Mode"; confirm the device re-enumerates as the matching Dedicated-RGB PID (`0x0C02`, `0x0C05`, `0x0C08` respectively).
- [ ] For each Dedicated-RGB PID: same flow, confirm re-enumeration as the matching Dual-RGB PID.
- [ ] On any other PID: confirm the menu entry is hidden.
- [ ] Confirm tooltip reads "Switch Dual-RGB / Dedicated Color Sensor Mode".