### PR TITLE
test-fw-update: poll for device re-enumeration after FW update instead of a fixed sleep

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -28,16 +28,41 @@ parser.add_argument('--serial', type=str, default=None, help='Serial number of t
 args = parser.parse_args()
 
 
-def wait_for_reboot( same_version ):
+def wait_for_reboot( serial, timeout = 30 ):
     """
-    Wait for the camera to finish rebooting after a FW update.
-    The test exit flow may cut USB power (via hub port disable), so we must ensure
-    the device has had enough time to complete its reboot before we exit.
-    When updating to a different version, FW may need time to flash a new ISP FW.
+    Wait for the camera to finish rebooting after a FW update and re-enumerate in normal
+    (non-recovery) mode, returning as soon as it is back -- up to `timeout` seconds.
+
+    The test exit flow may cut USB power (via hub port disable), so we must not return
+    while the device is still rebooting, REGARDLESS of rs-fw-update's exit code.
+
+    A same-version reflash comes back quickly, so we return early; a version change may
+    reflash a new ISP FW and takes longer to enumerate -- we must give it the full window
+    and not interfere with it. Polling handles both without guessing a fixed duration.
+
+    If the flash failed and left the device stuck in recovery, it never re-enumerates in
+    normal mode, so we wait the full timeout before letting the caller exit.
+
+    After a flash the device may expose its firmware_update_id (asic serial) and/or its
+    normal serial_number, so we match on either.
     """
-    sleep_time = 60 if not same_version else 3
-    log.d( "Waiting", sleep_time, "seconds for device to finish rebooting after FW update..." )
-    time.sleep( sleep_time )
+    # Give the device a moment to drop off the bus and begin rebooting, so we don't match
+    # the stale pre-reboot enumeration before it has even started to reset.
+    time.sleep( 3 )
+    log.d( "waiting up to", timeout, "seconds for device to re-enumerate after FW update..." )
+    timer = Timer( timeout )
+    timer.start()
+    while not timer.has_expired():
+        for d in rs.context().devices:
+            if d.is_in_recovery_mode():
+                continue
+            sn = d.get_info( rs.camera_info.serial_number ) if d.supports( rs.camera_info.serial_number ) else None
+            fwid = d.get_info( rs.camera_info.firmware_update_id ) if d.supports( rs.camera_info.firmware_update_id ) else None
+            if serial is None or serial == sn or serial == fwid:
+                log.d( "device re-enumerated after", round( timer.get_elapsed(), 1 ), "seconds" )
+                return
+        time.sleep( 2 )
+    log.w( "device did not re-enumerate in normal mode within", timeout, "seconds after FW update" )
 
 
 def send_hardware_monitor_command(device, command):
@@ -138,7 +163,6 @@ if device.supports(rs.camera_info.firmware_version):
 # Determine which firmware to use based on product.
 # The SDK no longer ships a bundled D400 FW, so a --custom-fw-<plat> path is required
 # for every product line; otherwise we cannot exercise the update flow.
-same_version = False
 custom_fw_path = None
 custom_fw_version = None
 if product_line == "D400" and args.custom_fw_d400:
@@ -210,11 +234,11 @@ custom_fw_version = extract_version_from_filename(custom_fw_path)
 log.d('Using custom FW version: ', custom_fw_version)
 
 if current_fw_version == custom_fw_version:
-    same_version = True
     if recovered or 'nightly' not in test.context:
         log.d('versions are same; skipping FW update')
         test.finish()
         test.print_results_and_exit()
+    # else: nightly re-flashes the same version on purpose, to exercise the update flow
 
 downgrade_counter = get_downgrade_counter( device )
 log.d( 'downgrade counter:', downgrade_counter )
@@ -252,7 +276,7 @@ result = subprocess.run( cmd )   # may throw
 # rs-fw-update may have begun a section flash before erroring out, leaving the device
 # mid-reboot. The test exit flow may cut USB power (hub port disable), so we must not
 # exit while the device is still rebooting.
-wait_for_reboot( same_version )
+wait_for_reboot( args.serial )
 
 if result.returncode != 0:
     log.e( 'rs-fw-update returned exit code', result.returncode )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -53,16 +53,24 @@ def wait_for_reboot( serial, timeout = 30 ):
     timer = Timer( timeout )
     timer.start()
     while not timer.has_expired():
-        for d in rs.context().devices:
-            if d.is_in_recovery_mode():
+        devices = rs.context().devices
+        for d in devices:
+            try:
+                if d.is_in_recovery_mode():
+                    continue
+                sn = d.get_info( rs.camera_info.serial_number ) if d.supports( rs.camera_info.serial_number ) else None
+                fwid = d.get_info( rs.camera_info.firmware_update_id ) if d.supports( rs.camera_info.firmware_update_id ) else None
+            except Exception:
+                # device dropped off the bus between enumeration and query (still rebooting) -- keep polling
                 continue
-            sn = d.get_info( rs.camera_info.serial_number ) if d.supports( rs.camera_info.serial_number ) else None
-            fwid = d.get_info( rs.camera_info.firmware_update_id ) if d.supports( rs.camera_info.firmware_update_id ) else None
             if serial is None or serial == sn or serial == fwid:
+                if serial is None and len( devices ) > 1:
+                    log.w( "no --serial given and multiple devices present; matched the first non-recovery",
+                           "device, which may be wrong on a multi-device rig" )
                 log.d( "device re-enumerated after", round( timer.get_elapsed(), 1 ), "seconds" )
                 return
         time.sleep( 2 )
-    log.w( "device did not re-enumerate in normal mode within", timeout, "seconds after FW update" )
+    log.e( "device did not re-enumerate in normal mode within", timeout, "seconds after FW update" )
 
 
 def send_hardware_monitor_command(device, command):


### PR DESCRIPTION
**Overview:** Replace the fixed post-flash sleep in `test-fw-update.py` with a bounded poll for the device to re-enumerate, fixing a case where a same-version nightly re-flash waited only 3s and let the runner's hub power-cycle hit a GMSL D401 mid-reboot — dropping it off the bus (observed on rs-ci-orin-04, recovered only by physical power-cycle).

### Problem
`wait_for_reboot()` slept `60s` if the flashed FW differed from current, but only `3s` when `same_version`. The "skip if already at target version" shortcut only fires when **not** in nightly context — so a nightly run **re-flashes the same version** (a real flash + reboot) yet still waited only **3s**. After the test exits, the runner power-cycles via the hub (`devices.enable_only(recycle=True)` / `close_hubs → disable_ports`); 3s isn't enough, so the recycle can land mid-reboot. On GMSL with no controllable recovery power the camera then fails to re-link.

Observed on `LRS_jetson_compile_pipeline` / rs-ci-orin-04: last healthy build #16948 (camera already at 5.17.3.10, re-flashed 5.17.3.10 under nightly context, test ran 389s = real flash); next orin-04 build #16950 and every build since fast-fail at the enumerate stage with `No /dev/video devices and no recovery device found`.

### Fix
`wait_for_reboot(serial, timeout=30)`:
- 3s settle (let the device drop off the bus), then **poll up to 30s** for it to re-enumerate in **normal (non-recovery)** mode, returning early once it's back (matched by `serial_number` or `firmware_update_id`).
- Runs regardless of `rs-fw-update`'s exit code (unchanged placement, before the return-code check).

| Case | Behavior |
|------|----------|
| Same-version reflash (nightly) | returns in a few seconds |
| Different FW (ISP reflash, slower enumerate) | waits as long as needed, up to 30s; recovery-mode blips are skipped so we don't return early |
| Failed flash stuck in recovery | waits the full window before exit, so the hub recycle can't cut power mid-reboot |

We still flash in nightly on purpose (to exercise the update flow); only the wait changed.

### Follow-up (not in this PR)
GMSL hosts without controllable recovery power shouldn't run destructive DFU/FW-update, or need a hub that can hard power-cycle the camera.

Jira: RSDSO-21629

---
🤖 Generated by AI
