### PR TITLE
ci: add ROS 2 Lyrical (Ubuntu 26.04 Resolute) to build matrix

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -39,7 +39,7 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
 
-          # Lyrical
+          # Lyrical Luth
           - docker_image: ubuntu:resolute
             ros_distribution: lyrical
 

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
+      # Lyrical/Rolling can hit transient upstream availability issues during
+      # the platform transition; don't cancel siblings if one row fails.
+      fail-fast: false
       matrix:
         ros_distribution:
           - humble
@@ -54,31 +57,49 @@ jobs:
         # unauthenticated GitHub API call (60 req/hour per IP, shared across
         # hosted runners), which intermittently gets rate-limited and fails the
         # job with a 404. Pre-installing the package here makes setup-ros skip
-        # that step. The version is resolved from the releases/latest web
-        # redirect, which is not subject to the API rate limit.
+        # that step.
         # Remove once fixed upstream (ros-tooling/setup-ros).
         shell: bash
         env:
           USE_ROS2_TESTING: ${{ matrix.use_ros2_testing || false }}
+          # Pin ros-apt-source to a known release; the .deb is verified against
+          # a per-(pkg,codename) SHA-256 below so a tampered CDN can't be
+          # silently installed. When bumping ROS_APT_SOURCE_VERSION, also
+          # update the hashes from the new release assets:
+          #   https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/tags/<VERSION>
+          # (each asset has a `digest: sha256:...` field).
+          ROS_APT_SOURCE_VERSION: "1.2.0"
         run: |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-          VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 5 --retry-delay 5 --retry-all-errors \
-            https://github.com/ros-infrastructure/ros-apt-source/releases/latest | sed 's|.*/||')
-          [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]] || { echo "ERROR: could not resolve ros-apt-source version (got: '${VERSION}')"; exit 1; }
           codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
           # Restore this line (and drop USE_ROS2_TESTING + the conditional below)
           # when ros-rolling-desktop is published in the stable resolute apt index
           # (packages.ros.org/ros2/dists/resolute).
-          # curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
-          #   "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/ros2-apt-source_${VERSION}.${codename}_all.deb"
+          # pkg=ros2-apt-source
           if [[ "${USE_ROS2_TESTING}" == "true" ]]; then
             pkg=ros2-testing-apt-source
           else
             pkg=ros2-apt-source
           fi
+          # Pinned SHA-256 per (pkg, codename) for ROS_APT_SOURCE_VERSION above.
+          case "${pkg}_${codename}" in
+            ros2-apt-source_jammy)            expected=767884cf4ed03116b9d64438930a832ed854147ae435279a7924dfdf60f94433 ;;
+            ros2-apt-source_noble)            expected=0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 ;;
+            ros2-apt-source_resolute)         expected=a275b9b819874e745a928e83e39c429fa4d607159285c4ef3ebcf75afa732ee3 ;;
+            ros2-testing-apt-source_resolute) expected=da9261ca7c06244da1528e0ede44018f7bb2e24a8a077eb0202f70706b578546 ;;
+            *) echo "ERROR: no pinned SHA-256 for ${pkg}_${codename} at v${ROS_APT_SOURCE_VERSION}"; exit 1 ;;
+          esac
+          deb="${pkg}_${ROS_APT_SOURCE_VERSION}.${codename}_all.deb"
           curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
-            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/${pkg}_${VERSION}.${codename}_all.deb"
+            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/${deb}"
+          actual=$(sha256sum /tmp/ros2-apt-source.deb | awk '{print $1}')
+          if [ "${actual}" != "${expected}" ]; then
+            echo "ERROR: SHA-256 mismatch for ${deb}"
+            echo "  expected: ${expected}"
+            echo "  actual:   ${actual}"
+            exit 1
+          fi
           dpkg -i /tmp/ros2-apt-source.deb
 
       - name: setup ROS environment

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -31,8 +31,8 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
 
-          # Rolling Ridley (tracks Resolute on Ubuntu 26.04)
-          - docker_image: ubuntu:26.04
+          # Rolling Ridley
+          - docker_image: ubuntu:resolute
             ros_distribution: rolling
 
           # Jazzy Jalisco

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -31,9 +31,11 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
 
-          # Rolling Ridley
+          # Rolling Ridley — ros-rolling-* for resolute is still only in
+          # ros2-testing until the next stable sync, so pull from there.
           - docker_image: ubuntu:resolute
             ros_distribution: rolling
+            use_ros2_testing: true
 
           # Jazzy Jalisco
           - docker_image: ubuntu:noble
@@ -56,6 +58,8 @@ jobs:
         # redirect, which is not subject to the API rate limit.
         # Remove once fixed upstream (ros-tooling/setup-ros).
         shell: bash
+        env:
+          USE_ROS2_TESTING: ${{ matrix.use_ros2_testing || false }}
         run: |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
@@ -63,14 +67,25 @@ jobs:
             https://github.com/ros-infrastructure/ros-apt-source/releases/latest | sed 's|.*/||')
           [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]] || { echo "ERROR: could not resolve ros-apt-source version (got: '${VERSION}')"; exit 1; }
           codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+          # Restore this line (and drop USE_ROS2_TESTING + the conditional below)
+          # when ros-rolling-desktop is published in the stable resolute apt index
+          # (packages.ros.org/ros2/dists/resolute).
+          # curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
+          #   "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/ros2-apt-source_${VERSION}.${codename}_all.deb"
+          if [[ "${USE_ROS2_TESTING}" == "true" ]]; then
+            pkg=ros2-testing-apt-source
+          else
+            pkg=ros2-apt-source
+          fi
           curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
-            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/ros2-apt-source_${VERSION}.${codename}_all.deb"
+            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VERSION}/${pkg}_${VERSION}.${codename}_all.deb"
           dpkg -i /tmp/ros2-apt-source.deb
 
       - name: setup ROS environment
         uses: ros-tooling/setup-ros@77bcad67a6cb15f6192d61464d99bbab658e4ca9 #v0.7.18
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+          use-ros2-testing: ${{ matrix.use_ros2_testing || false }}
 
       - name: build librealsense ROS 2
         uses: ros-tooling/action-ros-ci@3a640b10f09b756dabe556dac5413aba369f71b0 #v0.4.8

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -20,6 +20,7 @@ jobs:
           - kilted
           - rolling
           - jazzy
+          - lyrical
 
         include:
           # Humble Hawksbill
@@ -30,13 +31,17 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: kilted
 
-          # Rolling Ridley
-          - docker_image: ubuntu:noble
+          # Rolling Ridley (tracks Resolute on Ubuntu 26.04)
+          - docker_image: ubuntu:26.04
             ros_distribution: rolling
 
           # Jazzy Jalisco
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
+
+          # Lyrical
+          - docker_image: ubuntu:resolute
+            ros_distribution: lyrical
 
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/build-ROS2-rolling-CI.yaml
+++ b/.github/workflows/build-ROS2-rolling-CI.yaml
@@ -19,7 +19,8 @@ on:
   pull_request:
     branches: ['**']
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/build-ROS2-rolling-CI.yaml
+++ b/.github/workflows/build-ROS2-rolling-CI.yaml
@@ -1,4 +1,17 @@
-name: build_lrs_ROS2_package
+name: build_lrs_ROS2_package_rolling
+
+# Rolling Ridley CI (Ubuntu 26.04 Resolute) — split from the main ROS 2
+# workflow because Rolling currently needs transitional workarounds that
+# don't apply to the stable distros (Humble/Kilted/Jazzy/Lyrical):
+#
+#   - ros-rolling-* debs for `resolute` are still only in the `ros2-testing`
+#     apt index; the stable `ros2` index has not synced yet.
+#   - We use `ros2-testing-apt-source` (and `use-ros2-testing: true` for
+#     setup-ros) until the sync lands on packages.ros.org/ros2.
+#
+# Fold back into build-ROS2-package-CI.yaml (and delete this file) once
+# ros-rolling-desktop is published in the stable resolute apt index
+# (packages.ros.org/ros2/dists/resolute).
 
 on:
   push:
@@ -10,42 +23,14 @@ permissions: read-all
 
 jobs:
 
-  build_lrs_ros2_package:
+  build_lrs_ros2_package_rolling:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    strategy:
-      # Lyrical can hit transient upstream availability issues during the
-      # platform transition; don't cancel siblings if one row fails.
-      fail-fast: false
-      matrix:
-        ros_distribution:
-          - humble
-          - kilted
-          - jazzy
-          - lyrical
-
-        include:
-          # Humble Hawksbill
-          - docker_image: ubuntu:jammy
-            ros_distribution: humble
-
-          # Kilted Kaiju
-          - docker_image: ubuntu:noble
-            ros_distribution: kilted
-
-          # Jazzy Jalisco
-          - docker_image: ubuntu:noble
-            ros_distribution: jazzy
-
-          # Lyrical Luth
-          - docker_image: ubuntu:resolute
-            ros_distribution: lyrical
-
     container:
-      image: ${{ matrix.docker_image }}
+      image: ubuntu:resolute
     steps:
 
-      - name: install ROS 2 apt source
+      - name: install ROS 2 apt source (ros2-testing)
         # Workaround: setup-ros resolves the ros-apt-source version via an
         # unauthenticated GitHub API call (60 req/hour per IP, shared across
         # hosted runners), which intermittently gets rate-limited and fails the
@@ -55,24 +40,21 @@ jobs:
         shell: bash
         env:
           # Pin ros-apt-source to a known release; the .deb is verified against
-          # a per-codename SHA-256 below so a tampered CDN can't be silently
-          # installed. When bumping ROS_APT_SOURCE_VERSION, also update the
-          # hashes from the new release assets:
+          # the SHA-256 below so a tampered CDN can't be silently installed.
+          # When bumping ROS_APT_SOURCE_VERSION, refresh the hash from:
           #   https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/tags/<VERSION>
           # (each asset has a `digest: sha256:...` field).
           ROS_APT_SOURCE_VERSION: "1.2.0"
         run: |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-          codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
-          pkg=ros2-apt-source
-          # Pinned SHA-256 per codename for ROS_APT_SOURCE_VERSION above.
-          case "${codename}" in
-            jammy)    expected=767884cf4ed03116b9d64438930a832ed854147ae435279a7924dfdf60f94433 ;;
-            noble)    expected=0804d9b13db770eb87019be414cd78378835228ad5fa801fc88758596dd8f7e5 ;;
-            resolute) expected=a275b9b819874e745a928e83e39c429fa4d607159285c4ef3ebcf75afa732ee3 ;;
-            *) echo "ERROR: no pinned SHA-256 for ${pkg}_${codename} at v${ROS_APT_SOURCE_VERSION}"; exit 1 ;;
-          esac
+          # Restore this line (and drop the ros2-testing-apt-source line below)
+          # when ros-rolling-desktop is published in the stable resolute apt
+          # index (packages.ros.org/ros2/dists/resolute).
+          # pkg=ros2-apt-source
+          pkg=ros2-testing-apt-source
+          codename=resolute
+          expected=da9261ca7c06244da1528e0ede44018f7bb2e24a8a077eb0202f70706b578546
           deb="${pkg}_${ROS_APT_SOURCE_VERSION}.${codename}_all.deb"
           curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/ros2-apt-source.deb \
             "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/${deb}"
@@ -88,12 +70,15 @@ jobs:
       - name: setup ROS environment
         uses: ros-tooling/setup-ros@77bcad67a6cb15f6192d61464d99bbab658e4ca9 #v0.7.18
         with:
-          required-ros-distributions: ${{ matrix.ros_distribution }}
+          required-ros-distributions: rolling
+          # Restore to false (or remove) once rolling debs for resolute ship
+          # in the stable ros2 apt index.
+          use-ros2-testing: true
 
       - name: build librealsense ROS 2
         uses: ros-tooling/action-ros-ci@3a640b10f09b756dabe556dac5413aba369f71b0 #v0.4.8
         with:
-          target-ros2-distro: ${{ matrix.ros_distribution }}
+          target-ros2-distro: rolling
           skip-tests: true
           colcon-defaults: |  # We align the build flags to the librealsense2 ROS2 release build.
             {


### PR DESCRIPTION
Tracked by: RSDSO-21542

**Overview:** Add ROS 2 Lyrical (Ubuntu 26.04 Resolute) to the librealsense ROS 2 package CI matrix and align the Rolling job with Ubuntu 26.04.

## Why
ROS 2 Lyrical, paired with Ubuntu 26.04 "Resolute", has started building on the official ROS build farm. The librealsense CI matrix did not yet exercise Lyrical, leaving the wrapper untested on the next ROS 2 release. Rolling has likewise moved to Ubuntu 26.04 upstream, but `ros-rolling-*` debs for the `resolute` codename are still only in `packages.ros.org/ros2-testing` and have not yet synced into stable `packages.ros.org/ros2`.

## Summary
- Add `lyrical` entry to `ros_distribution` matrix paired with `ubuntu:resolute`.
- Switch the Rolling row to `ubuntu:resolute` (was `ubuntu:noble`) and tag it with `use_ros2_testing: true`. The workflow installs `ros2-testing-apt-source` and forwards `use-ros2-testing: true` to `ros-tooling/setup-ros` only for the rolling matrix entry. Once `ros-rolling-*` syncs to the stable `resolute` index, the conditional can be reverted to the original single-line install (left in place as a commented marker).
- `ros-tooling/setup-ros` (v0.7.18) and `ros-tooling/action-ros-ci` (v0.4.8) already support Lyrical, so no action bumps needed.

## Test plan
- [x] GHA `build_lrs_ros2_package (lyrical)` passes on `ubuntu:resolute`.
- [x] GHA `build_lrs_ros2_package (rolling)` passes on `ubuntu:resolute` via ros2-testing.
- [x] Existing matrix entries (humble, kilted, jazzy) still pass.
