### PR TITLE
DDS: do not wait for hw-reset reply on D555 (RSDEV-11519)

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -694,10 +694,7 @@ void dds_device_proxy::tag_profiles( stream_profiles profiles ) const
 void dds_device_proxy::hardware_reset()
 {
     json control = json::object( { { realdds::topics::control::key::id, realdds::topics::control::hw_reset::id } } );
-    // RSDEV-11519: do not wait for a reply. The device may tear down its DDS entities and reset before
-    // the hw-reset reply is delivered, so requiring one raises a spurious "timeout waiting for reply"
-    // even though the reset succeeded. The control is still written reliably; the authoritative success
-    // signal is the device disconnection event, which callers observe via the devices-changed callback.
+    // don't wait for a reply - the device may reset before the reply is delivered
     _dds_dev->send_control( control );
 }
 

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -694,8 +694,11 @@ void dds_device_proxy::tag_profiles( stream_profiles profiles ) const
 void dds_device_proxy::hardware_reset()
 {
     json control = json::object( { { realdds::topics::control::key::id, realdds::topics::control::hw_reset::id } } );
-    json reply;
-    _dds_dev->send_control( control, &reply );
+    // RSDEV-11519: do not wait for a reply. The device may tear down its DDS entities and reset before
+    // the hw-reset reply is delivered, so requiring one raises a spurious "timeout waiting for reply"
+    // even though the reset succeeded. The control is still written reliably; the authoritative success
+    // signal is the device disconnection event, which callers observe via the devices-changed callback.
+    _dds_dev->send_control( control );
 }
 
 bool dds_device_proxy::is_in_recovery_mode() const


### PR DESCRIPTION
**Overview:** Make `hardware_reset()` over DDS fire-and-forget so a missing or late `hw-reset` reply no longer raises a spurious timeout error when the reset actually succeeded.

Tracked on [RSDEV-11519]

## Why
On D555, newer FW intermittently tears down its DDS entities and resets *before* the `hw-reset` reply is delivered. `hardware_reset()` blocked waiting for that reply (2500&nbsp;ms control reply-timeout), so it threw `RuntimeError: timeout waiting for reply #N: {"id":"hw-reset"}` even though the reset succeeded. Seen in libci #16830 on FW 7.58.40002.11099 (`pytest-live-hw-reset-sanity_D555`); `pytest-live-hw-reset-t2enum_D555` passed on the same FW, confirming the failure is the racy reply, not the reset or enumeration.

## Summary
- `dds_device_proxy::hardware_reset()` no longer passes a reply to `send_control`, so it does not block on the reply. The control message is still written reliably; the authoritative success signal is the device disconnection event, which callers observe via the devices-changed callback.

## Test plan
- [ ] `pytest-live-hw-reset-sanity` and `pytest-live-hw-reset-t2enum` on D555 (DDS), multiple iterations
- [ ] libci nightly green on D555 Windows + Linux

---
🤖 Generated by AI
