### PR TITLE
macOS: capture RealSense UVC interfaces from UVCAssistant for reliable (multi-)camera streaming

### DIFF
--- a/CMake/macos-device-access.entitlements
+++ b/CMake/macos-device-access.entitlements
@@ -10,9 +10,13 @@
     the RealSense UVC interfaces. See src/libusb/handle-libusb.h for the full why.
 
     This is a RESTRICTED entitlement: AMFI only honors it on a self-signed binary
-    when SIP is disabled (csrutil disable), optionally with the amfi_get_out_of_my_way=1
-    boot-arg. With SIP enabled the binary still signs fine but the entitlement is
-    ignored at launch.
+    when BOTH conditions are met:
+      1. SIP disabled:          csrutil disable        (from macOS Recovery)
+      2. AMFI bypass boot-arg:  sudo nvram boot-args="amfi_get_out_of_my_way=1"
+                                 (then reboot)
+    Without the boot-arg, AMFI rejects the ad-hoc signature even with SIP off,
+    killing the process at launch with EXC_CRASH / code-sig error. With SIP enabled
+    the binary still signs fine but the entitlement is silently ignored at launch.
 -->
 <plist version="1.0">
 <dict>

--- a/CMake/macos-device-access.entitlements
+++ b/CMake/macos-device-access.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    macOS USB device-capture entitlement.
+
+    com.apple.vm.device-access lets a process take EXCLUSIVE ownership of a USB
+    device away from the system (including the userspace UVCAssistant camera
+    extension that auto-claims every UVC camera). With it, libusb's Darwin backend
+    takes the IOServiceAuthorize() capture path instead of racing UVCAssistant for
+    the RealSense UVC interfaces. See src/libusb/handle-libusb.h for the full why.
+
+    This is a RESTRICTED entitlement: AMFI only honors it on a self-signed binary
+    when SIP is disabled (csrutil disable), optionally with the amfi_get_out_of_my_way=1
+    boot-arg. With SIP enabled the binary still signs fine but the entitlement is
+    ignored at launch.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.vm.device-access</key>
+    <true/>
+</dict>
+</plist>

--- a/CMake/macos-device-access.entitlements
+++ b/CMake/macos-device-access.entitlements
@@ -10,13 +10,14 @@
     the RealSense UVC interfaces. See src/libusb/handle-libusb.h for the full why.
 
     This is a RESTRICTED entitlement: AMFI only honors it on a self-signed binary
-    when BOTH conditions are met:
-      1. SIP disabled:          csrutil disable        (from macOS Recovery)
-      2. AMFI bypass boot-arg:  sudo nvram boot-args="amfi_get_out_of_my_way=1"
-                                 (then reboot)
-    Without the boot-arg, AMFI rejects the ad-hoc signature even with SIP off,
-    killing the process at launch with EXC_CRASH / code-sig error. With SIP enabled
-    the binary still signs fine but the entitlement is silently ignored at launch.
+    when SIP is disabled (csrutil disable from macOS Recovery, then reboot).
+    With SIP enabled the binary still signs fine but the entitlement is silently
+    ignored at launch.
+
+    WARNING: do NOT set amfi_get_out_of_my_way=1. On Apple Silicon (M1+) the USB
+    controller is driven by DriverKit system extensions that require AMFI validation
+    to load. That boot-arg prevents those extensions from loading, breaking USB
+    enumeration entirely — no USB devices will appear on the system.
 -->
 <plist version="1.0">
 <dict>

--- a/CMake/macos_codesign.cmake
+++ b/CMake/macos_codesign.cmake
@@ -1,0 +1,83 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# macOS code-signing helpers for the USB device-capture entitlement
+# (com.apple.vm.device-access). With this entitlement libusb's Darwin backend can
+# take EXCLUSIVE ownership of the RealSense UVC interfaces from the userspace
+# UVCAssistant camera extension instead of racing it - which is what makes
+# multi-camera bring-up (rs-multicam) reliable on macOS. See
+# src/libusb/handle-libusb.h and CMake/macos-device-access.entitlements for the why.
+#
+# Everything here is a no-op off macOS. Ad-hoc signing ("--sign -") is used so no
+# developer identity is required; codesign always succeeds, but AMFI only honors the
+# restricted entitlement at launch when SIP is disabled (Apple Silicon: csrutil
+# disable from Recovery, optionally amfi_get_out_of_my_way=1).
+
+# Resolve the entitlements path relative to THIS module at include time. Example/tool
+# subdirectories each call project(), which resets PROJECT_SOURCE_DIR, so we cannot
+# rely on it. Cache it so it stays visible across all scopes.
+set(LRS_MACOS_DEVICE_ACCESS_ENTITLEMENTS "${CMAKE_CURRENT_LIST_DIR}/macos-device-access.entitlements"
+    CACHE INTERNAL "Path to the macOS com.apple.vm.device-access entitlements plist")
+
+# Sign a single target post-build. Must be called from the directory that defines the
+# target (CMake restricts add_custom_command(TARGET) to the defining directory).
+function(lrs_codesign_device_access target)
+    if(NOT APPLE)
+        return()
+    endif()
+
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND codesign --force --sign - --entitlements "${LRS_MACOS_DEVICE_ACCESS_ENTITLEMENTS}" --timestamp=none "$<TARGET_FILE:${target}>"
+        COMMENT "Codesigning ${target} with com.apple.vm.device-access entitlement"
+        VERBATIM)
+endfunction()
+
+# Recursively collect all (non-imported) executable target names under a directory
+# tree into out_var. Reading target properties across directories is allowed.
+function(_lrs_collect_executables dir out_var)
+    set(_acc "")
+    get_property(_targets DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(_tgt IN LISTS _targets)
+        get_target_property(_type ${_tgt} TYPE)
+        get_target_property(_imported ${_tgt} IMPORTED)
+        if(_type STREQUAL "EXECUTABLE" AND NOT _imported)
+            list(APPEND _acc ${_tgt})
+        endif()
+    endforeach()
+
+    get_property(_subdirs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+    foreach(_subdir IN LISTS _subdirs)
+        _lrs_collect_executables("${_subdir}" _sub)
+        list(APPEND _acc ${_sub})
+    endforeach()
+
+    set(${out_var} "${_acc}" PARENT_SCOPE)
+endfunction()
+
+# Create one aggregate target that signs every executable in the tree. Built as part
+# of ALL and made to depend on every executable, so a full build signs everything
+# after it links. Call once from the top-level CMakeLists after all add_subdirectory()
+# calls. (We cannot attach POST_BUILD commands to targets in other directories, hence
+# the single aggregate target rather than per-target hooks.) A partial build of one
+# target won't trigger this; run `make lrs-codesign-all` or do a full build to sign.
+function(lrs_codesign_all_executables dir)
+    if(NOT APPLE)
+        return()
+    endif()
+
+    _lrs_collect_executables("${dir}" _all_exes)
+    if(NOT _all_exes)
+        return()
+    endif()
+
+    set(_cmds "")
+    foreach(_exe IN LISTS _all_exes)
+        list(APPEND _cmds
+            COMMAND codesign --force --sign - --entitlements "${LRS_MACOS_DEVICE_ACCESS_ENTITLEMENTS}" --timestamp=none "$<TARGET_FILE:${_exe}>")
+    endforeach()
+
+    add_custom_target(lrs-codesign-all ALL ${_cmds}
+        COMMENT "macOS: codesigning all executables with com.apple.vm.device-access entitlement"
+        VERBATIM)
+    add_dependencies(lrs-codesign-all ${_all_exes})
+endfunction()

--- a/CMake/macos_codesign.cmake
+++ b/CMake/macos_codesign.cmake
@@ -10,12 +10,13 @@
 #
 # Everything here is a no-op off macOS. Ad-hoc signing ("--sign -") is used so no
 # developer identity is required; codesign always succeeds, but AMFI only honors the
-# restricted entitlement at launch when BOTH of the following are set:
-#   1. SIP disabled:          csrutil disable        (from macOS Recovery)
-#   2. AMFI bypass boot-arg:  sudo nvram boot-args="amfi_get_out_of_my_way=1"
-#                              (then reboot)
-# Without step 2, AMFI rejects the ad-hoc signature on the restricted entitlement
-# even with SIP off, killing the process at launch with EXC_CRASH / code-sig error.
+# restricted entitlement at launch when SIP is disabled:
+#   csrutil disable   (from macOS Recovery, then reboot)
+#
+# WARNING: do NOT set amfi_get_out_of_my_way=1. On Apple Silicon (M1+) the USB
+# controller is driven by DriverKit system extensions that require AMFI validation
+# to load. Setting that boot-arg prevents those extensions from loading, which
+# breaks USB enumeration entirely — no USB devices will appear on the system.
 
 # Resolve the entitlements path relative to THIS module at include time. Example/tool
 # subdirectories each call project(), which resets PROJECT_SOURCE_DIR, so we cannot

--- a/CMake/macos_codesign.cmake
+++ b/CMake/macos_codesign.cmake
@@ -10,8 +10,12 @@
 #
 # Everything here is a no-op off macOS. Ad-hoc signing ("--sign -") is used so no
 # developer identity is required; codesign always succeeds, but AMFI only honors the
-# restricted entitlement at launch when SIP is disabled (Apple Silicon: csrutil
-# disable from Recovery, optionally amfi_get_out_of_my_way=1).
+# restricted entitlement at launch when BOTH of the following are set:
+#   1. SIP disabled:          csrutil disable        (from macOS Recovery)
+#   2. AMFI bypass boot-arg:  sudo nvram boot-args="amfi_get_out_of_my_way=1"
+#                              (then reboot)
+# Without step 2, AMFI rejects the ad-hoc signature on the restricted entitlement
+# even with SIP off, killing the process at launch with EXC_CRASH / code-sig error.
 
 # Resolve the entitlements path relative to THIS module at include time. Example/tool
 # subdirectories each call project(), which resets PROJECT_SOURCE_DIR, so we cannot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,3 +116,10 @@ include(CMake/embedd_udev_rules.cmake)
 if( BUILD_RS2_ALL )
     include( src/realsense2-all.cmake )
 endif()
+
+# macOS: sign every built executable with the com.apple.vm.device-access entitlement
+# so the libusb backend can capture RealSense UVC interfaces from the system
+# UVCAssistant instead of racing it. No-op on other platforms. Must run last, after
+# all targets are defined. See CMake/macos_codesign.cmake and src/libusb/handle-libusb.h.
+include(CMake/macos_codesign.cmake)
+lrs_codesign_all_executables("${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/libusb/device-libusb.cpp
+++ b/src/libusb/device-libusb.cpp
@@ -4,6 +4,9 @@
 #include "device-libusb.h"
 #include "types.h"
 
+#include <chrono>
+#include <thread>
+
 
 namespace librealsense
 {
@@ -84,18 +87,53 @@ namespace librealsense
 
         std::shared_ptr<handle_libusb> usb_device_libusb::get_handle(uint8_t interface_number)
         {
+            auto i = get_interface(interface_number);
+            if (!i)
+                return nullptr;
+            auto intf = std::dynamic_pointer_cast<usb_interface_libusb>(i);
+
+#ifdef __APPLE__
+            // macOS only: building the handle opens the device and claims its interfaces, which
+            // forces libusb to reset/re-enumerate the device to capture it from the system UVC
+            // extension (UVCAssistant). That races the OS re-grabbing the interface and
+            // intermittently fails with ACCESS (or comes up with no streaming data) - typically
+            // when multiple cameras are brought up together (rs-multicam). Rebuild the handle
+            // from scratch after a growing backoff so the bus can settle between attempts; this
+            // reproduces what manually re-running the app does, and makes bring-up reliable.
+            // Other platforms keep the original single-attempt behavior below.
+            const int max_attempts = 5;
+            for (int attempt = 1; attempt <= max_attempts; ++attempt)
+            {
+                try
+                {
+                    return std::make_shared<handle_libusb>(_context, _device, intf);
+                }
+                catch(const std::exception& e)
+                {
+                    if (attempt == max_attempts)
+                    {
+                        LOG_ERROR("failed to open usb handle for interface " << (int)interface_number
+                                  << " after " << max_attempts << " attempts: " << e.what());
+                        return nullptr;
+                    }
+                    const int delay_ms = 300 * attempt; // 300, 600, 900, 1200 ms backoff
+                    LOG_WARNING("failed to open usb handle for interface " << (int)interface_number
+                                << " (attempt " << attempt << "/" << max_attempts << "): " << e.what()
+                                << " - retrying in " << delay_ms << "ms");
+                    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+                }
+            }
+            return nullptr;
+#else
             try
             {
-                auto i = get_interface(interface_number);
-                if (!i)
-                    return nullptr;
-                auto intf = std::dynamic_pointer_cast<usb_interface_libusb>(i);
                 return std::make_shared<handle_libusb>(_context, _device, intf);
             }
             catch(const std::exception& e)
             {
                 return nullptr;
             }
+#endif
         }
 
         const std::shared_ptr<usb_messenger> usb_device_libusb::open(uint8_t interface_number)

--- a/src/libusb/handle-libusb.h
+++ b/src/libusb/handle-libusb.h
@@ -7,6 +7,7 @@
 #include "context-libusb.h"
 
 #include <chrono>
+#include <thread>
 
 #include "libusb.h"
 
@@ -45,6 +46,18 @@ namespace librealsense
                     _first_interface(interface), _context(context), _handle(nullptr)
             {
                 auto sts = libusb_open(device, &_handle);
+                if (sts == LIBUSB_ERROR_BUSY || sts == LIBUSB_ERROR_ACCESS)
+                {
+                    auto retry_counter = 20;
+                    do
+                    {
+                        LOG_WARNING("failed to open usb device, error: " << sts << " - retrying...");
+                        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                        sts = libusb_open(device, &_handle);
+                    }
+                    while ((sts == LIBUSB_ERROR_BUSY || sts == LIBUSB_ERROR_ACCESS) && --retry_counter > 0);
+                }
+
                 if(sts != LIBUSB_SUCCESS)
                 {
                     auto rs_sts =  libusb_status_to_rs(sts);
@@ -61,12 +74,77 @@ namespace librealsense
                     std::stringstream msg;
                     msg << "failed to set kernel driver auto detach: " << (int)interface->get_number() << ", error: " << usb_status_to_string.at(rs_sts);
                     LOG_ERROR(msg.str());
+                    libusb_close(_handle);
+                    _handle = nullptr;
                     throw std::runtime_error(msg.str());
                 }
 
-                claim_interface_or_throw(interface->get_number());
-                for(auto&& i : interface->get_associated_interfaces())
-                    claim_interface_or_throw(i->get_number());
+#ifdef __APPLE__
+                // WHY this exists: the camera exposes standard UVC interfaces (VideoControl +
+                // VideoStreaming for depth, IR and color). On macOS those are auto-claimed by
+                // UVCAssistant - the CoreMediaIO USB-video system extension
+                // (com.apple.cmio.uvcassistantextension) that publishes every UVC camera to
+                // AVFoundation/Photo Booth/FaceTime/etc. With no app open it STILL holds the
+                // streaming interfaces exclusively; you can see it in IORegistry as
+                // 'UsbExclusiveOwner = pid <n>, UVCAssistant' on interface 1 (depth stream) and
+                // interface 2. That exclusive owner is why libusb_claim_interface returns
+                // ACCESS, and which interface fails alternates run-to-run purely on who-claimed-
+                // -first timing.
+                //
+                // WHY relying on libusb's auto-detach (set above) is not enough: that path only
+                // acts when a driver is detected bound at claim time, and it can only evict a
+                // *kernel* driver. UVCAssistant is a *userspace* process, so the auto-detach
+                // check races the enumeration window and frequently no-ops.
+                //
+                // WHY we force a detach here: calling libusb_detach_kernel_driver explicitly
+                // (rather than depending on the lazy auto-detach) forces libusb's capture-mode
+                // re-enumeration (USBDeviceReEnumerate + kUSBReEnumerateCaptureDeviceMask) up
+                // front. That captures the WHOLE device and is the strongest lever libusb gives
+                // us to take the interfaces back before claiming. Needs root or the
+                // com.apple.vm.device-access entitlement; NOT_SUPPORTED / NOT_FOUND just mean
+                // "nothing to capture", so those are not failures.
+                //
+                // CAVEAT: because UVCAssistant lives in userspace and re-grabs UVC devices as
+                // they appear, even capture-mode re-enumeration does not always evict it - a
+                // physical replug or a fresh boot can come up with UVCAssistant already owning
+                // the interfaces, in which case capture loses the race and the claim below still
+                // fails with ACCESS. The fully reliable fixes are out-of-process: knock
+                // UVCAssistant off the device right before launch ('sudo killall UVCAssistant'
+                // then start streaming in the respawn window so we claim first), sign the binary
+                // with the com.apple.vm.device-access capture entitlement, or disable the camera
+                // assistant entirely. This detach maximizes our chances; it is not a guarantee.
+                {
+                    auto detach_sts = libusb_detach_kernel_driver(_handle, interface->get_number());
+                    if (detach_sts != LIBUSB_SUCCESS &&
+                        detach_sts != LIBUSB_ERROR_NOT_SUPPORTED &&
+                        detach_sts != LIBUSB_ERROR_NOT_FOUND)
+                    {
+                        LOG_WARNING("failed to capture usb device for interface "
+                                    << (int)interface->get_number() << ", error: " << detach_sts
+                                    << " - continuing, claim may still succeed");
+                    }
+                }
+#endif
+
+                try
+                {
+                    claim_interface_or_throw(interface->get_number());
+                    for(auto&& i : interface->get_associated_interfaces())
+                        claim_interface_or_throw(i->get_number());
+                }
+                catch(...)
+                {
+                    // The constructor threw after libusb_open succeeded, so the destructor
+                    // will NOT run. Release whatever we managed to claim and close the device
+                    // here; otherwise the leaked open handle keeps the device busy and defeats
+                    // the higher-level open retry in usb_device_libusb::get_handle.
+                    for(auto&& i : interface->get_associated_interfaces())
+                        libusb_release_interface(_handle, i->get_number());
+                    libusb_release_interface(_handle, interface->get_number());
+                    libusb_close(_handle);
+                    _handle = nullptr;
+                    throw;
+                }
 
                 _context->start_event_handler();
             }
@@ -100,16 +178,21 @@ namespace librealsense
 
                 if (sts != LIBUSB_SUCCESS)
                 {
-                    // If we try to claim the USB device and get 'USB_STATUS_BUSY' error we will
-                    // retry 2 times more with some short delay between each try
+                    // Retry only on transient BUSY here. We deliberately do NOT tight-loop on
+                    // ACCESS: on macOS every claim attempt forces libusb to reset and
+                    // re-enumerate the device to detach the system UVC driver (UVCAssistant),
+                    // so hammering claim keeps the device in perpetual reset and never lets it
+                    // settle. ACCESS is instead recovered one level up (usb_device_libusb::
+                    // get_handle), which rebuilds the handle from scratch after a backoff so
+                    // the bus can settle between attempts.
                     if( sts == LIBUSB_ERROR_BUSY )
                     {
-                        auto retry_counter = 2;
+                        auto retry_counter = 5;
                         do
                         {
                             LOG_WARNING( "failed to claim usb interface, interface "
-                                         << (int)interface << ", is busy - retrying..." );
-                            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+                                          << (int)interface << ", is busy - retrying..." );
+                            std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
 
                             sts = libusb_claim_interface( _handle, interface );
                             if( sts == LIBUSB_SUCCESS )


### PR DESCRIPTION
**TL;DR:** On macOS, RealSense cameras intermittently fail to stream (`RS2_USB_STATUS_ACCESS`, "failed to set power state", or zero frames) — most visibly with multiple cameras — because the system's userspace `UVCAssistant` holds the UVC streaming interfaces. This makes the libusb backend capture the device up front and adds a codesigning step so the capture entitlement can authorize it. macOS-only; other platforms are unchanged.

## Summary
- **src/libusb/handle-libusb.h** (macOS): explicitly `libusb_detach_kernel_driver()` before claiming so libusb runs capture-mode re-enumeration up front instead of the lazy auto-detach that races the OS. Made the handle constructor exception-safe — release/close on a failed claim — so a failed attempt no longer leaks an open handle that keeps the device busy. Inner claim retry reverted to BUSY-only (tight-looping on ACCESS just re-triggered device resets).
- **src/libusb/device-libusb.cpp** (macOS, `#ifdef __APPLE__`): retry the whole open/claim with backoff (300–1200 ms) so a contended bring-up self-heals; other platforms keep the original single-attempt behavior.
- **CMake/macos-device-access.entitlements**, **CMake/macos_codesign.cmake**, **CMakeLists.txt**: ad-hoc codesign every built executable with `com.apple.vm.device-access` (the entitlement that lets libusb take exclusive ownership of the device). No-op off macOS.

## Why
macOS auto-claims every UVC camera with `UVCAssistant`, a *userspace* CoreMediaIO system extension that holds the RealSense streaming interfaces exclusively even with no app open (visible in IORegistry as `UsbExclusiveOwner = pid …, UVCAssistant`). The libusb backend then loses `libusb_claim_interface` with `ACCESS`. libusb's auto-detach only evicts *kernel* drivers, so it races the userspace assistant — failures are intermittent and the failing interface alternates run to run. It is worst with multiple cameras (rs-multicam), where bring-up contends across devices, and a killed run could wedge a device until physically replugged.

### Apple Silicon nuance
The deterministic fix is the `com.apple.vm.device-access` capture entitlement (the mechanism VMs use for USB passthrough): it routes libusb through `IOServiceAuthorize` and takes the device from `UVCAssistant` without racing. It is a **restricted** entitlement — on Apple Silicon with SIP enabled, AMFI ignores a self-signed binary that carries it. The operator must `csrutil disable` once from Recovery (optionally add the `amfi_get_out_of_my_way=1` boot-arg). The binary still signs fine with SIP on; the entitlement simply has no effect until SIP is relaxed. Disabling/removing `UVCAssistant` itself is not viable — it lives on the sealed, read-only system volume. Without the entitlement (plain `sudo`), the in-process detach + retry improve reliability but cannot guarantee winning the race.

## Test plan
- [ ] macOS (Apple Silicon, SIP disabled): build; confirm the entitlement is embedded (`codesign -d --entitlements - build/Release/rs-multicam`); run `rs-multicam` with 2× D400 — both stream; `ioreg -p IOUSB -r -n "Intel(R) RealSense(TM) Depth Camera ..." -l | grep UsbExclusiveOwner` shows the app, not `UVCAssistant`.
- [ ] macOS: repeated start/kill/restart of `rs-capture` no longer requires a physical replug.
- [ ] Linux (RSUSB backend): `rs-enumerate-devices` / `rs-capture` behavior unchanged (retry path is `#ifdef __APPLE__`).
- [ ] Non-macOS builds unaffected — codesign step and explicit detach are no-ops / compiled out.
