### PR TITLE
Device setup: fixture-owned port lifecycle

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -461,24 +461,26 @@ def _cleanup_devices():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def session_setup_teardown():
-    """Runs once per session: log startup info, yield, then clean up hub/devices on exit."""
+def session_setup_teardown(request):
+    """Runs once per session: register cleanup, yield, then clean up hub/devices on exit."""
     # Setup — runs once before the first test
     register_signal_handlers(_cleanup_devices)
 
     yield  # All tests run here
 
-    # Teardown — runs once after the last test
-    ensure_newline()
-    log.info("")
-    log.info("=" * 80)
-    log.info("Pytest Session Ending")
-    log.info("=" * 80)
-
-    try:
-        _cleanup_devices()
-    except Exception as e:
-        log.warning(f"Error during cleanup: {e}")
+    # Teardown — runs once after the last test. The module-scoped log handler is already closed
+    # (at the last module's teardown), so this output never tails a test's .log. Emit it with
+    # pytest's output capture suspended and via print() so it reaches the console -- otherwise
+    # fixture-teardown stdout is captured and discarded, and a logging.info would have no handler.
+    capmanager = request.config.pluginmanager.getplugin("capturemanager")
+    with capmanager.global_and_fixture_disabled():
+        print(f"\n-I- {'=' * 80}")  # leading newline: pytest's last progress line has no EOL yet
+        print("-I- Pytest Session Ending")
+        print(f"-I- {'=' * 80}")
+        try:
+            _cleanup_devices()
+        except Exception as e:
+            print(f"-W- Error during cleanup: {e}")
 
     log.info("=" * 80)
 

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -524,23 +524,30 @@ def __pytest_repeat_step_number(request):
 
 @pytest.fixture(scope="module", autouse=True)
 def module_device_setup(request, _test_device_serial, __pytest_repeat_step_number):
-    """Enable the target device(s) via the hub. Runs once per (module, parametrized value).
+    """Power the target device(s) on for the module and off again at teardown — once per
+    (module, parametrized value).
 
-    All resolution (markers, CLI filters, sentinels for missing/skipped devices) happens
-    in ``resolve_device_each_serials`` at collection time.  The fixture just consumes
-    ``_test_device_serial`` and dispatches:
+    Resolution (markers, CLI filters, missing/skip sentinels) happens in
+    ``resolve_device_each_serials`` at collection time; this fixture just consumes
+    ``_test_device_serial`` and owns the hub-port lifecycle:
 
     - ``None``            → test has no device markers; yield None.
-    - ``list[str]``       → multi-device marker; enable all serials and yield the list.
+    - ``list[str]``       → multi-device marker; enable all serials, yield the list, disable on teardown.
     - sentinel strings    → ``pytest.skip`` / ``pytest.fail``.
-    - plain serial string → enable that device and yield it.
+    - plain serial string → enable that device, yield it, disable on teardown.
 
-    ``autouse=True`` so the hub recycle fires at the first parametrized test in each
-    device group, not lazily at whichever test happens to be the first device-consumer.
-    Without it, a synthetic-only test that runs before a live-device test in the same
-    parametrize group would defer the recycle — making the recycle landing point
-    depend on test declaration order. For tests without any device marker
-    (``_test_device_serial is None``) the body yields None immediately, costing nothing.
+    Port state is owned by this fixture's lifecycle — enable on setup, disable on teardown — so
+    isolation and recycle fall out of pytest re-instantiating the fixture per
+    (module, device, repeat-step); there is no global port tracking. Isolation in the default
+    path comes from the *previous* module's teardown having powered its device off, so setup only
+    needs to power on its own. With ``--no-reset`` the device is isolated without a power-cycle
+    (``disable_other_ports=True``) and left on at teardown — matching the legacy fast path.
+
+    ``autouse=True`` is REQUIRED, not just an optimization: some tests build their own
+    ``rs.context()`` and never request ``test_device``/``test_context`` (e.g.
+    ``live/streaming/pytest-jpeg-compressed-format.py``, ``live/d500/pytest-detect-D555.py``);
+    they get their port powered only because this fixture runs automatically for every
+    device-marked module.
     """
     serial_number = _test_device_serial
 
@@ -548,6 +555,22 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         log.debug(f"Module {request.node.name} has no device requirements")
         yield None
         return
+
+    no_reset = request.config.getoption("--no-reset", default=False)
+    # Default: power-cycle the device and disable it on teardown (isolation comes from the
+    # previous module's teardown). --no-reset: isolate statelessly without a power-cycle and
+    # leave the device on (no teardown-disable), matching the legacy fast path.
+    recycle = not no_reset
+    disable_other_ports = no_reset
+    teardown_disable = not no_reset
+
+    def _teardown(serials):
+        if not teardown_disable:
+            return
+        try:
+            devices.disable(serials)
+        except Exception as e:
+            log.warning(f"Failed to disable {serials} on teardown: {e}")
 
     if isinstance(serial_number, list):
         # Multi-device path: parametrized list of serials. Sentinels are always strings,
@@ -558,11 +581,12 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         ]
         log.info(f"Configuration: {', '.join(names)}")
         try:
-            devices.enable_only(serial_number, recycle=True)
+            devices.enable_only(serial_number, recycle=recycle, disable_other_ports=disable_other_ports)
             log.debug(f"All {len(serial_number)} devices enabled and ready")
         except Exception as e:
             pytest.fail(f"Failed to enable devices: {e}")
         yield serial_number
+        _teardown(serial_number)
         return
 
     # Single-device path (parametrized string value, including sentinels).
@@ -574,35 +598,19 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         pytest.fail(f"No devices found matching requirements: {pattern}")
     log.debug(f"Test using parametrized device: {serial_number}")
 
-    # Enable the device for this module. Module-scoped fixture lifecycle handles
-    # recycle/reuse automatically: pytest re-instantiates this fixture per
-    # (module, _test_device_serial, __pytest_repeat_step_number), so the device
-    # is power-cycled exactly when it needs to change.
-    #
-    # --no-reset additionally skips enable_only on subsequent passes for the same
-    # serial within the same module, matching the legacy behavior.
     device = devices.get(serial_number)
     device_name = device.name if device else serial_number
     log.info(f"Configuration: {device_name} [{serial_number}]")
 
-    no_reset = request.config.getoption("--no-reset", default=False)
-    module_obj = request.module
-    already_enabled_serial = getattr(module_obj, '_module_last_serial', None)
-    if no_reset and already_enabled_serial == serial_number:
-        log.debug(f"Device {serial_number} already enabled (--no-reset), skipping hub setup")
-        yield serial_number
-        return
-
-    recycle = not no_reset
     try:
-        log.debug(f"{'Recycling' if recycle else 'Enabling'} device via hub...")
-        devices.enable_only([serial_number], recycle=recycle)
-        module_obj._module_last_serial = serial_number
+        log.debug(f"{'Enabling' if no_reset else 'Recycling'} device via hub...")
+        devices.enable_only([serial_number], recycle=recycle, disable_other_ports=disable_other_ports)
         log.debug(f"Device enabled and ready")
     except Exception as e:
         pytest.fail(f"Failed to enable device {serial_number}: {e}")
 
     yield serial_number
+    _teardown([serial_number])
 
 
 @pytest.fixture(scope="module")

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -397,16 +397,24 @@ def pytest_collection_modifyitems(session, config, items):
     filter_and_sort_items(config, items)
 
 
+def _emit_test_header(nodeid):
+    """Write the ``Test: <nodeid>`` banner into the current module+camera log."""
+    ensure_newline()
+    log.info("-" * 80)
+    log.info(f"Test: {nodeid}")
+    log.info("-" * 80)
+
+
 @pytest.fixture(autouse=True)
 def _test_log_banner(request):
     """Emit the per-test header into the log. Runs during test setup -- i.e. AFTER the
     module-scoped log handler (module_log) is open and the device is enabled -- so the header
     lands in the correct module+camera file. (Logging it from a per-test protocol hook instead
-    would race a parametrized module fixture's deferred teardown and land in the wrong file.)"""
-    ensure_newline()
-    log.info("-" * 80)
-    log.info(f"Test: {request.node.nodeid}")
-    log.info("-" * 80)
+    would race a parametrized module fixture's deferred teardown and land in the wrong file.)
+
+    Setup-phase failures in module_device_setup happen BEFORE this fixture runs, so those paths
+    emit the header themselves (via _emit_test_header) to keep the error anchored to its item."""
+    _emit_test_header(request.node.nodeid)
     yield
     ensure_newline()
 
@@ -472,8 +480,7 @@ def session_setup_teardown(request):
     # (at the last module's teardown), so this output never tails a test's .log. Emit it with
     # pytest's output capture suspended and via print() so it reaches the console -- otherwise
     # fixture-teardown stdout is captured and discarded, and a logging.info would have no handler.
-    capmanager = request.config.pluginmanager.getplugin("capturemanager")
-    with capmanager.global_and_fixture_disabled():
+    def _emit_session_end():
         print(f"\n-I- {'=' * 80}")  # leading newline: pytest's last progress line has no EOL yet
         print("-I- Pytest Session Ending")
         print(f"-I- {'=' * 80}")
@@ -481,6 +488,15 @@ def session_setup_teardown(request):
             _cleanup_devices()
         except Exception as e:
             print(f"-W- Error during cleanup: {e}")
+
+    # getplugin returns None if capture is disabled (e.g. -p no:capture); guard so teardown
+    # (and _cleanup_devices) still runs instead of raising AttributeError.
+    capmanager = request.config.pluginmanager.getplugin("capturemanager")
+    if capmanager is not None:
+        with capmanager.global_and_fixture_disabled():
+            _emit_session_end()
+    else:
+        _emit_session_end()
 
     log.info("=" * 80)
 
@@ -523,23 +539,44 @@ def __pytest_repeat_step_number(request):
     return getattr(request, 'param', 0)
 
 
+def _device_log_id(serial):
+    """Device-portion id used for the per-(module, camera) log filename.
+
+    Mirrors the device parametrize ids built in ``resolve_device_each_serials`` (``<name>-<sn>``,
+    ``+``-joined for multi-device, ``MISSING-``/``SKIP-`` for sentinels) -- and deliberately omits
+    any extra ``@pytest.mark.parametrize`` dimensions (config/resolution). So every parametrize
+    case of one camera shares ONE file (``<module>_<name>-<sn>.log``), with the device enable at
+    the top and disable at the bottom, while each camera still gets its own file. ``None`` for a
+    test with no device markers.
+    """
+    if serial is None:
+        return None
+    if isinstance(serial, list):
+        return '+'.join(f"{devices.get(sn).name}-{sn}" if devices.get(sn) else sn for sn in serial)
+    if serial.startswith(_MISSING_SENTINEL_PREFIX):
+        return f"MISSING-{serial[len(_MISSING_SENTINEL_PREFIX):]}"
+    if serial.startswith(_SKIP_SENTINEL_PREFIX):
+        return f"SKIP-{serial[len(_SKIP_SENTINEL_PREFIX):]}"
+    dev = devices.get(serial)
+    return f"{dev.name}-{serial}" if dev else serial
+
+
 @pytest.fixture(scope="module", autouse=True)
 def module_log(request, _test_device_serial):
     """Own the per-(module, camera) log file for the whole module lifecycle.
 
     Module-scoped so one file spans setup (device enable) -> every test -> teardown (device
     disable). Depends on ``_test_device_serial`` so pytest re-instantiates it per camera (one file
-    per module+camera) and so it satisfies the cross-camera module-fixture guard. The filename's
-    device id is the test's parametrize id (e.g. ``D455-213522252012``), recovered from the
-    triggering item's callspec so it matches the legacy naming.
+    per module+camera) and so it satisfies the cross-camera module-fixture guard. The filename uses
+    the device-portion id only (``_device_log_id``), so all of a camera's ``@parametrize`` cases
+    collapse into that camera's single file.
 
     ``module_device_setup`` depends on this fixture, so the handler opens before the device is
     enabled and closes after it is disabled -- keeping a parametrized module fixture's deferred
     teardown (pytest runs the previous camera's teardown during the next camera's protocol) from
     leaking the disable into the next camera's file.
     """
-    item = getattr(request, '_pyfuncitem', None)
-    device_id = getattr(getattr(item, 'callspec', None), 'id', None)
+    device_id = _device_log_id(_test_device_serial)
     handler = open_log(str(request.node.fspath), device_id, request.config)
     try:
         yield
@@ -580,6 +617,10 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         log.debug(f"Module {request.node.name} has no device requirements")
         yield None
         return
+
+    # nodeid of the item that triggered this module fixture -- used to anchor setup-phase failures
+    # (which happen before _test_log_banner runs) to the failing test in the log.
+    item_id = getattr(getattr(request, '_pyfuncitem', None), 'nodeid', None) or request.node.nodeid
 
     no_reset = request.config.getoption("--no-reset", default=False)
     # Decide whether setup power-cycles the device (vs just turning it on):
@@ -625,6 +666,7 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         except Exception as e:
             # Setup failed after possibly powering the port(s): teardown won't run (no yield),
             # so power off what we tried to enable here, lest it linger into the next module.
+            _emit_test_header(item_id)
             try:
                 devices.disable(serial_number)
             except Exception as cleanup_err:
@@ -637,9 +679,11 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     # Single-device path (parametrized string value, including sentinels).
     if serial_number.startswith(_SKIP_SENTINEL_PREFIX):
         pattern = serial_number[len(_SKIP_SENTINEL_PREFIX):]
+        _emit_test_header(item_id)
         pytest.skip(f"No suitable devices for requirements: {pattern}")
     if serial_number.startswith(_MISSING_SENTINEL_PREFIX):
         pattern = serial_number[len(_MISSING_SENTINEL_PREFIX):]
+        _emit_test_header(item_id)
         pytest.fail(f"No devices found matching requirements: {pattern}")
     log.debug(f"Test using parametrized device: {serial_number}")
 
@@ -654,6 +698,7 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     except Exception as e:
         # Setup failed after possibly powering the port: teardown won't run (no yield), so power
         # off what we tried to enable here, lest it linger into the next module.
+        _emit_test_header(item_id)
         try:
             devices.disable([serial_number])
         except Exception as cleanup_err:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -584,6 +584,12 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
             devices.enable_only(serial_number, recycle=recycle, disable_other_ports=disable_other_ports)
             log.debug(f"All {len(serial_number)} devices enabled and ready")
         except Exception as e:
+            # Setup failed after possibly powering the port(s): teardown won't run (no yield),
+            # so power off what we tried to enable here, lest it linger into the next module.
+            try:
+                devices.disable(serial_number)
+            except Exception as cleanup_err:
+                log.warning(f"Cleanup after failed enable raised: {cleanup_err}")
             pytest.fail(f"Failed to enable devices: {e}")
         yield serial_number
         _teardown(serial_number)
@@ -607,6 +613,12 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         devices.enable_only([serial_number], recycle=recycle, disable_other_ports=disable_other_ports)
         log.debug(f"Device enabled and ready")
     except Exception as e:
+        # Setup failed after possibly powering the port: teardown won't run (no yield), so power
+        # off what we tried to enable here, lest it linger into the next module.
+        try:
+            devices.disable([serial_number])
+        except Exception as cleanup_err:
+            log.warning(f"Cleanup after failed enable raised: {cleanup_err}")
         pytest.fail(f"Failed to enable device {serial_number}: {e}")
 
     yield serial_number

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -18,6 +18,7 @@ and fixtures that pytest requires in conftest.py for auto-discovery.
 import pytest
 import sys
 import os
+import re
 import logging
 
 # Defense against ROS 2 launch.logging: when ROS is sourced, launch_testing's
@@ -56,7 +57,7 @@ from rspy import devices, repo
 from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
-    open_log, close_log, print_terminal_summary,
+    open_log, close_log, _compose_log_name, print_terminal_summary,
     configure_junit_logging,
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
@@ -415,6 +416,7 @@ def _test_log_banner(request):
     Setup-phase failures in module_device_setup happen BEFORE this fixture runs, so those paths
     emit the header themselves (via _emit_test_header) to keep the error anchored to its item."""
     _emit_test_header(request.node.nodeid)
+    _record_log_alias(request)
     yield
     ensure_newline()
 
@@ -561,6 +563,60 @@ def _device_log_id(serial):
     return f"{dev.name}-{serial}" if dev else serial
 
 
+# Per-item log filenames to hardlink onto a camera's collapsed log, keyed by the camera log's
+# absolute path. Lets Jenkins' per-case report links (which reconstruct <module>_<full-bracket>.log
+# per item) resolve to the collapsed file WITHOUT any Jenkins/deploy-repo change.
+_log_alias_registry = {}
+
+
+def _per_item_log_name(fspath, item_name):
+    """The legacy per-item log filename (full bracket id) Jenkins reconstructs for an item."""
+    m = re.search(r'\[(.+)\]', item_name)
+    return _compose_log_name(fspath, m.group(1) if m else None)
+
+
+def _record_log_alias(request):
+    """Record this item's per-item log filename so module_log teardown can link it to the camera's
+    collapsed log. No-op for non-device tests or when the per-item name already equals the camera
+    name (single-param modules -- the common case -- need no alias)."""
+    logdir = getattr(request.config, '_test_logdir', None)
+    cs = getattr(request.node, 'callspec', None)
+    device_id = _device_log_id(cs.params.get('_test_device_serial') if cs else None)
+    if not logdir or device_id is None:
+        return
+    fspath = str(request.node.fspath)
+    camera_name = _compose_log_name(fspath, device_id)
+    item_name = _per_item_log_name(fspath, request.node.name)
+    if item_name != camera_name:
+        _log_alias_registry.setdefault(os.path.join(logdir, camera_name), set()).add(item_name)
+
+
+def _create_log_aliases(config, fspath, device_id):
+    """Hardlink (copy fallback) each recorded per-item name to the camera's collapsed log, so a
+    multi-param module's per-case Jenkins links all resolve to the one camera file."""
+    logdir = getattr(config, '_test_logdir', None)
+    if not logdir or device_id is None:
+        return
+    camera_path = os.path.join(logdir, _compose_log_name(fspath, device_id))
+    names = _log_alias_registry.pop(camera_path, ())
+    if not names or not os.path.exists(camera_path):
+        return
+    for item_name in names:
+        alias = os.path.join(logdir, item_name)
+        if alias == camera_path:
+            continue
+        try:
+            if os.path.lexists(alias):
+                os.remove(alias)          # retries re-create the alias; replace any stale one
+            os.link(camera_path, alias)   # hardlink: no content copy, archived as a real file
+        except OSError:
+            try:
+                import shutil
+                shutil.copyfile(camera_path, alias)
+            except OSError as e:
+                log.warning(f"Could not create per-case log alias {alias}: {e}")
+
+
 @pytest.fixture(scope="module", autouse=True)
 def module_log(request, _test_device_serial):
     """Own the per-(module, camera) log file for the whole module lifecycle.
@@ -582,6 +638,8 @@ def module_log(request, _test_device_serial):
         yield
     finally:
         close_log(handler)
+        # link any extra-param cases' per-item names to this camera's collapsed log (Jenkins links)
+        _create_log_aliases(request.config, str(request.node.fspath), device_id)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -557,10 +557,13 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         return
 
     no_reset = request.config.getoption("--no-reset", default=False)
-    # Default: power-cycle the device and disable it on teardown (isolation comes from the
-    # previous module's teardown). --no-reset: isolate statelessly without a power-cycle and
-    # leave the device on (no teardown-disable), matching the legacy fast path.
-    recycle = not no_reset
+    # We don't recycle on setup: the device is already off (the previous module's teardown
+    # disabled it, or query()'s initial disable-all did), so enabling it here IS the power-on
+    # -- teardown-off + setup-on is the power cycle. A setup recycle would just re-disable an
+    # already-off port (extra hub traffic + wait + settle) for no benefit.
+    # Default: enable, then disable on teardown (isolation comes from the previous teardown).
+    # --no-reset: also isolate statelessly here and leave the device on (no teardown-disable).
+    recycle = False
     disable_other_ports = no_reset
     teardown_disable = not no_reset
 

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -56,7 +56,7 @@ from rspy import devices, repo
 from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
-    start_test_log, stop_test_log, print_terminal_summary,
+    open_log, close_log, print_terminal_summary,
     configure_junit_logging,
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
@@ -397,18 +397,17 @@ def pytest_collection_modifyitems(session, config, items):
     filter_and_sort_items(config, items)
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, nextitem):
-    """Wrap each test with log separators and write per-test log file."""
-    file_handler = start_test_log(item)
+@pytest.fixture(autouse=True)
+def _test_log_banner(request):
+    """Emit the per-test header into the log. Runs during test setup -- i.e. AFTER the
+    module-scoped log handler (module_log) is open and the device is enabled -- so the header
+    lands in the correct module+camera file. (Logging it from a per-test protocol hook instead
+    would race a parametrized module fixture's deferred teardown and land in the wrong file.)"""
     ensure_newline()
     log.info("-" * 80)
-    log.info(f"Test: {item.nodeid}")
+    log.info(f"Test: {request.node.nodeid}")
     log.info("-" * 80)
-
-    outcome = yield
-    stop_test_log(file_handler, nextitem)
-
+    yield
     ensure_newline()
 
 
@@ -523,7 +522,31 @@ def __pytest_repeat_step_number(request):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def module_device_setup(request, _test_device_serial, __pytest_repeat_step_number):
+def module_log(request, _test_device_serial):
+    """Own the per-(module, camera) log file for the whole module lifecycle.
+
+    Module-scoped so one file spans setup (device enable) -> every test -> teardown (device
+    disable). Depends on ``_test_device_serial`` so pytest re-instantiates it per camera (one file
+    per module+camera) and so it satisfies the cross-camera module-fixture guard. The filename's
+    device id is the test's parametrize id (e.g. ``D455-213522252012``), recovered from the
+    triggering item's callspec so it matches the legacy naming.
+
+    ``module_device_setup`` depends on this fixture, so the handler opens before the device is
+    enabled and closes after it is disabled -- keeping a parametrized module fixture's deferred
+    teardown (pytest runs the previous camera's teardown during the next camera's protocol) from
+    leaking the disable into the next camera's file.
+    """
+    item = getattr(request, '_pyfuncitem', None)
+    device_id = getattr(getattr(item, 'callspec', None), 'id', None)
+    handler = open_log(str(request.node.fspath), device_id, request.config)
+    try:
+        yield
+    finally:
+        close_log(handler)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def module_device_setup(request, _test_device_serial, __pytest_repeat_step_number, module_log):
     """Power the target device(s) on for the module and off again at teardown — once per
     (module, parametrized value).
 

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -557,13 +557,16 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         return
 
     no_reset = request.config.getoption("--no-reset", default=False)
-    # We don't recycle on setup: the device is already off (the previous module's teardown
-    # disabled it, or query()'s initial disable-all did), so enabling it here IS the power-on
-    # -- teardown-off + setup-on is the power cycle. A setup recycle would just re-disable an
-    # already-off port (extra hub traffic + wait + settle) for no benefit.
-    # Default: enable, then disable on teardown (isolation comes from the previous teardown).
-    # --no-reset: also isolate statelessly here and leave the device on (no teardown-disable).
-    recycle = False
+    # With a hub, we don't recycle on setup: the device is already off (the previous module's
+    # teardown disabled it, or query()'s initial disable-all did), so enabling it here IS the
+    # power-on -- teardown-off + setup-on is the power cycle. A setup recycle would just re-disable
+    # an already-off port (extra hub traffic + wait + settle) for no benefit.
+    # Without a hub (e.g. Jetson/MIPI), teardown-disable is a no-op (no port to power off), so the
+    # setup MUST recycle -- enable_only(recycle=True) falls back to hardware_reset() -- to clear any
+    # state a previous module left behind; otherwise the device is never reset between modules.
+    # Default: enable (recycle iff no hub), then disable on teardown (isolation from prev teardown).
+    # --no-reset: isolate statelessly here and leave the device on (no recycle, no teardown-disable).
+    recycle = (not no_reset) and devices.hub is None
     disable_other_ports = no_reset
     teardown_disable = not no_reset
 
@@ -612,7 +615,7 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     log.info(f"Configuration: {device_name} [{serial_number}]")
 
     try:
-        log.debug(f"{'Enabling' if no_reset else 'Recycling'} device via hub...")
+        log.debug(f"{'Recycling' if recycle else 'Enabling'} device...")
         devices.enable_only([serial_number], recycle=recycle, disable_other_ports=disable_other_ports)
         log.debug(f"Device enabled and ready")
     except Exception as e:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -557,16 +557,24 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         return
 
     no_reset = request.config.getoption("--no-reset", default=False)
-    # With a hub, we don't recycle on setup: the device is already off (the previous module's
-    # teardown disabled it, or query()'s initial disable-all did), so enabling it here IS the
-    # power-on -- teardown-off + setup-on is the power cycle. A setup recycle would just re-disable
-    # an already-off port (extra hub traffic + wait + settle) for no benefit.
-    # Without a hub (e.g. Jetson/MIPI), teardown-disable is a no-op (no port to power off), so the
-    # setup MUST recycle -- enable_only(recycle=True) falls back to hardware_reset() -- to clear any
-    # state a previous module left behind; otherwise the device is never reset between modules.
-    # Default: enable (recycle iff no hub), then disable on teardown (isolation from prev teardown).
-    # --no-reset: isolate statelessly here and leave the device on (no recycle, no teardown-disable).
-    recycle = (not no_reset) and devices.hub is None
+    # Decide whether setup power-cycles the device (vs just turning it on):
+    #  --no-reset            -> never recycle; isolate statelessly and leave the device on.
+    #  no hub (Jetson/MIPI)  -> recycle; teardown-disable is a no-op there, so enable_only(recycle=
+    #                           True) falls back to hardware_reset() to clear prior state.
+    #  hub, port already ON  -> recycle. The device should be OFF here (prev module's teardown
+    #                           disabled it, or query()'s initial disable-all did). A powered port
+    #                           means a teardown was skipped (crash/kill) and the device was left
+    #                           in an unknown state -> power-cycle it clean. Self-heals the
+    #                           within-session leak that the old recycle=True sweep used to catch.
+    #  hub, port OFF         -> don't recycle; enabling it here IS the power-on (teardown-off +
+    #                           setup-on = the cycle). Avoids re-disabling an already-off port.
+    serials = serial_number if isinstance(serial_number, list) else [serial_number]
+    if no_reset:
+        recycle = False
+    elif devices.hub is None:
+        recycle = True
+    else:
+        recycle = devices.any_port_powered(serials)
     disable_other_ports = no_reset
     teardown_disable = not no_reset
 

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -76,12 +76,12 @@ def _mock_get(sn):
 _dev.by_spec = _mock_by_spec
 _dev.get = _mock_get
 _dev._device_by_sn = {sn: FakeDevice(sn, n) for sn, n in _sn_map.items()}
-# Hub presence drives the conftest's recycle decision (recycle iff no hub). By default we model a
-# hub-equipped bench with a truthy sentinel -> "don't recycle on setup" (the teardown-disable does
-# the cycle). Set E2E_NO_HUB=1 to model a hub-less bench (e.g. Jetson) where teardown-disable is a
-# no-op and setup must recycle via hardware_reset. Port ops are mocked above, so the sentinel is
-# never actually used. init_hub is stubbed so the real one doesn't probe (absent) hardware.
-_dev.hub = None if os.environ.get('E2E_NO_HUB') else object()
+# Default: model a hub-equipped bench with a truthy sentinel. Port ops are mocked above, so the
+# object is never actually used. init_hub is stubbed so the real one doesn't probe (absent)
+# hardware and reset this back to None. A scenario test file can patch devices.hub /
+# devices.any_port_powered at import time (before fixtures run) to model a hub-less bench or a
+# port left powered -- see pytest-hubless-setup.py and pytest-port-already-on.py.
+_dev.hub = object()
 _dev.init_hub = lambda: None
 _dev._context = None
 def _mock_query(**kw):
@@ -90,6 +90,10 @@ def _mock_query(**kw):
 _dev.query = _mock_query
 _dev.map_unknown_ports = lambda: None
 _dev.wait_until_all_ports_disabled = lambda: None
+# Hub hardware port-state probe used by the conftest recycle decision. Default OFF (the previous
+# teardown powered the device down -> setup just enables). A scenario test file patches this to
+# True to model a port left powered by a skipped teardown -> setup recycles it clean.
+_dev.any_port_powered = lambda serials: False
 
 # Track enable_only / disable calls so tests can verify hub port behavior
 def _mock_enable_only(serials, recycle=True, timeout=None, disable_other_ports=False):

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -76,7 +76,12 @@ def _mock_get(sn):
 _dev.by_spec = _mock_by_spec
 _dev.get = _mock_get
 _dev._device_by_sn = {sn: FakeDevice(sn, n) for sn, n in _sn_map.items()}
-_dev.hub = None
+# Truthy sentinel: the port-management e2e tests model a hub-equipped bench, so the conftest's
+# recycle decision (recycle iff no hub) resolves to "don't recycle on setup". Port ops are mocked
+# above, so the object is never actually used. init_hub is stubbed so the real one doesn't probe
+# (absent) hardware and reset this back to None.
+_dev.hub = object()
+_dev.init_hub = lambda: None
 _dev._context = None
 def _mock_query(**kw):
     _tracking["query_kwargs"].append(kw)

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -76,11 +76,12 @@ def _mock_get(sn):
 _dev.by_spec = _mock_by_spec
 _dev.get = _mock_get
 _dev._device_by_sn = {sn: FakeDevice(sn, n) for sn, n in _sn_map.items()}
-# Truthy sentinel: the port-management e2e tests model a hub-equipped bench, so the conftest's
-# recycle decision (recycle iff no hub) resolves to "don't recycle on setup". Port ops are mocked
-# above, so the object is never actually used. init_hub is stubbed so the real one doesn't probe
-# (absent) hardware and reset this back to None.
-_dev.hub = object()
+# Hub presence drives the conftest's recycle decision (recycle iff no hub). By default we model a
+# hub-equipped bench with a truthy sentinel -> "don't recycle on setup" (the teardown-disable does
+# the cycle). Set E2E_NO_HUB=1 to model a hub-less bench (e.g. Jetson) where teardown-disable is a
+# no-op and setup must recycle via hardware_reset. Port ops are mocked above, so the sentinel is
+# never actually used. init_hub is stubbed so the real one doesn't probe (absent) hardware.
+_dev.hub = None if os.environ.get('E2E_NO_HUB') else object()
 _dev.init_hub = lambda: None
 _dev._context = None
 def _mock_query(**kw):
@@ -97,8 +98,8 @@ def _mock_enable_only(serials, recycle=True, timeout=None, disable_other_ports=F
     _save_tracking()
 _dev.enable_only = _mock_enable_only
 
-def _mock_disable(serials):
-    _tracking.setdefault("disable_calls", []).append({"serials": list(serials)})
+def _mock_disable(serials, wait=True):
+    _tracking.setdefault("disable_calls", []).append({"serials": list(serials), "wait": wait})
     _save_tracking()
 _dev.disable = _mock_disable
 

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -15,7 +15,7 @@ if _py_dir not in sys.path:
 # Fake pyrealsense2 — track log_to_console calls so tests can verify --rslog
 import json as _json
 _tracking_log = os.path.join(os.path.dirname(os.path.abspath(__file__)), '_tracking.json')
-_tracking = {"rslog_calls": [], "query_kwargs": [], "enable_only_calls": []}
+_tracking = {"rslog_calls": [], "query_kwargs": [], "enable_only_calls": [], "disable_calls": []}
 def _save_tracking():
     with open(_tracking_log, 'w') as _f:
         _json.dump(_tracking, _f)
@@ -85,11 +85,17 @@ _dev.query = _mock_query
 _dev.map_unknown_ports = lambda: None
 _dev.wait_until_all_ports_disabled = lambda: None
 
-# Track enable_only calls so tests can verify hub port behavior
-def _mock_enable_only(serials, recycle=True):
-    _tracking["enable_only_calls"].append({"serials": list(serials), "recycle": recycle})
+# Track enable_only / disable calls so tests can verify hub port behavior
+def _mock_enable_only(serials, recycle=True, timeout=None, disable_other_ports=False):
+    _tracking["enable_only_calls"].append(
+        {"serials": list(serials), "recycle": recycle, "disable_other_ports": disable_other_ports})
     _save_tracking()
 _dev.enable_only = _mock_enable_only
+
+def _mock_disable(serials):
+    _tracking.setdefault("disable_calls", []).append({"serials": list(serials)})
+    _save_tracking()
+_dev.disable = _mock_disable
 
 # exec() the REAL conftest.py
 _conftest_path = os.path.join(_unit_tests_dir, 'conftest.py')

--- a/unit-tests/infra-tests/e2e/pytest-hubless-setup.py
+++ b/unit-tests/infra-tests/e2e/pytest-hubless-setup.py
@@ -1,0 +1,13 @@
+# Model a hub-less bench (e.g. Jetson). Patch devices.hub to None at import -- this runs during
+# collection, before module_device_setup -- so the conftest recycle decision takes the no-hub
+# branch: teardown-disable is a no-op there, so setup recycles via enable_only(recycle=True)
+# (which falls back to hardware_reset on a real hub-less machine).
+import rspy.devices as _devices
+_devices.hub = None
+
+import pytest
+
+
+@pytest.mark.device("D455")
+def test_d455(module_device_setup):
+    assert module_device_setup == '111'

--- a/unit-tests/infra-tests/e2e/pytest-port-already-on.py
+++ b/unit-tests/infra-tests/e2e/pytest-port-already-on.py
@@ -1,0 +1,13 @@
+# Model a device whose hub port was left powered by a skipped/crashed teardown. Patch
+# any_port_powered -> True at import (before module_device_setup runs) so the conftest recycle
+# decision takes the "already powered" branch: setup recycles the device clean (recycle=True)
+# instead of reusing a possibly-bad state.
+import rspy.devices as _devices
+_devices.any_port_powered = lambda serials: True
+
+import pytest
+
+
+@pytest.mark.device("D455")
+def test_d455(module_device_setup):
+    assert module_device_setup == '111'

--- a/unit-tests/infra-tests/helpers.py
+++ b/unit-tests/infra-tests/helpers.py
@@ -138,12 +138,15 @@ _E2E_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'e2e')
 _E2E_CONFTEST = os.path.join(_E2E_DIR, 'e2e_conftest.py')
 
 
-def run_e2e(test_filename, *extra_pytest_args):
+def run_e2e(test_filename, *extra_pytest_args, env=None):
     """Run a pytest subprocess on a static test file from e2e/.
 
     Copies e2e_conftest.py and the test file to a temp dir for isolation
     from the parent unit-tests/conftest.py. No content is generated — both
     files are static and checked into the repo.
+
+    :param env: optional dict of extra environment variables for the subprocess
+                (e.g. {'E2E_NO_HUB': '1'} to model a hub-less bench).
 
     Returns (returncode, stdout, tracking) where tracking is a dict with:
         - enable_only_calls: list of {serials, recycle} dicts
@@ -156,13 +159,15 @@ def run_e2e(test_filename, *extra_pytest_args):
         shutil.copy(_E2E_CONFTEST, os.path.join(tmpdir, 'conftest.py'))
         shutil.copy(os.path.join(_E2E_DIR, test_filename), os.path.join(tmpdir, test_filename))
 
-        env = os.environ.copy()
-        env['INFRA_UNIT_TESTS_DIR'] = os.path.normpath(os.path.join(_E2E_DIR, '..', '..'))  # unit-tests/
+        sub_env = os.environ.copy()
+        sub_env['INFRA_UNIT_TESTS_DIR'] = os.path.normpath(os.path.join(_E2E_DIR, '..', '..'))  # unit-tests/
+        if env:
+            sub_env.update(env)
 
         p = subprocess.run(
             [sys.executable, "-m", "pytest", test_filename, "-v", *extra_pytest_args],
             cwd=tmpdir,
-            env=env,
+            env=sub_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,

--- a/unit-tests/infra-tests/helpers.py
+++ b/unit-tests/infra-tests/helpers.py
@@ -176,7 +176,7 @@ def run_e2e(test_filename, *extra_pytest_args):
 
         tracking_file = os.path.join(tmpdir, '_tracking.json')
         tracking = json.loads(open(tracking_file).read()) if os.path.exists(tracking_file) else {
-            "enable_only_calls": [], "rslog_calls": [], "query_kwargs": []
+            "enable_only_calls": [], "rslog_calls": [], "query_kwargs": [], "disable_calls": []
         }
 
         return p.returncode, p.stdout, tracking

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -115,9 +115,10 @@ class TestCliOptionsRegistered:
                                      "--repeat", "3", "--no-reset")
         assert_outcomes(out, passed=3)
         calls = tracking["enable_only_calls"]
-        # First run enables without recycle, subsequent runs skip enable_only entirely
-        assert len(calls) == 1
-        assert calls[0]['recycle'] is False
+        # The module fixture re-instantiates per repeat pass and enables (without power-cycling)
+        # each time; --no-reset only suppresses the recycle, not the (idempotent) enable.
+        assert len(calls) == 3
+        assert all(c['recycle'] is False for c in calls)
 
     def test_device_nonexistent(self):
         """--device D999 with no matching device should produce 0 parametrized instances."""

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -79,7 +79,9 @@ class TestCliOptionsRegistered:
         calls = tracking["enable_only_calls"]
         # Two enable_only calls: initial module-fixture creation + post-retry-teardown re-creation.
         assert len(calls) == 2
-        assert all(c['recycle'] is True for c in calls)
+        assert all(c['recycle'] is False for c in calls)
+        # the device recycle now comes from the teardown-disable between attempts, not recycle=True
+        assert len(tracking["disable_calls"]) >= 1
 
     def test_retries_recreate_module_fixture(self):
         """Module-scoped fixtures must be torn down and re-instantiated between
@@ -101,13 +103,15 @@ class TestCliOptionsRegistered:
         assert rc == 0
 
     def test_repeat(self):
-        """--repeat 3 should repeat the test 3 times, recycling the device each time."""
+        """--repeat 3 repeats the test 3 times; each pass power-cycles the device via
+        teardown-disable + setup-enable (setup itself uses recycle=False)."""
         rc, out, tracking = run_e2e("pytest-device-setup.py", "-k", "test_d455 and not excluded",
                                      "--repeat", "3")
         assert_outcomes(out, passed=3)
         calls = tracking["enable_only_calls"]
         assert len(calls) == 3
-        assert all(c['recycle'] is True for c in calls)
+        assert all(c['recycle'] is False for c in calls)
+        assert len(tracking["disable_calls"]) >= 1  # teardown disables each pass -> the cycle
 
     def test_repeat_no_reset(self):
         """--repeat 3 --no-reset should repeat without recycling."""
@@ -115,10 +119,11 @@ class TestCliOptionsRegistered:
                                      "--repeat", "3", "--no-reset")
         assert_outcomes(out, passed=3)
         calls = tracking["enable_only_calls"]
-        # The module fixture re-instantiates per repeat pass and enables (without power-cycling)
-        # each time; --no-reset only suppresses the recycle, not the (idempotent) enable.
+        # --no-reset re-enables each pass but never disables on teardown, so the device is
+        # NOT power-cycled (left on) -- the distinguishing behavior vs the default path.
         assert len(calls) == 3
         assert all(c['recycle'] is False for c in calls)
+        assert tracking["disable_calls"] == []
 
     def test_device_nonexistent(self):
         """--device D999 with no matching device should produce 0 parametrized instances."""

--- a/unit-tests/infra-tests/test_e2e_port_management.py
+++ b/unit-tests/infra-tests/test_e2e_port_management.py
@@ -25,6 +25,17 @@ class TestDevicePortManagement:
         assert tracking["enable_only_calls"][0]['serials'] == ['111']
         assert tracking["enable_only_calls"][0]['recycle'] is False
 
+    def test_hubless_recycles_via_hw_reset(self):
+        """On a hub-less bench (e.g. Jetson) teardown-disable is a no-op, so setup MUST recycle --
+        enable_only(recycle=True) falls back to hardware_reset. With a hub it's recycle=False (the
+        teardown-disable does the cycle); E2E_NO_HUB=1 flips devices.hub to None to exercise the
+        hub-less branch of `recycle = (not no_reset) and devices.hub is None`."""
+        rc, out, tracking = run_e2e("pytest-device-setup.py", "-k", "test_d455 and not excluded",
+                                     env={"E2E_NO_HUB": "1"})
+        assert_outcomes(out, passed=1)
+        assert len(tracking["enable_only_calls"]) == 1
+        assert tracking["enable_only_calls"][0]['recycle'] is True
+
     def test_device_each_enables_one_port_per_test(self):
         """@device_each('D400*') should call enable_only once per device (recycle=False)."""
         rc, out, tracking = run_e2e("pytest-each-setup.py", "-k", "test_d400 and not d999")

--- a/unit-tests/infra-tests/test_e2e_port_management.py
+++ b/unit-tests/infra-tests/test_e2e_port_management.py
@@ -17,21 +17,22 @@ from helpers import run_e2e, assert_outcomes
 class TestDevicePortManagement:
 
     def test_device_marker_enables_correct_port(self):
-        """@device('D455') should call enable_only(['111'], recycle=True)."""
+        """@device('D455') enables the device (recycle=False -- the power cycle is
+        teardown-disable + setup-enable, so setup itself doesn't recycle)."""
         rc, out, tracking = run_e2e("pytest-device-setup.py", "-k", "test_d455 and not excluded")
         assert_outcomes(out, passed=1)
         assert len(tracking["enable_only_calls"]) == 1
         assert tracking["enable_only_calls"][0]['serials'] == ['111']
-        assert tracking["enable_only_calls"][0]['recycle'] is True
+        assert tracking["enable_only_calls"][0]['recycle'] is False
 
     def test_device_each_enables_one_port_per_test(self):
-        """@device_each('D400*') should call enable_only once per device, each with recycle=True."""
+        """@device_each('D400*') should call enable_only once per device (recycle=False)."""
         rc, out, tracking = run_e2e("pytest-each-setup.py", "-k", "test_d400 and not d999")
         assert_outcomes(out, passed=3)
         assert len(tracking["enable_only_calls"]) == 3
         serials_enabled = [c['serials'][0] for c in tracking["enable_only_calls"]]
         assert set(serials_enabled) == {'111', '222', '777'}
-        assert all(c['recycle'] is True for c in tracking["enable_only_calls"])
+        assert all(c['recycle'] is False for c in tracking["enable_only_calls"])
         assert all(len(c['serials']) == 1 for c in tracking["enable_only_calls"])
 
     def test_second_test_same_device_no_recycle(self):

--- a/unit-tests/infra-tests/test_e2e_port_management.py
+++ b/unit-tests/infra-tests/test_e2e_port_management.py
@@ -27,11 +27,18 @@ class TestDevicePortManagement:
 
     def test_hubless_recycles_via_hw_reset(self):
         """On a hub-less bench (e.g. Jetson) teardown-disable is a no-op, so setup MUST recycle --
-        enable_only(recycle=True) falls back to hardware_reset. With a hub it's recycle=False (the
-        teardown-disable does the cycle); E2E_NO_HUB=1 flips devices.hub to None to exercise the
-        hub-less branch of `recycle = (not no_reset) and devices.hub is None`."""
-        rc, out, tracking = run_e2e("pytest-device-setup.py", "-k", "test_d455 and not excluded",
-                                     env={"E2E_NO_HUB": "1"})
+        enable_only(recycle=True) falls back to hardware_reset. pytest-hubless-setup.py patches
+        devices.hub to None to exercise the no-hub branch of the conftest recycle decision."""
+        rc, out, tracking = run_e2e("pytest-hubless-setup.py")
+        assert_outcomes(out, passed=1)
+        assert len(tracking["enable_only_calls"]) == 1
+        assert tracking["enable_only_calls"][0]['recycle'] is True
+
+    def test_port_already_on_recycles(self):
+        """With a hub, setup expects the device OFF (prev teardown disabled it). If a required port
+        is still powered -- a skipped/crashed teardown -- setup recycles it clean instead of reusing
+        a stale state. pytest-port-already-on.py patches any_port_powered -> True for this branch."""
+        rc, out, tracking = run_e2e("pytest-port-already-on.py")
         assert_outcomes(out, passed=1)
         assert len(tracking["enable_only_calls"]) == 1
         assert tracking["enable_only_calls"][0]['recycle'] is True

--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -332,7 +332,16 @@ class Acroname(device_hub.device_hub):
                     # We don't know how to get the port from these yet!
                     return None  # int(match.group(2))
                 else:
-                    split_location = [int(x) for x in usb_location.split('.')]
+                    # Windows LocationInformation fields are hex (e.g. "0000.000d.0000.003.002...").
+                    # Parse base-16 so fields like "000d" don't raise; only the last two non-zero
+                    # indices (acroname sub-hub port + device port) are used and those are small
+                    # (<=4), so hex vs decimal is identical for them. Unparseable -> defer to
+                    # map_unknown_ports() enumeration.
+                    try:
+                        split_location = [int(x, 16) for x in usb_location.split('.')]
+                    except ValueError:
+                        log.d(f'could not parse usb location {usb_location!r}; deferring to port mapping')
+                        return None
                     # lambda helper to return the last 2 non-zero numbers, used when connecting using an additional hub
                     # ex: laptop -> hub -> acroname
                     get_last_two_digits = lambda array: tuple(
@@ -414,7 +423,8 @@ def get_port_from_usb(first_usb_index, second_usb_index ):
                              (3, 2): 6,
                              (3, 1): 7,
                              }
-    return acroname_port_usb_map[(first_usb_index, second_usb_index)]
+    # .get() -> None for an unmapped topology so the caller falls back to map_unknown_ports()
+    return acroname_port_usb_map.get( (first_usb_index, second_usb_index) )
 
 
 

--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -388,6 +388,9 @@ class Acroname(device_hub.device_hub):
                         match = re.search(r'^(\d+)\.(\d+)', usb_location[len(port) + 1:])
                         if match:
                             return get_port_from_usb(int(match.group(1)), int(match.group(2)))
+                # no known acroname hub prefixes this location (or sub-ports unparseable) -- log so a
+                # misconfigured intermediate hub is diagnosable, then defer to map_unknown_ports()
+                log.d( f'usb location {usb_location!r} not under a known acroname hub; deferring to port mapping' )
 
 specs = None
 def discover(retries = 0):
@@ -429,8 +432,13 @@ def get_port_from_usb(first_usb_index, second_usb_index ):
                              (3, 2): 6,
                              (3, 1): 7,
                              }
-    # .get() -> None for an unmapped topology so the caller falls back to map_unknown_ports()
-    return acroname_port_usb_map.get( (first_usb_index, second_usb_index) )
+    # .get() -> None for an unmapped topology so the caller falls back to map_unknown_ports().
+    # Log the miss (pre-PR this raised KeyError which the caller logged) so an operator with a
+    # misconfigured intermediate hub has a signal explaining why a device ended up unmapped.
+    port = acroname_port_usb_map.get( (first_usb_index, second_usb_index) )
+    if port is None:
+        log.d( f'unmapped acroname topology ({first_usb_index},{second_usb_index}); deferring to port mapping' )
+    return port
 
 
 

--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -347,7 +347,13 @@ class Acroname(device_hub.device_hub):
                     get_last_two_digits = lambda array: tuple(
                         reversed(list(reversed([i for i in array if i != 0]))[:2]))
                     # only the last two digits are necessary
-                    first_index, second_index = get_last_two_digits(split_location)
+                    last_two = get_last_two_digits(split_location)
+                    if len(last_two) < 2:
+                        # fewer than two non-zero fields (e.g. all-zero or single-field location):
+                        # not enough to identify a sub-hub+port pair -> defer to port mapping
+                        log.d(f'usb location {usb_location!r} has <2 non-zero fields; deferring to port mapping')
+                        return None
+                    first_index, second_index = last_two
 
                     return get_port_from_usb(first_index, second_index)
     else:

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -661,6 +661,29 @@ def enable_all():
     hub.enable_ports()
 
 
+def any_port_powered( serial_numbers ):
+    """
+    True if any of the given serials maps to a hub port that is currently powered on.
+
+    Uses the hub's hardware port state (hub.is_port_enabled), NOT the SDK enabled() -- so it is
+    reliable even when a device hasn't (re-)enumerated. Lets a setup detect a device left powered
+    by a skipped/crashed teardown so it can recycle it clean rather than reuse a stale state.
+    Returns False without a hub or for serials with no hub port (e.g. non-hub DDS devices).
+
+    A powered port here is unexpected (setup expects the device OFF -- prev teardown or query()'s
+    disable-all should have cleared it), so we log a warning naming the offender before returning.
+    """
+    if not hub:
+        return False
+    for sn in serial_numbers:
+        dev = get( sn )
+        if dev and dev.port is not None and hub.is_port_enabled( dev.port ):
+            log.w( f'{sn} port {dev.port} still powered at setup -- a prior teardown was likely '
+                   f'skipped (crash/kill); recycling to a clean state' )
+            return True
+    return False
+
+
 def disable( serial_numbers, wait = True ):
     """
     Disable the hub ports for the given serial-numbers and, by default, wait until the devices

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -592,19 +592,23 @@ def recovery():
     return { device.serial_number for device in _device_by_sn.values() if device.handle.is_in_recovery_mode() }
 
 
-def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME ):
+def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME, disable_other_ports = False ):
     """
-    Enable only the devices corresponding to the given serial-numbers. This can work either
-    with or without a hub: without, the devices will simply be HW-reset, but other devices
-    will still be present.
+    Enable the devices corresponding to the given serial-numbers and wait until they are online.
+    Works with or without a hub: without one the devices are simply HW-reset (recycle) and other
+    devices remain present.
 
     NOTE: will raise an exception if any SN is unknown!
 
-    :param serial_numbers: A collection of serial-numbers to enable - all others' ports are
-                           disabled and will no longer be usable!
-    :param recycle: If False, the devices will not be reset if they were already enabled. If
-                    True, the devices will be recycled by disabling the port, waiting, then
-                    re-enabling
+    Port state is intentionally NOT tracked here -- callers own it via their own lifecycle:
+    the pytest harness disables its device on fixture teardown; the legacy harness passes
+    disable_other_ports=True so each setup isolates statelessly.
+
+    :param serial_numbers: serial-numbers to enable.
+    :param recycle: If True, power-cycle the requested device(s) -- disable the port, wait for
+                    removal, then re-enable -- to reset them to a clean state.
+    :param disable_other_ports: If True, disable every other hub port so only the requested
+                    device(s) remain powered (stateless isolation).
     :param timeout: The maximum seconds to wait to make sure the devices are indeed online
     """
     if recycle:
@@ -616,28 +620,18 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
         ports = [ get( sn ).port for sn in serial_numbers ]
         # DDS (and other non-hub) devices have port=None; filter them out of hub operations
         wanted_ports = sorted( p for p in ports if p is not None )
-        enabled_ports = [ get( sn ).port for sn in enabled() if get( sn ).port is not None ]
         #
-        if recycle:
-            #
-            if not wanted_ports and not enabled_ports:
-                log.d( 'no hub ports to recycle; leaving hub as-is' )
-            elif enabled_ports:
-                log.d( 'enabling ports', wanted_ports,
-                       'disabling currently enabled ports', enabled_ports )
-                sns_to_remove = { sn for sn in enabled() if get( sn ).port in enabled_ports }
-                hub.disable_ports( enabled_ports )
-                _wait_until_removed( sns_to_remove, timeout = timeout )
-            #
-            if wanted_ports:
-                hub.enable_ports( wanted_ports )
-            #
+        if not wanted_ports:
+            log.d( 'no hub ports to enable; leaving hub as-is' )
+        elif recycle:
+            log.d( 'recycling ports', wanted_ports, '+ disabling others' if disable_other_ports else '' )
+            recycled_sns = { sn for sn in serial_numbers if get( sn ) and get( sn ).port is not None }
+            hub.disable_ports( wanted_ports )
+            _wait_until_removed( recycled_sns, timeout = timeout )
+            hub.enable_ports( wanted_ports, disable_other_ports = disable_other_ports )
         else:
-            #
-            if wanted_ports:
-                hub.enable_ports( wanted_ports, disable_other_ports = True )
-            else:
-                log.d( 'no hub ports to enable; leaving hub as-is' )
+            log.d( 'enabling ports', wanted_ports, '+ disabling others' if disable_other_ports else '' )
+            hub.enable_ports( wanted_ports, disable_other_ports = disable_other_ports )
         #
         if not _wait_for( serial_numbers, timeout = timeout ):
             raise TimeoutError( f'devices did not enumerate within {timeout}s after hub enable: {serial_numbers}' )
@@ -659,6 +653,20 @@ def enable_all():
     Enables all ports on the hub -- without a hub, this does nothing!
     """
     hub.enable_ports()
+
+
+def disable( serial_numbers ):
+    """
+    Disable the hub ports for the given serial-numbers. No-op without a hub or for devices
+    with no hub port (e.g. non-hub DDS devices). Used by the pytest harness to power off a
+    device on fixture teardown -- the counterpart to enable_only() at setup.
+    """
+    if not hub:
+        return
+    ports = sorted( get( sn ).port for sn in serial_numbers
+                    if get( sn ) and get( sn ).port is not None )
+    if ports:
+        hub.disable_ports( ports )
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -655,18 +655,27 @@ def enable_all():
     hub.enable_ports()
 
 
-def disable( serial_numbers ):
+def disable( serial_numbers, wait = True ):
     """
-    Disable the hub ports for the given serial-numbers. No-op without a hub or for devices
-    with no hub port (e.g. non-hub DDS devices). Used by the pytest harness to power off a
-    device on fixture teardown -- the counterpart to enable_only() at setup.
+    Disable the hub ports for the given serial-numbers and, by default, wait until the devices
+    are actually removed. No-op without a hub or for devices with no hub port (e.g. non-hub DDS
+    devices). Used by the pytest harness to power off a device on fixture teardown -- the
+    counterpart to enable_only() at setup.
+
+    Waiting matters for slow-dropping DDS/PoE devices (participant-lease latency, ~8s): without
+    it the removal can land during the *next* module's test and race its device discovery
+    (observed as a flaky 'Advanced mode expects camera to have a depth sensor' at setup). This
+    mirrors the _wait_until_removed() that enable_only(recycle=True) does on the enable path.
     """
     if not hub:
         return
-    ports = sorted( get( sn ).port for sn in serial_numbers
-                    if get( sn ) and get( sn ).port is not None )
-    if ports:
-        hub.disable_ports( ports )
+    sns = [ sn for sn in serial_numbers if get( sn ) and get( sn ).port is not None ]
+    ports = sorted( get( sn ).port for sn in sns )
+    if not ports:
+        return
+    hub.disable_ports( ports )
+    if wait:
+        _wait_until_removed( set( sns ) )
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -675,7 +675,10 @@ def disable( serial_numbers, wait = True ):
         return
     hub.disable_ports( ports )
     if wait:
-        _wait_until_removed( set( sns ) )
+        if not _wait_until_removed( set( sns ) ):
+            # don't fail teardown over this, but surface it: a port that didn't drop in time can
+            # linger into the next module and race its device discovery (the very thing wait guards)
+            log.w( f'disable: devices not removed within timeout: {sns}' )
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -604,6 +604,12 @@ def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME
     the pytest harness disables its device on fixture teardown; the legacy harness passes
     disable_other_ports=True so each setup isolates statelessly.
 
+    Note: leak recovery is per-session -- query() disables all ports at session start, but a
+    within-session crash that skips a fixture teardown will leave that device powered until the
+    next session (the previous recycle=True path used to disable all enabled ports here, which
+    acted as a within-session net; that net is gone). Callers needing stronger isolation against
+    a leaked port should pass disable_other_ports=True.
+
     :param serial_numbers: serial-numbers to enable.
     :param recycle: If True, power-cycle the requested device(s) -- disable the port, wait for
                     removal, then re-enable -- to reset them to a clean state.
@@ -666,6 +672,10 @@ def disable( serial_numbers, wait = True ):
     it the removal can land during the *next* module's test and race its device discovery
     (observed as a flaky 'Advanced mode expects camera to have a depth sensor' at setup). This
     mirrors the _wait_until_removed() that enable_only(recycle=True) does on the enable path.
+
+    A timed-out wait is non-fatal BY DESIGN: failing a teardown mis-attributes the error to the
+    test that just passed, and a transient hub blip would redden an otherwise-green suite. We log
+    loudly instead so a downstream flake can be traced back here -- do not "fix" this by raising.
     """
     if not hub:
         return
@@ -676,9 +686,9 @@ def disable( serial_numbers, wait = True ):
     hub.disable_ports( ports )
     if wait:
         if not _wait_until_removed( set( sns ) ):
-            # don't fail teardown over this, but surface it: a port that didn't drop in time can
-            # linger into the next module and race its device discovery (the very thing wait guards)
-            log.w( f'disable: devices not removed within timeout: {sns}' )
+            # non-fatal by design (see docstring): surface loudly so a downstream flake is traceable
+            log.w( f'disable: {sns} still enumerated after {PORTS_DISABLED_TIMEOUT}s; '
+                   f'next module setup may race their removal' )
 
 
 def _wait_until_removed( serial_numbers, timeout = PORTS_DISABLED_TIMEOUT ):

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -706,6 +706,9 @@ def disable( serial_numbers, wait = True ):
     ports = sorted( get( sn ).port for sn in sns )
     if not ports:
         return
+    # let the last command to the device/FW settle before we cut power, so we don't yank power
+    # mid-transaction (mirrors the pre-recycle settle in enable_only)
+    time.sleep( 1 )
     hub.disable_ports( ports )
     if wait:
         if not _wait_until_removed( set( sns ) ):

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -37,11 +37,6 @@ _unit_tests_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..',
 # Live-logging state: set to True when -s is passed (stdout not captured)
 live_logging = False
 
-# Per-module+device log handler tracking
-_current_log_key = None       # (fspath, device_id) tuple
-_current_file_handler = None
-
-
 def bridge_rspy_log():
     """Wrap rspy.log.d/i/w/e to also emit via Python logging."""
     def _wrap(original_fn, py_level):
@@ -178,67 +173,6 @@ def _log_key(item):
     return (str(item.fspath), device_id)
 
 
-def start_test_log(item):
-    """Open a per-module+device FileHandler. Reuses the existing handler when the key
-    (file + device param) hasn't changed, so all tests for the same module+device
-    share a single .log file.
-
-    Returns the FileHandler (to pass to stop_test_log), or None if logging is
-    not applicable (e.g. -s mode or no log directory configured).
-    """
-    global _current_log_key, _current_file_handler
-
-    logdir = getattr(item.config, '_test_logdir', None)
-    capture = item.config.getoption('capture', default='fd')
-
-    if not logdir or capture == 'no':
-        return None
-
-    key = _log_key(item)
-    if key == _current_log_key and _current_file_handler is not None:
-        return None  # reuse existing handler
-
-    # Key changed — close previous handler if any
-    if _current_file_handler is not None:
-        logging.getLogger().removeHandler(_current_file_handler)
-        _current_file_handler.close()
-        _current_file_handler = None
-        _current_log_key = None
-
-    log_name = test_log_name(item)
-    log_path = os.path.join(logdir, log_name)
-    try:
-        # mode='w': retries of the same (file, device) overwrite the previous
-        # pass's log so the Jenkins report links to the latest attempt.
-        # Appending would interleave timestamps from different passes.
-        file_handler = logging.FileHandler(log_path, mode='w')
-        file_handler.setFormatter(_NestedFormatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
-        file_handler.setLevel(logging.DEBUG)
-        logging.getLogger().addHandler(file_handler)
-        _current_log_key = key
-        _current_file_handler = file_handler
-        return file_handler
-    except Exception as e:
-        log.warning(f"Could not create test log file {log_path}: {e}")
-        return None
-
-
-def stop_test_log(handler, nextitem):
-    """Close the per-module+device FileHandler only when the next test has a different
-    key (different file or device) or when the session is ending (nextitem is None)."""
-    global _current_log_key, _current_file_handler
-
-    if _current_file_handler is None:
-        return
-
-    next_key = _log_key(nextitem)
-    if next_key == _current_log_key:
-        return  # next test shares the same log file
-
-    logging.getLogger().removeHandler(_current_file_handler)
-    _current_file_handler.close()
-    _current_file_handler = None
-    _current_log_key = None
 
 
 def print_terminal_summary(terminalreporter):
@@ -284,19 +218,17 @@ def ensure_newline():
         sys.stdout.flush()
 
 
-def test_log_name(item):
-    """Derive log filename from directory path + file basename + device param.
+def _compose_log_name(file_path, device_id):
+    """Build the log filename from a module file path + optional device param id.
 
     Mirrors the legacy run-unit-tests.py naming: directory components (relative to
     unit-tests/) are joined with '-' and prepended to the file's short name.
 
     Examples:
-      'live/frames/pytest-t2ff-pipeline.py::test_x[D455-104623060005]' -> 'pytest-live-frames-t2ff-pipeline_D455-104623060005.log'
-      'live/frames/pytest-t2ff-pipeline.py::test_x'                   -> 'pytest-live-frames-t2ff-pipeline.log'
-      'pytest-standalone.py::test_x'                                   -> 'pytest-standalone.log'
+      ('live/frames/pytest-t2ff-pipeline.py', 'D455-104623060005') -> 'pytest-live-frames-t2ff-pipeline_D455-104623060005.log'
+      ('live/frames/pytest-t2ff-pipeline.py', None)                -> 'pytest-live-frames-t2ff-pipeline.log'
+      ('pytest-standalone.py', None)                                -> 'pytest-standalone.log'
     """
-    file_path = str(item.fspath)
-
     # Resolve relative path within the unit-tests tree
     normalized = file_path.replace(os.sep, '/')
     marker = 'unit-tests/'
@@ -321,12 +253,50 @@ def test_log_name(item):
         dir_parts = dirname.replace('/', '-')
         basename = f"pytest-{dir_parts}-{basename[len('pytest-'):]}"
 
-    match = re.search(r'\[(.+)\]', item.name)
-    if match:
-        device_id = match.group(1)
-        log_name = f"{basename}_{device_id}"
-    else:
-        log_name = basename
-
+    log_name = f"{basename}_{device_id}" if device_id else basename
     log_name = re.sub(r'[<>:"/\\|?*]', '_', log_name)
     return log_name + ".log"
+
+
+def test_log_name(item):
+    """Derive log filename from a test item (directory path + file basename + device param)."""
+    match = re.search(r'\[(.+)\]', item.name)
+    device_id = match.group(1) if match else None
+    return _compose_log_name(str(item.fspath), device_id)
+
+
+def open_log(file_path, device_id, config):
+    """Open a per-(module, device) FileHandler on the root logger and return it (or None when
+    logging is off -- ``-s`` capture mode or no log dir configured).
+
+    The caller is the module-scoped log fixture, which closes this via ``close_log`` at module
+    teardown. Because the handler is owned by the module+device fixture lifecycle (not the per-test
+    protocol hook), the *whole* module+camera run -- device enable at setup, every test, device
+    disable at teardown -- lands in one file. This is what keeps a parametrized module fixture's
+    deferred teardown (pytest runs the previous param's teardown during the next param's protocol)
+    from leaking the disable into the next camera's log file.
+    """
+    logdir = getattr(config, '_test_logdir', None)
+    capture = config.getoption('capture', default='fd')
+    if not logdir or capture == 'no':
+        return None
+    log_path = os.path.join(logdir, _compose_log_name(file_path, device_id))
+    try:
+        # mode='w': retries/repeats of the same (module, device) overwrite the previous pass's
+        # log so the Jenkins report links to the latest attempt (appending would interleave passes).
+        handler = logging.FileHandler(log_path, mode='w')
+        handler.setFormatter(_NestedFormatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+        handler.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(handler)
+        return handler
+    except Exception as e:
+        log.warning(f"Could not create test log file {log_path}: {e}")
+        return None
+
+
+def close_log(handler):
+    """Detach and close a handler returned by open_log (no-op if None)."""
+    if handler is None:
+        return
+    logging.getLogger().removeHandler(handler)
+    handler.close()

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -527,7 +527,7 @@ def test_wrapper( test, configuration=None, repetition=1, serial_numbers=None, c
             if no_reset or not serial_numbers:
                 time.sleep(1)  # small pause between tries
             else:
-                devices.enable_only( serial_numbers, recycle=True )
+                devices.enable_only( serial_numbers, recycle=True, disable_other_ports=True )
         if test_wrapper_( test, configuration, repetition, retry, retry_count, serial_numbers,
                           custom_fw_d400_override=custom_fw_d400_override ):
             return True
@@ -732,7 +732,9 @@ try:
                         log.d( 'configuration:', configuration_str( configuration, repetition, sns=serial_numbers ) )
                         log.debug_indent()
                         should_reset = not no_reset
-                        devices.enable_only( serial_numbers, recycle=should_reset )
+                        # Legacy harness has no teardown hook, so isolate statelessly each test:
+                        # enable the wanted device(s) and disable every other port.
+                        devices.enable_only( serial_numbers, recycle=should_reset, disable_other_ports=True )
                     except (RuntimeError, TimeoutError, OSError) as e:
                         log.w( log.red + test.name + log.reset + ': ' + str( e ) )
                         test_ok = False


### PR DESCRIPTION
**Overview:** Make CI device port-management own its state through the test lifecycle (enable on setup, disable on teardown) instead of inferring it from the SDK's live device view. This fixes the nightly `test-dds-adapter-depth` regression, removes the fragile global port tracking, and makes repeat/retry behave correctly for free.

## Motivation
Nightly CI failed `test-dds-adapter-depth`: the test expects exactly one DDS device but saw two and timed out. Root cause: after `test-fw-update` reflashes the **D555**, the device reboots and the SDK momentarily stops reporting it (`enabled()` goes stale). The per-test port recycle decided *which ports to disable* from `enabled()` -- so the rebooting D555's hub port was **never disabled**, it stayed powered, lingered on the DDS domain, and polluted the next test.

More broadly the device-management layer had grown fragile:
- A global `_enabled_ports` set reconciled against SDK callbacks -- which **lag reality** for DDS devices (a flashed D555 isn't re-seen by a long-lived context until a full re-query).
- Port "recycle" decisions were coupled to that stale view, and to pytest-repeat / pytest-retry internals.

## What we did
- **`enable_only` is now stateless** (`rspy/devices.py`): no global tracking, no `enabled()` reconciliation. `recycle` = disable -> *wait for removal* -> re-enable the wanted set; new `disable_other_ports=` isolates at the hub when asked.
- **New `devices.disable(serials)`** -- the teardown counterpart -- which **waits for the device to actually be removed**, mirroring the enable path's `_wait_for`. This prevents a slow DDS/PoE drop (~8s lease latency) from landing inside the *next* module's test and racing its device discovery.
- **Pytest (`conftest.py`):** `module_device_setup` recast to a **paired enable-on-setup / disable-on-teardown** fixture, running once per **(module, device)**. `autouse=True` preserved (some tests build their own `rs.context()` and rely on it). Added setup-failure cleanup (a failed enable powers its own port back off); `--no-reset` isolates without a power-cycle and leaves the device on; retired the `_module_last_serial` bookkeeping.
- **Legacy harness (`run-unit-tests.py`):** isolates statelessly per test via `disable_other_ports=True` (small suite, no state to keep).
- **Windows Acroname fix (`rspy/acroname.py`):** parse USB `LocationInformation` fields as **hex** (e.g. `0000.000d.0000...`) so device-to-port mapping works on Windows; unparseable/unmapped topology returns `None` and falls back to `map_unknown_ports()` instead of raising.
- **infra-tests:** e2e mock updated to the new `enable_only` signature + tracks `disable`; one CLI behavior test updated (`--no-reset`+`--repeat` enables each pass without recycling).

## What we gained
- **The regression is fixed.** Port management no longer depends on `enabled()`, so a flashed/rebooting D555 gets its port powered off regardless of whether the SDK currently sees it -- it no longer lingers on the DDS domain.
- **Correct, symmetric power handling:** every device is powered on at setup (waited until online) and off at teardown (waited until removed) -- no overlap bleeding into the next test.
- **Simpler and self-correcting:** the global `_enabled_ports` tracking is gone; **retry and repeat power-cycle the device "for free"** via pytest re-instantiating the module fixture (teardown disable -> setup enable), with no special-case code.
- **Cross-platform device-to-port mapping** (Windows Acroname hex locations fixed), and **multi-camera** support via the same per-(module, device) lifecycle.

## Testing
- infra-tests: **119 passed, 9 skipped, 0 failed**.
- Real Acroname hub: `disable_other_ports=True` isolation, `disable()` power-off, and the recycle pattern verified; Windows location-to-port mapping verified (D455 -> port 0, D435I -> port 2).
- Full pytest flow on hardware: `device_each` parametrizes per device and `module_device_setup` runs once per (module, device).
- **Nightly #16926** (Linux + Windows, nightly FW `D555 7.58.40002`): `test-dds-adapter-depth` **passed on both platforms** (the runs that previously failed it). It surfaced a teardown/DDS-removal race that flaked an unrelated test (`test_legacy_firmware_logger`) and tripped a pytest-retry teardown error -- fixed by the `devices.disable()` removal-wait.
- **Nightly #16928 (re-validation): SUCCESS on all platforms** (Linux #14182, Windows #114767, Calibration, Image Quality, Jetson JP5/JP6). `test_legacy_firmware_logger` now **passes cleanly on the first attempt** (no retries, no StashKey error) and `test-dds-adapter-depth` passes -- confirming the DDS-removal race was the root cause and the teardown-wait resolves it.

Jira: RSDSO-21630

🤖 Generated by AI
