### PR TITLE
Fix macOS dispatcher mutex lock failed invalid argument during shutdown

### DIFF
--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -103,6 +103,11 @@ public:
             { _callbacks.raise( old, curr ); } );
     }
 
+    ~device_watcher_singleton()
+    {
+        _device_watcher->stop();
+    }
+
     rsutils::subscription subscribe( platform::device_changed_callback && cb )
     {
         return _callbacks.subscribe( std::move( cb ) );

--- a/src/core/notification.cpp
+++ b/src/core/notification.cpp
@@ -24,7 +24,7 @@ notification::notification( rs2_notification_category category,
 
 
 notifications_processor::notifications_processor()
-    : _dispatcher( 10 )
+    : _dispatcher( 10, "notifications" )
 {
 }
 

--- a/src/ds/ds-thermal-monitor.cpp
+++ b/src/ds/ds-thermal-monitor.cpp
@@ -12,7 +12,7 @@ namespace librealsense
         _monitor([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            }),
+            }, "thermal-monitor"),
         _poll_intervals_ms(2000), // Temperature check routine to be invoked every 2 sec
         _thermal_threshold_deg(2.f),
         _temp_base(0.f),

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -20,7 +20,7 @@ namespace librealsense
         _decoder(decoder)
     {
         _active_object = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
-            {  polling(cancellable_timer);  });
+            {  polling(cancellable_timer);  }, "error-handler");
     }
 
     polling_error_handler::~polling_error_handler()

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -177,7 +177,7 @@ namespace librealsense
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            })
+            }, "global-timestamp")
     {
         //LOG_DEBUG("start new time_diff_keeper ");
     }

--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -57,7 +57,7 @@ namespace librealsense
 
         rs_hid_device::rs_hid_device(rs_usb_device usb_device)
             : _usb_device(usb_device),
-              _action_dispatcher(10)
+              _action_dispatcher(10, "hid-device")
         {
             _id_to_sensor[REPORT_ID_GYROMETER_3D] = gyro;
             _id_to_sensor[REPORT_ID_ACCELEROMETER_3D] = accel;
@@ -150,7 +150,7 @@ namespace librealsense
                 _handle_interrupts_thread = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
                 {
                     handle_interrupt();
-                });
+                }, "hid-interrupts");
 
                 _handle_interrupts_thread->start();
 

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -145,7 +145,7 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
             }
             _changed = false;
         }
-    } )
+    }, "udev-device-watcher" )
 {
     _udev_ctx = udev_new();
     if( ! _udev_ctx )

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -37,7 +37,7 @@ std::shared_ptr< device_interface > playback_device_info::create_device()
 
 playback_device::playback_device( std::shared_ptr< const device_info > const & dev_info,
                                   std::shared_ptr< device_serializer::reader > const & serializer )
-    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max() ); } )
+    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max(), "playback-device" ); } )
     , m_device_info( dev_info )
     , m_is_started( false )
     , m_is_paused( false )

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -96,7 +96,7 @@ void playback_sensor::open(const stream_profiles& requests)
 
         m_dispatchers.emplace( std::make_pair(
             profile->get_unique_id(),
-            std::make_shared< dispatcher >( _default_queue_size, on_drop_callback ) ) );
+            std::make_shared< dispatcher >( _default_queue_size, "playback-sensor", on_drop_callback ) ) );
 
         m_dispatchers[profile->get_unique_id()]->start();
 

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -13,7 +13,7 @@ using namespace librealsense;
 
 librealsense::record_device::record_device(std::shared_ptr<librealsense::device_interface> device,
                                       std::shared_ptr<librealsense::device_serializer::writer> serializer):
-    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max());}),
+    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max(), "record-device");}),
     m_is_recording(true),
     m_record_total_pause_duration(0)
 {

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -21,7 +21,7 @@ namespace librealsense
     {
         pipeline::pipeline(std::shared_ptr<librealsense::context> ctx) :
             _ctx(ctx),
-            _dispatcher(10),
+            _dispatcher(10, "pipeline"),
             _hub( device_hub::make( ctx, RS2_PRODUCT_LINE_ANY_INTEL )),
             _synced_streams({ RS2_STREAM_COLOR, RS2_STREAM_DEPTH, RS2_STREAM_INFRARED, RS2_STREAM_FISHEYE })
         {}

--- a/src/polling-device-watcher.h
+++ b/src/polling-device-watcher.h
@@ -19,7 +19,7 @@ class polling_device_watcher : public librealsense::platform::device_watcher
 public:
     polling_device_watcher( const platform::backend * backend_ref )
         : _backend( backend_ref )
-        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); } )
+        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); }, "polling-device-watcher" )
         , _devices_data()
     {
         _devices_data = { _backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices() };

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -82,7 +82,7 @@ namespace librealsense
         rs_uvc_device::rs_uvc_device(const rs_usb_device& usb_device, const uvc_device_info &info, uint8_t usb_request_count) :
                 _usb_device(usb_device),
                 _info(info),
-                _action_dispatcher(10),
+                _action_dispatcher(10, "uvc-device"),
                 _usb_request_count(usb_request_count)
         {
             _parser = std::make_shared<uvc_parser>(usb_device, info);

--- a/src/uvc/uvc-streamer.cpp
+++ b/src/uvc/uvc-streamer.cpp
@@ -16,7 +16,7 @@ namespace librealsense
     namespace platform
     {
         uvc_streamer::uvc_streamer(uvc_streamer_context context) :
-            _context(context), _action_dispatcher(10)
+            _context(context), _action_dispatcher(10, "uvc-streamer")
         {
             auto inf = context.usb_device->get_interface(context.control->bInterfaceNumber);
             if (inf == nullptr)
@@ -93,7 +93,7 @@ namespace librealsense
                     if(_publish_frames && running())
                         _context.user_cb(_context.profile, fp->fo, []() mutable {});
                 }
-            });
+            }, "uvc-publish");
 
             _watchdog = std::make_shared<watchdog>([this]()
              {

--- a/third-party/rsutils/include/rsutils/concurrency/concurrency.h
+++ b/third-party/rsutils/include/rsutils/concurrency/concurrency.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <functional>
 #include <cassert>
+#include <string>
 
 const int QUEUE_MAX_SIZE = 10;
 // Simplest implementation of a blocking concurrent queue for thread messaging
@@ -315,6 +316,7 @@ public:
     // want...
     //
     dispatcher( unsigned int queue_capacity,
+                std::string name,
                 std::function< void( action ) > on_drop_callback = nullptr );
 
     ~dispatcher();
@@ -400,14 +402,15 @@ private:
     std::mutex _blocking_invoke_mutex;
 
     std::atomic<bool> _is_alive;
+    std::string _name;
 };
 
 template<class T = std::function<void(dispatcher::cancellable_timer)>>
 class active_object
 {
 public:
-    active_object(T operation)
-        : _operation(std::move(operation)), _dispatcher(1), _stopped(true)
+    active_object(T operation, std::string name)
+        : _operation(std::move(operation)), _dispatcher(1, std::move(name)), _stopped(true)
     {
     }
 
@@ -469,7 +472,7 @@ public:
                 std::lock_guard<std::mutex> lk(_m);
                 _kicked = false;
             }
-        });
+        }, "watchdog");
     }
 
     ~watchdog()

--- a/third-party/rsutils/src/dispatcher.cpp
+++ b/third-party/rsutils/src/dispatcher.cpp
@@ -5,11 +5,13 @@
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/time/waiting-on.h>
 
-dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_drop_callback )
+dispatcher::dispatcher( unsigned int cap, std::string name, std::function< void( action ) > on_drop_callback )
     : _queue( cap, on_drop_callback )
     , _was_stopped( true )
     , _is_alive( true )
+    , _name( std::move( name ) )
 {
+    LOG_DEBUG( "Dispatcher [" << this << "] (" << _name << ") constructed" );
     // We keep a running thread that takes stuff off our queue and dispatches them
     _thread = std::thread([&]()
     {
@@ -26,16 +28,32 @@ dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_dro
                     try
                     {
                         // While we're dispatching the item, we cannot stop!
-                        std::lock_guard< std::mutex > lock(_dispatch_mutex);
-                        item(time);
+                        try
+                        {
+                            std::lock_guard< std::mutex > lock(_dispatch_mutex);
+                            try
+                            {
+                                item(time);
+                            }
+                            catch (const std::exception& e)
+                            {
+                                LOG_ERROR("Dispatcher [" << this << "] (" << _name << ") exception caught in action body: " << e.what());
+                                throw;
+                            }
+                        }
+                        catch (const std::exception& e)
+                        {
+                            LOG_ERROR("Dispatcher [" << this << "] (" << _name << ") exception caught locking _dispatch_mutex: " << e.what());
+                            throw;
+                        }
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_ERROR("Dispatcher [" << this << "] exception caught: " << e.what());
+                        // Already logged above
                     }
                     catch (...)
                     {
-                        LOG_ERROR("Dispatcher [" << this << "] unknown exception caught!");
+                        LOG_ERROR("Dispatcher [" << this << "] (" << _name << ") unknown exception caught!");
                     }
                 }
             }
@@ -46,6 +64,7 @@ dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_dro
 
 dispatcher::~dispatcher()
 {
+    LOG_DEBUG( "Dispatcher [" << this << "] (" << _name << ") destructed" );
     // Don't get into any more dispatches
     _is_alive = false;
 


### PR DESCRIPTION
### Description
This PR resolves the intermittent `mutex lock failed: Invalid argument` crash/assertion failure during application shutdown or exit on macOS, particularly when using the `rs-enumerate-devices` tool.

---

### The Problem (Evidence & Logs)
When running `rs-enumerate-devices`, the application would fail to claim USB interfaces due to macOS-exclusive locks, and then crash/log assertion errors on exit.

#### 1. Evidence of Interface 0 (Depth Sensor) Claim Failure & Exit Crash:
```text
 ~/Doc/ro/librealsense │ master !12  sudo build/Release/rs-enumerate-devices       1 ✘ │ base  │ 06:17:49 PM 

 18/06 18:17:59,112 ERROR [0x16f11f000] (handle-libusb.h:127) failed to claim usb interface: 0, error: RS2_USB_STATUS_ACCESS
 18/06 18:17:59,112 ERROR [0x1f73eac40] (uvc-sensor.cpp:428) acquire_power failed: failed to set power state
 18/06 18:17:59,113 ERROR [0x1f73eac40] (context-libusb.cpp:30) libusb_init failed with status: -99 (attempt 1)
 18/06 18:17:59,217 ERROR [0x1f73eac40] (librealsense-exception.h:53) cannot access depth sensor
 18/06 18:17:59,217 ERROR [0x1f73eac40] (rs.cpp:283) [rs2_create_device( info_list:0xa030a2790, index:0 ) Backend] cannot access depth sensor
 18/06 18:17:59,217 ERROR [0x1f73eac40] (rs.cpp:283) [rs2_delete_device( device:nullptr ) UNKNOWN] null pointer passed for argument "device"
Could not create device - cannot access depth sensor . Check SDK logs for details
No device detected. Is it plugged in?
 18/06 18:18:01,080 ERROR [0x16eeef000] (dispatcher.cpp:40) Dispatcher [0x1015ed2c0] (active-object) exception caught in action body: mutex lock failed: Invalid argument
 18/06 18:18:01,080 ERROR [0x16eeef000] (dispatcher.cpp:46) Dispatcher [0x1015ed2c0] (active-object) exception caught locking _dispatch_mutex: mutex lock failed: Invalid argument
```

#### 2. Evidence of Interface 3 (RGB Camera) Claim Failure & Exit Crash:
```text
Stream Profiles supported by RGB Camera
 Supported modes:
 18/06 18:21:51,442 ERROR [0x16b643000] (handle-libusb.h:127) failed to claim usb interface: 3, error: RS2_USB_STATUS_ACCESS
 18/06 18:21:51,443 ERROR [0x1f73eac40] (uvc-sensor.cpp:428) acquire_power failed: failed to set power state
 18/06 18:21:51,443 ERROR [0x1f73eac40] (rs.cpp:283) [rs2_get_stream_profiles( sensor:0x70cccc190 ) UNKNOWN] failed to set power state
 18/06 18:21:51,443 ERROR [0x1f73eac40] (rs.cpp:283) [rs2_delete_stream_profiles_list( list:nullptr ) UNKNOWN] null pointer passed for argument "list"
 18/06 18:21:53,213 ERROR [0x16b157000] (context-libusb.cpp:30) libusb_init failed with status: -99 (attempt 1)
RealSense error calling rs2_get_stream_profiles(sensor:0x70cccc190):
    failed to set power state
```

#### 3. Named Thread Crash Log (Targeting the issue):
By naming the remaining unnamed dispatchers in the codebase, we isolated the crash specifically to the `polling-device-watcher` thread during teardown:
```text
 18/06 18:24:19,530 ERROR [0x16b537000] (dispatcher.cpp:40) Dispatcher [0x1052707c0] (polling-device-watcher) exception caught in action body: mutex lock failed: Invalid argument
 18/06 18:24:19,530 ERROR [0x16b537000] (dispatcher.cpp:46) Dispatcher [0x1052707c0] (polling-device-watcher) exception caught locking _dispatch_mutex: mutex lock failed: Invalid argument
```

---

### Root Cause
During application teardown (when `rs2::context` goes out of scope and `main` exits), static/local singletons such as `device_watcher_singleton` are destructed. 

The compiler-generated default destructor for `device_watcher_singleton` destroys its member variables in reverse declaration order:
1. `_callbacks` (`rsutils::signal`)
2. `_device_watcher` (`std::shared_ptr<device_watcher>`)

Since `_callbacks` is destroyed first, but the worker thread of `_device_watcher` is still running, a race condition occurs. If the `polling_device_watcher` background thread fires a poll check and detects a state change, it calls `_callbacks.raise(...)`. Since `_callbacks` has already been destructed, it attempts to lock a destroyed mutex, resulting in `std::system_error` / `EINVAL` (`Invalid argument`).

---

### The Fix
1. **Destructor Order Fix**: Added an explicit destructor to `device_watcher_singleton` inside `src/backend-device-factory.cpp` that calls `_device_watcher->stop()`. This guarantees the watcher thread is stopped and joined before any member variables (specifically `_callbacks`) are deallocated.
2. **Named Dispatchers**: Added required names to all constructors of `dispatcher` and `active_object` to help developers immediately identify which thread threw an exception.

---

### Verified New Behavior
After applying this fix and releasing macOS native webcam locks (via `sudo killall VDCAssistant AppleCameraAssistant`), `rs-enumerate-devices` successfully claims all USB interfaces (Stereo Module + RGB Camera), prints all supported profiles, and exits cleanly with `exit code 0` without printing any mutex exceptions:

```text
Stream Profiles supported by Stereo Module
 Supported modes:
    STREAM      RESOLUTION     FORMAT      FPS
    ...
Stream Profiles supported by RGB Camera
 Supported modes:
    STREAM      RESOLUTION     FORMAT      FPS
    ...
(Exits cleanly)
```
