### PR TITLE
skip pytest-ah-configurations on D585S pending RSDEV-12174

### DIFF
--- a/unit-tests/live/frames/pytest-ah-configurations.py
+++ b/unit-tests/live/frames/pytest-ah-configurations.py
@@ -18,6 +18,10 @@ HD_RESOLUTION = (1280, 720)
 pytestmark = [
     pytest.mark.device_each("D585S"),
     pytest.mark.context("nightly"),
+    # Disabled while D585S FW bug RSDEV-12174 is open: the 2nd open(D+C+S) cycle's
+    # streams produce zero frames and leave the device bricked until USB power-cycle.
+    # Restoration tracked by RSDEV-12175.
+    pytest.mark.skip(reason="RSDEV-12174: D585S FW set_xu / streaming fails on 2nd open(D+C+S) cycle"),
 ]
 
 


### PR DESCRIPTION
Tracked by: RSDEV-12174

**Overview:** Skip `pytest-ah-configurations.py` on D585S nightly until the firmware bug RSDEV-12174 is fixed; restoration tracked by RSDEV-12175.

## Why
On D585S FW 8.58.38355.9052, the 2nd open(Depth+Color+Safety) cycle's streams open and start successfully at the V4L2/UVC layer but emit zero frames for the entire 5s window. Once tripped, `set_xu(0x0B / DS5_ENABLE_AUTO_EXPOSURE)` times out and the device drops from enumeration until USB power-cycle. Failure is destructive — running the test nightly risks bricking the D585S and cascading into adjacent tests on the same hub.

Reproduced standalone (no test infra) on three D585S units across two hosts (`333622320169`/vtglnx163, `353322320713`/vtglnx164, `353322320589`/rslnx391), ~30% failure rate per run on the libci cycle, deterministic at cycle 2 on the minimal repro.

## Summary
- Added `pytest.mark.skip(reason="RSDEV-12174: ...")` to `unit-tests/live/frames/pytest-ah-configurations.py` pytestmark list.
- Comment block references RSDEV-12174 (FW bug) and RSDEV-12175 (SDK restoration ticket).

## Test plan
- [ ] Nightly libci run with the branch reports `SKIPPED` for `test_ah_configurations[D585S-*]` (not FAILED).
- [ ] When firmware fix lands (RSDEV-12174 closed), remove the skip marker per RSDEV-12175 and confirm stable PASS across several nightly runs.