### PR TITLE
Center of mass - use Euclidean distance and support non-aligned depth input

### DIFF
--- a/common/objects-in-frame.h
+++ b/common/objects-in-frame.h
@@ -24,7 +24,7 @@ struct object_in_frame
     std::string name;
     float mean_depth;
     float metadata_depth;         // distance reported by the detection model (meters); 0 if unavailable
-    float com_rel_u, com_rel_v;  // Center of Mass (COM) 2D position, [0,1] relative to the detection bbox; 0.5 if unavailable
+    float com_rel_u, com_rel_v;    // COM 2D position, [0,1] relative to the color detection bbox; 0.5 if unavailable
     int   score;                  // detection confidence, 0-100
     size_t id;
     object_type type = object_type::other;

--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -19,6 +19,14 @@ static constexpr int      MIN_DEPTH            = 400;
 static constexpr int      MAX_DEPTH            = 8000;
 static constexpr int      NO_DEPTH             = 10000;
 static constexpr float    GOOD_DEPTH_RATIO     = 0.3f;
+// A cluster is treated as noise if a neighbour within NEARBY_REJECT_RANGE depth_8u
+// units (≈1200 mm) has at least NEARBY_REJECT_RATIO times more pixels.
+// This rejects foreground dust/clutter that sits slightly in front of the real body
+// while still allowing a small person cluster (e.g. person off-centre in wide bbox)
+// to win over a distant background cluster that is far outside the rejection range.
+static constexpr float    MIN_CLUSTER_FRACT       = 0.03f;  // auto-pass — no neighbour check
+static constexpr float    NEARBY_REJECT_RATIO     = 2.0f;   // neighbour must be ≥2× larger
+static constexpr int      NEARBY_REJECT_RANGE_D8U = 40;     // ≈1200 mm window
 // Fraction of ROI height used for centroid — limits the search to the torso region
 // and prevents leg pixels (which dominate the lower bbox) from pulling the COM down.
 static constexpr float    COM_UPPER_FRACTION   = 0.65f;
@@ -274,28 +282,49 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
             if (v >= 1) { patchSum += v; ++patchCnt; }
         }
     uint8_t const center_d8u = patchCnt > 0 ? (uint8_t)(patchSum / patchCnt) : 0;
+
     if (dbg) { dbg->center_d8u = center_d8u; dbg->center_d8u_cnt = patchCnt; dbg->n_clusters = (int)allRanges.size(); }
 
-    // Always pick the NEAREST cluster (smallest midpoint depth_8u).
-    // Background is always farther than the person, and the histogram is already
-    // restricted to the upper torso region so floor/leg pixels can't inflate a far
-    // cluster.  The nearest cluster is therefore the person's body in the common case;
-    // the one exception is foreground clutter (e.g. a desk) partially overlapping the
-    // bbox, where the clutter's cluster would be picked — correct by depth geometry.
+    // Pick the NEAREST cluster (smallest midpoint depth_8u).
+    // A small cluster (< MIN_CLUSTER_FRACT) is skipped when a significantly larger
+    // neighbour exists within NEARBY_REJECT_RANGE_D8U — this rejects noise/clutter
+    // that sits just in front of the real body.  A cluster that passes MIN_CLUSTER_FRACT
+    // is always accepted; a small cluster with no dominant neighbour nearby is also
+    // accepted (e.g. person occupying a small fraction of a wide bbox with far background).
     int histRangeStart = allRanges[0].start;
     int histRangeEnd   = allRanges[0].end;
     int bestMidD       = INT_MAX;
-    for (auto const& r : allRanges) {
-        int midD = (r.start + r.end) / 2;
-        if (midD < bestMidD) { bestMidD = midD; histRangeStart = r.start; histRangeEnd = r.end; }
+    int selectedIdx    = 0;
+
+    for (int i = 0; i < (int)allRanges.size(); ++i) {
+        int midD = (allRanges[i].start + allRanges[i].end) / 2;
+        if (midD >= bestMidD) continue;  // not nearer than current best
+
+        if (allRanges[i].fract < MIN_CLUSTER_FRACT) {
+            // Check whether a dominant neighbour within ≈1200 mm makes this noise.
+            bool dominated = false;
+            for (int j = 0; j < (int)allRanges.size(); ++j) {
+                if (j == i) continue;
+                int midJ = (allRanges[j].start + allRanges[j].end) / 2;
+                if (std::abs(midJ - midD) <= NEARBY_REJECT_RANGE_D8U &&
+                    allRanges[j].fract >= NEARBY_REJECT_RATIO * allRanges[i].fract) {
+                    dominated = true;
+                    break;
+                }
+            }
+            if (dominated) continue;
+        }
+
+        bestMidD = midD;
+        histRangeStart = allRanges[i].start;
+        histRangeEnd   = allRanges[i].end;
+        selectedIdx    = i;
     }
 
     if (dbg) {
-        // Find the fract of the selected cluster
-        for (auto const& r : allRanges)
-            if (r.start == histRangeStart && r.end == histRangeEnd) { dbg->cluster_fract = r.fract; break; }
         dbg->cluster_start = histRangeStart;
         dbg->cluster_end   = histRangeEnd;
+        dbg->cluster_fract = allRanges[selectedIdx].fract;
     }
 
     if ((histRangeEnd - histRangeStart) >= (MaxDepth8U - 1)) return false;

--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -25,11 +25,14 @@ static constexpr float    GOOD_DEPTH_RATIO     = 0.3f;
 // while still allowing a small person cluster (e.g. person off-centre in wide bbox)
 // to win over a distant background cluster that is far outside the rejection range.
 static constexpr float    MIN_CLUSTER_FRACT       = 0.03f;  // auto-pass — no neighbour check
-static constexpr float    NEARBY_REJECT_RATIO     = 2.0f;   // neighbour must be ≥2× larger
-static constexpr int      NEARBY_REJECT_RANGE_D8U = 40;     // ≈1200 mm window
-// Fraction of ROI height used for centroid — limits the search to the torso region
-// and prevents leg pixels (which dominate the lower bbox) from pulling the COM down.
+static constexpr float    NEARBY_REJECT_RATIO     = 1.5f;   // neighbour must be ≥1.5× larger
+static constexpr int      NEARBY_REJECT_RANGE_D8U = 15;     // ≈450 mm window
+// Fraction of ROI height used for histogram — wide enough to sample the full torso.
 static constexpr float    COM_UPPER_FRACTION   = 0.65f;
+// Fraction of ROI height used for the 2D centroid (dot position) — restricts to the
+// upper body so the dot lands near the chest rather than the waist.  Falls back to
+// COM_UPPER_FRACTION if no cluster pixels exist in the narrower region.
+static constexpr float    COM_CENTROID_FRACTION = 0.55f;
 static constexpr int      NUM_DEPTH_SAMPLES    = 5;
 
 // depth_8u value for MAX_DEPTH: ceil((MAX_DEPTH-400)/SCALE_DEPTH) — fits in uint8 with SCALE_DEPTH=30
@@ -172,25 +175,31 @@ bool center_of_mass_calculator::calc_center_of_mask(
 {
     if (max_y <= 0 || max_y > mask_height) max_y = mask_height;
 
-    // Both X and Y are computed over the upper max_y rows only — keeps the symmetry
-    // metric and both centroids consistent with the same torso-region pixels.
-    long long sumX = 0, sumY = 0; long long cntX = 0, cntY = 0;
+    // X: full mask height — wider sample for a stable horizontal centroid, blended
+    // toward bbox center proportionally to left-right imbalance (IR depth shadows
+    // cause one-sided coverage that biases the raw centroid).
+    long long sumX = 0; long long cntX = 0;
     int leftPx = 0, rightPx = 0;
     int const midX = mask_width / 2;
-    for (int y = 0; y < max_y; ++y)
+    for (int y = 0; y < mask_height; ++y)
         for (int x = 0; x < mask_width; ++x)
             if (mask[y * mask_width + x]) {
-                sumX += x; sumY += y; ++cntX;
+                sumX += x; ++cntX;
                 if (x < midX) ++leftPx; else ++rightPx;
             }
-    cntY = cntX;
 
-    if (cntX == 0) return false;
+    // Y: upper portion only — excludes leg pixels that pull the centroid downward.
+    long long sumY = 0; long long cntY = 0;
+    for (int y = 0; y < max_y; ++y)
+        for (int x = 0; x < mask_width; ++x)
+            if (mask[y * mask_width + x]) { sumY += y; ++cntY; }
+
+    if (cntX == 0 || cntY == 0) return false;
 
     float const centroidX = float(sumX) / cntX;
     float const symmetry  = 2.0f * std::min(leftPx, rightPx) / float(leftPx + rightPx);
     com.x = (int)(symmetry * centroidX + (1.0f - symmetry) * midX);
-    com.y = (int)(float(sumY) / cntY);
+    com.y = (int)(sumY / cntY);
     return true;
 }
 
@@ -200,8 +209,7 @@ bool center_of_mass_calculator::calc_center_of_mask(
 
 bool center_of_mass_calculator::calculate_com_with_depth_range(
     const depth_image_8& depth_8u,
-    const rect& roi, float& depth_mean, vec2i& center_mass_point,
-    com_debug_info* dbg)
+    const rect& roi, float& depth_mean, vec2i& center_mass_point)
 {
     int roiW = roi.width, roiH = roi.height;
     if (roiW <= 0 || roiH <= 0) return false;
@@ -270,21 +278,6 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
 
     if (allRanges.empty()) return false;
 
-    int const cx = roi.x + roi.width  / 2;
-    int const cy = roi.y + roi.height / 2;
-    // 5×5 patch mean around the ROI center — more stable than a single pixel
-    int const x0 = std::max(cx - 2, 0), x1 = std::min(cx + 2, depth_8u.width  - 1);
-    int const y0 = std::max(cy - 2, 0), y1 = std::min(cy + 2, depth_8u.height - 1);
-    int patchSum = 0, patchCnt = 0;
-    for (int py = y0; py <= y1; ++py)
-        for (int px = x0; px <= x1; ++px) {
-            uint8_t v = depth_8u.data[py * depth_8u.width + px];
-            if (v >= 1) { patchSum += v; ++patchCnt; }
-        }
-    uint8_t const center_d8u = patchCnt > 0 ? (uint8_t)(patchSum / patchCnt) : 0;
-
-    if (dbg) { dbg->center_d8u = center_d8u; dbg->center_d8u_cnt = patchCnt; dbg->n_clusters = (int)allRanges.size(); }
-
     // Pick the NEAREST cluster (smallest midpoint depth_8u).
     // A small cluster (< MIN_CLUSTER_FRACT) is skipped when a significantly larger
     // neighbour exists within NEARBY_REJECT_RANGE_D8U — this rejects noise/clutter
@@ -294,7 +287,6 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
     int histRangeStart = allRanges[0].start;
     int histRangeEnd   = allRanges[0].end;
     int bestMidD       = INT_MAX;
-    int selectedIdx    = 0;
 
     for (int i = 0; i < (int)allRanges.size(); ++i) {
         int midD = (allRanges[i].start + allRanges[i].end) / 2;
@@ -318,77 +310,46 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
         bestMidD = midD;
         histRangeStart = allRanges[i].start;
         histRangeEnd   = allRanges[i].end;
-        selectedIdx    = i;
-    }
-
-    if (dbg) {
-        dbg->cluster_start = histRangeStart;
-        dbg->cluster_end   = histRangeEnd;
-        dbg->cluster_fract = allRanges[selectedIdx].fract;
     }
 
     if ((histRangeEnd - histRangeStart) >= (MaxDepth8U - 1)) return false;
 
-    float const meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
+    float meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
+
+    // Optionally extend toward a nearby head cluster (closer to camera, within ~150 mm).
+    for (auto const& r : allRanges) {
+        if (r.end < histRangeStart) {
+            float meanRange = calc_hist_range_mean(hist, r.start, r.end);
+            if ((meanDepth8U - meanRange) <= 5) { histRangeStart = r.start; break; }
+        }
+    }
+    // Recompute mean over the final range (possibly extended to include head cluster).
+    meanDepth8U = calc_hist_range_mean(hist, histRangeStart, histRangeEnd);
     depth_mean = std::floor(meanDepth8U * SCALE_DEPTH + SUBTRACT_FROM_DEPTH);
 
     // Build mask and find 2D center-of-mass.
-    // Only use pixels in the upper COM_UPPER_FRACTION of the ROI height so that
-    // leg pixels (which dominate the lower bbox) don't pull the centroid down.
+    // Use COM_CENTROID_FRACTION (narrower than the histogram region) so the dot
+    // lands in the upper-body (chest/shoulder) area rather than the waist.
+    // If the selected cluster has no pixels that high, place the dot at the
+    // horizontal centroid of the cluster and the vertical center of the upper region.
     std::vector<uint8_t> mask(roiW * roiH, 0);
     for (int j = 0; j < (int)roiData.size(); ++j)
         if (roiData[j] >= histRangeStart && roiData[j] <= histRangeEnd) mask[j] = 1;
 
-    int const comMaxY = std::max(1, (int)(roiH * COM_UPPER_FRACTION));
+    int const centroidMaxY = std::max(1, (int)(roiH * COM_CENTROID_FRACTION));
     vec2i com;
-    if (!calc_center_of_mask(mask, roiW, roiH, com, comMaxY)) return false;
+    if (!calc_center_of_mask(mask, roiW, roiH, com, centroidMaxY))
+    {
+        // Cluster pixels are below the upper-body region; use horizontal centroid
+        // of the full upper histogram region for X, and the center of the upper
+        // body band for Y — still unambiguously "top body."
+        int const histMaxY = std::max(1, (int)(roiH * COM_UPPER_FRACTION));
+        if (!calc_center_of_mask(mask, roiW, roiH, com, histMaxY))
+            return false;
+        com.y = centroidMaxY / 2;
+    }
 
     center_mass_point = {com.x + roi.x, com.y + roi.y};
-    return true;
-}
-
-// ---------------------------------------------------------------------------
-// run_non_range_com_calculation_flow  (fallback when histogram path fails)
-// ---------------------------------------------------------------------------
-
-bool center_of_mass_calculator::run_non_range_com_calculation_flow(
-    const rect& color_rect, const depth_image_16& depth,
-    vec2f person_center, const camera_intrinsics* intrinsics,
-    person_center_of_mass& result)
-{
-    // Clamp starting sample point inside the bbox
-    vec2f samplePt = person_center;
-    if (color_rect.y > person_center.y)
-        samplePt.y = (float)(color_rect.y + 10);
-
-    // Sample the center column at NUM_DEPTH_SAMPLES+3 evenly-spaced Y positions and
-    // take the NEAREST (minimum) valid depth.  The person is always in front of the
-    // background, so minimum valid depth in the column equals person depth even when
-    // most pixels are invalid (sparse IR) or some samples hit background.
-    float yProgression = color_rect.height / (float)(NUM_DEPTH_SAMPLES + 3);
-    float chosenDepth = 0.0f;
-
-    auto tryDepth = [&](float d) {
-        if (d > MIN_DEPTH && d <= MAX_DEPTH && (chosenDepth == 0.0f || d < chosenDepth))
-            chosenDepth = d;
-    };
-
-    tryDepth((float)get_depth_at_color_pixel(depth, samplePt));
-    for (int i = 0; i < NUM_DEPTH_SAMPLES + 3; ++i) {
-        float sampleY = std::min(color_rect.y + (i + 1) * yProgression,
-                                  float(color_rect.y + color_rect.height - 1));
-        tryDepth((float)get_depth_at_color_pixel(depth, {person_center.x, sampleY}));
-    }
-
-    result.mean_body_depth = chosenDepth;
-
-    if (intrinsics && chosenDepth > MIN_DEPTH) {
-        vec2i centerPx = {(int)(person_center.x + 0.5f), (int)(person_center.y + 0.5f)};
-        result.world_pos = pixel_to_camera(centerPx, chosenDepth, *intrinsics);
-        result.image_pos = {person_center.x, person_center.y};
-        float dx = result.world_pos.x, dy = result.world_pos.y, dz = result.world_pos.z;
-        result.mean_body_depth = std::sqrt(dx*dx + dy*dy + dz*dz);
-    }
     return true;
 }
 
@@ -403,41 +364,41 @@ bool center_of_mass_calculator::calculate(
     const vec2f&            person_center_color,
     const camera_intrinsics*    intrinsics,
     person_center_of_mass&      result,
-    com_debug_info*             dbg)
+    vec2f                       depth_shift)
 {
     if (!raw_depth.data || raw_depth.width == 0 || raw_depth.height == 0)
         return false;
     if (!depth_8u.data || depth_8u.width != raw_depth.width || depth_8u.height != raw_depth.height)
         return false;
 
-    // 1. With aligned depth, the color bbox IS the depth ROI — just clamp to bounds
-    rect roi = clamp_rect_to_image(color_bbox, raw_depth.width, raw_depth.height);
+    // Apply the precomputed color→raw-depth pixel shift.
+    // Round to the nearest integer so the forward and reverse shifts are consistent.
+    int const shift_xi = (int)std::round(depth_shift.x);
+    int const shift_yi = (int)std::round(depth_shift.y);
+    rect shifted_bbox{ color_bbox.x + shift_xi, color_bbox.y + shift_yi,
+                       color_bbox.width, color_bbox.height };
+    rect roi = clamp_rect_to_image(shifted_bbox, raw_depth.width, raw_depth.height);
 
-    // 2. Histogram-based COM + mean depth
     float depth_mean = 0.0f;
     vec2i center_mass_point = {0, 0};
-    bool  status = calculate_com_with_depth_range(
-                       depth_8u, roi, depth_mean, center_mass_point, dbg);
+    bool  status = calculate_com_with_depth_range(depth_8u, roi, depth_mean, center_mass_point);
 
     if (status) {
         result.mean_body_depth = (depth_mean <= MIN_DEPTH) ? 0.0f : depth_mean;
 
         if (intrinsics && depth_mean > MIN_DEPTH) {
-            float localDepth = (float)get_mean_surrounding_depth(
-                                   raw_depth, center_mass_point, 5, 0, NO_DEPTH);
-            result.world_pos = pixel_to_camera(center_mass_point, localDepth, *intrinsics);
-            result.image_pos = {(float)center_mass_point.x, (float)center_mass_point.y};
-            float dx = result.world_pos.x, dy = result.world_pos.y, dz = result.world_pos.z;
-            float euclidean = std::sqrt(dx*dx + dy*dy + dz*dz);
-            if (euclidean > MIN_DEPTH)
-                result.mean_body_depth = euclidean;
+            // Project COM pixel (in raw-depth space) using histogram depth_mean as Z.
+            vec3f pt = pixel_to_camera(center_mass_point, depth_mean, *intrinsics);
+            result.world_pos = pt;
+            // Reverse-shift image_pos from raw-depth space back to the caller's input space.
+            result.image_pos = { (float)center_mass_point.x - shift_xi,
+                                 (float)center_mass_point.y - shift_yi };
+            result.mean_body_depth = std::sqrt(pt.x*pt.x + pt.y*pt.y + pt.z*pt.z);
         }
-        if (dbg) { dbg->histogram_ok = true; dbg->image_pos_x = result.image_pos.x; dbg->image_pos_y = result.image_pos.y; }
     } else {
-        // Fallback: sample-based estimation along the bbox center column
-        run_non_range_com_calculation_flow(
-            color_bbox, raw_depth, person_center_color, intrinsics, result);
-        if (dbg) { dbg->histogram_ok = false; dbg->image_pos_x = result.image_pos.x; dbg->image_pos_y = result.image_pos.y; }
+        // Histogram failed — depth data too sparse for a reliable measurement.
+        if (intrinsics)
+            result.image_pos = { person_center_color.x, person_center_color.y };
     }
 
     return true;

--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -354,6 +354,49 @@ bool center_of_mass_calculator::calculate_com_with_depth_range(
 }
 
 // ---------------------------------------------------------------------------
+// run_non_range_com_calculation_flow  (fallback when histogram path fails)
+// ---------------------------------------------------------------------------
+
+bool center_of_mass_calculator::run_non_range_com_calculation_flow(
+    const rect& color_rect, const depth_image_16& depth,
+    vec2f person_center, const camera_intrinsics* intrinsics,
+    person_center_of_mass& result)
+{
+    // Clamp starting sample point inside the bbox
+    vec2f samplePt = person_center;
+    if (color_rect.y > person_center.y)
+        samplePt.y = (float)(color_rect.y + 10);
+
+    // Sample the center column at NUM_DEPTH_SAMPLES+3 evenly-spaced Y positions and
+    // take the NEAREST (minimum) valid depth.  The person is always in front of the
+    // background, so minimum valid depth in the column equals person depth even when
+    // most pixels are invalid (sparse IR) or some samples hit background.
+    float yProgression = color_rect.height / (float)(NUM_DEPTH_SAMPLES + 3);
+    float chosenDepth = 0.0f;
+
+    auto tryDepth = [&](float d) {
+        if (d > MIN_DEPTH && d <= MAX_DEPTH && (chosenDepth == 0.0f || d < chosenDepth))
+            chosenDepth = d;
+    };
+
+    tryDepth((float)get_depth_at_color_pixel(depth, samplePt));
+    for (int i = 0; i < NUM_DEPTH_SAMPLES + 3; ++i) {
+        float sampleY = std::min(color_rect.y + (i + 1) * yProgression,
+                                  float(color_rect.y + color_rect.height - 1));
+        tryDepth((float)get_depth_at_color_pixel(depth, {person_center.x, sampleY}));
+    }
+
+    result.mean_body_depth = chosenDepth;
+
+    if (intrinsics && chosenDepth > MIN_DEPTH) {
+        vec2i centerPx = {(int)(person_center.x + 0.5f), (int)(person_center.y + 0.5f)};
+        result.world_pos = pixel_to_camera(centerPx, chosenDepth, *intrinsics);
+        result.image_pos = {person_center.x, person_center.y};
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // calculate  (main entry point)
 // ---------------------------------------------------------------------------
 
@@ -396,9 +439,8 @@ bool center_of_mass_calculator::calculate(
             result.mean_body_depth = std::sqrt(pt.x*pt.x + pt.y*pt.y + pt.z*pt.z);
         }
     } else {
-        // Histogram failed — depth data too sparse for a reliable measurement.
-        if (intrinsics)
-            result.image_pos = { person_center_color.x, person_center_color.y };
+        // Histogram failed — depth data too sparse. Fall back to column sampling.
+        run_non_range_com_calculation_flow(color_bbox, raw_depth, person_center_color, intrinsics, result);
     }
 
     return true;

--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -386,6 +386,8 @@ bool center_of_mass_calculator::run_non_range_com_calculation_flow(
         vec2i centerPx = {(int)(person_center.x + 0.5f), (int)(person_center.y + 0.5f)};
         result.world_pos = pixel_to_camera(centerPx, chosenDepth, *intrinsics);
         result.image_pos = {person_center.x, person_center.y};
+        float dx = result.world_pos.x, dy = result.world_pos.y, dz = result.world_pos.z;
+        result.mean_body_depth = std::sqrt(dx*dx + dy*dy + dz*dz);
     }
     return true;
 }
@@ -425,6 +427,10 @@ bool center_of_mass_calculator::calculate(
                                    raw_depth, center_mass_point, 5, 0, NO_DEPTH);
             result.world_pos = pixel_to_camera(center_mass_point, localDepth, *intrinsics);
             result.image_pos = {(float)center_mass_point.x, (float)center_mass_point.y};
+            float dx = result.world_pos.x, dy = result.world_pos.y, dz = result.world_pos.z;
+            float euclidean = std::sqrt(dx*dx + dy*dy + dz*dz);
+            if (euclidean > MIN_DEPTH)
+                result.mean_body_depth = euclidean;
         }
         if (dbg) { dbg->histogram_ok = true; dbg->image_pos_x = result.image_pos.x; dbg->image_pos_y = result.image_pos.y; }
     } else {

--- a/common/utilities/com/center-of-mass.cpp
+++ b/common/utilities/com/center-of-mass.cpp
@@ -20,7 +20,7 @@ static constexpr int      MAX_DEPTH            = 8000;
 static constexpr int      NO_DEPTH             = 10000;
 static constexpr float    GOOD_DEPTH_RATIO     = 0.3f;
 // A cluster is treated as noise if a neighbour within NEARBY_REJECT_RANGE depth_8u
-// units (≈1200 mm) has at least NEARBY_REJECT_RATIO times more pixels.
+// units (≈450 mm) has at least NEARBY_REJECT_RATIO times more pixels.
 // This rejects foreground dust/clutter that sits slightly in front of the real body
 // while still allowing a small person cluster (e.g. person off-centre in wide bbox)
 // to win over a distant background cluster that is far outside the rejection range.
@@ -199,7 +199,7 @@ bool center_of_mass_calculator::calc_center_of_mask(
     float const centroidX = float(sumX) / cntX;
     float const symmetry  = 2.0f * std::min(leftPx, rightPx) / float(leftPx + rightPx);
     com.x = (int)(symmetry * centroidX + (1.0f - symmetry) * midX);
-    com.y = (int)(sumY / cntY);
+    com.y = (int)(float(sumY) / cntY);
     return true;
 }
 

--- a/common/utilities/com/center-of-mass.h
+++ b/common/utilities/com/center-of-mass.h
@@ -57,19 +57,6 @@ struct person_center_of_mass {
     vec2f image_pos;        // Center of Mass (COM) pixel in color/depth image; zero if intrinsics not provided
 };
 
-// Debug snapshot filled by calculate() — pass a non-null pointer to collect it.
-struct com_debug_info {
-    bool  histogram_ok   = false; // true = histogram path used; false = fallback
-    int   center_d8u     = 0;     // patch-mean depth_8u at ROI center (0 = no valid pixels)
-    int   center_d8u_cnt = 0;     // valid pixels in the 5×5 anchor patch
-    int   n_clusters     = 0;     // depth clusters found in ROI histogram
-    int   cluster_start  = 0;     // selected cluster: depth_8u range start
-    int   cluster_end    = 0;     // selected cluster: depth_8u range end
-    float cluster_fract  = 0.f;   // selected cluster: fraction of valid ROI pixels
-    float image_pos_x    = 0.f;   // raw COM pixel X before EMA
-    float image_pos_y    = 0.f;   // raw COM pixel Y before EMA
-};
-
 // ---------------------------------------------------------------------------
 // center_of_mass_calculator
 // ---------------------------------------------------------------------------
@@ -103,12 +90,15 @@ public:
     // If intrinsics != nullptr, also projects the COM pixel to 3D camera space
     // (result.world_pos) using the standard pinhole model.
     //
-    //   raw_depth          — aligned 16-bit depth frame (same pixel grid as color)
+    //   raw_depth          — raw 16-bit depth frame (aligned or non-aligned)
     //   depth_8u           — output of create_depth_8u() for the same frame
-    //   color_bbox         — person bounding box in color image coordinates
-    //   person_center_color — person center in color image (bbox center or tracker output)
-    //   intrinsics         — camera intrinsics; pass nullptr to skip world_pos/image_pos
-    //   result             — filled on return
+    //   color_bbox         — person bounding box (in color image or scaled-depth coords)
+    //   person_center_color — person center in the same coordinate space as color_bbox
+    //   intrinsics         — depth camera intrinsics; pass nullptr to skip world_pos/image_pos
+    //   result             — filled on return; image_pos is in the same space as color_bbox
+    //   depth_shift        — precomputed pixel offset from color space to raw-depth space
+    //                        (call rs2_project_color_pixel_to_depth_pixel at bbox center).
+    //                        Pass {0,0} for aligned depth (default).
     //
     // Returns false on invalid input (null data, zero-size image).
     //
@@ -141,7 +131,7 @@ public:
                           const vec2f&                person_center_color,
                           const camera_intrinsics*    intrinsics,
                           person_center_of_mass&      result,
-                          com_debug_info*             dbg = nullptr);
+                          vec2f                       depth_shift = {0.f, 0.f});
 
 private:
     static int  get_depth_at_color_pixel(const depth_image_16& depth, vec2f color_pt);
@@ -159,8 +149,7 @@ private:
     static bool calculate_com_with_depth_range(const depth_image_8& depth_8u,
                                                const rect& roi,
                                                float& depth_mean,
-                                               vec2i& center_mass_point,
-                                               com_debug_info* dbg = nullptr);
+                                               vec2i& center_mass_point);
 
     static float calc_hist_range_mean(const std::vector<float>& hist,
                                       int range_start, int range_end);
@@ -170,11 +159,6 @@ private:
                                     vec2i& com,
                                     int max_y = 0);  // 0 = use full height
 
-    static bool run_non_range_com_calculation_flow(const rect&                 color_rect,
-                                                   const depth_image_16&       depth,
-                                                   vec2f                       person_center,
-                                                   const camera_intrinsics*    intrinsics,
-                                                   person_center_of_mass&      result);
 };
 
 } // namespace com

--- a/common/utilities/com/center-of-mass.h
+++ b/common/utilities/com/center-of-mass.h
@@ -52,7 +52,7 @@ struct camera_intrinsics {
 // ---------------------------------------------------------------------------
 
 struct person_center_of_mass {
-    float mean_body_depth;  // average distance to person (mm); 0 = unreliable
+    float mean_body_depth;  // Euclidean distance to person (mm); 0 = unreliable
     vec3f world_pos;        // 3D camera coords (mm); zero if intrinsics not provided
     vec2f image_pos;        // Center of Mass (COM) pixel in color/depth image; zero if intrinsics not provided
 };

--- a/common/utilities/com/center-of-mass.h
+++ b/common/utilities/com/center-of-mass.h
@@ -80,12 +80,11 @@ public:
     //   5. Builds a binary mask of pixels in the cluster and finds their spatial
     //      median (X and Y independently) → the 2D COM pixel.
     //   6. Attempts to extend the range slightly to include the head if a nearby
-    //      secondary peak exists within 10 depth_8u bins (~200 mm).
+    //      secondary peak exists within 5 depth_8u bins (~150 mm).
     //
     // Fallback path (when the ROI has too few valid depth pixels for the histogram):
-    //   Samples depth at NUM_DEPTH_SAMPLES evenly-spaced points along the vertical
-    //   center of the bbox. Picks the best reading using a max-within-tolerance
-    //   heuristic, falling back to mean±stddev filtering if no single sample wins.
+    //   Samples NUM_DEPTH_SAMPLES+3 evenly-spaced points along the vertical center of
+    //   the bbox and picks the nearest valid reading (minimum depth in column).
     //
     // If intrinsics != nullptr, also projects the COM pixel to 3D camera space
     // (result.world_pos) using the standard pinhole model.
@@ -158,6 +157,12 @@ private:
                                     int mask_width, int mask_height,
                                     vec2i& com,
                                     int max_y = 0);  // 0 = use full height
+
+    static bool run_non_range_com_calculation_flow(const rect&              color_rect,
+                                                   const depth_image_16&    depth,
+                                                   vec2f                    person_center,
+                                                   const camera_intrinsics* intrinsics,
+                                                   person_center_of_mass&   result);
 
 };
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3766,8 +3766,8 @@ namespace rs2
                     if( depth_px[0] >= 0.f && depth_px[0] < float( depth_intrin.width ) &&
                         depth_px[1] >= 0.f && depth_px[1] < float( depth_intrin.height ) )
                     {
-                        shift_x = depth_px[0] - center_px[0];
-                        shift_y = depth_px[1] - center_px[1];
+                        shift_x = depth_px[0] - center_px[0] * depth_scale_x;
+                        shift_y = depth_px[1] - center_px[1] * depth_scale_y;
                     }
                     com::person_center_of_mass com_result{};
                     com::center_of_mass_calculator::calculate( com_raw, com_depth8u, com_bbox, com_center,

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -3760,14 +3760,20 @@ namespace rs2
                     float shift_x = 0.f, shift_y = 0.f;
                     float center_px[2] = { color_bbox.x + color_bbox.w * 0.5f,
                                            color_bbox.y + color_bbox.h * 0.5f };
-                    float depth_px[2]  = { center_px[0], center_px[1] };
-                    rs2_project_color_pixel_to_depth_pixel( depth_px, depth_data, 0.001f, 0.1f, 10.f,
+                    float const depth_units = df.get_units();
+                    float depth_px[2]  = { -1.f, -1.f };
+                    rs2_project_color_pixel_to_depth_pixel( depth_px, depth_data, depth_units, 0.1f, 10.f,
                         &depth_intrin, &color_intrin, &color_to_depth, &depth_to_color, center_px );
                     if( depth_px[0] >= 0.f && depth_px[0] < float( depth_intrin.width ) &&
                         depth_px[1] >= 0.f && depth_px[1] < float( depth_intrin.height ) )
                     {
-                        shift_x = depth_px[0] - center_px[0] * depth_scale_x;
-                        shift_y = depth_px[1] - center_px[1] * depth_scale_y;
+                        uint16_t center_raw = depth_data[(int)depth_px[1] * depth_intrin.width + (int)depth_px[0]];
+                        float const center_m = center_raw * depth_units;
+                        if( center_m > 0.4f && center_m < 8.0f )
+                        {
+                            shift_x = depth_px[0] - center_px[0] * depth_scale_x;
+                            shift_y = depth_px[1] - center_px[1] * depth_scale_y;
+                        }
                     }
                     com::person_center_of_mass com_result{};
                     com::center_of_mass_calculator::calculate( com_raw, com_depth8u, com_bbox, com_center,

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -30,6 +30,7 @@
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <regex>
 #include <algorithm>
+#include <fstream>
 
 namespace rs2
 {
@@ -3715,16 +3716,14 @@ namespace rs2
                                       float( det.bottom_right_y - det.top_left_y ) };
                 rs2::rect normalized_color_bbox = color_bbox.normalize( color_frame_rect );
 
-                // Depth is aligned to color, so color and depth pixels share the same coordinate
-                // frame (up to a resolution scale factor).  A depth-dependent reverse-projection
-                // (rs2_project_color_pixel_to_depth_pixel) is NOT needed and is harmful: the
-                // search result varies frame-to-frame with depth noise, making the ROI jitter and
-                // the COM jump.  Simple scaling gives a perfectly stable, deterministic depth bbox.
+                // depth_bbox_full: simple resolution scaling of the color bbox.
+                // COM runs within this region for a stable, deterministic depth measurement.
+                // The depth-view dot position is corrected for sensor parallax separately
+                // by projecting the single COM pixel through rs2_project_color_pixel_to_depth_pixel.
                 float const depth_scale_x = float( depth_intrin.width  ) / float( color_intrin.width  );
                 float const depth_scale_y = float( depth_intrin.height ) / float( color_intrin.height );
-                // depth_bbox_full: scaled from color bbox, before clamping to the depth frame boundary.
-                // Used to compute com_rel_u/v so they stay consistent with the color bbox at render time
-                // (the color bbox is also unclipped).  Clipping only affects the actual ROI sampled.
+                // depth_bbox_full: unclipped scaled bbox — used for com_rel_u/v normalization.
+                // Clipping only affects the actual ROI sampled.
                 rs2::rect depth_bbox_full{
                     color_bbox.x * depth_scale_x, color_bbox.y * depth_scale_y,
                     color_bbox.w * depth_scale_x, color_bbox.h * depth_scale_y };
@@ -3747,23 +3746,38 @@ namespace rs2
                         com::center_of_mass_calculator::create_depth_8u( com_raw, com_depth8u );
                         depth8u_ready = true;
                     }
-                    int const com_x = int( depth_bbox.x );
-                    int const com_y = int( depth_bbox.y );
+                    int const com_x = (int)depth_bbox.x;
+                    int const com_y = (int)depth_bbox.y;
                     com::rect  com_bbox{ com_x, com_y,
-                                         int( depth_bbox.x + depth_bbox.w + 0.5f ) - com_x,
-                                         int( depth_bbox.y + depth_bbox.h + 0.5f ) - com_y };
+                                         (int)( depth_bbox.x + depth_bbox.w + 0.5f ) - com_x,
+                                         (int)( depth_bbox.y + depth_bbox.h + 0.5f ) - com_y };
                     com::vec2f com_center{ depth_bbox.x + depth_bbox.w * 0.5f,
                                            depth_bbox.y + depth_bbox.h * 0.5f };
                     com::camera_intrinsics com_intrin{ depth_intrin.fx, depth_intrin.fy,
                                                        depth_intrin.ppx, depth_intrin.ppy };
+                    // Project bbox center from color space to raw-depth space to get
+                    // the stereo-baseline pixel shift; keep {0,0} if no depth at bbox center.
+                    float shift_x = 0.f, shift_y = 0.f;
+                    float center_px[2] = { color_bbox.x + color_bbox.w * 0.5f,
+                                           color_bbox.y + color_bbox.h * 0.5f };
+                    float depth_px[2]  = { center_px[0], center_px[1] };
+                    rs2_project_color_pixel_to_depth_pixel( depth_px, depth_data, 0.001f, 0.1f, 10.f,
+                        &depth_intrin, &color_intrin, &color_to_depth, &depth_to_color, center_px );
+                    if( depth_px[0] >= 0.f && depth_px[0] < float( depth_intrin.width ) &&
+                        depth_px[1] >= 0.f && depth_px[1] < float( depth_intrin.height ) )
+                    {
+                        shift_x = depth_px[0] - center_px[0];
+                        shift_y = depth_px[1] - center_px[1];
+                    }
                     com::person_center_of_mass com_result{};
-                    com::center_of_mass_calculator::calculate( com_raw, com_depth8u, com_bbox, com_center, &com_intrin, com_result );
+                    com::center_of_mass_calculator::calculate( com_raw, com_depth8u, com_bbox, com_center,
+                                                               &com_intrin, com_result, { shift_x, shift_y } );
                     if( com_result.mean_body_depth > 0.f )
                     {
                         viewer_depth_m = com_result.mean_body_depth / 1000.f;
+                        auto clamp01 = []( float v ) { return v < 0.f ? 0.f : v > 1.f ? 1.f : v; };
                         if( depth_bbox_full.w > 0.f && depth_bbox_full.h > 0.f )
                         {
-                            auto clamp01 = []( float v ) { return v < 0.f ? 0.f : v > 1.f ? 1.f : v; };
                             com_rel_u = clamp01( ( com_result.image_pos.x - depth_bbox_full.x ) / depth_bbox_full.w );
                             com_rel_v = clamp01( ( com_result.image_pos.y - depth_bbox_full.y ) / depth_bbox_full.h );
                         }


### PR DESCRIPTION
1.Use Euclidean distance using histogram mean depth as Z instead of noisy per-pixel sampling
2. support non-aligned depth input via rs2_project_color_pixel_to_depth_pixel at bbox center
3. Noise-aware cluster selection — rejects small foreground clusters dominated by a larger neighbour within 450 mm; extends selected cluster toward nearby head cluster (~150 mm)

