### PR TITLE
Fix Windows slow-IMU partial device: HID gate uses device_path

### DIFF
--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -376,7 +376,7 @@ namespace librealsense
                             // misbehaving HID driver (HID class advertised but
                             // never bound) doesn't make the device invisible
                             // forever.
-                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 10000 );
+                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 15000 );
                             auto since_first = std::chrono::steady_clock::now() - _data._first_event;
                             if( hid_binding_in_progress( curr ) && since_first < MAX_DEFERRAL )
                             {

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -234,7 +234,7 @@ namespace librealsense
             std::set< DEVINST > visited_composites;
             for( auto && uvc : curr.uvc_devices )
             {
-                std::wstring path( uvc.id.begin(), uvc.id.end() );
+                std::wstring path( uvc.device_path.begin(), uvc.device_path.end() );
                 cm_node iface = cm_node::from_device_path( path.c_str() );
                 if( ! iface.valid() )
                     continue;
@@ -376,7 +376,7 @@ namespace librealsense
                             // misbehaving HID driver (HID class advertised but
                             // never bound) doesn't make the device invisible
                             // forever.
-                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 5000 );
+                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 10000 );
                             auto since_first = std::chrono::steady_clock::now() - _data._first_event;
                             if( hid_binding_in_progress( curr ) && since_first < MAX_DEFERRAL )
                             {


### PR DESCRIPTION
Windows-only fix for the slow-IMU "partial device" race.

The win_event_device_watcher HID-binding deferral gate (hid_binding_in_progress) read uvc_device_info.id, which is only populated by the Linux v4l2 backend and is always empty on Windows (MF sets device_path). The empty path made cm_node::from_device_path resolve nothing, so the gate always returned false and never deferred — the device was emitted as partial (no Motion Module) whenever the IMU HID interface enumerated slower than the UVC interfaces (~6-13s on D455/D585).

Changes (src/mf/mf-backend.cpp):
- Use uvc.device_path (the Windows-populated path) so the gate resolves the composite and detects the IMU HID still binding.
- Raise MAX_DEFERRAL 5s -> 10s to cover observed IMU boot times.

No-IMU / EOL units are unaffected: no HID-class child -> gate stays false -> they appear immediately with their full sensor set.