### PR TITLE
Viewer - add stream window swapping

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1324,10 +1324,29 @@ namespace rs2
         ImGui::SetCursorScreenPos(pos);
     }
 
-    // Generate streams layout, creates a grid-like layout with factor amount of columns
+    // Serial number of the camera a stream belongs to, used to key the saved tile arrangement
+    static std::string stream_serial(const stream_model* sm)
+    {
+        if (sm && sm->dev && sm->dev->dev && sm->dev->dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER))
+            return sm->dev->dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+        return {};
+    }
+
+    // A stable per-camera identifier for a stream (type + index), so a saved arrangement can
+    // be matched back to the same streams across sessions / re-attach.
+    static std::string stream_descriptor(const stream_model* sm)
+    {
+        if (!sm) return {};
+        return std::to_string(static_cast<int>(sm->profile.stream_type())) + "_" +
+               std::to_string(sm->profile.stream_index());
+    }
+
+    // Generate streams layout, creates a grid-like layout with factor amount of columns.
+    // The streams are assigned to cells column-major (top-to-bottom, then next column) in
+    // the given order. The order is taken as-is (default sort or the user's arrangement).
     std::map<int, rect> generate_layout(const rect& r,
         int top_bar_height, size_t factor,
-        const std::set<stream_model*>& active_streams,
+        const std::vector<stream_model*>& streams_ordered,
         std::map<stream_model*, int>& stream_index
     )
     {
@@ -1335,33 +1354,18 @@ namespace rs2
         if (factor == 0) return results;
 
         // Calc the number of rows
-        auto complement = ceil((float)active_streams.size() / factor);
+        auto complement = ceil((float)streams_ordered.size() / factor);
 
         auto cell_width = static_cast<float>(r.w / factor);
         auto cell_height = static_cast<float>(r.h / complement);
 
-        // using the active streams sorted acc to stream type and stream index
-        // typical order will then be: depth, color, ir1, ir2, motion....
-        std::vector<stream_model*> active_streams_ordered;
-        for (auto&& active_stream : active_streams)
-        {
-            active_streams_ordered.push_back(active_stream);
-        }
-
-        std::sort(active_streams_ordered.begin(), active_streams_ordered.end(),
-            [](const stream_model* sm1, const stream_model* sm2)
-            {
-                return (sm1->profile.stream_type() < sm2->profile.stream_type()) ||
-                    ((sm1->profile.stream_type() == sm2->profile.stream_type()) && (sm1->profile.stream_index() < sm2->profile.stream_index()));
-            });
-
-        auto it = active_streams_ordered.begin();
+        auto it = streams_ordered.begin();
         for (auto x = 0; x < factor; x++)
         {
             for (auto y = 0; y < complement; y++)
             {
                 // There might be spare boxes at the end (3 streams in 2x2 array for example)
-                if (it == active_streams_ordered.end()) break;
+                if (it == streams_ordered.end()) break;
 
                 rect rxy = { r.x + x * cell_width, r.y + y * cell_height + top_bar_height,
                     cell_width, cell_height - top_bar_height };
@@ -1397,6 +1401,141 @@ namespace rs2
         }
     }
 
+    // Order the active streams for display. The default order is by stream type then index
+    // (depth, color, ir1, ir2, motion...). On top of that, each camera's tiles are placed
+    // according to the arrangement the user saved for that camera's serial (loaded from the
+    // config file); cameras with no saved arrangement keep the default order. Live drag
+    // re-arrangements are kept in the runtime _streams_order between frames.
+    std::vector<stream_model*> viewer_model::order_active_streams(
+        const std::set<stream_model*>& active_streams,
+        const std::map<stream_model*, int>& stream_index)
+    {
+        std::map<int, stream_model*> by_key;
+        for (auto&& sm : active_streams)
+            by_key[stream_index.at(sm)] = sm;
+
+        // Default order: by stream type, then stream index
+        std::vector<stream_model*> default_ordered(active_streams.begin(), active_streams.end());
+        std::sort(default_ordered.begin(), default_ordered.end(),
+            [](const stream_model* sm1, const stream_model* sm2)
+            {
+                return (sm1->profile.stream_type() < sm2->profile.stream_type()) ||
+                    ((sm1->profile.stream_type() == sm2->profile.stream_type()) && (sm1->profile.stream_index() < sm2->profile.stream_index()));
+            });
+
+        // Drop streams that are no longer active from the runtime order
+        _streams_order.erase(
+            std::remove_if(_streams_order.begin(), _streams_order.end(),
+                [&](int key) { return by_key.find(key) == by_key.end(); }),
+            _streams_order.end());
+
+        // Append newly-activated streams, keeping their default relative order
+        for (auto&& sm : default_ordered)
+        {
+            auto key = stream_index.at(sm);
+            if (std::find(_streams_order.begin(), _streams_order.end(), key) == _streams_order.end())
+                _streams_order.push_back(key);
+        }
+
+        // Apply each camera's saved arrangement: reorder a camera's streams among the slots
+        // they already occupy, following the saved descriptor order. Streams not present in
+        // the saved order (e.g. newly enabled) keep their relative position at the end.
+        std::map<std::string, std::vector<size_t>> serial_positions;
+        for (size_t i = 0; i < _streams_order.size(); i++)
+            serial_positions[stream_serial(by_key[_streams_order[i]])].push_back(i);
+
+        for (auto&& sp : serial_positions)
+        {
+            const std::string& serial = sp.first;
+            if (serial.empty()) continue;
+
+            auto saved = get_saved_arrangement(serial);
+            if (saved.empty()) continue;
+
+            auto& positions = sp.second;
+            std::vector<int> remaining;
+            for (auto pos : positions) remaining.push_back(_streams_order[pos]);
+
+            std::vector<int> reordered;
+            for (auto&& desc : saved)
+            {
+                for (auto it = remaining.begin(); it != remaining.end(); ++it)
+                {
+                    if (stream_descriptor(by_key[*it]) == desc)
+                    {
+                        reordered.push_back(*it);
+                        remaining.erase(it);
+                        break;
+                    }
+                }
+            }
+            for (auto key : remaining) reordered.push_back(key);
+
+            for (size_t k = 0; k < positions.size(); k++)
+                _streams_order[positions[k]] = reordered[k];
+        }
+
+        std::vector<stream_model*> ordered;
+        ordered.reserve(_streams_order.size());
+        for (auto key : _streams_order)
+            ordered.push_back(by_key[key]);
+
+        return ordered;
+    }
+
+    // Read a camera's saved tile arrangement from the config (cached in memory). Returns an
+    // empty list when the camera has no saved arrangement.
+    std::vector<std::string> viewer_model::get_saved_arrangement(const std::string& serial)
+    {
+        auto it = _stream_arrangement_by_serial.find(serial);
+        if (it != _stream_arrangement_by_serial.end())
+            return it->second;
+
+        std::vector<std::string> order;
+        std::string key = "stream_layout." + serial;
+        auto& cfg = config_file::instance();
+        if (cfg.contains(key.c_str()))
+        {
+            std::stringstream ss(cfg.get(key.c_str(), ""));
+            std::string tok;
+            while (std::getline(ss, tok, ','))
+                if (!tok.empty()) order.push_back(tok);
+        }
+        _stream_arrangement_by_serial[serial] = order;
+        return order;
+    }
+
+    // Save the current arrangement of every active camera to the config, keyed by serial.
+    // Derived from the runtime _streams_order, so it captures the latest drag re-arrangement.
+    void viewer_model::persist_stream_arrangements()
+    {
+        std::map<std::string, std::vector<std::string>> by_serial;
+        for (auto key : _streams_order)
+        {
+            auto it = streams.find(key);
+            if (it == streams.end()) continue;
+            const stream_model* sm = &it->second;
+            auto serial = stream_serial(sm);
+            if (serial.empty()) continue;
+            by_serial[serial].push_back(stream_descriptor(sm));
+        }
+
+        auto& cfg = config_file::instance();
+        for (auto&& kv : by_serial)
+        {
+            _stream_arrangement_by_serial[kv.first] = kv.second;
+
+            std::string joined;
+            for (size_t i = 0; i < kv.second.size(); i++)
+            {
+                if (i) joined += ",";
+                joined += kv.second[i];
+            }
+            std::string key = "stream_layout." + kv.first;
+            cfg.set(key.c_str(), joined.c_str());
+        }
+    }
+
     std::map<int, rect> viewer_model::calc_layout(const rect& r)
     {
         const int top_bar_height = 32;
@@ -1408,7 +1547,7 @@ namespace rs2
             if (stream.second.is_stream_visible())
             {
                 force_minimum_size_for_display(stream.second);
-                
+
                 active_streams.insert(&stream.second);
                 stream_index[&stream.second] = stream.first;
             }
@@ -1428,11 +1567,13 @@ namespace rs2
         }
         else
         {
+            auto streams_ordered = order_active_streams(active_streams, stream_index);
+
             // Go over all available fx(something) layouts
-            for (size_t f = 1; f <= active_streams.size(); f++)
+            for (size_t f = 1; f <= streams_ordered.size(); f++)
             {
                 auto l = generate_layout(r, top_bar_height, f,
-                    active_streams, stream_index);
+                    streams_ordered, stream_index);
 
                 // Keep the "best" layout in result
                 if (evaluate_layout(l) > evaluate_layout(results))
@@ -1441,6 +1582,67 @@ namespace rs2
         }
 
         return get_interpolated_layout(results);
+    }
+
+    // Drag one stream tile onto another to swap their positions. The swap is recorded in
+    // _streams_order and takes effect on the next calc_layout (animated by the layout
+    // interpolation). Active only while allow_streams_reorder is on.
+    void viewer_model::handle_streams_reorder(const std::map<int, rect>& layout, const mouse_info& mouse)
+    {
+        const bool down = mouse.mouse_down[0];
+        const float2 cursor = mouse.cursor;
+
+        // The title bar is drawn in the reserved strip above the frame rect, so extend the
+        // grab area upward to include it - dragging the title bar is the intuitive gesture.
+        const float header_height = 32.f;
+        auto grab_rect = [header_height](const rect& r)
+        {
+            return rect{ r.x, r.y - header_height, r.w, r.h + header_height };
+        };
+
+        // Find the tile (frame or its title bar) currently under the cursor
+        int hovered = -1;
+        for (auto&& kvp : layout)
+        {
+            if (grab_rect(kvp.second).contains(cursor))
+            {
+                hovered = kvp.first;
+                break;
+            }
+        }
+
+        if (down && !_prev_reorder_mouse_down)
+        {
+            // Mouse pressed - start a potential drag from the hovered tile
+            _dragged_stream = hovered;
+            _drag_origin = cursor;
+            _is_dragging_stream = false;
+        }
+        else if (down && _dragged_stream != -1)
+        {
+            // Held - promote to an actual drag once moved past a small threshold
+            if ((cursor - _drag_origin).length() > 6.f)
+                _is_dragging_stream = true;
+        }
+        else if (!down && _prev_reorder_mouse_down)
+        {
+            // Released - perform the swap if dropped over a different tile
+            if (_is_dragging_stream && _dragged_stream != -1 && hovered != -1 && hovered != _dragged_stream)
+            {
+                auto it_a = std::find(_streams_order.begin(), _streams_order.end(), _dragged_stream);
+                auto it_b = std::find(_streams_order.begin(), _streams_order.end(), hovered);
+                if (it_a != _streams_order.end() && it_b != _streams_order.end())
+                {
+                    std::iter_swap(it_a, it_b);
+                    // Remember this camera's new tile arrangement (per serial) in the config
+                    persist_stream_arrangements();
+                }
+            }
+            _dragged_stream = -1;
+            _is_dragging_stream = false;
+        }
+
+        _prev_reorder_mouse_down = down;
     }
 
     rs2::frame viewer_model::handle_ready_frames(const rect& viewer_rect, ux_window& window, int devices, std::string& error_message)
@@ -1809,6 +2011,16 @@ namespace rs2
         {
             show_no_stream_overlay(font2, static_cast<int>(view_rect.x), static_cast<int>(view_rect.y), static_cast<int>(win.width()), static_cast<int>(win.height() - output_height));
         }
+
+        // While in re-arrange mode we drive tile drag-to-swap and suppress the per-tile
+        // mouse interactions (zoom/pan/ruler) by feeding the tiles a neutral mouse.
+        const bool reorder_mode = allow_streams_reorder && !fullscreen && layout.size() > 1;
+        mouse_info neutral_mouse;
+        neutral_mouse.cursor = neutral_mouse.prev_cursor = { -1e5f, -1e5f };
+        if (reorder_mode)
+            handle_streams_reorder(layout, mouse);
+        const mouse_info& active_mouse = reorder_mode ? neutral_mouse : mouse;
+
         for (auto &&kvp : layout)
         {
             auto&& view_rect = kvp.second;
@@ -1818,7 +2030,7 @@ namespace rs2
             auto stream_rect = view_rect.adjust_ratio(stream_size).grow(-3);
 
             if (should_render_frame(stream_mv)) {
-                stream_mv.show_frame(stream_rect, mouse, error_message);
+                stream_mv.show_frame(stream_rect, active_mouse, error_message);
             }
 
             auto p = stream_mv.dev->dev.as<playback>();
@@ -1837,7 +2049,7 @@ namespace rs2
             }
 
             stream_mv.show_stream_header(font1, stream_rect, *this);
-            stream_mv.show_stream_footer(font1, stream_rect, mouse, streams, *this);
+            stream_mv.show_stream_footer(font1, stream_rect, active_mouse, streams, *this);
 
 
             if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG }))
@@ -1871,7 +2083,7 @@ namespace rs2
                                 stream_mv.show_stream_imu( font1,
                                                            stream_rect,
                                                            axis,
-                                                           mouse,
+                                                           active_mouse,
                                                            stream_type == RS2_STREAM_GYRO ? "Radians/Sec" : "Meter/Sec^2" );
                             }
                         }
@@ -1886,7 +2098,7 @@ namespace rs2
                                                                      { (float)motion.linear_acceleration.x,
                                                                        (float)motion.linear_acceleration.y,
                                                                        (float)motion.linear_acceleration.z },
-                                                                     mouse,
+                                                                     active_mouse,
                                                                      "Meter/Sec^2",
                                                                      "Linear Acceletion" );
                             stream_mv.show_stream_imu( font1,
@@ -1894,7 +2106,7 @@ namespace rs2
                                                        { (float)motion.angular_velocity.x,
                                                          (float)motion.angular_velocity.y,
                                                          (float)motion.angular_velocity.z },
-                                                       mouse,
+                                                       active_mouse,
                                                        "Radians/Sec",
                                                        "Angular Velocity",
                                                        height + 9 );
@@ -2115,10 +2327,60 @@ namespace rs2
                     if (!distances.empty())
                     {
                         ruler_length = calculate_ruler_max_distance(distances);
-                        draw_color_ruler(mouse, streams[stream], stream_rect, rgb_per_distance_vec, ruler_length, depth_units);
+                        draw_color_ruler(active_mouse, streams[stream], stream_rect, rgb_per_distance_vec, ruler_length, depth_units);
                     }
                 }
             }
+        }
+
+        // Re-arrange mode: outline the tiles and show drag-to-swap feedback. The grab area
+        // includes the title bar strip above the frame, so the outlines do too.
+        if (reorder_mode)
+        {
+            const float header_height = 32.f;
+            auto grab_rect = [header_height](const rect& r)
+            {
+                return rect{ r.x, r.y - header_height, r.w, r.h + header_height };
+            };
+
+            for (auto&& kvp : layout)
+            {
+                glColor3f(light_blue.x, light_blue.y, light_blue.z);
+                draw_rect(grab_rect(kvp.second).grow(-3), 1);
+            }
+
+            if (_is_dragging_stream && _dragged_stream != -1)
+            {
+                // The tile being dragged
+                auto src = layout.find(_dragged_stream);
+                if (src != layout.end())
+                {
+                    glColor3f(light_grey.x, light_grey.y, light_grey.z);
+                    draw_rect(grab_rect(src->second).grow(-3), 3);
+                }
+
+                // The drop target under the cursor (frame or its title bar)
+                for (auto&& kvp : layout)
+                {
+                    if (kvp.first != _dragged_stream && grab_rect(kvp.second).contains(mouse.cursor))
+                    {
+                        glColor3f(light_blue.x, light_blue.y, light_blue.z);
+                        draw_rect(grab_rect(kvp.second).grow(-3), 4);
+                        break;
+                    }
+                }
+
+                // A small ghost rectangle that follows the cursor
+                if (src != layout.end())
+                {
+                    auto gw = src->second.w * 0.4f;
+                    auto gh = src->second.h * 0.4f;
+                    rect ghost{ mouse.cursor.x - gw / 2.f, mouse.cursor.y - gh / 2.f, gw, gh };
+                    glColor3f(white.x, white.y, white.z);
+                    draw_rect(ghost, 2);
+                }
+            }
+            glColor3f(1.f, 1.f, 1.f);
         }
     }
 
@@ -2464,7 +2726,10 @@ namespace rs2
         ImGui::PushFont(window.get_large_font());
         ImGui::PushStyleColor(ImGuiCol_Border, black);
 
-        int buttons = window.is_fullscreen() ? 4 : 3;
+        // The re-arrange-tiles toggle always occupies a slot immediately to the left of the
+        // Settings button. It is enabled in 2D view and disabled (greyed out) in 3D view.
+        const int rearrange_slot = 1;
+        int buttons = (window.is_fullscreen() ? 4 : 3) + rearrange_slot;
 
         ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons));
         ImGui::PushStyleColor(ImGuiCol_Text, is_3d_view ? light_grey : light_blue);
@@ -2492,7 +2757,32 @@ namespace rs2
         ImGui::PopStyleColor(2);
         ImGui::SameLine();
 
-        ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons - 2));
+        // Re-arrange tiles toggle, placed next to the Settings button. Disabled in 3D view.
+        {
+            ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons - 2));
+            ImGui::BeginDisabled(is_3d_view);
+            ImGui::PushStyleColor(ImGuiCol_Text, allow_streams_reorder ? light_blue : light_grey);
+            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, allow_streams_reorder ? light_blue : light_grey);
+            if (ImGui::Button(textual_icons::up_down_left_right, { panel_y, panel_y }))
+            {
+                allow_streams_reorder = !allow_streams_reorder;
+            }
+            ImGui::PopStyleColor(2);
+            ImGui::EndDisabled();
+            if (!is_3d_view && ImGui::IsItemHovered())
+            {
+                // Match the Settings tooltip font (base font, not the large toolbar font)
+                ImGui::PushFont(window.get_font());
+                RsImGui::CustomTooltip("%s", allow_streams_reorder
+                    ? "Re-arrange tiles: ON - drag a stream tile onto another to swap them"
+                    : "Re-arrange tiles - drag stream tiles to swap their positions");
+                ImGui::PopFont();
+                window.link_hovered();
+            }
+            ImGui::SameLine();
+        }
+
+        ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons - 2 - rearrange_slot));
 
         static bool settings_open = false;
         ImGui::PushStyleColor(ImGuiCol_Text, !settings_open ? light_grey : light_blue);
@@ -2511,7 +2801,7 @@ namespace rs2
         if (window.is_fullscreen())
         {
             ImGui::SameLine();
-            ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons - 4));
+            ImGui::SetCursorPosX(window.width() - panel_width - panel_y * (buttons - 4 - rearrange_slot));
 
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, button_color);
             ImGui::PushStyleColor(ImGuiCol_Text, light_grey);

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -23,6 +23,7 @@
 #include <rsutils/accelerators/gpu.h>
 #include <rsutils/os/special-folder.h>
 #include <rsutils/string/trim-newlines.h>
+#include <rsutils/string/split.h>
 #include <common/utilities/imgui/wrap.h>
 #include <common/labeled-point-cloud-utilities.h>
 #include <common/utilities/com/center-of-mass.h>
@@ -1512,12 +1513,7 @@ namespace rs2
         std::string key = "stream_layout." + serial;
         auto& cfg = config_file::instance();
         if (cfg.contains(key.c_str()))
-        {
-            std::stringstream ss(cfg.get(key.c_str(), ""));
-            std::string tok;
-            while (std::getline(ss, tok, ','))
-                if (!tok.empty()) order.push_back(tok);
-        }
+            order = rsutils::string::split(cfg.get(key.c_str(), ""), ',');
         _stream_arrangement_by_serial[serial] = order;
         return order;
     }
@@ -1555,7 +1551,8 @@ namespace rs2
 
     std::map<int, rect> viewer_model::calc_layout(const rect& r)
     {
-        const int top_bar_height = 32;
+        // The reserved title-bar strip at the top of each cell (see tile_grab_rect)
+        const int top_bar_height = static_cast<int>(TILE_HEADER_HEIGHT);
 
         std::set<stream_model*> active_streams;
         std::map<stream_model*, int> stream_index;
@@ -2302,8 +2299,8 @@ namespace rs2
             }
 
             glColor3f(header_window_bg.x, header_window_bg.y, header_window_bg.z);
-            stream_rect.y -= 32;
-            stream_rect.h += 32;
+            stream_rect.y -= TILE_HEADER_HEIGHT;
+            stream_rect.h += TILE_HEADER_HEIGHT;
             stream_rect.w += 1;
             draw_rect(stream_rect);
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1341,6 +1341,14 @@ namespace rs2
                std::to_string(sm->profile.stream_index());
     }
 
+    // The tile title bar is drawn in the reserved strip above the frame rect. The drag grab
+    // area (and its drawn outline) extends upward by this much to include the title bar.
+    static constexpr float TILE_HEADER_HEIGHT = 32.f;
+    static rect tile_grab_rect(const rect& r)
+    {
+        return rect{ r.x, r.y - TILE_HEADER_HEIGHT, r.w, r.h + TILE_HEADER_HEIGHT };
+    }
+
     // Generate streams layout, creates a grid-like layout with factor amount of columns.
     // The streams are assigned to cells column-major (top-to-bottom, then next column) in
     // the given order. The order is taken as-is (default sort or the user's arrangement).
@@ -1442,7 +1450,11 @@ namespace rs2
         // the saved order (e.g. newly enabled) keep their relative position at the end.
         std::map<std::string, std::vector<size_t>> serial_positions;
         for (size_t i = 0; i < _streams_order.size(); i++)
-            serial_positions[stream_serial(by_key[_streams_order[i]])].push_back(i);
+        {
+            auto kit = by_key.find(_streams_order[i]);
+            if (kit == by_key.end()) continue;
+            serial_positions[stream_serial(kit->second)].push_back(i);
+        }
 
         for (auto&& sp : serial_positions)
         {
@@ -1461,7 +1473,8 @@ namespace rs2
             {
                 for (auto it = remaining.begin(); it != remaining.end(); ++it)
                 {
-                    if (stream_descriptor(by_key[*it]) == desc)
+                    auto kit = by_key.find(*it);
+                    if (kit != by_key.end() && stream_descriptor(kit->second) == desc)
                     {
                         reordered.push_back(*it);
                         remaining.erase(it);
@@ -1478,7 +1491,11 @@ namespace rs2
         std::vector<stream_model*> ordered;
         ordered.reserve(_streams_order.size());
         for (auto key : _streams_order)
-            ordered.push_back(by_key[key]);
+        {
+            auto kit = by_key.find(key);
+            if (kit != by_key.end())
+                ordered.push_back(kit->second);
+        }
 
         return ordered;
     }
@@ -1592,19 +1609,11 @@ namespace rs2
         const bool down = mouse.mouse_down[0];
         const float2 cursor = mouse.cursor;
 
-        // The title bar is drawn in the reserved strip above the frame rect, so extend the
-        // grab area upward to include it - dragging the title bar is the intuitive gesture.
-        const float header_height = 32.f;
-        auto grab_rect = [header_height](const rect& r)
-        {
-            return rect{ r.x, r.y - header_height, r.w, r.h + header_height };
-        };
-
         // Find the tile (frame or its title bar) currently under the cursor
         int hovered = -1;
         for (auto&& kvp : layout)
         {
-            if (grab_rect(kvp.second).contains(cursor))
+            if (tile_grab_rect(kvp.second).contains(cursor))
             {
                 hovered = kvp.first;
                 break;
@@ -2015,10 +2024,20 @@ namespace rs2
         // While in re-arrange mode we drive tile drag-to-swap and suppress the per-tile
         // mouse interactions (zoom/pan/ruler) by feeding the tiles a neutral mouse.
         const bool reorder_mode = allow_streams_reorder && !fullscreen && layout.size() > 1;
-        mouse_info neutral_mouse;
+        mouse_info neutral_mouse{};
         neutral_mouse.cursor = neutral_mouse.prev_cursor = { -1e5f, -1e5f };
         if (reorder_mode)
+        {
             handle_streams_reorder(layout, mouse);
+        }
+        else
+        {
+            // Clear any drag state so a drag interrupted by leaving re-arrange mode (toggle
+            // off, fullscreen, last stream closed) can't trigger a phantom swap on re-entry.
+            _dragged_stream = -1;
+            _is_dragging_stream = false;
+            _prev_reorder_mouse_down = false;
+        }
         const mouse_info& active_mouse = reorder_mode ? neutral_mouse : mouse;
 
         for (auto &&kvp : layout)
@@ -2337,16 +2356,10 @@ namespace rs2
         // includes the title bar strip above the frame, so the outlines do too.
         if (reorder_mode)
         {
-            const float header_height = 32.f;
-            auto grab_rect = [header_height](const rect& r)
-            {
-                return rect{ r.x, r.y - header_height, r.w, r.h + header_height };
-            };
-
             for (auto&& kvp : layout)
             {
                 glColor3f(light_blue.x, light_blue.y, light_blue.z);
-                draw_rect(grab_rect(kvp.second).grow(-3), 1);
+                draw_rect(tile_grab_rect(kvp.second).grow(-3), 1);
             }
 
             if (_is_dragging_stream && _dragged_stream != -1)
@@ -2356,16 +2369,16 @@ namespace rs2
                 if (src != layout.end())
                 {
                     glColor3f(light_grey.x, light_grey.y, light_grey.z);
-                    draw_rect(grab_rect(src->second).grow(-3), 3);
+                    draw_rect(tile_grab_rect(src->second).grow(-3), 3);
                 }
 
                 // The drop target under the cursor (frame or its title bar)
                 for (auto&& kvp : layout)
                 {
-                    if (kvp.first != _dragged_stream && grab_rect(kvp.second).contains(mouse.cursor))
+                    if (kvp.first != _dragged_stream && tile_grab_rect(kvp.second).contains(mouse.cursor))
                     {
                         glColor3f(light_blue.x, light_blue.y, light_blue.z);
-                        draw_rect(grab_rect(kvp.second).grow(-3), 4);
+                        draw_rect(tile_grab_rect(kvp.second).grow(-3), 4);
                         break;
                     }
                 }
@@ -2774,8 +2787,8 @@ namespace rs2
                 // Match the Settings tooltip font (base font, not the large toolbar font)
                 ImGui::PushFont(window.get_font());
                 RsImGui::CustomTooltip("%s", allow_streams_reorder
-                    ? "Re-arrange tiles: ON - drag a stream tile onto another to swap them"
-                    : "Re-arrange tiles - drag stream tiles to swap their positions");
+                    ? "Re-arrange tiles: ON - drag a stream tile onto another to swap them.\nArrangement is saved per camera."
+                    : "Re-arrange tiles - drag stream tiles to swap their positions.\nArrangement is saved per camera.");
                 ImGui::PopFont();
                 window.link_hovered();
             }

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -97,6 +97,19 @@ namespace rs2
 
         std::map<int, rect> calc_layout(const rect& r);
 
+        // Order the active streams for display: default is by stream type then index
+        // (depth, color, ir1, ir2, motion...), unless the user manually re-arranged
+        // the tiles - see _streams_order and the per-serial saved arrangements.
+        std::vector<stream_model*> order_active_streams(const std::set<stream_model*>& active_streams,
+            const std::map<stream_model*, int>& stream_index);
+
+        // Handle drag-to-swap of stream tiles while in re-arrange mode
+        void handle_streams_reorder(const std::map<int, rect>& layout, const mouse_info& mouse);
+
+        // Per-camera (serial) tile arrangement persistence in the config file
+        std::vector<std::string> get_saved_arrangement(const std::string& serial);
+        void persist_stream_arrangements();
+
         void show_no_stream_overlay(ImFont* font, int min_x, int min_y, int max_x, int max_y);
         void show_no_device_overlay(ImFont* font, int min_x, int min_y);
         void show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y, rs2_format format);
@@ -138,6 +151,8 @@ namespace rs2
         std::map<int, int> streams_origin;
         bool fullscreen = false;
         stream_model* selected_stream = nullptr;
+        // When true, stream tiles can be re-arranged by dragging one onto another (toggled from the top bar)
+        bool allow_streams_reorder = false;
         std::shared_ptr<syncer_model> syncer;
         post_processing_filters ppf;
 
@@ -264,6 +279,18 @@ namespace rs2
         streams_layout _layout;
         streams_layout _old_layout;
         std::chrono::high_resolution_clock::time_point _transition_start_time;
+
+        // User-defined display order of the stream tiles (holds stream keys from 'streams').
+        // Reconciled against the active streams every frame in order_active_streams().
+        std::vector<int> _streams_order;
+        // Cached per-camera (serial) tile arrangement, mirrored to the config file. Each value
+        // is an ordered list of stream descriptors (see stream_descriptor()).
+        std::map<std::string, std::vector<std::string>> _stream_arrangement_by_serial;
+        // Drag-to-swap state (valid while allow_streams_reorder is on)
+        int _dragged_stream = -1;
+        bool _is_dragging_stream = false;
+        bool _prev_reorder_mouse_down = false;
+        float2 _drag_origin{ 0.f, 0.f };
 
         // 3D-Viewer state
         float3 pos = { 0.0f, 0.0f, -0.5f };


### PR DESCRIPTION
**Viewer** — drag-to-rearrange stream tiles with per-camera persistence

**What**
Adds the ability to rearrange the 2D viewer stream tiles by drag-and-drop, and remembers each camera's chosen arrangement.

**Changes**
* Drag-to-swap: a new toolbar toggle (next to Settings) enables re-arrange mode. While active, drag any tile — by its frame or its title bar — onto another to swap their positions. Source/target highlights and a cursor ghost give visual feedback. The button is shown in 3D view too, but disabled.
* Per-camera persistence: a camera's tile arrangement is saved to the config file keyed by serial number (as stable stream_type_index descriptors). On reopen or re-attach, the saved arrangement is restored; cameras with no saved layout use the default.
* Default layout unchanged: tiles still fill column-major (depth top-left, etc.).
