### PR TITLE
improve center of mass accuracy (pick the nearest cluster)

### DIFF
--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 #include <common/utilities/com/center-of-mass.h>
+#include <climits>
 #include <cmath>
 #include <algorithm>
 #include <vector>
@@ -13,18 +14,19 @@ namespace com {
 // ---------------------------------------------------------------------------
 
 static constexpr uint16_t SUBTRACT_FROM_DEPTH  = 400;  // depths below this map to depth_8u=0
-static constexpr float    SCALE_DEPTH          = 20.0f;
+static constexpr float    SCALE_DEPTH          = 30.0f;  // covers MAX_DEPTH in uint8: ceil((8000-400)/30)=254
 static constexpr int      MIN_DEPTH            = 400;
 static constexpr int      MAX_DEPTH            = 8000;
 static constexpr int      NO_DEPTH             = 10000;
 static constexpr float    GOOD_DEPTH_RATIO     = 0.3f;
+// Fraction of ROI height used for centroid — limits the search to the torso region
+// and prevents leg pixels (which dominate the lower bbox) from pulling the COM down.
+static constexpr float    COM_UPPER_FRACTION   = 0.65f;
 static constexpr int      NUM_DEPTH_SAMPLES    = 5;
-static constexpr int      MAX_DEPTH_FOR_SAMPLES = 650;
-static constexpr int      MAX_STD_DEPTH_SAMPLES = 450;
 
-// depth_8u value for MAX_DEPTH_FOR_BLOB (4500 mm): ceil((4500-400)/20) = 205
+// depth_8u value for MAX_DEPTH: ceil((MAX_DEPTH-400)/SCALE_DEPTH) — fits in uint8 with SCALE_DEPTH=30
 static const int MaxDepth8U =
-    (int)std::ceil((4500 - (int)SUBTRACT_FROM_DEPTH) / SCALE_DEPTH);
+    (int)std::ceil(((int)MAX_DEPTH - (int)SUBTRACT_FROM_DEPTH) / SCALE_DEPTH);
 
 // ---------------------------------------------------------------------------
 // 3D helpers (used only when intrinsics != nullptr)
@@ -157,34 +159,30 @@ float center_of_mass_calculator::calc_hist_range_mean(
 // ---------------------------------------------------------------------------
 
 bool center_of_mass_calculator::calc_center_of_mask(
-    const std::vector<uint8_t>& mask, int mask_width, int mask_height, vec2i& com)
+    const std::vector<uint8_t>& mask, int mask_width, int mask_height, vec2i& com,
+    int max_y)
 {
-    int sumAll = 0;
-    for (uint8_t v : mask) if (v) ++sumAll;
-    if (sumAll == 0) return false;
-    int halfNum = (sumAll + 1) / 2;
+    if (max_y <= 0 || max_y > mask_height) max_y = mask_height;
 
-    std::vector<int> projX(mask_width, 0);
-    for (int y = 0; y < mask_height; ++y)
+    // Both X and Y are computed over the upper max_y rows only — keeps the symmetry
+    // metric and both centroids consistent with the same torso-region pixels.
+    long long sumX = 0, sumY = 0; long long cntX = 0, cntY = 0;
+    int leftPx = 0, rightPx = 0;
+    int const midX = mask_width / 2;
+    for (int y = 0; y < max_y; ++y)
         for (int x = 0; x < mask_width; ++x)
-            if (mask[y * mask_width + x]) projX[x]++;
+            if (mask[y * mask_width + x]) {
+                sumX += x; sumY += y; ++cntX;
+                if (x < midX) ++leftPx; else ++rightPx;
+            }
+    cntY = cntX;
 
-    int acc = 0; com.x = mask_width - 1;
-    for (int x = 0; x < mask_width; ++x) {
-        acc += projX[x];
-        if (acc > halfNum) { com.x = x; break; }
-    }
+    if (cntX == 0) return false;
 
-    std::vector<int> projY(mask_height, 0);
-    for (int y = 0; y < mask_height; ++y)
-        for (int x = 0; x < mask_width; ++x)
-            if (mask[y * mask_width + x]) projY[y]++;
-
-    acc = 0; com.y = mask_height - 1;
-    for (int y = 0; y < mask_height; ++y) {
-        acc += projY[y];
-        if (acc > halfNum) { com.y = y; break; }
-    }
+    float const centroidX = float(sumX) / cntX;
+    float const symmetry  = 2.0f * std::min(leftPx, rightPx) / float(leftPx + rightPx);
+    com.x = (int)(symmetry * centroidX + (1.0f - symmetry) * midX);
+    com.y = (int)(float(sumY) / cntY);
     return true;
 }
 
@@ -194,7 +192,8 @@ bool center_of_mass_calculator::calc_center_of_mask(
 
 bool center_of_mass_calculator::calculate_com_with_depth_range(
     const depth_image_8& depth_8u,
-    const rect& roi, float& depth_mean, vec2i& center_mass_point)
+    const rect& roi, float& depth_mean, vec2i& center_mass_point,
+    com_debug_info* dbg)
 {
     int roiW = roi.width, roiH = roi.height;
     if (roiW <= 0 || roiH <= 0) return false;
@@ -205,15 +204,23 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
         for (int x = 0; x < roiW; ++x)
             roiData[y * roiW + x] = depth_8u.data[(roi.y + y) * depth_8u.width + (roi.x + x)];
 
+    // Restrict histogram to the upper portion of the bbox (torso region) so that
+    // lower-body / floor pixels don't inflate a far-background cluster beyond the
+    // person cluster.  The same upper-fraction is used later for the COM Y centroid.
+    int const histRows = std::max(1, (int)(roiH * COM_UPPER_FRACTION));
+
     // Histogram: bin i = count of pixels with depth_8u value i
     int histSize = MaxDepth8U + 1;
     std::vector<float> hist(histSize, 0.0f);
-    for (uint8_t v : roiData)
-        if (v >= 1 && v < histSize) hist[v] += 1.0f;
+    for (int y = 0; y < histRows; ++y)
+        for (int x = 0; x < roiW; ++x) {
+            uint8_t v = roiData[y * roiW + x];
+            if (v >= 1 && v < histSize) hist[v] += 1.0f;
+        }
 
     int sumEl = 0;
     for (float v : hist) sumEl += (int)v;
-    if (sumEl < (int)(GOOD_DEPTH_RATIO * roiW * roiH)) return false;
+    if (sumEl < (int)(GOOD_DEPTH_RATIO * roiW * histRows)) return false;
 
     std::vector<float> histFract(histSize);
     for (int i = 0; i < histSize; ++i) histFract[i] = hist[i] / sumEl;
@@ -229,14 +236,16 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
         for (int i = 1; i < histSize; ++i)
             if (histFract[i] > maxVal) { maxVal = histFract[i]; maxLoc = i; }
 
-        if (maxVal < 0.01) break;
+        if (maxVal < 0.001) break;
 
-        // Extend high until bins drop below 1%
+        // Extend only to adjacent bins above 1% — keeps distinct depth layers separate.
+        // The peak threshold (0.001) is intentionally lower so sparse person peaks are
+        // extracted, but the extension threshold stays high to prevent a sparse person
+        // cluster from growing into the dense background cluster across the valley.
         int rangeEnd = maxLoc + 1;
         while (rangeEnd < histSize && histFract[rangeEnd] >= 0.01f) ++rangeEnd;
         rangeEnd = std::min(rangeEnd, histSize - 1);
 
-        // Extend low until bins drop below 1%
         int rangeStart = maxLoc - 1;
         while (rangeStart >= 1 && histFract[rangeStart] >= 0.01f) --rangeStart;
         rangeStart = std::max(rangeStart, 1);
@@ -247,62 +256,63 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
             fract += histFract[j];
             histFract[j] = 0;
         }
-        histFract[0] = 0;
 
         allRanges.push_back({rangeStart, rangeEnd, fract});
     }
 
     if (allRanges.empty()) return false;
 
-    // Select the dominant cluster.
-    //
-    // The previous approach selected the cluster with the most pixels (largest fraction).
-    // That caused the background to win whenever it occupied more of the bounding box
-    // than the person, making the COM teleport to the wall / floor.
-    //
-    // Fix: sort clusters by depth (nearest first — smallest rangeStart = closest to
-    // camera) and pick the first one that accounts for at least MIN_BODY_FRACTION of
-    // all valid pixels.  The person is always in front of any background object, so
-    // the nearest significant cluster IS the person.  If no cluster meets the
-    // fraction threshold (e.g. person is very far or partially out of frame), fall
-    // back to the nearest cluster overall — still better than picking the background.
-    static constexpr float MIN_BODY_FRACTION = 0.10f;
-    std::sort(allRanges.begin(), allRanges.end(),
-        [](const DepthRange& a, const DepthRange& b) { return a.start < b.start; });
+    int const cx = roi.x + roi.width  / 2;
+    int const cy = roi.y + roi.height / 2;
+    // 5×5 patch mean around the ROI center — more stable than a single pixel
+    int const x0 = std::max(cx - 2, 0), x1 = std::min(cx + 2, depth_8u.width  - 1);
+    int const y0 = std::max(cy - 2, 0), y1 = std::min(cy + 2, depth_8u.height - 1);
+    int patchSum = 0, patchCnt = 0;
+    for (int py = y0; py <= y1; ++py)
+        for (int px = x0; px <= x1; ++px) {
+            uint8_t v = depth_8u.data[py * depth_8u.width + px];
+            if (v >= 1) { patchSum += v; ++patchCnt; }
+        }
+    uint8_t const center_d8u = patchCnt > 0 ? (uint8_t)(patchSum / patchCnt) : 0;
+    if (dbg) { dbg->center_d8u = center_d8u; dbg->center_d8u_cnt = patchCnt; dbg->n_clusters = (int)allRanges.size(); }
 
+    // Always pick the NEAREST cluster (smallest midpoint depth_8u).
+    // Background is always farther than the person, and the histogram is already
+    // restricted to the upper torso region so floor/leg pixels can't inflate a far
+    // cluster.  The nearest cluster is therefore the person's body in the common case;
+    // the one exception is foreground clutter (e.g. a desk) partially overlapping the
+    // bbox, where the clutter's cluster would be picked — correct by depth geometry.
     int histRangeStart = allRanges[0].start;
     int histRangeEnd   = allRanges[0].end;
+    int bestMidD       = INT_MAX;
     for (auto const& r : allRanges) {
-        if (r.fract >= MIN_BODY_FRACTION) {
-            histRangeStart = r.start;
-            histRangeEnd   = r.end;
-            break;
-        }
+        int midD = (r.start + r.end) / 2;
+        if (midD < bestMidD) { bestMidD = midD; histRangeStart = r.start; histRangeEnd = r.end; }
+    }
+
+    if (dbg) {
+        // Find the fract of the selected cluster
+        for (auto const& r : allRanges)
+            if (r.start == histRangeStart && r.end == histRangeEnd) { dbg->cluster_fract = r.fract; break; }
+        dbg->cluster_start = histRangeStart;
+        dbg->cluster_end   = histRangeEnd;
     }
 
     if ((histRangeEnd - histRangeStart) >= (MaxDepth8U - 1)) return false;
 
-    float meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
-
-    // Optionally extend toward a nearby head cluster (closer to camera, within 100 mm)
-    for (auto const& r : allRanges) {
-        if (r.end < histRangeStart) {
-            float meanRange = calc_hist_range_mean(hist, r.start, r.end);
-            if ((meanDepth8U - meanRange) <= 5) { histRangeStart = r.start; break; }
-        }
-    }
-
-    // Recompute mean over the final range (possibly extended to include head cluster)
-    meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
+    float const meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
     depth_mean = std::floor(meanDepth8U * SCALE_DEPTH + SUBTRACT_FROM_DEPTH);
 
-    // Build mask and find 2D center-of-mass
+    // Build mask and find 2D center-of-mass.
+    // Only use pixels in the upper COM_UPPER_FRACTION of the ROI height so that
+    // leg pixels (which dominate the lower bbox) don't pull the centroid down.
     std::vector<uint8_t> mask(roiW * roiH, 0);
     for (int j = 0; j < (int)roiData.size(); ++j)
         if (roiData[j] >= histRangeStart && roiData[j] <= histRangeEnd) mask[j] = 1;
 
+    int const comMaxY = std::max(1, (int)(roiH * COM_UPPER_FRACTION));
     vec2i com;
-    if (!calc_center_of_mask(mask, roiW, roiH, com)) return false;
+    if (!calc_center_of_mask(mask, roiW, roiH, com, comMaxY)) return false;
 
     center_mass_point = {com.x + roi.x, com.y + roi.y};
     return true;
@@ -322,47 +332,30 @@ bool center_of_mass_calculator::run_non_range_com_calculation_flow(
     if (color_rect.y > person_center.y)
         samplePt.y = (float)(color_rect.y + 10);
 
-    float averageDepth = (float)get_depth_at_color_pixel(depth, samplePt);
+    // Sample the center column at NUM_DEPTH_SAMPLES+3 evenly-spaced Y positions and
+    // take the NEAREST (minimum) valid depth.  The person is always in front of the
+    // background, so minimum valid depth in the column equals person depth even when
+    // most pixels are invalid (sparse IR) or some samples hit background.
+    float yProgression = color_rect.height / (float)(NUM_DEPTH_SAMPLES + 3);
+    float chosenDepth = 0.0f;
 
-    int   count = NUM_DEPTH_SAMPLES + 3;
-    std::vector<float> depthSamples(count, 0.0f);
-    float yProgression = color_rect.height / (float)NUM_DEPTH_SAMPLES;
-    float chosenDepth  = averageDepth;
+    auto tryDepth = [&](float d) {
+        if (d > MIN_DEPTH && d <= MAX_DEPTH && (chosenDepth == 0.0f || d < chosenDepth))
+            chosenDepth = d;
+    };
 
-    for (int i = 0; i < count; ++i) {
-        if (i >= NUM_DEPTH_SAMPLES - 1 && chosenDepth >= MIN_DEPTH) break;
-        float sampleY = std::min( color_rect.y + (i + 1) * yProgression,
-                                   float( color_rect.y + color_rect.height - 1 ) );
-        depthSamples[i] = (float)get_depth_at_color_pixel(depth, {person_center.x, sampleY});
-        if (chosenDepth <= MAX_DEPTH) {
-            if ((std::abs(chosenDepth - depthSamples[i]) < MAX_DEPTH_FOR_SAMPLES
-                    && chosenDepth < depthSamples[i]) ||
-                (chosenDepth == 0 && depthSamples[i] < MAX_DEPTH
-                    && depthSamples[i] > MIN_DEPTH))
-                chosenDepth = depthSamples[i];
-        }
+    tryDepth((float)get_depth_at_color_pixel(depth, samplePt));
+    for (int i = 0; i < NUM_DEPTH_SAMPLES + 3; ++i) {
+        float sampleY = std::min(color_rect.y + (i + 1) * yProgression,
+                                  float(color_rect.y + color_rect.height - 1));
+        tryDepth((float)get_depth_at_color_pixel(depth, {person_center.x, sampleY}));
     }
 
-    if (chosenDepth <= MAX_DEPTH) {
-        averageDepth = chosenDepth;
-    } else {
-        int   nonZero = 0;
-        float sumV = 0, sumV2 = 0;
-        for (float v : depthSamples)
-            if (v > 0) { sumV += v; sumV2 += v * v; ++nonZero; }
-        if (nonZero >= NUM_DEPTH_SAMPLES - 1) {
-            float mean   = sumV / nonZero;
-            float stdDev = std::sqrt(std::max(0.0f, sumV2 / nonZero - mean * mean));
-            if (stdDev < MAX_STD_DEPTH_SAMPLES && mean < MAX_DEPTH && mean > MIN_DEPTH)
-                averageDepth = mean;
-        }
-    }
+    result.mean_body_depth = chosenDepth;
 
-    result.mean_body_depth = (averageDepth <= MIN_DEPTH) ? 0.0f : averageDepth;
-
-    if (intrinsics && averageDepth > MIN_DEPTH) {
+    if (intrinsics && chosenDepth > MIN_DEPTH) {
         vec2i centerPx = {(int)(person_center.x + 0.5f), (int)(person_center.y + 0.5f)};
-        result.world_pos = pixel_to_camera(centerPx, averageDepth, *intrinsics);
+        result.world_pos = pixel_to_camera(centerPx, chosenDepth, *intrinsics);
         result.image_pos = {person_center.x, person_center.y};
     }
     return true;
@@ -378,7 +371,8 @@ bool center_of_mass_calculator::calculate(
     const rect&             color_bbox,
     const vec2f&            person_center_color,
     const camera_intrinsics*    intrinsics,
-    person_center_of_mass&      result)
+    person_center_of_mass&      result,
+    com_debug_info*             dbg)
 {
     if (!raw_depth.data || raw_depth.width == 0 || raw_depth.height == 0)
         return false;
@@ -392,7 +386,7 @@ bool center_of_mass_calculator::calculate(
     float depth_mean = 0.0f;
     vec2i center_mass_point = {0, 0};
     bool  status = calculate_com_with_depth_range(
-                       depth_8u, roi, depth_mean, center_mass_point);
+                       depth_8u, roi, depth_mean, center_mass_point, dbg);
 
     if (status) {
         result.mean_body_depth = (depth_mean <= MIN_DEPTH) ? 0.0f : depth_mean;
@@ -403,10 +397,12 @@ bool center_of_mass_calculator::calculate(
             result.world_pos = pixel_to_camera(center_mass_point, localDepth, *intrinsics);
             result.image_pos = {(float)center_mass_point.x, (float)center_mass_point.y};
         }
+        if (dbg) { dbg->histogram_ok = true; dbg->image_pos_x = result.image_pos.x; dbg->image_pos_y = result.image_pos.y; }
     } else {
         // Fallback: sample-based estimation along the bbox center column
         run_non_range_com_calculation_flow(
             color_bbox, raw_depth, person_center_color, intrinsics, result);
+        if (dbg) { dbg->histogram_ok = false; dbg->image_pos_x = result.image_pos.x; dbg->image_pos_y = result.image_pos.y; }
     }
 
     return true;

--- a/common/utilities/com/center-of-mass.h
+++ b/common/utilities/com/center-of-mass.h
@@ -57,6 +57,19 @@ struct person_center_of_mass {
     vec2f image_pos;        // Center of Mass (COM) pixel in color/depth image; zero if intrinsics not provided
 };
 
+// Debug snapshot filled by calculate() — pass a non-null pointer to collect it.
+struct com_debug_info {
+    bool  histogram_ok   = false; // true = histogram path used; false = fallback
+    int   center_d8u     = 0;     // patch-mean depth_8u at ROI center (0 = no valid pixels)
+    int   center_d8u_cnt = 0;     // valid pixels in the 5×5 anchor patch
+    int   n_clusters     = 0;     // depth clusters found in ROI histogram
+    int   cluster_start  = 0;     // selected cluster: depth_8u range start
+    int   cluster_end    = 0;     // selected cluster: depth_8u range end
+    float cluster_fract  = 0.f;   // selected cluster: fraction of valid ROI pixels
+    float image_pos_x    = 0.f;   // raw COM pixel X before EMA
+    float image_pos_y    = 0.f;   // raw COM pixel Y before EMA
+};
+
 // ---------------------------------------------------------------------------
 // center_of_mass_calculator
 // ---------------------------------------------------------------------------
@@ -127,7 +140,8 @@ public:
                           const rect&                 color_bbox,
                           const vec2f&                person_center_color,
                           const camera_intrinsics*    intrinsics,
-                          person_center_of_mass&      result);
+                          person_center_of_mass&      result,
+                          com_debug_info*             dbg = nullptr);
 
 private:
     static int  get_depth_at_color_pixel(const depth_image_16& depth, vec2f color_pt);
@@ -145,14 +159,16 @@ private:
     static bool calculate_com_with_depth_range(const depth_image_8& depth_8u,
                                                const rect& roi,
                                                float& depth_mean,
-                                               vec2i& center_mass_point);
+                                               vec2i& center_mass_point,
+                                               com_debug_info* dbg = nullptr);
 
     static float calc_hist_range_mean(const std::vector<float>& hist,
                                       int range_start, int range_end);
 
     static bool calc_center_of_mask(const std::vector<uint8_t>& mask,
                                     int mask_width, int mask_height,
-                                    vec2i& com);
+                                    vec2i& com,
+                                    int max_y = 0);  // 0 = use full height
 
     static bool run_non_range_com_calculation_flow(const rect&                 color_rect,
                                                    const depth_image_16&       depth,


### PR DESCRIPTION

- Restrict histogram to upper 65% of bbox (torso region) so floor/leg pixels don't inflate a background cluster past the person cluster.
- Split peak/extension thresholds (0.1% / 1%): low peak to detect sparse depth bodies, high extension to prevent merging distinct depth layers.
- Always pick the nearest cluster (minimum midpoint depth_8u) instead of MIN_BODY_FRACTION threshold; person is always nearer than background.
- Rewrite fallback to take minimum valid depth across evenly-spaced column samples; old greedy approach locked onto background when first sample was invalid or beyond MAX_DEPTH.