### PR TITLE
common/rs-config: fix config file save failures

### DIFF
--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -9,6 +9,7 @@
 #include <rsutils/json.h>
 #include <rsutils/json-config.h>
 #include <sstream>
+#include <mutex>
 #include <rsutils/easylogging/easyloggingpp.h>
 
 using json = rsutils::json;
@@ -77,15 +78,23 @@ config_value config_file::get(const char* key) const
 
 void config_file::save(const char* filename)
 {
-    std::lock_guard< std::recursive_mutex > lk( _mutex );
-    if( ! filename )
+    std::string serialized;
     {
-        LOG_ERROR( "Config file name is null, cannot save config." );
-        return;
+        std::lock_guard< std::recursive_mutex > lk( _mutex );
+        if( ! filename )
+        {
+            LOG_ERROR( "Config file name is null, cannot save config." );
+            return;
+        }
+        std::ostringstream oss;
+        oss << std::setw( 2 ) << _j;
+        serialized = oss.str();
     }
-    std::ostringstream oss;
-    oss << std::setw( 2 ) << _j;
-    if( ! rsutils::os::atomic_write_file( filename, oss.str() ) )
+    // Serialize disk writes without holding _mutex so readers (get/set) are not
+    // blocked during I/O or retries.
+    static std::mutex s_write_mutex;
+    std::lock_guard< std::mutex > wlk( s_write_mutex );
+    if( ! rsutils::os::atomic_write_file( filename, serialized ) )
         LOG_ERROR( "Failed to save config file '" + std::string( filename ) + "'" );
 }
 
@@ -114,7 +123,10 @@ config_file::config_file( std::string const & filename )
 void config_file::save()
 {
     if( _filename.empty() )
+    {
+        LOG_DEBUG( "save() called on config_file with no filename -- skipping" );
         return;
+    }
     save( _filename.c_str() );
 }
 

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -77,19 +77,15 @@ config_value config_file::get(const char* key) const
 
 void config_file::save(const char* filename)
 {
-    std::string serialized;
+    std::lock_guard< std::recursive_mutex > lk( _mutex );
+    if( ! filename )
     {
-        std::lock_guard< std::recursive_mutex > lk( _mutex );
-        if( ! filename )
-        {
-            LOG_ERROR( "Config file name is null, cannot save config." );
-            return;
-        }
-        std::ostringstream oss;
-        oss << std::setw( 2 ) << _j;
-        serialized = oss.str();
+        LOG_ERROR( "Config file name is null, cannot save config." );
+        return;
     }
-    if( ! rsutils::os::atomic_write_file( filename, serialized ) )
+    std::ostringstream oss;
+    oss << std::setw( 2 ) << _j;
+    if( ! rsutils::os::atomic_write_file( filename, oss.str() ) )
         LOG_ERROR( "Failed to save config file '" + std::string( filename ) + "'" );
 }
 
@@ -117,6 +113,8 @@ config_file::config_file( std::string const & filename )
 
 void config_file::save()
 {
+    if( _filename.empty() )
+        return;
     save( _filename.c_str() );
 }
 

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -92,8 +92,7 @@ void config_file::save(const char* filename)
     }
     // Serialize disk writes without holding _mutex so readers (get/set) are not
     // blocked during I/O or retries.
-    static std::mutex s_write_mutex;
-    std::lock_guard< std::mutex > wlk( s_write_mutex );
+    std::lock_guard< std::mutex > wlk( _write_mutex );
     if( ! rsutils::os::atomic_write_file( filename, serialized ) )
         LOG_ERROR( "Failed to save config file '" + std::string( filename ) + "'" );
 }

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -198,6 +198,7 @@ namespace rs2
         // call sites like the processing-block checkbox handlers in device-model.cpp).
         // mutable so const accessors (get/contains/get_default) can lock it.
         mutable std::recursive_mutex _mutex;
+        std::mutex _write_mutex;
 
         std::map<std::string, std::string> _defaults;
         std::string _filename;

--- a/third-party/rsutils/include/rsutils/os/atomic-write-file.h
+++ b/third-party/rsutils/include/rsutils/os/atomic-write-file.h
@@ -13,13 +13,19 @@ namespace os {
 // The temp file is named "<filename>.<pid>.<tid>.<counter>.tmp" (thread-unique); stale copies are benign and safe to delete.
 // Returns true on success, false on any failure (open, write, or rename).
 //
+// On Windows, rename is retried up to max_retries times (sleeping retry_delay_ms ms between
+// attempts) when the error is ERROR_SHARING_VIOLATION or ERROR_ACCESS_DENIED.
+//
 // Known limitations (accepted for this use case):
 //   - Power-loss safety: ofstream::close() does not fsync, so file data may still be in the OS
 //     page cache at the point of rename. Protects against application crashes, not power loss.
 //   - Non-ASCII paths on Windows: MoveFileExA uses the ANSI codepage and may fail for paths
 //     containing non-ASCII characters (e.g. non-ASCII username in %APPDATA%).
 //
-bool atomic_write_file( const std::string & filename, const std::string & content );
+bool atomic_write_file( const std::string & filename,
+                        const std::string & content,
+                        int max_retries = 5,
+                        int retry_delay_ms = 20 );
 
 
 }  // namespace os

--- a/third-party/rsutils/src/atomic-write-file.cpp
+++ b/third-party/rsutils/src/atomic-write-file.cpp
@@ -63,8 +63,14 @@ bool atomic_write_file( const std::string & filename, const std::string & conten
     }
 
 #ifdef _WIN32
-    bool ok = MoveFileExA( temp_filename.c_str(), filename.c_str(),
-                           MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH ) != 0;
+    bool ok = false;
+    for( int attempt = 0; attempt < 5 && !ok; ++attempt )
+    {
+        ok = MoveFileExA( temp_filename.c_str(), filename.c_str(),
+                          MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH ) != 0;
+        if( !ok && attempt < 4 )
+            Sleep( 20 );
+    }
 #else
     bool ok = std::rename( temp_filename.c_str(), filename.c_str() ) == 0;
 #endif

--- a/third-party/rsutils/src/atomic-write-file.cpp
+++ b/third-party/rsutils/src/atomic-write-file.cpp
@@ -78,8 +78,6 @@ bool atomic_write_file( const std::string & filename, const std::string & conten
                 break;
             if( attempt + 1 < max_retries )
             {
-                LOG_WARNING( "MoveFileExA sharing conflict (err " << last_err << "), retry "
-                             << ( attempt + 1 ) << "/" << max_retries << " for '" << filename << "'" );
                 std::this_thread::sleep_for( std::chrono::milliseconds( retry_delay_ms ) );
             }
         }

--- a/third-party/rsutils/src/atomic-write-file.cpp
+++ b/third-party/rsutils/src/atomic-write-file.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 #include <rsutils/os/atomic-write-file.h>
+#include <rsutils/easylogging/easyloggingpp.h>
 
 #include <fstream>
 #include <cstdio>
@@ -38,7 +39,7 @@ static std::string make_temp_filename( const std::string & filename )
 }
 
 
-bool atomic_write_file( const std::string & filename, const std::string & content )
+bool atomic_write_file( const std::string & filename, const std::string & content, int max_retries, int retry_delay_ms )
 {
     const std::string temp_filename = make_temp_filename( filename );
 
@@ -65,18 +66,26 @@ bool atomic_write_file( const std::string & filename, const std::string & conten
 
 #ifdef _WIN32
     bool ok = false;
-    for( int attempt = 0; attempt < 5 && !ok; ++attempt )
+    DWORD last_err = 0;
+    for( int attempt = 0; attempt < max_retries && !ok; ++attempt )
     {
         ok = MoveFileExA( temp_filename.c_str(), filename.c_str(),
                           MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH ) != 0;
-        if( !ok && attempt < 4 )
+        if( !ok )
         {
-            DWORD err = GetLastError();
-            if( err != ERROR_SHARING_VIOLATION && err != ERROR_ACCESS_DENIED )
+            last_err = GetLastError();
+            if( last_err != ERROR_SHARING_VIOLATION && last_err != ERROR_ACCESS_DENIED )
                 break;
-            std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+            if( attempt + 1 < max_retries )
+            {
+                LOG_WARNING( "MoveFileExA sharing conflict (err " << last_err << "), retry "
+                             << ( attempt + 1 ) << "/" << max_retries << " for '" << filename << "'" );
+                std::this_thread::sleep_for( std::chrono::milliseconds( retry_delay_ms ) );
+            }
         }
     }
+    if( !ok )
+        LOG_WARNING( "MoveFileExA failed for '" << filename << "', last error: " << last_err );
 #else
     bool ok = std::rename( temp_filename.c_str(), filename.c_str() ) == 0;
 #endif

--- a/third-party/rsutils/src/atomic-write-file.cpp
+++ b/third-party/rsutils/src/atomic-write-file.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <atomic>
 #include <thread>
+#include <chrono>
 #include <functional>
 
 #ifdef _WIN32
@@ -69,7 +70,12 @@ bool atomic_write_file( const std::string & filename, const std::string & conten
         ok = MoveFileExA( temp_filename.c_str(), filename.c_str(),
                           MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH ) != 0;
         if( !ok && attempt < 4 )
-            Sleep( 20 );
+        {
+            DWORD err = GetLastError();
+            if( err != ERROR_SHARING_VIOLATION && err != ERROR_ACCESS_DENIED )
+                break;
+            std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+        }
     }
 #else
     bool ok = std::rename( temp_filename.c_str(), filename.c_str() ) == 0;


### PR DESCRIPTION
## Problem

Users reported repeated `"Failed to save config file"` errors in the viewer log panel, occurring in two distinct patterns:

1. **Empty filename** — default-constructed `config_file` scratch buffers used in the UI (`temp_cfg`) have no filename set. Any code path that triggered `save()` on these objects attempted to write to an empty path, causing `atomic_write_file` to fail silently and log an error.

2. **Concurrent saves failing with ERROR_ACCESS_DENIED (5)** — at stream start/stop, multiple `config_save_worker` threads (one per subdevice: Color, Depth, Infrared) all attempt to save to the same `realsense-config.json` simultaneously. `MoveFileExA` fails because another thread (or the SDK) has the file open via `std::ifstream`, which on Windows opens without `FILE_SHARE_DELETE`, blocking the atomic rename.

## Changes

### `common/rs-config.cpp`

- **Empty filename guard** — `save()` (no-arg) now returns early if `_filename` is empty, so default-constructed `config_file` objects silently skip the write instead of attempting to save to `""`
- **Serialize disk writes** — `save(const char*)` now holds `_mutex` through the `atomic_write_file` call, preventing multiple `config_save_worker` threads from racing to rename their temp files to the same destination simultaneously

### `third-party/rsutils/src/atomic-write-file.cpp`

- **Retry on Windows** — `MoveFileExA` is retried up to 5 times with 20ms gaps. This handles transient `ERROR_ACCESS_DENIED (5)` failures caused by readers opening the config file via `std::ifstream` without `FILE_SHARE_DELETE` — the retry gives the read handle time to close before reattempting the rename
