### PR TITLE
Revert "align D5x5 visual preset to D585S values"

### DIFF
--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -159,6 +159,15 @@ namespace librealsense
             case ds::RS455_PID:
             case ds::RS457_PID:
             case ds::D555_PID:
+            case ds::D585_LEGACY_PID:
+            case ds::D535_2C_PID:
+            case ds::D585_2C_PID:
+            case ds::D585_2C_PROTO_PID:
+            case ds::D535_3C_PID:
+            case ds::D535F_PID:
+            case ds::D585_3C_PID:
+            case ds::D585F_PID:
+            case ds::D585_3C_PROTO_PID:
                 default_450_mid_low_res( p );
                 switch( res )
                 {
@@ -177,15 +186,6 @@ namespace librealsense
                 }
                 break;
             case ds::D585S_PID:
-            case ds::D585_LEGACY_PID:
-            case ds::D535_2C_PID:
-            case ds::D585_2C_PID:
-            case ds::D585_2C_PROTO_PID:
-            case ds::D535_3C_PID:
-            case ds::D535F_PID:
-            case ds::D585_3C_PID:
-            case ds::D585F_PID:
-            case ds::D585_3C_PROTO_PID:
                 default_585S( p );
                 break;
             case ds::RS405U_PID:


### PR DESCRIPTION
**Overview:** Reverts #15232, restoring the D585/D535 camera family to the D450 default visual preset instead of the D585S preset.

## Why
#15232 moved the D585 family PIDs (D585, D535, and their 2C/3C/F variants) into the default_585S preset group. That preset is wrong for these devices; this revert restores their original default_450_mid_low_res preset.

## Summary
- Revert of f4666473 — moves the D585/D535 family PIDs back from the `default_585S` case to the `default_450_mid_low_res` case in `apply_preset()`. `D585S_PID` continues to use `default_585S`.

## Test plan
- [ ] CI compile across platforms (auto-triggered libci)
- [ ] Advanced-mode default preset on a D585/D535 device matches pre-#15232 values

🤖 Generated by AI
