### PR TITLE
pytest: per-camera D585S safety-mode fixture + guard against cross-camera module fixtures

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -384,8 +384,61 @@ def pytest_generate_tests(metafunc):
     resolve_device_each_serials(metafunc)
 
 
-def pytest_collection_modifyitems(config, items):
+# Module-scoped fixtures that are intentionally device-independent (not re-created per camera).
+_PER_CAMERA_FIXTURE_ALLOWLIST = {
+    "_test_device_serial",          # the per-camera anchor itself (parametrized per device)
+    "__pytest_repeat_step_number",  # per-repeat pass, device-independent
+}
+
+
+def _fixture_reaches(fm, fixturedef, target, node):
+    """True if fixturedef transitively depends on the fixture named `target`."""
+    return any(arg == target
+               or any(_fixture_reaches(fm, dep, target, node)
+                      for dep in (fm.getfixturedefs(arg, node) or []))
+               for arg in fixturedef.argnames)
+
+
+def _assert_module_fixtures_are_per_camera(session, items):
+    """Guard: in a device-parametrized test, every module-scoped fixture must be re-created
+    per camera, i.e. it must (transitively) depend on _test_device_serial. A module-scoped
+    fixture that doesn't is instantiated once and SHARED across all cameras in the module, so
+    its teardown runs at module end (or a retry teardown) rather than at each camera boundary
+    — a subtle trap that previously left a disconnected D585S restore firing mid-module
+    (Jenkins win #114673). Fail collection loudly so the mistake can't slip in unnoticed.
+    """
+    fm = session._fixturemanager
+    offenders = set()
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        if not callspec or callspec.params.get("_test_device_serial") is None:
+            continue  # not bound to a camera
+        for name in item.fixturenames:
+            if name in _PER_CAMERA_FIXTURE_ALLOWLIST:
+                continue
+            defs = fm.getfixturedefs(name, item)
+            if not defs:
+                continue
+            fixturedef = defs[-1]
+            if fixturedef.scope != "module":
+                continue
+            if "site-packages" in fixturedef.func.__code__.co_filename:
+                continue  # don't police plugin fixtures (pytest-retry/repeat/etc.)
+            if not _fixture_reaches(fm, fixturedef, "_test_device_serial", item):
+                offenders.add(name)
+    if offenders:
+        raise pytest.UsageError(
+            f"Module-scoped fixture(s) {sorted(offenders)} are used by device-parametrized tests "
+            "but do not depend on _test_device_serial, so they are created once and SHARED across "
+            "every camera in the module — their teardown runs at module end, not per camera. "
+            "Depend on test_device (or _test_device_serial) for per-camera lifecycle, or add the "
+            "fixture to _PER_CAMERA_FIXTURE_ALLOWLIST if it is genuinely device-independent."
+        )
+
+
+def pytest_collection_modifyitems(session, config, items):
     """Auto-skip nightly/dds tests, filter --live, sort by priority."""
+    _assert_module_fixtures_are_per_camera(session, items)
     test_dirs = config.getoption("--test-dir", default=[])
     if test_dirs:
         abs_dirs = [os.path.abspath(p) for p in test_dirs]
@@ -684,45 +737,31 @@ def test_context_var():
 
 
 @pytest.fixture(scope="module")
-def _safety_mode_state():
-    """Module-scoped state holder for D585S service mode, keyed by device serial number.
+def test_device_wrapped(test_device):
+    """Like test_device, but puts a D585S into service mode for the module's tests on this
+    device and restores run mode at teardown.
 
-    Each serial gets its own entry so that multiple D585S cameras in the same module
-    (e.g. via device_each) are each entered into service mode independently.
-    Teardown runs once at module end, restoring run mode for every camera that was entered.
-    """
-    state = {}  # serial_number -> {'sensor': ..., 'entered': False}
-    yield state
-    for sn, entry in state.items():
-        if entry['entered'] and entry['sensor'] is not None:
-            try:
-                entry['sensor'].set_option(rs.option.safety_mode, rs.safety_mode.run)
-            except Exception as e:
-                # Don't throw on cleanup failure, to not mask test failures and also after test device is usually reset.
-                log.error(f"safety_mode restore failed for {sn}: {e}")
-
-
-@pytest.fixture(scope="module")
-def test_device_wrapped(test_device, _safety_mode_state):
-    """Like test_device, but puts D585S into service mode once per module per device.
-
-    Many option-setting operations on D585S require service mode. No-op for all other
-    device families. Service mode is entered on the first test in the module that uses
-    this fixture for a given serial, and restored once at module teardown — not toggled
-    per test case. Multiple D585S cameras are each tracked independently by serial.
+    Many option-setting operations on D585S require service mode. No-op for all other device
+    families. This fixture is parametrized per device (via test_device), so both the enter and
+    the restore run while this camera is the one currently enabled on the hub: service mode is
+    entered once for the device's tests and restored at that device's teardown, before the hub
+    switches to the next camera. That keeps enter/restore per-camera (a module-scoped state
+    holder shared across cameras would defer the restore to module end, when the hub has already
+    powered the camera off — see Jenkins win #114673).
     """
     dev, ctx = test_device
     is_d585s = dev.supports(rs.camera_info.name) and "D585S" in dev.get_info(rs.camera_info.name)
+    safety_sensor = None
     if is_d585s:
-        sn = dev.get_info(rs.camera_info.serial_number)
-        if sn not in _safety_mode_state:
-            _safety_mode_state[sn] = {'sensor': None, 'entered': False}
-        entry = _safety_mode_state[sn]
-        if not entry['entered']:
-            safety_sensor = dev.first_safety_sensor()
-            if safety_sensor.get_option(rs.option.safety_mode) != rs.safety_mode.service:
-                # Will throw on failure — intentional so we fail the test rather than run without service mode.
-                safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
-            entry['sensor'] = safety_sensor
-            entry['entered'] = True
+        safety_sensor = dev.first_safety_sensor()
+        if safety_sensor.get_option(rs.option.safety_mode) != rs.safety_mode.service:
+            # Will throw on failure — intentional so we fail the test rather than run without service mode.
+            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
     yield dev, ctx
+    if safety_sensor is not None:
+        try:
+            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        except Exception as e:
+            # Best-effort: don't mask test failures, and the device may already be reset by teardown time.
+            sn = dev.get_info(rs.camera_info.serial_number) if dev.supports(rs.camera_info.serial_number) else "?"
+            log.warning(f"safety_mode restore skipped for {sn}: {e}")

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -400,12 +400,10 @@ def _fixture_reaches(fm, fixturedef, target, node):
 
 
 def _assert_module_fixtures_are_per_camera(session, items):
-    """Guard: in a device-parametrized test, every module-scoped fixture must be re-created
-    per camera, i.e. it must (transitively) depend on _test_device_serial. A module-scoped
-    fixture that doesn't is instantiated once and SHARED across all cameras in the module, so
-    its teardown runs at module end (or a retry teardown) rather than at each camera boundary
-    — a subtle trap that previously left a disconnected D585S restore firing mid-module
-    (Jenkins win #114673). Fail collection loudly so the mistake can't slip in unnoticed.
+    """Guard: in a device-parametrized test, every module-scoped fixture must be re-created per
+    camera, i.e. (transitively) depend on _test_device_serial. One that doesn't is created once
+    and SHARED across all cameras, so its teardown runs at module end instead of per camera —
+    fail collection so that mistake can't slip in.
     """
     fm = session._fixturemanager
     offenders = set()
@@ -738,16 +736,12 @@ def test_context_var():
 
 @pytest.fixture(scope="module")
 def test_device_wrapped(test_device):
-    """Like test_device, but puts a D585S into service mode for the module's tests on this
-    device and restores run mode at teardown.
+    """Like test_device, but puts a D585S into service mode for this device's tests and restores
+    run mode at teardown. No-op for other device families.
 
-    Many option-setting operations on D585S require service mode. No-op for all other device
-    families. This fixture is parametrized per device (via test_device), so both the enter and
-    the restore run while this camera is the one currently enabled on the hub: service mode is
-    entered once for the device's tests and restored at that device's teardown, before the hub
-    switches to the next camera. That keeps enter/restore per-camera (a module-scoped state
-    holder shared across cameras would defer the restore to module end, when the hub has already
-    powered the camera off — see Jenkins win #114673).
+    Parametrized per device (via test_device), so enter and restore both run while this camera is
+    the enabled one: service mode is restored at the device's own teardown, before the hub
+    switches to the next camera (not deferred to module end via shared state).
     """
     dev, ctx = test_device
     is_d585s = dev.supports(rs.camera_info.name) and "D585S" in dev.get_info(rs.camera_info.name)

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -400,35 +400,50 @@ def _fixture_reaches(fm, fixturedef, target, node):
 
 
 def _assert_module_fixtures_are_per_camera(session, items):
-    """Guard: in a device-parametrized test, every module-scoped fixture must be re-created per
-    camera, i.e. (transitively) depend on _test_device_serial. One that doesn't is created once
-    and SHARED across all cameras, so its teardown runs at module end instead of per camera —
-    fail collection so that mistake can't slip in.
+    """Guard: in a module that runs across more than one camera, every module-scoped fixture
+    must be re-created per camera, i.e. (transitively) depend on _test_device_serial. One that
+    doesn't is created once and SHARED across all of the module's cameras, so its teardown runs
+    at module end instead of per camera — fail collection so that mistake can't slip in.
+
+    Only modules with >1 distinct camera are checked: with a single camera, module scope is
+    already per-camera, so a module-scoped fixture there is harmless (e.g. a device_each that
+    matches one device, or a no-device CI run that resolves to a single skip sentinel).
     """
     fm = session._fixturemanager
-    offenders = set()
+    # Group device-parametrized items by module and collect each module's distinct cameras.
+    module_items = {}    # module path -> [items]
+    module_cameras = {}  # module path -> set of distinct _test_device_serial values
     for item in items:
         callspec = getattr(item, "callspec", None)
         if not callspec or callspec.params.get("_test_device_serial") is None:
             continue  # not bound to a camera
-        for name in item.fixturenames:
-            if name in _PER_CAMERA_FIXTURE_ALLOWLIST:
-                continue
-            defs = fm.getfixturedefs(name, item)
-            if not defs:
-                continue
-            fixturedef = defs[-1]
-            if fixturedef.scope != "module":
-                continue
-            if "site-packages" in fixturedef.func.__code__.co_filename:
-                continue  # don't police plugin fixtures (pytest-retry/repeat/etc.)
-            if not _fixture_reaches(fm, fixturedef, "_test_device_serial", item):
-                offenders.add(name)
+        mod = item.nodeid.split("::", 1)[0]
+        module_items.setdefault(mod, []).append(item)
+        module_cameras.setdefault(mod, set()).add(str(callspec.params.get("_test_device_serial")))
+
+    offenders = set()
+    for mod, mod_items in module_items.items():
+        if len(module_cameras[mod]) < 2:
+            continue  # single camera → module scope is already per-camera
+        for item in mod_items:
+            for name in item.fixturenames:
+                if name in _PER_CAMERA_FIXTURE_ALLOWLIST:
+                    continue
+                defs = fm.getfixturedefs(name, item)
+                if not defs:
+                    continue
+                fixturedef = defs[-1]
+                if fixturedef.scope != "module":
+                    continue
+                if "site-packages" in fixturedef.func.__code__.co_filename:
+                    continue  # don't police plugin fixtures (pytest-retry/repeat/etc.)
+                if not _fixture_reaches(fm, fixturedef, "_test_device_serial", item):
+                    offenders.add(name)
     if offenders:
         raise pytest.UsageError(
-            f"Module-scoped fixture(s) {sorted(offenders)} are used by device-parametrized tests "
-            "but do not depend on _test_device_serial, so they are created once and SHARED across "
-            "every camera in the module — their teardown runs at module end, not per camera. "
+            f"Module-scoped fixture(s) {sorted(offenders)} are used by a module that runs on more "
+            "than one camera but do not depend on _test_device_serial, so they are created once and "
+            "SHARED across the module's cameras — their teardown runs at module end, not per camera. "
             "Depend on test_device (or _test_device_serial) for per-camera lifecycle, or add the "
             "fixture to _PER_CAMERA_FIXTURE_ALLOWLIST if it is genuinely device-independent."
         )

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -67,7 +67,7 @@ from rspy.pytest.device_helpers import (
     _MISSING_SENTINEL_PREFIX,
     _SKIP_SENTINEL_PREFIX,
 )
-from rspy.pytest.collection import filter_and_sort_items
+from rspy.pytest.collection import filter_and_sort_items, assert_module_fixtures_are_per_camera
 from rspy.pytest.plugins import check_required_plugins
 
 log = logging.getLogger('librealsense')
@@ -384,74 +384,9 @@ def pytest_generate_tests(metafunc):
     resolve_device_each_serials(metafunc)
 
 
-# Module-scoped fixtures that are intentionally device-independent (not re-created per camera).
-_PER_CAMERA_FIXTURE_ALLOWLIST = {
-    "_test_device_serial",          # the per-camera anchor itself (parametrized per device)
-    "__pytest_repeat_step_number",  # per-repeat pass, device-independent
-}
-
-
-def _fixture_reaches(fm, fixturedef, target, node):
-    """True if fixturedef transitively depends on the fixture named `target`."""
-    return any(arg == target
-               or any(_fixture_reaches(fm, dep, target, node)
-                      for dep in (fm.getfixturedefs(arg, node) or []))
-               for arg in fixturedef.argnames)
-
-
-def _assert_module_fixtures_are_per_camera(session, items):
-    """Guard: in a module that runs across more than one camera, every module-scoped fixture
-    must be re-created per camera, i.e. (transitively) depend on _test_device_serial. One that
-    doesn't is created once and SHARED across all of the module's cameras, so its teardown runs
-    at module end instead of per camera — fail collection so that mistake can't slip in.
-
-    Only modules with >1 distinct camera are checked: with a single camera, module scope is
-    already per-camera, so a module-scoped fixture there is harmless (e.g. a device_each that
-    matches one device, or a no-device CI run that resolves to a single skip sentinel).
-    """
-    fm = session._fixturemanager
-    # Group device-parametrized items by module and collect each module's distinct cameras.
-    module_items = {}    # module path -> [items]
-    module_cameras = {}  # module path -> set of distinct _test_device_serial values
-    for item in items:
-        callspec = getattr(item, "callspec", None)
-        if not callspec or callspec.params.get("_test_device_serial") is None:
-            continue  # not bound to a camera
-        mod = item.nodeid.split("::", 1)[0]
-        module_items.setdefault(mod, []).append(item)
-        module_cameras.setdefault(mod, set()).add(str(callspec.params.get("_test_device_serial")))
-
-    offenders = set()
-    for mod, mod_items in module_items.items():
-        if len(module_cameras[mod]) < 2:
-            continue  # single camera → module scope is already per-camera
-        for item in mod_items:
-            for name in item.fixturenames:
-                if name in _PER_CAMERA_FIXTURE_ALLOWLIST:
-                    continue
-                defs = fm.getfixturedefs(name, item)
-                if not defs:
-                    continue
-                fixturedef = defs[-1]
-                if fixturedef.scope != "module":
-                    continue
-                if "site-packages" in fixturedef.func.__code__.co_filename:
-                    continue  # don't police plugin fixtures (pytest-retry/repeat/etc.)
-                if not _fixture_reaches(fm, fixturedef, "_test_device_serial", item):
-                    offenders.add(name)
-    if offenders:
-        raise pytest.UsageError(
-            f"Module-scoped fixture(s) {sorted(offenders)} are used by a module that runs on more "
-            "than one camera but do not depend on _test_device_serial, so they are created once and "
-            "SHARED across the module's cameras — their teardown runs at module end, not per camera. "
-            "Depend on test_device (or _test_device_serial) for per-camera lifecycle, or add the "
-            "fixture to _PER_CAMERA_FIXTURE_ALLOWLIST if it is genuinely device-independent."
-        )
-
-
 def pytest_collection_modifyitems(session, config, items):
     """Auto-skip nightly/dds tests, filter --live, sort by priority."""
-    _assert_module_fixtures_are_per_camera(session, items)
+    assert_module_fixtures_are_per_camera(session, items)
     test_dirs = config.getoption("--test-dir", default=[])
     if test_dirs:
         abs_dirs = [os.path.abspath(p) for p in test_dirs]
@@ -759,6 +694,9 @@ def test_device_wrapped(test_device):
     switches to the next camera (not deferred to module end via shared state).
     """
     dev, ctx = test_device
+    # Read serial up front, while the device is still healthy: the restore path below runs in an
+    # except block where the device may be disconnected, so get_info() there could throw too.
+    sn = dev.get_info(rs.camera_info.serial_number) if dev.supports(rs.camera_info.serial_number) else "?"
     is_d585s = dev.supports(rs.camera_info.name) and "D585S" in dev.get_info(rs.camera_info.name)
     safety_sensor = None
     if is_d585s:
@@ -772,5 +710,4 @@ def test_device_wrapped(test_device):
             safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
         except Exception as e:
             # Best-effort: don't mask test failures, and the device may already be reset by teardown time.
-            sn = dev.get_info(rs.camera_info.serial_number) if dev.supports(rs.camera_info.serial_number) else "?"
             log.warning(f"safety_mode restore skipped for {sn}: {e}")

--- a/unit-tests/infra-tests/test_fixture_guard.py
+++ b/unit-tests/infra-tests/test_fixture_guard.py
@@ -1,0 +1,196 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Tests for rspy/pytest/collection.py fixture guard (assert_module_fixtures_are_per_camera).
+
+Verifies the collection-phase guard that fails collection when a module running on more
+than one camera uses a module-scoped fixture that is NOT re-created per camera (i.e. does
+not transitively depend on _test_device_serial), since its teardown would then run at
+module end instead of per camera.
+"""
+
+import types
+import pytest
+from rspy.pytest.collection import (
+    assert_module_fixtures_are_per_camera,
+    _fixture_reaches,
+    _PER_CAMERA_FIXTURE_ALLOWLIST,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders for the minimal slice of pytest objects the guard touches.
+# ---------------------------------------------------------------------------
+
+def make_fixturedef(argnames=(), scope="module", co_filename="/repo/unit-tests/conftest.py"):
+    """A fake FixtureDef with the attributes the guard reads."""
+    fd = types.SimpleNamespace()
+    fd.argnames = tuple(argnames)
+    fd.scope = scope
+    fd.func = types.SimpleNamespace(__code__=types.SimpleNamespace(co_filename=co_filename))
+    return fd
+
+
+class FakeFixtureManager:
+    """Maps fixture name -> [fixturedef]; node arg is accepted and ignored."""
+    def __init__(self, defs_by_name):
+        self._defs = defs_by_name
+
+    def getfixturedefs(self, name, node):
+        return self._defs.get(name)
+
+
+def make_item(nodeid, serial, fixturenames, has_callspec=True, serial_in_params=True):
+    item = types.SimpleNamespace()
+    item.nodeid = nodeid
+    item.fixturenames = list(fixturenames)
+    if has_callspec:
+        params = {}
+        if serial_in_params:
+            params["_test_device_serial"] = serial
+        item.callspec = types.SimpleNamespace(params=params)
+    # else: no callspec attribute at all
+    return item
+
+
+def make_session(defs_by_name):
+    session = types.SimpleNamespace()
+    session._fixturemanager = FakeFixtureManager(defs_by_name)
+    return session
+
+
+def two_camera_items(fixture_name):
+    """Two items in the same module, on two distinct cameras, both using fixture_name."""
+    fixturenames = ["_test_device_serial", fixture_name]
+    return [
+        make_item("mod.py::test_a[D455-111]", "111", fixturenames),
+        make_item("mod.py::test_a[D435-222]", "222", fixturenames),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# assert_module_fixtures_are_per_camera
+# ---------------------------------------------------------------------------
+
+class TestPerCameraGuard:
+    def test_positive_fixture_reaches_serial(self):
+        """Module-scoped fixture that transitively reaches _test_device_serial → passes."""
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "needs_device": [make_fixturedef(argnames=("_test_device_serial",))],
+        }
+        items = two_camera_items("needs_device")
+        # No raise.
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_negative_fixture_does_not_reach_serial(self):
+        """Module-scoped fixture not reaching _test_device_serial in a 2-camera module → raises."""
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "shared_state": [make_fixturedef(argnames=())],
+        }
+        items = two_camera_items("shared_state")
+        with pytest.raises(pytest.UsageError, match="shared_state"):
+            assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_allowlist_escape_hatch(self):
+        """An allowlisted fixture is exempt even when module-scoped and device-independent."""
+        name = next(iter(_PER_CAMERA_FIXTURE_ALLOWLIST - {"_test_device_serial"}))
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            name: [make_fixturedef(argnames=())],
+        }
+        items = two_camera_items(name)
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_site_packages_fixture_ignored(self):
+        """A third-party plugin fixture (co_filename under site-packages) is not policed."""
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "plugin_fx": [make_fixturedef(
+                argnames=(), co_filename="/x/site-packages/pytest_thing/plugin.py")],
+        }
+        items = two_camera_items("plugin_fx")
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_single_camera_module_not_checked(self):
+        """With a single distinct camera, a device-independent module fixture is harmless."""
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "shared_state": [make_fixturedef(argnames=())],
+        }
+        fixturenames = ["_test_device_serial", "shared_state"]
+        items = [
+            make_item("mod.py::test_a[D455-111]", "111", fixturenames),
+            make_item("mod.py::test_b[D455-111]", "111", fixturenames),
+        ]
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_function_scoped_fixture_not_checked(self):
+        """A non-module-scoped fixture is fine even if device-independent."""
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "fn_fx": [make_fixturedef(argnames=(), scope="function")],
+        }
+        items = two_camera_items("fn_fx")
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_item_without_callspec_skipped(self):
+        """Non-parametrized items (no callspec) are not bound to a camera → ignored."""
+        defs = {"shared_state": [make_fixturedef(argnames=())]}
+        items = [make_item("mod.py::test_plain", None,
+                            ["shared_state"], has_callspec=False)]
+        assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+    def test_serial_key_absent_skipped_but_present_none_checked(self):
+        """Key-absent means 'not device-bound' (skip); present-but-None means device-bound.
+
+        A 2-camera module where one item carries _test_device_serial=None alongside a real
+        camera still counts that item as bound, so its offending fixture is caught.
+        """
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "shared_state": [make_fixturedef(argnames=())],
+        }
+        fixturenames = ["_test_device_serial", "shared_state"]
+        items = [
+            make_item("mod.py::test_a[D455-111]", "111", fixturenames),
+            make_item("mod.py::test_a[none]", None, fixturenames),  # present-but-None
+        ]
+        with pytest.raises(pytest.UsageError, match="shared_state"):
+            assert_module_fixtures_are_per_camera(make_session(defs), items)
+
+
+# ---------------------------------------------------------------------------
+# _fixture_reaches
+# ---------------------------------------------------------------------------
+
+class TestFixtureReaches:
+    def test_direct_dependency(self):
+        defs = {"_test_device_serial": [make_fixturedef(scope="function")]}
+        fm = FakeFixtureManager(defs)
+        fd = make_fixturedef(argnames=("_test_device_serial",))
+        assert _fixture_reaches(fm, fd, "_test_device_serial", node=None) is True
+
+    def test_transitive_dependency(self):
+        defs = {
+            "_test_device_serial": [make_fixturedef(scope="function")],
+            "mid": [make_fixturedef(argnames=("_test_device_serial",))],
+        }
+        fm = FakeFixtureManager(defs)
+        fd = make_fixturedef(argnames=("mid",))
+        assert _fixture_reaches(fm, fd, "_test_device_serial", node=None) is True
+
+    def test_no_path_returns_false(self):
+        defs = {"other": [make_fixturedef(argnames=())]}
+        fm = FakeFixtureManager(defs)
+        fd = make_fixturedef(argnames=("other",))
+        assert _fixture_reaches(fm, fd, "_test_device_serial", node=None) is False
+
+    def test_cycle_does_not_recurse_forever(self):
+        """A→B→A override cycle must terminate (visited-set guard), not RecursionError."""
+        a = make_fixturedef(argnames=("b",))
+        b = make_fixturedef(argnames=("a",))
+        fm = FakeFixtureManager({"a": [a], "b": [b]})
+        assert _fixture_reaches(fm, a, "_test_device_serial", node=None) is False

--- a/unit-tests/py/rspy/pytest/collection.py
+++ b/unit-tests/py/rspy/pytest/collection.py
@@ -6,6 +6,82 @@
 import pytest
 
 
+# Module-scoped fixtures that are intentionally device-independent (not re-created per camera).
+_PER_CAMERA_FIXTURE_ALLOWLIST = {
+    "_test_device_serial",          # the per-camera anchor itself (parametrized per device)
+    # Local override of pytest-repeat's fixture (lives in conftest, so the site-packages
+    # bypass below doesn't filter it out); per-repeat pass, device-independent.
+    "__pytest_repeat_step_number",
+}
+
+
+def _fixture_reaches(fm, fixturedef, target, node, visited=None):
+    """True if fixturedef transitively depends on the fixture named `target`.
+
+    `visited` tracks already-explored fixturedefs so diamond dependencies aren't re-walked
+    and fixture-override cycles can't recurse forever.
+    """
+    if visited is None:
+        visited = set()
+    if id(fixturedef) in visited:
+        return False
+    visited.add(id(fixturedef))
+    return any(arg == target
+               or any(_fixture_reaches(fm, dep, target, node, visited)
+                      for dep in (fm.getfixturedefs(arg, node) or []))
+               for arg in fixturedef.argnames)
+
+
+def assert_module_fixtures_are_per_camera(session, items):
+    """Guard: in a module that runs across more than one camera, every module-scoped fixture
+    must be re-created per camera, i.e. (transitively) depend on _test_device_serial. One that
+    doesn't is created once and SHARED across all of the module's cameras, so its teardown runs
+    at module end instead of per camera — fail collection so that mistake can't slip in.
+
+    Only modules with >1 distinct camera are checked: with a single camera, module scope is
+    already per-camera, so a module-scoped fixture there is harmless (e.g. a device_each that
+    matches one device, or a no-device CI run that resolves to a single skip sentinel).
+    """
+    fm = session._fixturemanager
+    # Group device-parametrized items by module and collect each module's distinct cameras.
+    module_items = {}    # module path -> [items]
+    module_cameras = {}  # module path -> set of distinct _test_device_serial values
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        if not callspec or "_test_device_serial" not in callspec.params:
+            continue  # not bound to a camera (key absent != present-but-None)
+        mod = item.nodeid.split("::", 1)[0]
+        module_items.setdefault(mod, []).append(item)
+        module_cameras.setdefault(mod, set()).add(str(callspec.params.get("_test_device_serial")))
+
+    offenders = set()
+    for mod, mod_items in module_items.items():
+        if len(module_cameras[mod]) < 2:
+            continue  # single camera → module scope is already per-camera
+        for item in mod_items:
+            for name in item.fixturenames:
+                if name in _PER_CAMERA_FIXTURE_ALLOWLIST:
+                    continue
+                defs = fm.getfixturedefs(name, item)
+                if not defs:
+                    continue
+                fixturedef = defs[-1]
+                if fixturedef.scope != "module":
+                    continue
+                if "site-packages" in fixturedef.func.__code__.co_filename:
+                    continue  # don't police plugin fixtures (pytest-retry/repeat/etc.)
+                if not _fixture_reaches(fm, fixturedef, "_test_device_serial", item):
+                    offenders.add(name)
+    if offenders:
+        raise pytest.UsageError(
+            f"Module-scoped fixture(s) {sorted(offenders)} are used by a module that runs on more "
+            "than one camera but do not depend on _test_device_serial, so they are created once and "
+            "SHARED across the module's cameras — their teardown runs at module end, not per camera. "
+            "Depend on test_device (or _test_device_serial) for per-camera lifecycle, or add the "
+            "fixture to _PER_CAMERA_FIXTURE_ALLOWLIST if it is genuinely device-independent."
+        )
+
+
 def filter_and_sort_items(config, items):
     """Auto-skip nightly/dds tests unless opted in, filter --live/--not-live, and sort by priority.
 


### PR DESCRIPTION
**Overview:** Fixes a spurious `safety_mode restore failed` error that appeared mid-run on D555 nightly builds, and adds a guard so the underlying mistake can't be reintroduced. Jira: RSDSO-21657.

### Problem
`test_device_wrapped` entered/restored D585S service mode through a module-global `_safety_mode_state` fixture. Because that fixture doesn't depend on the device parametrization, it is created **once per module and shared across every camera**, so its teardown runs only at module end (or a pytest-retry teardown) — not per camera. In a `device_each` module that mixes a D585S with other cameras, the hub powers the D585S off when it switches to the next camera, so the deferred restore fired against a disconnected device:

```
safety_mode restore failed for 333622320113: MFCreateDeviceSource(...) HResult 0x80070003
```

(seen mid-D555 run in Jenkins win #114673).

### Fix
- Fold the D585S enter/restore into the **per-camera** `test_device_wrapped` (parametrized via `test_device`), so service mode is entered and restored while that camera is still the enabled device, at its own teardown boundary. Restore failure now logs `warning` (best-effort), not `error`.
- Add a collection-time guard (`pytest_collection_modifyitems`) that fails collection if a device-parametrized test uses a module-scoped fixture that doesn't depend on `_test_device_serial`, with `_PER_CAMERA_FIXTURE_ALLOWLIST` as the escape hatch.

### Validation
- Ran `pytest-presets.py` on 2 cameras (D455 + D415): per-camera setup→teardown clean, **no spurious `safety_mode` line**, 8/8 passed.
- Full-suite `--collect-only`: guard has **no false positives** (482 tests), and it **catches a deliberately bad fixture** (negative test).

---
🤖 Generated by AI
