### PR TITLE
Display full API version (with build number) in viewer, tools and examples

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -124,11 +124,9 @@ namespace rs2
     {
         std::stringstream ss;
 
-        rs2_error* e = nullptr;
-
         ss << "| | |\n";
         ss << "|---|---|\n";
-        ss << "|**librealsense**|" << api_version_to_string(rs2_get_api_version(&e)) << (is_debug() ? " DEBUG" : " RELEASE") << "|\n";
+        ss << "|**librealsense**|" << RS2_API_FULL_VERSION_STR << (is_debug() ? " DEBUG" : " RELEASE") << "|\n";
         ss << "|**OS**|" << rsutils::os::get_os_name() << "|\n";
 
         for (auto& dm : devices)

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -699,7 +699,7 @@ namespace rs2
 
         ImGui::SetCursorScreenPos({ float(x + 20), float(y + 16) });
         ImGui::Text("Welcome to"); ImGui::SameLine();
-        std::string txt = rsutils::string::from() << "librealsense " << RS2_API_VERSION_STR << "!";
+        std::string txt = rsutils::string::from() << "librealsense " << RS2_API_FULL_VERSION_STR << "!";
 
         ImGui::PushStyleColor(ImGuiCol_Text, alpha(white, 1.f - t));
         ImGui::Text("%s", txt.c_str());

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -279,8 +279,7 @@ namespace rs2
 
         _fullscreen = config_file::instance().get(configurations::window::is_fullscreen);
 
-        rs2_error* e = nullptr;
-        _title_str = rsutils::string::from() << _title << " v" << api_version_to_string(rs2_get_api_version(&e));
+        _title_str = rsutils::string::from() << _title << " v" << RS2_API_FULL_VERSION_STR;
         auto debug = is_debug();
         if (debug)
         {

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -279,6 +279,7 @@ namespace rs2
 
         _fullscreen = config_file::instance().get(configurations::window::is_fullscreen);
 
+        // RS2_API_FULL_VERSION_STR is the compile-time version (incl. build #); a loaded-library mismatch is caught separately via rs2_get_api_version()
         _title_str = rsutils::string::from() << _title << " v" << RS2_API_FULL_VERSION_STR;
         auto debug = is_debug();
         if (debug)

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1028,7 +1028,7 @@ namespace rs2
         syncer = std::make_shared<syncer_model>();
         updates = std::make_shared<updates_model>();
         reset_camera();
-        not_model->add_log( "librealsense version: " + std::string( RS2_API_FULL_VERSION_STR ) + "\n" );
+        not_model->add_log( rsutils::string::from() << "librealsense version: " << RS2_API_FULL_VERSION_STR << "\n" );
 
         update_configuration();
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1028,8 +1028,7 @@ namespace rs2
         syncer = std::make_shared<syncer_model>();
         updates = std::make_shared<updates_model>();
         reset_camera();
-        rs2_error* e = nullptr;
-        not_model->add_log( "librealsense version: " + api_version_to_string( rs2_get_api_version( &e ) ) + "\n" );
+        not_model->add_log( "librealsense version: " + std::string( RS2_API_FULL_VERSION_STR ) + "\n" );
 
         update_configuration();
 

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -94,11 +94,10 @@ void report_error(std::string error)
     if (button == IDCANCEL)
     {
         std::stringstream ss;
-        rs2_error* e = nullptr;
 
         ss << "| | |\n";
         ss << "|---|---|\n";
-        ss << "|**librealsense**|" << rs2::api_version_to_string(rs2_get_api_version(&e)) << (rs2::is_debug() ? " DEBUG" : " RELEASE") << "|\n";
+        ss << "|**librealsense**|" << RS2_API_FULL_VERSION_STR << (rs2::is_debug() ? " DEBUG" : " RELEASE") << "|\n";
         ss << "|**OS**|" << rsutils::os::get_os_name() << "|\n\n";
         ss << "RealSense Viewer / Depth Quality Tool has crashed with the following error message:\n";
         ss << "```\n";

--- a/examples/cmake/hello_librealsense2.cpp
+++ b/examples/cmake/hello_librealsense2.cpp
@@ -10,7 +10,7 @@ int main()
 {
     rs2::context ctx;
 
-    std::cout << "hello from librealsense - " << RS2_API_VERSION_STR << std::endl;
+    std::cout << "hello from librealsense - " << RS2_API_FULL_VERSION_STR << std::endl;
     std::cout << "You have " << ctx.query_devices().size() << " RealSense devices connected" << std::endl;
 
     return 0;


### PR DESCRIPTION
**Overview:** The realsense-viewer, CLI tools, and SDK examples now display the full API version including the build number (X.Y.Z.build) instead of the short X.Y.Z form.

Tracked on [RSDSO-21628]

## Why
User-facing version displays showed only `X.Y.Z`, dropping the build number — which is what uniquely identifies a specific build. The runtime `rs2_get_api_version()` encodes only major/minor/patch and cannot carry the build number, so any display routed through it lost that detail.

## Summary
- Switched all user-facing version displays in the viewer/tools/examples to the compile-time `RS2_API_FULL_VERSION_STR` macro (the only source that includes the build number):
  - GUI window title bar (`ux-window.cpp`)
  - "Welcome to librealsense" splash (`notifications.cpp`)
  - Hardware/issue report table (`device-model.cpp`) and Windows crash report (`windows-app-bootstrap.cpp`)
  - "librealsense version: ..." log line (`viewer.cpp`)
  - `hello_librealsense2` example
- Dropped the now-unused `rs2_error*` locals at those sites.
- `--version` (via `cli.h`) and `rs-dds-config` already used the full version — unchanged.
- Left `rs2_get_api_version()` in place where the macro would be wrong: the integer upgrade-greeting comparison (`viewer.cpp`) and runtime library-mismatch detection.

## Test plan
- [x] Built `realsense-viewer` (Release, VS2022 x64) — compiles cleanly with all changed `common/` files.
- [x] Launched the viewer (Release, D455 connected) — title bar reads `RealSense Viewer v2.58.0.0` (full 4-component version; previously `v2.58.0`).


