### PR TITLE
viewer: disable histogram eq for D585 proto (0C07/0C08), rename OD to Person Detection

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -361,6 +361,18 @@ namespace rs2
             depth_colorizer->set_option(RS2_OPTION_VISUAL_PRESET, option_value);
         }
 
+        // Disable histogram equalization for D585 prototype variants (0C07, 0C08).
+        // Must be applied AFTER the VISUAL_PRESET restore block above: re-setting the Dynamic
+        // preset (default) re-enables histogram equalization via its on_set callback.
+        if (s->supports(RS2_CAMERA_INFO_PRODUCT_ID))
+        {
+            std::string device_pid = s->get_info(RS2_CAMERA_INFO_PRODUCT_ID);
+            if (device_pid == "0C07" || device_pid == "0C08")
+            {
+                depth_colorizer->set_option(RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED, 0.f);
+            }
+        }
+
         std::stringstream ss;
         ss << "##" << dev.get_info(RS2_CAMERA_INFO_NAME)
             << "/" << s->get_info(RS2_CAMERA_INFO_NAME)

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -106,7 +106,10 @@ namespace librealsense
         for( auto p : results )
         {
             if( p->get_stream_type() == RS2_STREAM_OBJECT_DETECTION )
+            {
                 assign_stream( _owner->_object_detection_stream, p );
+                p->set_name( "Person Detection" );
+            }
         }
         return results;
     }

--- a/src/ds/d500/d500-object-detection.h
+++ b/src/ds/d500/d500-object-detection.h
@@ -41,7 +41,7 @@ namespace librealsense
                                                std::shared_ptr< uvc_sensor > uvc_sensor,
                                                std::map< uint32_t, rs2_format > od_fourcc_to_rs2_format,
                                                std::map< uint32_t, rs2_stream > od_fourcc_to_rs2_stream )
-            : synthetic_sensor( "Object Detection Camera", uvc_sensor, owner, od_fourcc_to_rs2_format, od_fourcc_to_rs2_stream )
+            : synthetic_sensor( "Person Detection Camera", uvc_sensor, owner, od_fourcc_to_rs2_format, od_fourcc_to_rs2_stream )
             , _owner( owner )
         {
         }


### PR DESCRIPTION
**Overview:** In the viewer, default-disable histogram equalization on the depth colorizer for D585 prototype variants (PIDs 0C07/0C08), and re-label the D500 object-detection sensor and stream as "Person Detection".

## Why
- D585 prototypes (0C07/0C08) produce a better default depth visualization with histogram equalization off.
- The D500 object-detection sensor is product-positioned as a person-detection feature; the viewer should reflect that name.

## Summary
- `common/subdevice-model.cpp`: when the streaming sensor's `RS2_CAMERA_INFO_PRODUCT_ID` is `0C07` or `0C08`, set `RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED = 0` on the depth colorizer. Applied **after** the existing `VISUAL_PRESET` restore block — the Dynamic preset's `on_set` callback would otherwise re-enable equalization.
- `src/ds/d500/d500-object-detection.h`: synthetic sensor display name `"Object Detection Camera"` → `"Person Detection Camera"`.
- `src/ds/d500/d500-object-detection.cpp`: in `init_stream_profiles()`, override the `RS2_STREAM_OBJECT_DETECTION` profile name to `"Person Detection"` so the viewer shows the stream under the renamed sensor.

Scope is intentionally narrow: `rs2_stream_to_string(RS2_STREAM_OBJECT_DETECTION)`, the public enum, ROS bag identifiers, and log strings are unchanged.

## Test plan
- [ ] Connect a D585 prototype (PID 0C07 or 0C08), start the depth stream in the viewer, verify "Histogram Equalization Enabled" under *Stereo Module > Depth Visualization* is **unchecked** by default.
- [ ] Verify other PIDs (e.g. D455/D405) still default to histogram equalization **enabled**.
- [ ] Verify the sensor previously named "Object Detection Camera" now shows as "Person Detection Camera" in the viewer device tree, and its stream label reads "Person Detection".

🤖 Generated with [Claude Code](https://claude.com/claude-code)