### PR TITLE
Ensure rs-dds-adapter is killed in finally block to prevent leaks

### DIFF
--- a/unit-tests/dds/adapter/test-depth.py
+++ b/unit-tests/dds/adapter/test-depth.py
@@ -113,8 +113,8 @@ try:
     del context
 
 finally:
-    # Always ensure the adapter process is terminated, even if test fails
-    with test.closure( 'Stop rs-dds-adapter', on_fail=test.ABORT ):
+    # Kill directly, not via test.closure: an aborted test would make the closure throw and skip the kill.
+    if adapter_process:
         try:
             # Try graceful termination first (SIGTERM lets adapter release DDS resources on Linux)
             adapter_process.send_signal( signal.SIGTERM )


### PR DESCRIPTION
When test-dds-adapter-depth aborts (e.g. the wait-for-device timeout), the cleanup was wrapped in a `test.closure`. On an aborted test `abort()` calls `sys.exit()` before clearing `test_in_progress`, so opening that closure in `finally` throws `"test case is already running"` and the kill never runs — leaking `rs-dds-adapter`, which then poisons later tests in the session.

Fix: kill the adapter directly in `finally` (plain try/except + `kill_all_dds_adapters()`), so it can't be blocked by leftover test state. No other behavior change.