### PR TITLE
Add M420 and NV12 to DDS video encoding translation

### DIFF
--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -100,7 +100,7 @@ typedef enum rs2_format
     RS2_FORMAT_FG              , /**< 16-bit per-pixel frame grabber format. */
     RS2_FORMAT_Y411            , /**< 12-bit per-pixel. */
     RS2_FORMAT_Y16I            , /**< 12-bit per pixel interleaved. 12-bit left, 12-bit right. */
-    RS2_FORMAT_M420            , /**< 24-bit for every pixel: y for each pixel, and u,v data for every four pixels - packed as 2 lines of y, 1 line of u,v */
+    RS2_FORMAT_M420            , /**< YUV 4:2:0: y for each pixel, and u,v data for every four pixels - packed as 2 lines of y, 1 line of u,v. 12 bits per pixel on average. */
     RS2_FORMAT_COMBINED_MOTION , /**< Combined motion data, as in the combined_motion structure */
     RS2_FORMAT_NV12            , /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -68,7 +68,7 @@ enum rs2_format  // copy from rs2_sensor.h
     RS2_FORMAT_FG,    /**< 16-bit per-pixel frame grabber format. */
     RS2_FORMAT_Y411,  /**< 12-bit per-pixel. */
     RS2_FORMAT_Y16I,  /**< 12-bit per pixel interleaved. 12-bit left, 12-bit right. */
-    RS2_FORMAT_M420,  /**< 24-bit per pixel: y for each pixel, and u,v for every four pixels - packed as 2 lines of y, 1 line of u,v */
+    RS2_FORMAT_M420,  /**< YUV 4:2:0: y for each pixel, and u,v for every four pixels - packed as 2 lines of y, 1 line of u,v. 12 bits per pixel on average. */
     RS2_FORMAT_COMBINED_MOTION, /**< Combined motion data, as in the combined_motion structure */
     RS2_FORMAT_NV12,  /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
     RS2_FORMAT_COUNT  /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -67,7 +67,10 @@ enum rs2_format  // copy from rs2_sensor.h
     RS2_FORMAT_Z16H,  /**< DEPRECATED! - Variable-length Huffman-compressed 16-bit depth values. */
     RS2_FORMAT_FG,    /**< 16-bit per-pixel frame grabber format. */
     RS2_FORMAT_Y411,  /**< 12-bit per-pixel. */
-    RS2_FORMAT_COMBINED_MOTION,
+    RS2_FORMAT_Y16I,  /**< 12-bit per pixel interleaved. 12-bit left, 12-bit right. */
+    RS2_FORMAT_M420,  /**< 24-bit per pixel: y for each pixel, and u,v for every four pixels - packed as 2 lines of y, 1 line of u,v */
+    RS2_FORMAT_COMBINED_MOTION, /**< Combined motion data, as in the combined_motion structure */
+    RS2_FORMAT_NV12,  /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
     RS2_FORMAT_COUNT  /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 };
 
@@ -93,6 +96,8 @@ int dds_video_encoding::to_rs2() const
         { "BYR2", RS2_FORMAT_RAW16 },
         { "R10", RS2_FORMAT_RAW10 },
         { "Y10B", RS2_FORMAT_Y10BPACK },
+        { "M420", RS2_FORMAT_M420 },  // Used by D500 color streams
+        { "NV12", RS2_FORMAT_NV12 },
     };
 
     std::string s = to_string();
@@ -126,6 +131,8 @@ dds_video_encoding dds_video_encoding::from_rs2( int rs2_format )
     case RS2_FORMAT_RAW10: encoding = "R10"; break;
     case RS2_FORMAT_UYVY: encoding = "uyvy"; break;
     case RS2_FORMAT_Y10BPACK: encoding = "Y10B"; break;
+    case RS2_FORMAT_M420: encoding = "M420"; break;  // Used by D500 color streams
+    case RS2_FORMAT_NV12: encoding = "NV12"; break;
     default:
         DDS_THROW( runtime_error, "cannot translate rs2_format " + std::to_string( rs2_format ) + " to any known dds_video_encoding" );
     };


### PR DESCRIPTION
**Overview:** Map the M420 and NV12 color formats to DDS video encodings so `rs-dds-adapter` can publish cameras that expose them (e.g. D585S / D500-family) instead of throwing.

## Why
`dds_video_encoding::from_rs2()` has no case for `RS2_FORMAT_M420` (or `NV12`), so publishing a device with an M420 color profile throws `cannot translate rs2_format 32 to any known dds_video_encoding`. The adapter's add-device loop (`lrs-device-watcher.cpp`) has no per-device guard, so the throw aborts publication of the whole enumeration batch — any other device in the same batch (including a device-under-test) is then never advertised over DDS.

Note: this is a latent failure mode. It is **not** the cause of the recent nightly `test-dds-adapter-depth` red — that was a separate DDS-domain collision with a native D555 and is tracked separately.

## Summary
- Add `M420` and `NV12` to the rs2_format ↔ DDS encoding maps in `dds-stream-profile.cpp`.
- Sync the file's local `rs2_format` enum copy with `rs_sensor.h` (it was missing `Y16I` / `M420` / `NV12`, so `COMBINED_MOTION` resolved to the wrong value).

## Test plan
- [x] Built locally with `BUILD_WITH_DDS=ON` (realdds + rs-dds-adapter compile clean)
- [ ] libci (auto-runs on PR push)

🤖 Generated by AI
