### PR TITLE
Remove redundent conversions

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -203,13 +203,9 @@ std::vector< rs2_format > device::map_supported_color_formats( rs2_format source
     {
     case RS2_FORMAT_M420:
         target_formats.push_back(RS2_FORMAT_M420);
-        target_formats.push_back(RS2_FORMAT_Y16);
-        target_formats.push_back(RS2_FORMAT_Y8);
         break;
     case RS2_FORMAT_NV12:
         target_formats.push_back(RS2_FORMAT_NV12);
-        target_formats.push_back(RS2_FORMAT_Y16);
-        target_formats.push_back(RS2_FORMAT_Y8);
         break;
     case RS2_FORMAT_YUYV:
         break;


### PR DESCRIPTION
Since these conversions interrupt the IR -> color  conversions and no need for them I removed it
Approved by Evgeni