### PR TITLE
Viewer: fix per-cycle GL texture leak on stream start/stop (RSDEV-12247)

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -380,6 +380,10 @@ namespace rs2
         rsutils::time::stopwatch _t;
     };
 
+    // IMPORTANT: the destructor calls glDeleteTextures(), which requires a
+    // current OpenGL context. Owners must ensure a valid GL context is current
+    // at the point of destruction. See ux-window.cpp for the canonical pattern:
+    // an owned texture_buffer must be released *before* glfwDestroyWindow().
     class texture_buffer
     {
         GLuint texture;
@@ -395,15 +399,22 @@ namespace rs2
         rect curr_preview_rect{};
         int texture_id = 0;
 
-        texture_buffer(const texture_buffer& other)
-        {
-            texture = other.texture;
-        }
+        // Own the GL texture properly. Each Stop/Start cycle gc_streams destroys
+        // and recreates this object, so without a destructor the GL texture (and
+        // the driver-side allocation behind it) leaks every cycle.
+        // Copy/move deleted because shallow-copying `texture` would double-free.
+        texture_buffer( const texture_buffer & )             = delete;
+        texture_buffer & operator=( const texture_buffer & ) = delete;
+        texture_buffer( texture_buffer && )                  = delete;
+        texture_buffer & operator=( texture_buffer && )      = delete;
 
-        texture_buffer& operator=(const texture_buffer& other)
+        ~texture_buffer()
         {
-            texture = other.texture;
-            return *this;
+            if( texture )
+            {
+                glDeleteTextures( 1, &texture );
+                texture = 0;
+            }
         }
 
         rs2::frame get_last_frame(bool with_texture = false) const {

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -447,7 +447,7 @@ namespace rs2
         // Prepare the splash screen and do some initialization in the background
         int x, y, comp;
         auto r = stbi_load_from_memory(splash, (int)splash_size, &x, &y, &comp, false);
-        _splash_tex.upload_image(x, y, r);
+        _splash_tex->upload_image(x, y, r);
         stbi_image_free(r);
     }
 
@@ -504,11 +504,11 @@ namespace rs2
             shader->set_power(power);
             shader->set_ray_center(float2{ ox, oy });
             shader->end();
-            _2d_vis->draw_texture(_splash_tex.get_gl_handle(), opacity);
+            _2d_vis->draw_texture(_splash_tex->get_gl_handle(), opacity);
         }
         else
         {
-            _splash_tex.show({ 0.f,0.f,float(_width),float(_height) }, opacity);
+            _splash_tex->show({ 0.f,0.f,float(_width),float(_height) }, opacity);
         }
 
         std::string hourglass = std::string(rsutils::string::from() << textual_icons::hourglass);
@@ -681,6 +681,9 @@ namespace rs2
         ImGui::GetIO().Fonts->ClearFonts();  // To be refactored into Viewer theme object
         ImPlot::DestroyContext();
         RsImGui::PopNewFrame();
+        // Release the splash texture while the GL context is still current —
+        // member dtors below would otherwise run glDeleteTextures with no context.
+        _splash_tex.reset();
         glfwDestroyWindow(_win);
 
         glfwDestroyCursor(_hand_cursor);

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -76,7 +76,7 @@ namespace rs2
         bool is_ui_aligned() { return _is_ui_aligned; }
         bool is_fullscreen() { return _fullscreen; }
 
-        texture_buffer& get_splash() { return _splash_tex; }
+        texture_buffer& get_splash() { return *_splash_tex; }
 
         void reload();
         void refresh();
@@ -112,7 +112,10 @@ namespace rs2
         bool                     _first_frame;
         std::atomic<bool>        _app_ready;
         std::atomic<bool>        _keep_alive;
-        texture_buffer           _splash_tex;
+        // Held by unique_ptr so we can release it (and its GL texture) BEFORE
+        // ~ux_window destroys the GLFW window + context. Member dtors run after
+        // the dtor body, by which time glDeleteTextures would have no context.
+        std::unique_ptr<texture_buffer> _splash_tex = std::make_unique<texture_buffer>();
         rsutils::time::stopwatch   _splash_timer;
         std::string              _title_str;
         std::vector<std::string> _on_load_message;


### PR DESCRIPTION
Tracked by: RSDEV-12247

## Summary
- Per-cycle ~3 MB leak on every depth Stop/Start in the viewer (≈50 MB after 20 cycles in soak; >1 GB after 25 in the original repro).
- Root cause: `texture_buffer` (common/rendering.h) calls `glGenTextures` in `upload()` but has **no destructor** — every stream Stop, `gc_streams` destroys+recreates the stream's `texture_buffer`, leaking the GL texture handle and its driver-side allocation. Rule-of-three violation present since 2017.
- Fix: add `~texture_buffer { glDeleteTextures }` (and zero the handle); delete copy/move (the prior shallow copy ctor would otherwise cause double-free).
- Secondary: `ux_window::_splash_tex` is a value-member destroyed *after* `glfwDestroyWindow` — now held via `unique_ptr` and reset in `~ux_window` body before the context is torn down, so its `glDeleteTextures` runs with a valid context.

## Numbers (D455, Release, 20× depth-only start/stop, 10s stream + 5s idle)
| | slope (MB/iter) | total delta (MB) |
|--|--|--|
| before | 2.85 | +48 |
| after  | 0.53 | +1 |

## Test
Automated regression test (`mem_leak_depth_start_stop`) lives in a separate PR: #15277.

## Test plan
- [ ] Manual viewer smoke: launch, depth Stop/Start ×10, watch Private Bytes — should stay flat.
- [ ] Manual viewer exit: no GL warnings on shutdown (validates `_splash_tex` order fix).
- [ ] CI builds the existing viewer + DQT targets cleanly with the deleted copy/move operators.