### PR TITLE
enable_only: track powered hub ports from our own actions (RSDSO-21630)

### DIFF
--- a/unit-tests/infra-tests/test_enable_only_port_tracking.py
+++ b/unit-tests/infra-tests/test_enable_only_port_tracking.py
@@ -1,0 +1,77 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Regression test for the core port-tracking fix (RSDSO-21630).
+
+enable_only(recycle=True) must decide which ports to disable from _enabled_ports -- the set of
+ports WE powered on -- NOT from enabled() (the SDK's view of present devices). The two diverge
+when a device is powered but momentarily absent from the SDK, e.g. a DDS device (D555) rebooting
+after a FW update: its port is still on, but enabled() doesn't list it.
+
+Before the fix, enable_only derived the disable set from enabled(), so such a port was left
+powered (it lingered on the DDS domain and broke unrelated tests). These tests pin the new
+behavior: the powered port is disabled even though no device for it is SDK-visible.
+"""
+
+import types
+import pytest
+from unittest.mock import MagicMock
+
+import rspy.devices as dev
+
+
+def test_recycle_disables_tracked_port_absent_from_sdk(monkeypatch):
+    """A port in _enabled_ports but absent from enabled() must still be disabled on recycle."""
+    # Target device we want online, on port 0.
+    target = types.SimpleNamespace(port=0, serial_number='111')
+    monkeypatch.setattr(dev, '_device_by_sn', {'111': target})
+    # SDK currently sees nothing (e.g. the port-8 device is mid-reboot after a FW flash).
+    monkeypatch.setattr(dev, 'enabled', lambda: set())
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: True)
+    monkeypatch.setattr(dev, 'time', types.SimpleNamespace(sleep=lambda _: None))
+    # We previously powered ports 0 and 8 (8 = the now-rebooting DDS device).
+    monkeypatch.setattr(dev, '_enabled_ports', {0, 8})
+    fake_hub = MagicMock()
+    monkeypatch.setattr(dev, 'hub', fake_hub)
+
+    dev.enable_only(['111'], recycle=True, timeout=1)
+
+    # Recycle disables exactly the ports we know are powered -- including port 8, which
+    # enabled() never reported. (The old enabled()-based logic would have left 8 on.)
+    assert fake_hub.disable_ports.call_count == 1
+    assert sorted(fake_hub.disable_ports.call_args.args[0]) == [0, 8]
+    # ...then re-enables only the wanted port.
+    assert fake_hub.enable_ports.call_args.args[0] == [0]
+
+
+def test_recycle_with_nothing_powered_does_not_disable(monkeypatch):
+    """Empty _enabled_ports (nothing powered, the normal post-map_unknown_ports state) means
+    there is nothing to disable -- enable_only just enables the wanted port."""
+    target = types.SimpleNamespace(port=0, serial_number='111')
+    monkeypatch.setattr(dev, '_device_by_sn', {'111': target})
+    monkeypatch.setattr(dev, 'enabled', lambda: set())
+    monkeypatch.setattr(dev, '_wait_for', lambda *a, **kw: True)
+    monkeypatch.setattr(dev, 'time', types.SimpleNamespace(sleep=lambda _: None))
+    monkeypatch.setattr(dev, '_enabled_ports', set())
+    fake_hub = MagicMock()
+    monkeypatch.setattr(dev, 'hub', fake_hub)
+
+    dev.enable_only(['111'], recycle=True, timeout=1)
+
+    fake_hub.disable_ports.assert_not_called()
+    assert fake_hub.enable_ports.call_args.args[0] == [0]
+
+
+def test_disable_failure_keeps_port_tracked(monkeypatch):
+    """If the hub's disable call fails, the port must stay in _enabled_ports so a later
+    recycle retries it (a failed disable may have left the port powered)."""
+    monkeypatch.setattr(dev, '_enabled_ports', {8})
+    fake_hub = MagicMock()
+    fake_hub.disable_ports.return_value = False  # hub reports failure
+    monkeypatch.setattr(dev, 'hub', fake_hub)
+
+    ok = dev._disable_hub_ports([8])
+
+    assert ok is False
+    assert dev._enabled_ports == {8}  # not dropped -- still considered powered

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -79,6 +79,9 @@ _enabled_ports = set()
 
 
 def _enable_hub_ports( ports = None, disable_other_ports = False, sleep_on_change = 0 ):
+    """Enable hub ports and record them in _enabled_ports. ports=None means all ports.
+    The record is updated even if the hub call reports failure: a port that did power on must
+    not be left untracked, or a later recycle would skip disabling it. Returns the hub result."""
     global _enabled_ports
     ok = hub.enable_ports( ports, disable_other_ports = disable_other_ports, sleep_on_change = sleep_on_change )
     if ports is None:
@@ -91,9 +94,13 @@ def _enable_hub_ports( ports = None, disable_other_ports = False, sleep_on_chang
 
 
 def _disable_hub_ports( ports = None, sleep_on_change = 0 ):
+    """Disable hub ports and drop them from _enabled_ports. ports=None means all ports.
+    Only updates the record if the hub call succeeded: a failed disable may leave the port
+    powered, so keep tracking it (a later recycle must retry). Returns the hub result."""
     global _enabled_ports
     ok = hub.disable_ports( ports, sleep_on_change = sleep_on_change )
-    _enabled_ports = set() if ports is None else _enabled_ports - set( ports )
+    if ok:
+        _enabled_ports = set() if ports is None else _enabled_ports - set( ports )
     return ok
 
 
@@ -287,7 +294,7 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
         recycle the ports in certain cases that leave the ports in a bad state
     :param disable_dds: Whether we want to see dds devices or not
     """
-    global rs
+    global rs, _enabled_ports
     if not rs:
         return
     init_hub()
@@ -302,7 +309,6 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
             _enable_hub_ports()  # Enable without sleeping - we'll poll ourselves
         else:
             # didn't recycle: seed our record from the hub's actual port state
-            global _enabled_ports
             _enabled_ports = set( hub.ports() )
     #
     # Get all devices, and store by serial-number

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -73,6 +73,29 @@ import time
 _device_by_sn = dict()
 _context = None
 
+# Ports we have powered on, tracked from our own enable/disable actions rather than from
+# enabled() (which reflects SDK device presence and lags a device rebooting on a live port).
+_enabled_ports = set()
+
+
+def _enable_hub_ports( ports = None, disable_other_ports = False, sleep_on_change = 0 ):
+    global _enabled_ports
+    ok = hub.enable_ports( ports, disable_other_ports = disable_other_ports, sleep_on_change = sleep_on_change )
+    if ports is None:
+        _enabled_ports = set( hub.all_ports() )
+    elif disable_other_ports:
+        _enabled_ports = set( ports )
+    else:
+        _enabled_ports |= set( ports )
+    return ok
+
+
+def _disable_hub_ports( ports = None, sleep_on_change = 0 ):
+    global _enabled_ports
+    ok = hub.disable_ports( ports, sleep_on_change = sleep_on_change )
+    _enabled_ports = set() if ports is None else _enabled_ports - set( ports )
+    return ok
+
 
 class Device:
     def __init__( self, sn, dev ):
@@ -190,7 +213,7 @@ def map_unknown_ports():
     if not devices_with_unknown_ports:
         # All ports are known, but still enabled from query(). Disable all so unmapped ports
         # (e.g. loose cables) can't produce rogue devices mid-test.
-        hub.disable_ports()
+        _disable_hub_ports()
         wait_until_all_ports_disabled()
         return
     #
@@ -214,7 +237,7 @@ def map_unknown_ports():
             device._port = unknown_ports[0]
             return
         #
-        hub.disable_ports( ports )
+        _disable_hub_ports( ports )
         wait_until_all_ports_disabled()
         #
         # Enable one port at a time to try and find what device is connected to it
@@ -222,7 +245,7 @@ def map_unknown_ports():
         for port in unknown_ports:
             #
             log.d( 'enabling port', port )
-            hub.enable_ports( [port], disable_other_ports=True )
+            _enable_hub_ports( [port], disable_other_ports=True )
             sn = None
             port_enable_time = timestamp()
             for retry in range( MAX_ENUMERATION_TIME ):
@@ -246,11 +269,11 @@ def map_unknown_ports():
                 else:
                     log.w( "Device with serial number", sn, "was found in port", port,
                             "but was not in context" )
-            hub.disable_ports( [port] )
+            _disable_hub_ports( [port] )
             wait_until_all_ports_disabled()
     finally:
         # Disable all ports so tests start from a clean state
-        hub.disable_ports()
+        _disable_hub_ports()
         wait_until_all_ports_disabled()
         log.debug_unindent()
 
@@ -275,8 +298,12 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
         if not hub.is_connected():
             hub.connect(hub_reset)
         if recycle_ports:
-            hub.disable_ports( sleep_on_change = 5 )
-            hub.enable_ports()  # Enable without sleeping - we'll poll ourselves
+            _disable_hub_ports( sleep_on_change = 5 )
+            _enable_hub_ports()  # Enable without sleeping - we'll poll ourselves
+        else:
+            # didn't recycle: seed our record from the hub's actual port state
+            global _enabled_ports
+            _enabled_ports = set( hub.ports() )
     #
     # Get all devices, and store by serial-number
     global _device_by_sn, _context, _port_to_sn
@@ -616,7 +643,8 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         ports = [ get( sn ).port for sn in serial_numbers ]
         # DDS (and other non-hub) devices have port=None; filter them out of hub operations
         wanted_ports = sorted( p for p in ports if p is not None )
-        enabled_ports = [ get( sn ).port for sn in enabled() if get( sn ).port is not None ]
+        # ports we powered on -- not enabled(), which misses a device rebooting on a live port
+        enabled_ports = sorted( _enabled_ports )
         #
         if recycle:
             #
@@ -626,16 +654,16 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
                 log.d( 'enabling ports', wanted_ports,
                        'disabling currently enabled ports', enabled_ports )
                 sns_to_remove = { sn for sn in enabled() if get( sn ).port in enabled_ports }
-                hub.disable_ports( enabled_ports )
+                _disable_hub_ports( enabled_ports )
                 _wait_until_removed( sns_to_remove, timeout = timeout )
             #
             if wanted_ports:
-                hub.enable_ports( wanted_ports )
+                _enable_hub_ports( wanted_ports )
             #
         else:
             #
             if wanted_ports:
-                hub.enable_ports( wanted_ports, disable_other_ports = True )
+                _enable_hub_ports( wanted_ports, disable_other_ports = True )
             else:
                 log.d( 'no hub ports to enable; leaving hub as-is' )
         #
@@ -658,7 +686,7 @@ def enable_all():
     """
     Enables all ports on the hub -- without a hub, this does nothing!
     """
-    hub.enable_ports()
+    _enable_hub_ports()
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):


### PR DESCRIPTION
**Overview:** The LibCI per-test port setup (`rspy/devices.py` → `enable_only`, recycle path) decides which hub ports to disable from `enabled()`, which is reconstructed from SDK device-change callbacks. A device that is powered (port on) but momentarily absent from the SDK — e.g. a D555 rebooting after the `test-fw-update` test — is not in `enabled()`, so its hub port is never disabled. It stays powered, rejoins the DDS domain, and breaks unrelated tests.

**Symptom:** `test-dds-adapter-depth` fails under `nightly linux dds` (e.g. [build #13875](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/13875/)). The test waits for exactly one DDS device but sees two — the bridged D455 plus the leftover D555 on virtual port 8 (UniFi PoE) — and times out with `timeout waiting for 1 device(s)`.

**Root cause:** port state is inferred from SDK presence (`enabled()`) instead of from our own enable/disable actions. The two diverge whenever a device is powered but transiently invisible to the SDK (FW-flash reboot, slow DDS re-discovery).

**Fix:** track the set of ports we powered on (`_enabled_ports`) from our own enable/disable actions, via thin `_enable_hub_ports` / `_disable_hub_ports` wrappers, and have `enable_only` decide what to disable from that record. It still disables only the ports we know are on — not every port on every test.

**Relation to #15222:** #15222 fixes the same bug by disabling **all** device ports in the recycle path. This PR supersedes that approach: rather than blanket-disabling (and re-querying device presence), it keeps an authoritative record of what we powered, which is cheaper and doesn't depend on SDK callbacks. (The `test-depth.py` finally-kill part of #15222 already landed separately as #15237.)

Jira: RSDSO-21630

---
🤖 Generated by AI
