### PR TITLE
Fix platform camera multi-pin streaming regression (RGB8/Y8 fail to resolve)

### DIFF
--- a/src/platform/uvc-device.h
+++ b/src/platform/uvc-device.h
@@ -266,9 +266,13 @@ public:
 
     void probe_and_commit( stream_profile profile, frame_callback callback, int buffers ) override
     {
-        auto dev_index = get_dev_index_by_profiles( profile );
+        // get_profiles() advertises pin_index as the sub-device index for SDK-level distinctness, but each
+        // sub-device expects its own native backend pin index (e.g. the Windows MF stream index) when probing.
+        // Forward the matched sub-device's native profile so the backend selects the correct endpoint.
+        stream_profile native_profile;
+        uint32_t dev_index = get_dev_index_by_profiles( profile, native_profile );
         _configured_indexes.insert( dev_index );
-        _dev[dev_index]->probe_and_commit( profile, callback, buffers );
+        _dev[dev_index]->probe_and_commit( native_profile, callback, buffers );
     }
 
 
@@ -298,8 +302,11 @@ public:
 
     void close( stream_profile profile ) override
     {
-        auto dev_index = get_dev_index_by_profiles( profile );
-        _dev[dev_index]->close( profile );
+        // Forward the matched sub-device's native profile (see probe_and_commit) so the backend closes the
+        // same endpoint it opened.
+        stream_profile native_profile;
+        uint32_t dev_index = get_dev_index_by_profiles( profile, native_profile );
+        _dev[dev_index]->close( native_profile );
         _configured_indexes.erase( dev_index );
     }
 
@@ -399,7 +406,11 @@ public:
     }
 
 private:
-    uint32_t get_dev_index_by_profiles( const stream_profile & profile ) const
+    // Returns the sub-device index matching 'profile' (as advertised to the SDK by get_profiles()), and outputs the
+    // sub-device's native profile - which keeps the backend pin index (e.g. the Windows MF stream index) needed to
+    // probe/play the right endpoint. get_profiles() overwrites pin_index with the sub-device index when _dev.size()
+    // > 1, so we compare on a stamped copy but hand back the unstamped native profile.
+    uint32_t get_dev_index_by_profiles( const stream_profile & profile, stream_profile & native_profile ) const
     {
         uint32_t dev_index = 0;
         for( auto & elem : _dev )
@@ -407,10 +418,14 @@ private:
             auto pin_stream_profiles = elem->get_profiles();
             for( auto & p : pin_stream_profiles )
             {
+                stream_profile stamped = p;
                 if( _dev.size() > 1 )
-                    p.pin_index = dev_index;  // match the stamping applied in get_profiles()
-                if( p == profile )
+                    stamped.pin_index = dev_index;  // match the stamping applied in get_profiles()
+                if( stamped == profile )
+                {
+                    native_profile = p;
                     return dev_index;
+                }
             }
             ++dev_index;
         }

--- a/src/platform/uvc-device.h
+++ b/src/platform/uvc-device.h
@@ -306,8 +306,11 @@ public:
         // same endpoint it opened.
         stream_profile native_profile;
         uint32_t dev_index = get_dev_index_by_profiles( profile, native_profile );
-        _dev[dev_index]->close( native_profile );
+        // Erase first: set::erase won't throw, and close() doesn't read _configured_indexes - so if the
+        // backend close throws, the index is already gone and stream_on/start_callbacks won't touch a
+        // device whose close failed.
         _configured_indexes.erase( dev_index );
+        _dev[dev_index]->close( native_profile );
     }
 
     void set_power_state( power_state state ) override


### PR DESCRIPTION
**Overview:** Fixes a regression where Platform Cameras (laptop webcams) with multiple pins could not stream Color RGB8 or IR Y8 — `rs2_open` failed with "Failed to resolve the request ... Into: NV12 / Y8".

## Why
PR #15253 added `platform::stream_profile::pin_index`, but it ends up meaning two different things on two stacked layers: the backend (e.g. Windows MF) stream index *within* a device, and the sub-device index *across* devices in `multi_pins_uvc_device`. When the wrapper holds more than one sub-device (e.g. a webcam whose color and IR pins are grouped into one sensor), `get_profiles()` stamps the sub-device index over the backend index, and `probe_and_commit` then forwarded that value down to the backend, whose new pin guard (`mf-uvc.cpp`) rejected every media type → the request failed to resolve/open.

## Summary
- `multi_pins_uvc_device::probe_and_commit` / `close` now forward the matched sub-device's **native** profile (its real backend pin index) while still matching the incoming request on the SDK-stamped value.
- `get_profiles()` is unchanged, so the `stream_id_resolver` (D585 dual-RGB Color 1 / Color 2 routing) sees the same `pin_index` values as before.
- When the wrapper has a single sub-device, the native and stamped profiles are identical, so the forwarded profile is byte-for-byte unchanged (no-op for D400/D500 and single-pin cameras).

## Test plan
- [x] Reproduced on an integrated webcam (Chicony, multi-pin Platform Camera). Unpatched: `Color RGB8 1280x720` and `IR Y8` both fail to resolve (`Into: NV12` / `Into: Y8`). Patched: both stream (RGB8 1280x720 and IR Y8, frames received).
- [x] D585 dual-RGB path verified safe by static analysis: no change to `get_profiles()` / `stream_id_resolver`; its `multi_pins` usage either hits the single-sub-device no-op or a case the unpatched code already mishandled.
- [ ] CI (libci) green.

---
🤖 Generated by AI
