### PR TITLE
Enable close-range on dual-RGB (depth-only limitation); keep dedicated-color unconditional

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2973,13 +2973,9 @@ namespace rs2
                             }
 
                             dg.end();
-                            if( !pb_available && pb->unavailable_tooltip
+                            if( !pb_available && !pb->unavailable_tooltip.empty()
                                 && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
-                            {
-                                auto tooltip = pb->unavailable_tooltip();
-                                if( !tooltip.empty() )
-                                    RsImGui::CustomTooltip( "%s", tooltip.c_str() );
-                            }
+                                RsImGui::CustomTooltip( "%s", pb->unavailable_tooltip.c_str() );
 
                             ImGui::PopStyleColor(5);
                             ImGui::PopFont();
@@ -3032,6 +3028,16 @@ namespace rs2
                     draw_later.push_back([windows_width, &window, sub, pos, &viewer, this, pb]() {
                         ImGui::SetCursorPos({ windows_width - 42, pos.y - 3 });
 
+                        const bool pb_available = pb->is_available();
+                        // RAII guard pairing BeginDisabled/EndDisabled: keeps them balanced
+                        // even if an exception is thrown between begin and the explicit end()
+                        // call below (which runs before the tooltip hover check).
+                        struct disable_guard {
+                            bool active, ended;
+                            disable_guard( bool a ) : active( a ), ended( false ) { if( active ) ImGui::BeginDisabled( true ); }
+                            void end() { if( active && !ended ) { ended = true; ImGui::EndDisabled(); } }
+                            ~disable_guard() { end(); }
+                        } dg( !pb_available );
                         try
                         {
                             ImGui::PushFont(window.get_font());
@@ -3083,6 +3089,15 @@ namespace rs2
                                     RsImGui::CustomTooltip("%s", label.c_str());
                                     window.link_hovered();
                                 }
+                            }
+
+                            dg.end();
+                            if( !pb_available && pb->unavailable_tooltip
+                                && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
+                            {
+                                auto tooltip = pb->unavailable_tooltip();
+                                if( !tooltip.empty() )
+                                    RsImGui::CustomTooltip( "%s", tooltip.c_str() );
                             }
 
                             ImGui::PopStyleColor(5);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -3086,13 +3086,9 @@ namespace rs2
                             }
 
                             dg.end();
-                            if( !pb_available && pb->unavailable_tooltip
+                            if( !pb_available && !pb->unavailable_tooltip.empty()
                                 && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
-                            {
-                                auto tooltip = pb->unavailable_tooltip();
-                                if( !tooltip.empty() )
-                                    RsImGui::CustomTooltip( "%s", tooltip.c_str() );
-                            }
+                                RsImGui::CustomTooltip( "%s", pb->unavailable_tooltip.c_str() );
 
                             ImGui::PopStyleColor(5);
                             ImGui::PopFont();

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2973,9 +2973,13 @@ namespace rs2
                             }
 
                             dg.end();
-                            if( !pb_available && !pb->unavailable_tooltip.empty()
+                            if( !pb_available && pb->unavailable_tooltip
                                 && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
-                                RsImGui::CustomTooltip( "%s", pb->unavailable_tooltip.c_str() );
+                            {
+                                auto tooltip = pb->unavailable_tooltip();
+                                if( !tooltip.empty() )
+                                    RsImGui::CustomTooltip( "%s", tooltip.c_str() );
+                            }
 
                             ImGui::PopStyleColor(5);
                             ImGui::PopFont();

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -29,6 +29,16 @@ using namespace rs2::sw_update;
 
 namespace rs2
 {
+    // RAII guard pairing BeginDisabled/EndDisabled: keeps them balanced even if an exception is
+    // thrown between begin and the explicit end() call (which runs before the tooltip hover check).
+    struct disable_guard
+    {
+        bool active, ended;
+        disable_guard( bool a ) : active( a ), ended( false ) { if( active ) ImGui::BeginDisabled( true ); }
+        void end() { if( active && !ended ) { ended = true; ImGui::EndDisabled(); } }
+        ~disable_guard() { end(); }
+    };
+
     void imgui_easy_theming(ImFont*& font_dynamic, ImFont*& font_18, ImFont*& monofont, int& font_size)
     {
         ImGuiStyle& style = ImGui::GetStyle();
@@ -2881,15 +2891,7 @@ namespace rs2
                         ImGui::SetCursorPos({ windows_width - 42, pos.y - 3 });
 
                         const bool pb_available = pb->is_available();
-                        // RAII guard pairing BeginDisabled/EndDisabled: keeps them balanced
-                        // even if an exception is thrown between begin and the explicit end()
-                        // call below (which runs before the tooltip hover check).
-                        struct disable_guard {
-                            bool active, ended;
-                            disable_guard( bool a ) : active( a ), ended( false ) { if( active ) ImGui::BeginDisabled( true ); }
-                            void end() { if( active && !ended ) { ended = true; ImGui::EndDisabled(); } }
-                            ~disable_guard() { end(); }
-                        } dg( !pb_available );
+                        disable_guard dg( !pb_available );
                         try
                         {
                             ImGui::PushFont(window.get_font());
@@ -3029,15 +3031,7 @@ namespace rs2
                         ImGui::SetCursorPos({ windows_width - 42, pos.y - 3 });
 
                         const bool pb_available = pb->is_available();
-                        // RAII guard pairing BeginDisabled/EndDisabled: keeps them balanced
-                        // even if an exception is thrown between begin and the explicit end()
-                        // call below (which runs before the tooltip hover check).
-                        struct disable_guard {
-                            bool active, ended;
-                            disable_guard( bool a ) : active( a ), ended( false ) { if( active ) ImGui::BeginDisabled( true ); }
-                            void end() { if( active && !ended ) { ended = true; ImGui::EndDisabled(); } }
-                            ~disable_guard() { end(); }
-                        } dg( !pb_available );
+                        disable_guard dg( !pb_available );
                         try
                         {
                             ImGui::PushFont(window.get_font());

--- a/common/embedded-filter-model.h
+++ b/common/embedded-filter-model.h
@@ -51,11 +51,11 @@ namespace rs2
         // When it returns false the enable toggle is grayed out in the UI.
         // Set by the owner after construction for filters with runtime constraints
         // (e.g. close range, which works on depth only and must be off while RGB streams).
-        std::function<bool()> available;
+        std::function<bool()> available_predicate;
         // Optional; returns the message explaining why the toggle is unavailable.
         std::function<std::string()> unavailable_tooltip;
 
-        bool is_available() const { return !available || available(); }
+        bool is_available() const { return !available_predicate || available_predicate(); }
 
         void embedded_filter_enable_disable(bool actual);
 

--- a/common/embedded-filter-model.h
+++ b/common/embedded-filter-model.h
@@ -50,7 +50,7 @@ namespace rs2
         // Optional predicate; null means always available.
         // When it returns false the enable toggle is grayed out in the UI.
         // Set by the owner after construction for filters with runtime constraints
-        // (e.g. close range, which works on depth only and must be off while RGB streams).
+        // (e.g. close range, which works on depth only and must be off while color streams).
         std::function<bool()> available_predicate;
         // Optional message shown when the toggle is unavailable; empty = none.
         std::string unavailable_tooltip;

--- a/common/embedded-filter-model.h
+++ b/common/embedded-filter-model.h
@@ -52,8 +52,8 @@ namespace rs2
         // Set by the owner after construction for filters with runtime constraints
         // (e.g. close range, which works on depth only and must be off while RGB streams).
         std::function<bool()> available_predicate;
-        // Optional; returns the message explaining why the toggle is unavailable.
-        std::function<std::string()> unavailable_tooltip;
+        // Optional message shown when the toggle is unavailable; empty = none.
+        std::string unavailable_tooltip;
 
         bool is_available() const { return !available_predicate || available_predicate(); }
 

--- a/common/embedded-filter-model.h
+++ b/common/embedded-filter-model.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <librealsense2/rs.hpp>
+#include <functional>
 #include <string>
 
 
@@ -45,6 +46,16 @@ namespace rs2
         bool is_enabled() const { return _enabled; }
 
         bool _is_visible = true;
+
+        // Optional predicate; null means always available.
+        // When it returns false the enable toggle is grayed out in the UI.
+        // Set by the owner after construction for filters with runtime constraints
+        // (e.g. close range, which works on depth only and must be off while RGB streams).
+        std::function<bool()> available;
+        // Optional; returns the message explaining why the toggle is unavailable.
+        std::function<std::string()> unavailable_tooltip;
+
+        bool is_available() const { return !available || available(); }
 
         void embedded_filter_enable_disable(bool actual);
 

--- a/common/processing-block-model.h
+++ b/common/processing-block-model.h
@@ -60,9 +60,7 @@ namespace rs2
         // Set by the owner after construction for filters with runtime constraints
         // (e.g. in subdevice_model for Improved Close Range Depth: requires CUDA and specific stream config).
         std::function<bool()> available;
-        // Optional; returns the message explaining why the toggle is unavailable.
-        // May depend on runtime state, so the reason can differ between calls.
-        std::function<std::string()> unavailable_tooltip;
+        std::string unavailable_tooltip;
 
         bool is_available() const { return !available || available(); }
 

--- a/common/processing-block-model.h
+++ b/common/processing-block-model.h
@@ -60,7 +60,9 @@ namespace rs2
         // Set by the owner after construction for filters with runtime constraints
         // (e.g. in subdevice_model for Improved Close Range Depth: requires CUDA and specific stream config).
         std::function<bool()> available;
-        std::string unavailable_tooltip;
+        // Optional; returns the message explaining why the toggle is unavailable.
+        // May depend on runtime state, so the reason can differ between calls.
+        std::function<std::string()> unavailable_tooltip;
 
         bool is_available() const { return !available || available(); }
 

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -321,6 +321,10 @@ namespace rs2
                 // a member of this subdevice_model — so it cannot outlive its owner.
                 model->available_predicate = [this]()
                 {
+                    // Only a live color stream conflicts with close range; while stopped
+                    // the toggle stays available even if color is selected for the next run.
+                    if( !streaming )
+                        return true;
                     for( auto& p : profiles )
                     {
                         auto it = stream_enabled.find( p.unique_id() );

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -319,22 +319,17 @@ namespace rs2
             {
                 // Safe to capture this: the lambda lives in model which lives in embedded_filters,
                 // a member of this subdevice_model — so it cannot outlive its owner.
-                auto is_color_enabled = [this]()
+                model->available_predicate = [this]()
                 {
                     for( auto& p : profiles )
                     {
                         auto it = stream_enabled.find( p.unique_id() );
-                        if( it == stream_enabled.end() || !it->second ) continue;
-                        if( p.stream_type() == RS2_STREAM_COLOR )
-                            return true;
+                        if( it != stream_enabled.end() && it->second && p.stream_type() == RS2_STREAM_COLOR )
+                            return false;
                     }
-                    return false;
+                    return true;
                 };
-                model->available_predicate = [is_color_enabled]() { return !is_color_enabled(); };
-                model->unavailable_tooltip = []() -> std::string
-                {
-                    return "Improved Close Range Depth works on depth only; please disable the RGB stream";
-                };
+                model->unavailable_tooltip = "Improved Close Range Depth cannot be activated while RGB streams are active";
             }
 
             embedded_filters.push_back(model);

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -311,12 +311,11 @@ namespace rs2
             auto model = std::make_shared<embedded_filter_model>(
                 this, shared_filter->get_type(), shared_filter, viewer, error_message);
 
-            // The close-range filter works on depth only. On the 0C07 dual-RGB variant the depth
-            // sensor also exposes RGB/color streams, so disable the toggle while any RGB stream is
-            // enabled. The 0C08 dedicated-color variant does not have this limitation.
+            // Dual-RGB variants (0C01/0C04/0C07) share a depth+color sensor, so close-range runs depth-only.
             std::string device_pid = s->supports( RS2_CAMERA_INFO_PRODUCT_ID )
                                    ? s->get_info( RS2_CAMERA_INFO_PRODUCT_ID ) : "";
-            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE && device_pid == "0C07" )
+            const bool is_dual_rgb = ( device_pid == "0C01" || device_pid == "0C04" || device_pid == "0C07" );
+            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE && is_dual_rgb )
             {
                 // Safe to capture this: the lambda lives in model which lives in embedded_filters,
                 // a member of this subdevice_model — so it cannot outlive its owner.
@@ -331,7 +330,7 @@ namespace rs2
                     }
                     return false;
                 };
-                model->available = [is_color_enabled]() { return !is_color_enabled(); };
+                model->available_predicate = [is_color_enabled]() { return !is_color_enabled(); };
                 model->unavailable_tooltip = []() -> std::string
                 {
                     return "Improved Close Range Depth works on depth only; please disable the RGB stream";

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -311,9 +311,12 @@ namespace rs2
             auto model = std::make_shared<embedded_filter_model>(
                 this, shared_filter->get_type(), shared_filter, viewer, error_message);
 
-            // The close-range filter works on depth only. On dual-RGB devices the depth sensor
-            // also exposes RGB/color streams, so disable the toggle while any RGB stream is enabled.
-            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE )
+            // The close-range filter works on depth only. On the 0C07 dual-RGB variant the depth
+            // sensor also exposes RGB/color streams, so disable the toggle while any RGB stream is
+            // enabled. The 0C08 dedicated-color variant does not have this limitation.
+            std::string device_pid = s->supports( RS2_CAMERA_INFO_PRODUCT_ID )
+                                   ? s->get_info( RS2_CAMERA_INFO_PRODUCT_ID ) : "";
+            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE && device_pid == "0C07" )
             {
                 // Safe to capture this: the lambda lives in model which lives in embedded_filters,
                 // a member of this subdevice_model — so it cannot outlive its owner.

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -311,11 +311,11 @@ namespace rs2
             auto model = std::make_shared<embedded_filter_model>(
                 this, shared_filter->get_type(), shared_filter, viewer, error_message);
 
-            // Dual-RGB variants (0C01/0C04/0C07) share a depth+color sensor, so close-range runs depth-only.
+            // Dual-color variants (0C01/0C04/0C07) share a depth+color sensor, so close-range runs depth-only.
             std::string device_pid = s->supports( RS2_CAMERA_INFO_PRODUCT_ID )
                                    ? s->get_info( RS2_CAMERA_INFO_PRODUCT_ID ) : "";
-            const bool is_dual_rgb = ( device_pid == "0C01" || device_pid == "0C04" || device_pid == "0C07" );
-            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE && is_dual_rgb )
+            const bool is_dual_color = ( device_pid == "0C01" || device_pid == "0C04" || device_pid == "0C07" );
+            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE && is_dual_color )
             {
                 // Safe to capture this: the lambda lives in model which lives in embedded_filters,
                 // a member of this subdevice_model — so it cannot outlive its owner.
@@ -329,7 +329,7 @@ namespace rs2
                     }
                     return true;
                 };
-                model->unavailable_tooltip = "Improved Close Range Depth cannot be activated while RGB streams are active";
+                model->unavailable_tooltip = "Improved Close Range Depth cannot be activated while color streams are active";
             }
 
             embedded_filters.push_back(model);

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -204,19 +204,37 @@ namespace rs2
             if( ! get_rs_depth_range_loader().is_loaded() )
             {
                 model->available = []() { return false; };
-                model->unavailable_tooltip = "Improved Close Range Depth library not found; install librealsense2-enhanced-depth package";
+                model->unavailable_tooltip = []() -> std::string { return "Improved Close Range Depth library not found; install librealsense2-enhanced-depth package"; };
             }
             else if( !rsutils::rs2_is_cuda_available() )
             {
                 model->available = []() { return false; };
-                model->unavailable_tooltip = "Improved Close Range Depth requires CUDA (not detected on this system)";
+                model->unavailable_tooltip = []() -> std::string { return "Improved Close Range Depth requires CUDA (not detected on this system)"; };
             }
             else
             {
-                // Safe to capture this: the lambda lives in model which lives in post_processing,
-                // a member of this subdevice_model — so the lambda cannot outlive its owner.
-                model->available = [this]()
+                // Safe to capture this: the lambdas live in model which lives in post_processing,
+                // a member of this subdevice_model — so they cannot outlive their owner.
+
+                // On dual-RGB devices the depth sensor also exposes RGB/color streams; the improver
+                // operates on depth only, so it must be disabled while any RGB stream is enabled.
+                auto is_color_enabled = [this]()
                 {
+                    for( auto& p : profiles )
+                    {
+                        auto it = stream_enabled.find( p.unique_id() );
+                        if( it == stream_enabled.end() || !it->second ) continue;
+                        if( p.stream_type() == RS2_STREAM_COLOR )
+                            return true;
+                    }
+                    return false;
+                };
+
+                model->available = [this, is_color_enabled]()
+                {
+                    if( is_color_enabled() )
+                        return false;
+
                     // Resolution check — VGA (640x480) minimum
                     if( ui.is_multiple_resolutions )
                     {
@@ -249,7 +267,12 @@ namespace rs2
                     }
                     return depth && ir1 && ir2;
                 };
-                model->unavailable_tooltip = "Depth, IR Left/Right streams have to be enabled at VGA or higher resolution";
+                model->unavailable_tooltip = [is_color_enabled]() -> std::string
+                {
+                    if( is_color_enabled() )
+                        return "Improved Close Range Depth works on depth only; please disable the RGB stream";
+                    return "Depth, IR Left/Right streams have to be enabled at VGA or higher resolution";
+                };
             }
 
             post_processing.push_back( model );

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -204,37 +204,19 @@ namespace rs2
             if( ! get_rs_depth_range_loader().is_loaded() )
             {
                 model->available = []() { return false; };
-                model->unavailable_tooltip = []() -> std::string { return "Improved Close Range Depth library not found; install librealsense2-enhanced-depth package"; };
+                model->unavailable_tooltip = "Improved Close Range Depth library not found; install librealsense2-enhanced-depth package";
             }
             else if( !rsutils::rs2_is_cuda_available() )
             {
                 model->available = []() { return false; };
-                model->unavailable_tooltip = []() -> std::string { return "Improved Close Range Depth requires CUDA (not detected on this system)"; };
+                model->unavailable_tooltip = "Improved Close Range Depth requires CUDA (not detected on this system)";
             }
             else
             {
-                // Safe to capture this: the lambdas live in model which lives in post_processing,
-                // a member of this subdevice_model — so they cannot outlive their owner.
-
-                // On dual-RGB devices the depth sensor also exposes RGB/color streams; the improver
-                // operates on depth only, so it must be disabled while any RGB stream is enabled.
-                auto is_color_enabled = [this]()
+                // Safe to capture this: the lambda lives in model which lives in post_processing,
+                // a member of this subdevice_model — so the lambda cannot outlive its owner.
+                model->available = [this]()
                 {
-                    for( auto& p : profiles )
-                    {
-                        auto it = stream_enabled.find( p.unique_id() );
-                        if( it == stream_enabled.end() || !it->second ) continue;
-                        if( p.stream_type() == RS2_STREAM_COLOR )
-                            return true;
-                    }
-                    return false;
-                };
-
-                model->available = [this, is_color_enabled]()
-                {
-                    if( is_color_enabled() )
-                        return false;
-
                     // Resolution check — VGA (640x480) minimum
                     if( ui.is_multiple_resolutions )
                     {
@@ -267,12 +249,7 @@ namespace rs2
                     }
                     return depth && ir1 && ir2;
                 };
-                model->unavailable_tooltip = [is_color_enabled]() -> std::string
-                {
-                    if( is_color_enabled() )
-                        return "Improved Close Range Depth works on depth only; please disable the RGB stream";
-                    return "Depth, IR Left/Right streams have to be enabled at VGA or higher resolution";
-                };
+                model->unavailable_tooltip = "Depth, IR Left/Right streams have to be enabled at VGA or higher resolution";
             }
 
             post_processing.push_back( model );
@@ -333,6 +310,30 @@ namespace rs2
 
             auto model = std::make_shared<embedded_filter_model>(
                 this, shared_filter->get_type(), shared_filter, viewer, error_message);
+
+            // The close-range filter works on depth only. On dual-RGB devices the depth sensor
+            // also exposes RGB/color streams, so disable the toggle while any RGB stream is enabled.
+            if( shared_filter->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE )
+            {
+                // Safe to capture this: the lambda lives in model which lives in embedded_filters,
+                // a member of this subdevice_model — so it cannot outlive its owner.
+                auto is_color_enabled = [this]()
+                {
+                    for( auto& p : profiles )
+                    {
+                        auto it = stream_enabled.find( p.unique_id() );
+                        if( it == stream_enabled.end() || !it->second ) continue;
+                        if( p.stream_type() == RS2_STREAM_COLOR )
+                            return true;
+                    }
+                    return false;
+                };
+                model->available = [is_color_enabled]() { return !is_color_enabled(); };
+                model->unavailable_tooltip = []() -> std::string
+                {
+                    return "Improved Close Range Depth works on depth only; please disable the RGB stream";
+                };
+            }
 
             embedded_filters.push_back(model);
         }

--- a/src/ds/d500/d500-close-range-embedded-filter.cpp
+++ b/src/ds/d500/d500-close-range-embedded-filter.cpp
@@ -58,15 +58,16 @@ void close_range_xu_option::set( float value )
     if( ! ep )
         throw invalid_value_exception( "Close Range: depth sensor not alive for set" );
 
-    // Close-range operates on depth only. On dual-RGB devices the depth sensor also streams RGB,
-    // so block enabling while any color stream is active (enforced here, not just in the viewer).
+    // Close-range operates on depth only. On dual-color devices the depth sensor also streams color,
+    // so block enabling while any color stream is active. get_active_streams() is scoped to this
+    // endpoint, so on dedicated-color variants (separate endpoints) this loop is a safe no-op.
     if( value != 0.f )
     {
         for( auto & sp : ep->get_active_streams() )
         {
             if( sp && sp->get_stream_type() == RS2_STREAM_COLOR )
                 throw wrong_api_call_sequence_exception(
-                    "Improved Close Range Depth cannot be activated while RGB streams are active" );
+                    "Improved Close Range Depth cannot be activated while color streams are active" );
         }
     }
 

--- a/src/ds/d500/d500-close-range-embedded-filter.cpp
+++ b/src/ds/d500/d500-close-range-embedded-filter.cpp
@@ -58,6 +58,18 @@ void close_range_xu_option::set( float value )
     if( ! ep )
         throw invalid_value_exception( "Close Range: depth sensor not alive for set" );
 
+    // Close-range operates on depth only. On dual-RGB devices the depth sensor also streams RGB,
+    // so block enabling while any color stream is active (enforced here, not just in the viewer).
+    if( value != 0.f )
+    {
+        for( auto & sp : ep->get_active_streams() )
+        {
+            if( sp && sp->get_stream_type() == RS2_STREAM_COLOR )
+                throw wrong_api_call_sequence_exception(
+                    "Improved Close Range Depth cannot be activated while RGB streams are active" );
+        }
+    }
+
     ep->invoke_powered(
         [this, value]( platform::uvc_device & dev )
         {

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -166,8 +166,27 @@ namespace librealsense
             uvc->set_frame_metadata_modifier(callback);
     }
 
+    void d500_depth_sensor::color_stream_allowed_or_throw( const stream_profiles & requests ) const
+    {
+        bool color_requested = false;
+        for( auto & p : requests )
+            if( p && p->get_stream_type() == RS2_STREAM_COLOR )
+                color_requested = true;
+        if( ! color_requested )
+            return;  // color only lives on this sensor for dual-color devices
+
+        for( auto & f : _embedded_filters )
+            if( f && f->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE
+                && f->supports_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED )
+                && f->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ).query() != 0.f )
+                throw wrong_api_call_sequence_exception(
+                    "Color streams cannot be activated while Improved Close Range Depth is enabled" );
+    }
+
     void d500_depth_sensor::open( const stream_profiles & requests )
     {
+        color_stream_allowed_or_throw( requests );
+
         group_multiple_fw_calls(*this, [&]() {
             _depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();
             set_frame_metadata_modifier([&](frame_additional_data& data) {data.depth_units = _depth_units.load(); });

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -51,6 +51,10 @@ namespace librealsense
         embedded_filters get_supported_embedded_filters() const override { return _embedded_filters; }
         void add_embedded_filter( std::shared_ptr< embedded_filter_interface > filter ) { _embedded_filters.push_back( filter ); }
 
+        // Throws if a color stream in 'requests' cannot start now. Dual-color: color shares this sensor
+        // and close-range works on depth only, so color is blocked while close-range is enabled.
+        void color_stream_allowed_or_throw( const stream_profiles & requests ) const;
+
         // Streams contributed by feature mixins (e.g. dual-color) that this sensor physically carries. They are
         // assigned to matching profiles (by stream type + index) during init_stream_profiles.
         void add_stream( std::shared_ptr< stream_interface > stream ) { _extra_streams.push_back( stream ); }

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -123,6 +123,10 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
+
+            // Improved Close Range Depth - USB toggle
+            register_feature( std::make_shared< close_range_filter_feature >(
+                    dynamic_cast< d500_depth_sensor & >( get_depth_sensor() ) ) );
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override


### PR DESCRIPTION
**Overview:** Enables the close-range filter on the dual-color devices (0C01/0C04/0C07) with a depth-only limitation. Enabling close-range while color streams (and starting color while close-range is enabled) is blocked at the SDK level, and the viewer toggle is grayed out. Dedicated-color variants (0C02/0C05/0C08) keep close-range enabled unconditionally.

## Why
Close-range was enabled on dedicated-color only. #15219 had removed the dual-color registration; this re-adds it. Because the dual-color depth sensor also streams color, close-range must run on depth only — so close-range and color are mutually exclusive on that sensor.

## Summary
- Re-add the `close_range_filter_feature` registration for `rs5x5_device` (dual-color) in `d500-factory.cpp` — reverses #15219's removal. Registered unconditionally (unlike D555, whose FW-version gate exists only because its close-range support landed mid-cycle).
- SDK, both directions: `close_range_xu_option::set()` throws if close-range is enabled while a color stream is active; `d500_depth_sensor::open()` throws if a color stream is started while close-range is enabled.
- Viewer: on dual-color PIDs, gray out the close-range embedded-filter toggle while any color stream is enabled, with a matching tooltip.
- Add optional `available_predicate` / `unavailable_tooltip` to `embedded_filter_model` and reuse a shared `disable_guard` for the toggle rendering.

## Test plan
- [ ] CI build/compile passes on all platforms.
- [ ] Viewer on a dual-color device: enabling a color stream grays out the close-range toggle with the depth-only message; disabling color re-enables it. (pending hardware)
- [ ] SDK: enabling close-range while color is active, and starting color while close-range is enabled, both throw `wrong_api_call_sequence_exception`. (pending hardware)
- [ ] Viewer on a dedicated-color device: the toggle is unaffected by color streaming.

---
🤖 Generated by AI
