### PR TITLE
Disable all device ports in enable_only recycle and stabilize CI

### DIFF
--- a/unit-tests/dds/adapter/test-depth.py
+++ b/unit-tests/dds/adapter/test-depth.py
@@ -113,8 +113,8 @@ try:
     del context
 
 finally:
-    # Always ensure the adapter process is terminated, even if test fails
-    with test.closure( 'Stop rs-dds-adapter', on_fail=test.ABORT ):
+    # Kill directly, not via test.closure: an aborted test would make the closure throw and skip the kill.
+    if adapter_process:
         try:
             # Try graceful termination first (SIGTERM lets adapter release DDS resources on Linux)
             adapter_process.send_signal( signal.SIGTERM )

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -393,6 +393,16 @@ def enabled():
     return { device.serial_number for device in _device_by_sn.values() if device.enabled }
 
 
+def port_enabled():
+    """
+    :return: A set of device serial-numbers whose hub port is currently enabled, queried from the
+    hub (the source of truth for port state) -- as opposed to enabled(), which is device presence.
+    """
+    global _device_by_sn
+    active = hub.ports() if hub else []
+    return { device.serial_number for device in _device_by_sn.values() if device.port in active }
+
+
 def by_product_line( product_line, ignored_products ):
     """
     :param product_line: The product line we're interested in, as a string ("L500", etc.)
@@ -616,7 +626,8 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         ports = [ get( sn ).port for sn in serial_numbers ]
         # DDS (and other non-hub) devices have port=None; filter them out of hub operations
         wanted_ports = sorted( p for p in ports if p is not None )
-        enabled_ports = [ get( sn ).port for sn in enabled() if get( sn ).port is not None ]
+        enabled_sns = port_enabled()
+        enabled_ports = [ get( sn ).port for sn in enabled_sns if get( sn ).port is not None ]
         #
         if recycle:
             #
@@ -625,7 +636,7 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
             elif enabled_ports:
                 log.d( 'enabling ports', wanted_ports,
                        'disabling currently enabled ports', enabled_ports )
-                sns_to_remove = { sn for sn in enabled() if get( sn ).port in enabled_ports }
+                sns_to_remove = { sn for sn in enabled_sns if get( sn ).port in enabled_ports }
                 hub.disable_ports( enabled_ports )
                 _wait_until_removed( sns_to_remove, timeout = timeout )
             #

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -636,21 +636,27 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         #
         if recycle:
             #
-            if not wanted_ports and not enabled_ports:
-                log.d( 'no hub ports to recycle; leaving hub as-is' )
-            elif enabled_ports:
-                log.d( 'enabling ports', wanted_ports,
-                       'disabling currently enabled ports', enabled_ports )
-                sns_to_remove = { sn for sn in enabled_sns if get( sn ).port in enabled_ports }
-                hub.disable_ports( enabled_ports )
+            # Only toggle what differs: disable the enabled ports we don't want, enable the wanted
+            # ports that are off. A wanted port that's already enabled is left untouched -- recycling
+            # it would needlessly power-cycle the device (DDS/PoE like D555 re-enumerate slowly and
+            # would time out the wait below).
+            ports_to_disable = [ p for p in enabled_ports if p not in wanted_ports ]
+            ports_to_enable  = [ p for p in wanted_ports if p not in enabled_ports ]
+            #
+            if ports_to_disable:
+                log.d( 'disabling ports', ports_to_disable )
+                sns_to_remove = { sn for sn in enabled_sns if get( sn ).port in ports_to_disable }
+                hub.disable_ports( ports_to_disable )
                 for sn in sns_to_remove:
                     get( sn )._port_enabled = False
                 _wait_until_removed( sns_to_remove, timeout = timeout )
             #
-            if wanted_ports:
-                hub.enable_ports( wanted_ports )
+            if ports_to_enable:
+                log.d( 'enabling ports', ports_to_enable )
+                hub.enable_ports( ports_to_enable )
                 for sn in serial_numbers:
-                    get( sn )._port_enabled = True
+                    if get( sn ).port in ports_to_enable:
+                        get( sn )._port_enabled = True
             #
         else:
             #

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -122,6 +122,7 @@ class Device:
                 log.d('    location is', self._location)
 
         self._removed = False
+        self._port_enabled = True
 
     @property
     def serial_number( self ):
@@ -192,6 +193,8 @@ def map_unknown_ports():
         # (e.g. loose cables) can't produce rogue devices mid-test.
         hub.disable_ports()
         wait_until_all_ports_disabled()
+        for device in _device_by_sn.values():
+            device._port_enabled = False
         return
     #
     ports = hub.ports()
@@ -252,6 +255,8 @@ def map_unknown_ports():
         # Disable all ports so tests start from a clean state
         hub.disable_ports()
         wait_until_all_ports_disabled()
+        for device in _device_by_sn.values():
+            device._port_enabled = False
         log.debug_unindent()
 
 
@@ -395,12 +400,12 @@ def enabled():
 
 def port_enabled():
     """
-    :return: A set of device serial-numbers whose hub port is currently enabled, queried from the
-    hub (the source of truth for port state) -- as opposed to enabled(), which is device presence.
+    :return: A set of device serial-numbers whose hub port devices.py has enabled. Cached state
+    (maintained by enable_only/enable_all), not queried from the hub, and not the device-changed
+    presence cache (enabled()) -- which is unreliable across hw-reset / fw-update.
     """
     global _device_by_sn
-    active = hub.ports() if hub else []
-    return { device.serial_number for device in _device_by_sn.values() if device.port in active }
+    return { device.serial_number for device in _device_by_sn.values() if device._port_enabled }
 
 
 def by_product_line( product_line, ignored_products ):
@@ -638,15 +643,22 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
                        'disabling currently enabled ports', enabled_ports )
                 sns_to_remove = { sn for sn in enabled_sns if get( sn ).port in enabled_ports }
                 hub.disable_ports( enabled_ports )
+                for sn in sns_to_remove:
+                    get( sn )._port_enabled = False
                 _wait_until_removed( sns_to_remove, timeout = timeout )
             #
             if wanted_ports:
                 hub.enable_ports( wanted_ports )
+                for sn in serial_numbers:
+                    get( sn )._port_enabled = True
             #
         else:
             #
             if wanted_ports:
                 hub.enable_ports( wanted_ports, disable_other_ports = True )
+                for device in _device_by_sn.values():
+                    if device.port is not None:
+                        device._port_enabled = device.serial_number in serial_numbers
             else:
                 log.d( 'no hub ports to enable; leaving hub as-is' )
         #
@@ -670,6 +682,8 @@ def enable_all():
     Enables all ports on the hub -- without a hub, this does nothing!
     """
     hub.enable_ports()
+    for device in _device_by_sn.values():
+        device._port_enabled = True
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -43,6 +43,11 @@ MAX_ENUMERATION_TIME = 20  # [sec]
 # latency in the device-changed callback. Observed on D555/PoE: ~8s after PoE cut.
 PORTS_DISABLED_TIMEOUT = 10  # [sec]
 
+# A DDS/PoE device (e.g. D555) bricks if its hub port is re-powered before it has fully shut down:
+# it re-powers mid-shutdown and never re-enumerates. Re-enabling ~22s after disabling was observed
+# to brick a D555; a multi-minute gap was fine. Keep a port off at least this long before re-enable.
+POE_SETTLE_TIME = 30  # [sec]
+
 # We need both pyrealsense2 and hub. We can work without hub, but
 # without pyrealsense2 no devices at all will be returned.
 from rspy import device_hub
@@ -637,17 +642,18 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         if recycle:
             #
             # Only toggle what differs: disable the enabled ports we don't want, enable the wanted
-            # ports that are off. Never disable a DDS/PoE device (e.g. D555): cutting its PoE port
-            # and re-enabling it shortly after bricks its re-enumeration (it re-powers mid-shutdown
-            # and never comes back). Leaving it up is safe -- it doesn't interfere with USB tests.
-            dds_ports = { get( sn ).port for sn in enabled_sns if get( sn ).is_dds }
-            ports_to_disable = [ p for p in enabled_ports if p not in wanted_ports and p not in dds_ports ]
+            # ports that are off. A wanted port that's already enabled is left untouched.
+            ports_to_disable = [ p for p in enabled_ports if p not in wanted_ports ]
             ports_to_enable  = [ p for p in wanted_ports if p not in enabled_ports ]
             #
             if ports_to_disable:
                 log.d( 'disabling ports', ports_to_disable )
                 sns_to_remove = { sn for sn in enabled_sns if get( sn ).port in ports_to_disable }
-                hub.disable_ports( ports_to_disable )
+                # A DDS/PoE device (e.g. D555) bricks if its port is re-powered before it has fully
+                # shut down -- it never re-enumerates. Hold the port off long enough on disable so a
+                # later re-enable always starts from a fully-powered-down device.
+                settle = POE_SETTLE_TIME if any( get( sn ).is_dds for sn in sns_to_remove ) else 0
+                hub.disable_ports( ports_to_disable, sleep_on_change = settle )
                 for sn in sns_to_remove:
                     get( sn )._port_enabled = False
                 _wait_until_removed( sns_to_remove, timeout = timeout )

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -637,10 +637,11 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         if recycle:
             #
             # Only toggle what differs: disable the enabled ports we don't want, enable the wanted
-            # ports that are off. A wanted port that's already enabled is left untouched -- recycling
-            # it would needlessly power-cycle the device (DDS/PoE like D555 re-enumerate slowly and
-            # would time out the wait below).
-            ports_to_disable = [ p for p in enabled_ports if p not in wanted_ports ]
+            # ports that are off. Never disable a DDS/PoE device (e.g. D555): cutting its PoE port
+            # and re-enabling it shortly after bricks its re-enumeration (it re-powers mid-shutdown
+            # and never comes back). Leaving it up is safe -- it doesn't interfere with USB tests.
+            dds_ports = { get( sn ).port for sn in enabled_sns if get( sn ).is_dds }
+            ports_to_disable = [ p for p in enabled_ports if p not in wanted_ports and p not in dds_ports ]
             ports_to_enable  = [ p for p in wanted_ports if p not in enabled_ports ]
             #
             if ports_to_disable:


### PR DESCRIPTION
Three independent LibCI nightly fixes:

- **rspy/devices (`enable_only`)** — recycle path now disables **all** device ports, not just those flagged `enabled()`. The DDS D555 sits on a hub port but isn't in `enabled()`, so its port stayed up and it lingered on the DDS domain — breaking tests that expect a single device (e.g. dds-adapter-depth's wait-for-1-device). `all()` catches it.

- **dds-adapter-depth (`test-depth.py`)** — kill `rs-dds-adapter` directly in `finally` instead of wrapping it in a `test.closure`. On an aborted test, `abort()` calls `sys.exit()` before `test_in_progress` is cleared, so opening a closure in `finally` threw `"test case is already running"` and the kill never ran — leaking the adapter into the rest of the session.