### PR TITLE
Use center of mass from FW for person detection

### DIFF
--- a/common/objects-in-frame.h
+++ b/common/objects-in-frame.h
@@ -46,4 +46,5 @@ struct atomic_objects_in_frame : public objects_in_frame
 {
     std::mutex mutex;
     bool sensor_is_on = true;
+    int ticks_without_od_frame = 0;  // render ticks since last OD frame; cleared on every OD frame arrival
 };

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3584,39 +3584,6 @@ namespace rs2
         return rs2::rect{ dst_tl[0], dst_tl[1], dst_br[0] - dst_tl[0], dst_br[1] - dst_tl[1] }.intersection( depth_frame_rect );
     }
 
-    float viewer_model::sample_mean_depth( const rs2::depth_frame & df, const rs2::rect & depth_bbox )
-    {
-        uint16_t const * const depth_data   = reinterpret_cast< uint16_t const * >( df.get_data() );
-        float const            depth_scale  = df.get_units();
-        int const              depth_width  = df.get_width();
-        int const              depth_height = df.get_height();
-        int const cx = int( depth_bbox.x + depth_bbox.w * 0.5f );
-        int const cy = int( depth_bbox.y + depth_bbox.h * 0.5f );
-        static const int offsets[][2] = { { -2, -2 }, {  0, -2 }, {  2, -2 },
-                                          { -2,  0 }, {  0,  0 }, {  2,  0 },
-                                          { -2,  2 }, {  0,  2 }, {  2,  2 } };
-        float total = 0.f;
-        int hits = 0;
-        for( auto const & off : offsets )
-        {
-            int const x = cx + off[0];
-            int const y = cy + off[1];
-            if( x < 0 || x >= depth_width || y < 0 || y >= depth_height )
-                continue;
-            uint16_t const d = depth_data[y * depth_width + x];
-            if( d != 0 )
-            {
-                total += d * depth_scale;
-                ++hits;
-            }
-        }
-
-        float val = hits > 0 ? total / hits : 0.f;
-        if( val > 5.0f ) // Above 5 meters not accurate, prefer to not show.
-            val = 0.f;
-        return val;
-    }
-
     void viewer_model::process_object_detection_frames( std::map< int, rs2::frame > & last_frames )
     {
         // Scan last_frames for an object detection frame, a color frame, and a depth frame.
@@ -3696,11 +3663,8 @@ namespace rs2
                                                                     color_to_depth, depth_to_color, depth_frame_rect );
                 rs2::rect normalized_depth_bbox = depth_bbox.normalize( depth_frame_rect );
 
-                // Currently detection depth is not calculated in device, later we will use detection depth data.
-                float const mean_depth = sample_mean_depth( df, depth_bbox );
-
                 std::string name = object_type_to_string( static_cast< object_type >( det.class_id ) );
-                new_objects.emplace_back( size_t( i ), name, normalized_color_bbox, normalized_depth_bbox, mean_depth,
+                new_objects.emplace_back( size_t( i ), name, normalized_color_bbox, normalized_depth_bbox, det.depth,
                                           static_cast< object_type >( det.class_id ) );
             }
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3620,8 +3620,26 @@ namespace rs2
         if( ! objects )
             return;
 
-        // Require both color and depth; clear detections if either is absent
-        if( ! odf || ! cf || ! df || odf.get_detection_count() == 0 )
+        // No OD frame this tick. When OD fps < render fps this is normal (e.g. OD@15fps, RGB@30fps).
+        // Keep last known detections to avoid flicker, but clear if absent for too long (OD sensor stopped).
+        static constexpr int MAX_STALE_OD_TICKS = 10;
+        if( ! odf )
+        {
+            if( ++objects->ticks_without_od_frame > MAX_STALE_OD_TICKS )
+            {
+                std::lock_guard< std::mutex > lock( objects->mutex );
+                objects->clear();
+            }
+            return;
+        }
+        objects->ticks_without_od_frame = 0;
+
+        // OD frame arrived but depth not yet available — skip without clearing
+        if( ! df )
+            return;
+
+        // Fresh OD frame with no detections — clear
+        if( odf.get_detection_count() == 0 )
         {
             std::lock_guard< std::mutex > lock( objects->mutex );
             objects->clear();

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -228,7 +228,6 @@ namespace rs2
                                                const rs2_extrinsics & color_to_depth,
                                                const rs2_extrinsics & depth_to_color,
                                                const rs2::rect &    depth_frame_rect );
-        static float sample_mean_depth( const rs2::depth_frame & df, const rs2::rect & depth_bbox );
         void process_object_detection_frames( std::map< int, rs2::frame > & last_frames );
 
         void check_permissions();

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -128,7 +128,7 @@ typedef struct rs2_object_detection
     int top_left_y;     /**< Top-left corner pixel Y coordinate */
     int bottom_right_x; /**< Bottom-right corner pixel X coordinate */
     int bottom_right_y; /**< Bottom-right corner pixel Y coordinate */
-    float depth;        /**< Mean depth in meters at detection location */
+    float depth;        /**< Distance to detected object in meters, as computed by firmware */
 } rs2_object_detection;
 
 /** \brief Severity of the librealsense logger. */

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -184,7 +184,8 @@ namespace librealsense
 
     void d500_depth_sensor::start( rs2_frame_callback_sptr callback )
     {
-        _owner->on_depth_sensor_starting();
+        if( _owner )
+            _owner->on_depth_sensor_starting();
         synthetic_sensor::start( callback );
     }
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -182,6 +182,12 @@ namespace librealsense
         }); //group_multiple_fw_calls
     }
 
+    void d500_depth_sensor::start( rs2_frame_callback_sptr callback )
+    {
+        _owner->on_depth_sensor_starting();
+        synthetic_sensor::start( callback );
+    }
+
     void d500_depth_sensor::close()
     {
         if( _owner && _owner->_thermal_monitor )

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -40,6 +40,7 @@ namespace librealsense
         rs2_intrinsics get_intrinsics( const stream_profile & profile ) const override;
         void set_frame_metadata_modifier( on_frame_md callback ) override;
         void open( const stream_profiles & requests ) override;
+        void start( rs2_frame_callback_sptr callback ) override;
         void close() override;
         rs2_intrinsics get_color_intrinsics( const stream_profile & profile ) const;
         stream_profiles init_stream_profiles() override;
@@ -52,7 +53,7 @@ namespace librealsense
         void add_embedded_filter( std::shared_ptr< embedded_filter_interface > filter ) { _embedded_filters.push_back( filter ); }
 
     protected:
-        const d500_device * _owner;
+        d500_device * _owner;
         mutable std::atomic< float > _depth_units;
         float _stereo_baseline_mm;
 
@@ -106,6 +107,8 @@ namespace librealsense
             size_t dataLength = 0) const override;
 
         void hardware_reset() override;
+
+        virtual void on_depth_sensor_starting() {}
 
         platform::usb_spec get_usb_spec() const;
         virtual double get_device_time_ms() override;

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -108,7 +108,7 @@ namespace librealsense
 
         void hardware_reset() override;
 
-        virtual void on_depth_sensor_starting() {}
+        virtual void on_depth_sensor_starting() noexcept {}
 
         platform::usb_spec get_usb_spec() const;
         virtual double get_device_time_ms() override;

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -100,7 +100,7 @@ namespace librealsense
         od_ep->register_processing_block( od_pbf );
     }
 
-    void d500_object_detection::on_depth_sensor_starting()
+    void d500_object_detection::on_depth_sensor_starting() noexcept
     {
         // Firmware requires the Align_Depth XU (selector 0x10) to be set before depth
         // streaming starts; it is silently ignored if sent after streaming begins.

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -3,6 +3,7 @@
 
 #include "d500-object-detection.h"
 
+#include "ds/ds-private.h"
 #include "d500-info.h"
 #include "ds/ds-timestamp.h"
 #include <src/global_timestamp_reader.h>
@@ -97,6 +98,33 @@ namespace librealsense
                                             { { RS2_FORMAT_Y8, RS2_STREAM_OBJECT_DETECTION } },
                                             []() { return std::make_shared< identity_processing_block >(); } };
         od_ep->register_processing_block( od_pbf );
+    }
+
+    void d500_object_detection::on_depth_sensor_starting()
+    {
+        // Firmware requires the Align_Depth XU (selector 0x10) to be set before depth
+        // streaming starts; it is silently ignored if sent after streaming begins.
+        auto raw_depth = get_raw_depth_sensor();
+        if( !raw_depth )
+            return;
+
+        try
+        {
+            raw_depth->invoke_powered( []( platform::uvc_device & dev )
+            {
+                uint8_t enable = 1;
+                if( !dev.set_xu( ds::depth_xu, ds::DS5_ALIGN_DEPTH, &enable, sizeof( enable ) ) )
+                    LOG_WARNING( "Failed to enable Align_Depth XU on depth sensor" );
+            } );
+        }
+        catch( std::exception const & e )
+        {
+            LOG_WARNING( "Align_Depth XU exception: " << e.what() );
+        }
+        catch( ... )
+        {
+            LOG_WARNING( "Align_Depth XU: unknown exception" );
+        }
     }
 
     stream_profiles d500_object_detection_sensor::init_stream_profiles()

--- a/src/ds/d500/d500-object-detection.h
+++ b/src/ds/d500/d500-object-detection.h
@@ -22,7 +22,7 @@ namespace librealsense
         std::shared_ptr< synthetic_sensor > create_object_detection_device( std::shared_ptr< context > ctx,
                                                                             const std::vector< platform::uvc_device_info > & od_devices_info );
 
-        void on_depth_sensor_starting() override;
+        void on_depth_sensor_starting() noexcept override;
 
     private:
         friend class d500_object_detection_sensor;

--- a/src/ds/d500/d500-object-detection.h
+++ b/src/ds/d500/d500-object-detection.h
@@ -22,6 +22,8 @@ namespace librealsense
         std::shared_ptr< synthetic_sensor > create_object_detection_device( std::shared_ptr< context > ctx,
                                                                             const std::vector< platform::uvc_device_info > & od_devices_info );
 
+        void on_depth_sensor_starting() override;
+
     private:
         friend class d500_object_detection_sensor;
 

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -33,9 +33,11 @@ namespace librealsense
         const uint16_t D585_3C_PROTO_PID      = 0x0C08;
         
         // DS500 depth XU identifiers
-        const uint8_t DS5_HKR_PVT_TEMPERATURE = 0x15;
+        // Note: selector values differ from the D400-family depth_xu selectors in ds-private.h.
+        const uint8_t DS5_ALIGN_DEPTH              = 0x10;  // Enable depth-to-RGB alignment for OD distance; must be sent before depth streaming starts
+        const uint8_t DS5_HKR_PVT_TEMPERATURE      = 0x15;
         const uint8_t DS5_HKR_PROJECTOR_TEMPERATURE = 0x16;
-        const uint8_t DS5_HKR_OHM_TEMPERATURE = 0x17;
+        const uint8_t DS5_HKR_OHM_TEMPERATURE      = 0x17;
 
         // d500 Devices supported by the current version
         static const std::set<std::uint16_t> rs500_sku_pid = {


### PR DESCRIPTION
Firmware requires the Align_Depth XU (DS5_ALIGN_DEPTH = 0x10 on depth_xu) to be set before depth streaming starts; it is silently ignored if sent after. Add a virtual on_depth_sensor_starting() hook on d500_device, called from d500_depth_sensor::start() before synthetic_sensor::start(), so d500_object_detection can arm the XU at the correct point. The viewer now uses det.depth (firmware-computed distance from the OD payload) instead of the host-computed sample_mean_depth fallback.
