### PR TITLE
D500: add person distance firmware alignment support

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -25,7 +25,6 @@
 #include <rsutils/string/trim-newlines.h>
 #include <common/utilities/imgui/wrap.h>
 #include <common/labeled-point-cloud-utilities.h>
-#include <common/utilities/com/center-of-mass.h>
 
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <regex>
@@ -3566,29 +3565,9 @@ namespace rs2
             objects = it->second.dev->detected_objects;
     }
 
-    rs2::rect viewer_model::project_color_bbox_to_depth( const rs2::rect &     color_bbox,
-                                                         const uint16_t *      depth_data,
-                                                         float                 depth_scale,
-                                                         const rs2_intrinsics & depth_intrin,
-                                                         const rs2_intrinsics & color_intrin,
-                                                         const rs2_extrinsics & color_to_depth,
-                                                         const rs2_extrinsics & depth_to_color,
-                                                         const rs2::rect &     depth_frame_rect )
-    {
-        // Project both corners of the color bbox into depth-frame coordinates
-        float src_tl[2] = { color_bbox.x, color_bbox.y };
-        float src_br[2] = { color_bbox.x + color_bbox.w, color_bbox.y + color_bbox.h };
-        float dst_tl[2], dst_br[2];
-        rs2_project_color_pixel_to_depth_pixel( dst_tl, depth_data, depth_scale, 0.1f, 10.f,
-                                                &depth_intrin, &color_intrin, &color_to_depth, &depth_to_color, src_tl );
-        rs2_project_color_pixel_to_depth_pixel( dst_br, depth_data, depth_scale, 0.1f, 10.f,
-                                                &depth_intrin, &color_intrin, &color_to_depth, &depth_to_color, src_br );
-        return rs2::rect{ dst_tl[0], dst_tl[1], dst_br[0] - dst_tl[0], dst_br[1] - dst_tl[1] }.intersection( depth_frame_rect );
-    }
-
     void viewer_model::process_object_detection_frames( std::map< int, rs2::frame > & last_frames )
     {
-        // Scan last_frames for an object detection frame, a color frame, and a depth frame.
+        // Scan last_frames for an object detection frame, a color frame, and an optional depth frame.
         // These types have no default constructor; initialise from an empty rs2::frame.
         rs2::object_detection_frame odf{ rs2::frame{} };
         rs2::video_frame cf{ rs2::frame{} };
@@ -3636,10 +3615,6 @@ namespace rs2
         }
         objects->ticks_without_od_frame = 0;
 
-        // OD frame arrived but depth not yet available — skip without clearing
-        if( ! df )
-            return;
-
         // Fresh OD frame with no detections — clear
         if( odf.get_detection_count() == 0 )
         {
@@ -3651,22 +3626,19 @@ namespace rs2
         try
         {
             auto color_vsp = cf.get_profile().as< rs2::video_stream_profile >();
-            auto depth_vsp = df.get_profile().as< rs2::video_stream_profile >();
-
             rs2_intrinsics color_intrin = color_vsp.get_intrinsics();
-            rs2_intrinsics depth_intrin = depth_vsp.get_intrinsics();
-            rs2_extrinsics color_to_depth = color_vsp.get_extrinsics_to( depth_vsp );
-            rs2_extrinsics depth_to_color = depth_vsp.get_extrinsics_to( color_vsp );
-
             rs2::rect color_frame_rect{ 0.f, 0.f, float( color_intrin.width ), float( color_intrin.height ) };
-            rs2::rect depth_frame_rect{ 0.f, 0.f, float( depth_intrin.width ), float( depth_intrin.height ) };
 
-            uint16_t const * const depth_data = reinterpret_cast< uint16_t const * >( df.get_data() );
-
-            com::depth_image_16 com_raw{ depth_data, depth_intrin.width, depth_intrin.height };
-            std::vector< uint8_t > depth8u_buf( depth_intrin.width * depth_intrin.height );
-            com::depth_image_8 com_depth8u{ depth8u_buf.data(), depth_intrin.width, depth_intrin.height };
-            bool depth8u_ready = false;
+            bool has_depth_profile = false;
+            rs2_intrinsics depth_intrin{};
+            rs2::rect depth_frame_rect{};
+            if( df )
+            {
+                auto depth_vsp = df.get_profile().as< rs2::video_stream_profile >();
+                depth_intrin = depth_vsp.get_intrinsics();
+                depth_frame_rect = rs2::rect{ 0.f, 0.f, float( depth_intrin.width ), float( depth_intrin.height ) };
+                has_depth_profile = depth_intrin.width > 0 && depth_intrin.height > 0;
+            }
 
             objects_in_frame new_objects;
             unsigned int const count = odf.get_detection_count();
@@ -3715,65 +3687,22 @@ namespace rs2
                                       float( det.bottom_right_y - det.top_left_y ) };
                 rs2::rect normalized_color_bbox = color_bbox.normalize( color_frame_rect );
 
-                // Depth is aligned to color, so color and depth pixels share the same coordinate
-                // frame (up to a resolution scale factor).  A depth-dependent reverse-projection
-                // (rs2_project_color_pixel_to_depth_pixel) is NOT needed and is harmful: the
-                // search result varies frame-to-frame with depth noise, making the ROI jitter and
-                // the COM jump.  Simple scaling gives a perfectly stable, deterministic depth bbox.
-                float const depth_scale_x = float( depth_intrin.width  ) / float( color_intrin.width  );
-                float const depth_scale_y = float( depth_intrin.height ) / float( color_intrin.height );
-                // depth_bbox_full: scaled from color bbox, before clamping to the depth frame boundary.
-                // Used to compute com_rel_u/v so they stay consistent with the color bbox at render time
-                // (the color bbox is also unclipped).  Clipping only affects the actual ROI sampled.
-                rs2::rect depth_bbox_full{
-                    color_bbox.x * depth_scale_x, color_bbox.y * depth_scale_y,
-                    color_bbox.w * depth_scale_x, color_bbox.h * depth_scale_y };
-                rs2::rect depth_bbox = depth_bbox_full.intersection( depth_frame_rect );
-                rs2::rect normalized_depth_bbox = depth_bbox.normalize( depth_frame_rect );
-
-                float const hkr_depth_m = det.depth;
-                float viewer_depth_m = 0.f;
-                float com_rel_u = 0.5f, com_rel_v = 0.5f;
-
-                // TODO: temporary fallback — viewer-side COM runs only when HKR firmware
-                // returns 0 (XU command not supported or device not ready).
-                // Checked per-detection intentionally: firmware could return 0 for individual
-                // detections (e.g. out-of-range) even when HKR COM is otherwise working.
-                // Remove once HKR COM is fully implemented and reliable on all devices.
-                if( hkr_depth_m == 0.f )
+                rs2::rect normalized_depth_bbox = normalized_color_bbox;
+                if( has_depth_profile )
                 {
-                    if( !depth8u_ready )
-                    {
-                        com::center_of_mass_calculator::create_depth_8u( com_raw, com_depth8u );
-                        depth8u_ready = true;
-                    }
-                    int const com_x = int( depth_bbox.x );
-                    int const com_y = int( depth_bbox.y );
-                    com::rect  com_bbox{ com_x, com_y,
-                                         int( depth_bbox.x + depth_bbox.w + 0.5f ) - com_x,
-                                         int( depth_bbox.y + depth_bbox.h + 0.5f ) - com_y };
-                    com::vec2f com_center{ depth_bbox.x + depth_bbox.w * 0.5f,
-                                           depth_bbox.y + depth_bbox.h * 0.5f };
-                    com::camera_intrinsics com_intrin{ depth_intrin.fx, depth_intrin.fy,
-                                                       depth_intrin.ppx, depth_intrin.ppy };
-                    com::person_center_of_mass com_result{};
-                    com::center_of_mass_calculator::calculate( com_raw, com_depth8u, com_bbox, com_center, &com_intrin, com_result );
-                    if( com_result.mean_body_depth > 0.f )
-                    {
-                        viewer_depth_m = com_result.mean_body_depth / 1000.f;
-                        if( depth_bbox_full.w > 0.f && depth_bbox_full.h > 0.f )
-                        {
-                            auto clamp01 = []( float v ) { return v < 0.f ? 0.f : v > 1.f ? 1.f : v; };
-                            com_rel_u = clamp01( ( com_result.image_pos.x - depth_bbox_full.x ) / depth_bbox_full.w );
-                            com_rel_v = clamp01( ( com_result.image_pos.y - depth_bbox_full.y ) / depth_bbox_full.h );
-                        }
-                    }
+                    float const depth_scale_x = float( depth_intrin.width  ) / float( color_intrin.width  );
+                    float const depth_scale_y = float( depth_intrin.height ) / float( color_intrin.height );
+                    rs2::rect depth_bbox{
+                        color_bbox.x * depth_scale_x, color_bbox.y * depth_scale_y,
+                        color_bbox.w * depth_scale_x, color_bbox.h * depth_scale_y };
+                    normalized_depth_bbox = depth_bbox.intersection( depth_frame_rect ).normalize( depth_frame_rect );
                 }
 
-                float const mean_depth = hkr_depth_m > 0.f ? hkr_depth_m : viewer_depth_m;
+                float const hkr_depth_m = det.depth;
+                float com_rel_u = 0.5f, com_rel_v = 0.5f;
 
                 std::string name = object_type_to_string( static_cast< object_type >( det.class_id ) );
-                new_objects.emplace_back( obj_id++, name, normalized_color_bbox, normalized_depth_bbox, mean_depth,
+                new_objects.emplace_back( obj_id++, name, normalized_color_bbox, normalized_depth_bbox, hkr_depth_m,
                                           hkr_depth_m, com_rel_u, com_rel_v, det.score,
                                           static_cast< object_type >( det.class_id ) );
             }

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -220,14 +220,6 @@ namespace rs2
 
     private:
         void get_frame_objects_container( rs2::frame & frame, std::shared_ptr< atomic_objects_in_frame > & objects );
-        rs2::rect project_color_bbox_to_depth( const rs2::rect &    color_bbox,
-                                               const uint16_t *     depth_data,
-                                               float                depth_scale,
-                                               const rs2_intrinsics & depth_intrin,
-                                               const rs2_intrinsics & color_intrin,
-                                               const rs2_extrinsics & color_to_depth,
-                                               const rs2_extrinsics & depth_to_color,
-                                               const rs2::rect &    depth_frame_rect );
         void process_object_detection_frames( std::map< int, rs2::frame > & last_frames );
 
         void check_permissions();

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -138,6 +138,7 @@ extern "C" {
         RS2_OPTION_DISPARITY_SHIFT, /**< Embedded filter: stereo disparity shift (pre-stream only) */
         RS2_OPTION_THRESHOLD, /**< Embedded filter: merge threshold in mm (pre-stream only) */
         RS2_OPTION_DOWNSCALE_RATIO, /**< Embedded filter: secondary-frame downscale ratio (pre-stream only) */
+        RS2_OPTION_ALIGN_DEPTH, /**< Enable firmware depth-to-color alignment for object detection distance (pre-stream only) */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -42,6 +42,23 @@ constexpr bool hw_mon_over_xu = false;
 
 namespace librealsense
 {
+    static bool supports_person_distance_align_depth( uint16_t pid )
+    {
+        switch( pid )
+        {
+        case ds::D555_PID:
+        case ds::D585_LEGACY_PID:
+        case ds::D585_2C_PID:
+        case ds::D585_3C_PID:
+        case ds::D585F_PID:
+        case ds::D585_2C_PROTO_PID:
+        case ds::D585_3C_PROTO_PID:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     std::map<uint32_t, rs2_format> d500_depth_fourcc_to_rs2_format = {
         {rs_fourcc('Y','U','Y','2'), RS2_FORMAT_YUYV},
         {rs_fourcc('Y','U','Y','V'), RS2_FORMAT_YUYV},
@@ -568,6 +585,12 @@ namespace librealsense
                 });
 
                 depth_sensor->register_option(RS2_OPTION_DEPTH_UNITS, depth_scale);
+            }
+
+            if( supports_person_distance_align_depth( _pid ) )
+            {
+                depth_sensor.register_option( RS2_OPTION_ALIGN_DEPTH,
+                                              std::make_shared< d500_align_depth_option >( raw_depth_sensor ) );
             }
 
             // defining the temperature options

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -28,14 +28,28 @@ namespace librealsense
         { rs_fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_OBJECT_DETECTION },
     };
 
+    static std::vector< platform::uvc_device_info >
+    find_object_detection_devices( const std::vector< platform::uvc_device_info > & uvc_devices )
+    {
+        // Newer D585 firmware exposes EP12 after CDC interfaces. Older D555/D585
+        // firmware used MI 9 for the OD stream.
+        static const uint32_t od_stream_mis[] = { 11, 9 };
+        for( auto mi : od_stream_mis )
+        {
+            auto od_devs_info = filter_by_mi( uvc_devices, mi );
+            if( ! od_devs_info.empty() )
+                return od_devs_info;
+        }
+        return {};
+    }
+
 
     d500_object_detection::d500_object_detection( std::shared_ptr< const d500_info > const & dev_info )
         : device( dev_info )
         , d500_device( dev_info )
         , _object_detection_stream( new stream( RS2_STREAM_OBJECT_DETECTION ) )
     {
-        static const uint32_t od_stream_mi = 9; // UVC interface index of the object-detection stream.
-        auto od_devs_info = filter_by_mi( dev_info->get_group().uvc_devices, od_stream_mi );
+        auto od_devs_info = find_object_detection_devices( dev_info->get_group().uvc_devices );
 
         // Skip if the device does not expose the stream; the rest of the device enumerates normally.
         if( od_devs_info.empty() )
@@ -100,35 +114,14 @@ namespace librealsense
         od_ep->register_processing_block( od_pbf );
     }
 
-    static void set_align_depth_xu( std::shared_ptr< uvc_sensor > raw_depth, bool enable )
-    {
-        if( !raw_depth )
-            return;
-        try
-        {
-            raw_depth->invoke_powered( [enable]( platform::uvc_device & dev )
-            {
-                uint8_t val = enable ? 1 : 0;
-                if( !dev.set_xu( ds::depth_xu, ds::DS5_ALIGN_DEPTH, &val, sizeof( val ) ) )
-                    LOG_WARNING( "Failed to " << ( enable ? "enable" : "disable" ) << " Align_Depth XU" );
-            } );
-        }
-        catch( std::exception const & e ) { LOG_WARNING( "Align_Depth XU exception: " << e.what() ); }
-        catch( ... )                       { LOG_WARNING( "Align_Depth XU: unknown exception" ); }
-    }
-
     void d500_object_detection_sensor::start( rs2_frame_callback_sptr callback )
     {
-        // TODO: FW does not yet support the Align_Depth XU — re-enable once FW is ready.
-        // set_align_depth_xu( _owner->get_raw_depth_sensor(), true );
         synthetic_sensor::start( callback );
     }
 
     void d500_object_detection_sensor::stop()
     {
         synthetic_sensor::stop();
-        // TODO: FW does not yet support the Align_Depth XU — re-enable once FW is ready.
-        // set_align_depth_xu( _owner->get_raw_depth_sensor(), false );
     }
 
     stream_profiles d500_object_detection_sensor::init_stream_profiles()

--- a/src/ds/d500/d500-options.cpp
+++ b/src/ds/d500/d500-options.cpp
@@ -3,6 +3,7 @@
 
 
 #include "d500-options.h"
+#include "d500-private.h"
 
 namespace librealsense
 {
@@ -47,6 +48,21 @@ namespace librealsense
     option_range rgb_tnr_option::get_range() const
     {
         return *_range;
+    }
+
+    d500_align_depth_option::d500_align_depth_option( const std::weak_ptr< uvc_sensor > & ep )
+        : uvc_xu_option< uint8_t >( ep,
+                                    ds::depth_xu,
+                                    ds::DS5_ALIGN_DEPTH,
+                                    "Enable firmware depth-to-color alignment for object detection distance. Can only be set before depth streaming",
+                                    { { 0.f, "Disabled" }, { 1.f, "Enabled" } },
+                                    false )
+    {
+    }
+
+    option_range d500_align_depth_option::get_range() const
+    {
+        return option_range{ 0, 1, 1, 0 };
     }
 
     temperature_option::temperature_option( std::shared_ptr< hw_monitor > hwm,

--- a/src/ds/d500/d500-options.h
+++ b/src/ds/d500/d500-options.h
@@ -38,6 +38,14 @@ namespace librealsense
         std::shared_ptr<hw_monitor> _hwm;
         std::weak_ptr< sensor_base > _sensor;
     };
+
+    class d500_align_depth_option : public uvc_xu_option< uint8_t >
+    {
+    public:
+        explicit d500_align_depth_option( const std::weak_ptr< uvc_sensor > & ep );
+
+        option_range get_range() const override;
+    };
     
     class temperature_option : public readonly_option
     {

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -579,6 +579,7 @@ std::string const & get_string_( rs2_option value )
         CASE( DISPARITY_SHIFT )
         CASE( THRESHOLD )
         CASE( DOWNSCALE_RATIO )
+        CASE( ALIGN_DEPTH )
 #undef CASE
         return arr;
     }();

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/Option.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/Option.cs
@@ -285,6 +285,9 @@ namespace Intel.RealSense
         vertical_binning = 89,
 
         /// <summary>Control the receiver sensitivity to incoming light, both projected and ambient</summary>
-        receiver_sensitivity = 90
+        receiver_sensitivity = 90,
+
+        /// <summary>Enable firmware depth-to-color alignment for object detection distance</summary>
+        AlignDepth = 109
     }
 }

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -202,6 +202,7 @@ PYBIND11_MODULE(NAME, m) {
         .value("safety_preset_active_index", RS2_OPTION_SAFETY_PRESET_ACTIVE_INDEX)
         .value("safety_mode", RS2_OPTION_SAFETY_MODE)
         .value("rgb_tnr_enabled", RS2_OPTION_RGB_TNR_ENABLED)
+        .value("align_depth", RS2_OPTION_ALIGN_DEPTH)
         .value("count", RS2_OPTION_COUNT);
 
     py::enum_<platform::power_state> power_state(m, "power_state");

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseTypes.h
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseTypes.h
@@ -150,6 +150,7 @@ enum class ERealSenseOptionType : uint8
     SAFETY_PRESET_ACTIVE_INDEX                 , /**< Set / Get current active safety preset index**/
     SAFETY_MODE                                , /**< Safety camera operation mode see rs2_safety_mode for values. */
     RGB_TNR_ENABLED                            , /**< RGB Temporal Noise Reduction enabling ON (1) / OFF (0)*/
+    ALIGN_DEPTH = 109                          , /**< Enable firmware depth-to-color alignment for object detection distance */
 };
 
 UENUM(Blueprintable)


### PR DESCRIPTION
## Summary
- Register the ALIGN_DEPTH firmware option for supported D555 and D585 devices.
- Use firmware-reported person distance in the viewer instead of viewer-side COM fallback.
- Expose the new option through C#, Python, and Unreal wrappers.
- Probe both current and legacy object-detection UVC interfaces.

## Validation
- git diff --check

## Notes
- No docs/ changes are included.
