### PR TITLE
Embed tests' logs into JUnit XML for the Jenkins Test Result page

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -57,7 +57,7 @@ from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
     start_test_log, stop_test_log, print_terminal_summary,
-    configure_junit_failure_logging,
+    configure_junit_logging,
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
 from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
@@ -417,7 +417,7 @@ def pytest_runtest_makereport(item, call):
 
 def pytest_sessionstart(session):
     """Configure the junitxml plugin once it exists (after pytest_configure)."""
-    configure_junit_failure_logging(session.config)
+    configure_junit_logging(session.config)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -57,6 +57,7 @@ from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
     start_test_log, stop_test_log, print_terminal_summary,
+    configure_junit_failure_logging,
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
 from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
@@ -412,6 +413,11 @@ def pytest_runtest_makereport(item, call):
     if call.when == "call":
         ensure_newline()
         log.debug(f"Test execution took {report.duration:.3f}s")
+
+
+def pytest_sessionstart(session):
+    """Configure the junitxml plugin once it exists (after pytest_configure)."""
+    configure_junit_failure_logging(session.config)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -107,6 +107,32 @@ def setup_test_logging(config):
     config._test_logdir = logdir
 
 
+def configure_junit_failure_logging(config):
+    """Embed each FAILED test's captured log into its JUnit <system-out> so the Jenkins
+    Test Result page shows the log inline, without the JUnit Attachments plugin.
+
+    Scoped to failures via log_passing_tests=False so passing tests add nothing to the
+    XML -- only the (few) failing tests carry their log, keeping the report small.
+
+    Must run after the junitxml plugin has created its LogXML (we set xmlpath in
+    setup_test_logging, which runs earlier in pytest_configure), so call from
+    pytest_sessionstart.
+    """
+    if not getattr(config.option, 'xmlpath', None):
+        return
+    try:
+        from _pytest.junitxml import LogXML
+    except Exception as e:
+        log.debug(f'Could not import LogXML to configure JUnit failure logging: {e}')
+        return
+    for plugin in config.pluginmanager.get_plugins():
+        if isinstance(plugin, LogXML):
+            plugin.logging = 'all'            # capture stdout/stderr + log records into the XML
+            plugin.log_passing_tests = False  # ...but only emit them for failing tests
+            log.debug('JUnit: failing tests will embed their log in <system-out>')
+            return
+
+
 def configure_logging(config, debug_requested):
     """Configure root logger level, live logging, and suppress noisy loggers.
 

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -120,7 +120,7 @@ def configure_junit_logging(config):
         return
     try:
         from _pytest.junitxml import LogXML
-    except Exception as e:
+    except ImportError as e:
         log.debug(f'Could not import LogXML to configure JUnit logging: {e}')
         return
     for plugin in config.pluginmanager.get_plugins():
@@ -129,6 +129,8 @@ def configure_junit_logging(config):
             plugin.log_passing_tests = True  # ...for every test, including passing ones
             log.debug('JUnit: tests will embed their log in <system-out>')
             return
+    log.warning('JUnit: xmlpath is set but no LogXML plugin instance was found -- '
+                'test logs will NOT be embedded in the XML.')
 
 
 def configure_logging(config, debug_requested):

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -107,12 +107,10 @@ def setup_test_logging(config):
     config._test_logdir = logdir
 
 
-def configure_junit_failure_logging(config):
-    """Embed each FAILED test's captured log into its JUnit <system-out> so the Jenkins
-    Test Result page shows the log inline, without the JUnit Attachments plugin.
-
-    Scoped to failures via log_passing_tests=False so passing tests add nothing to the
-    XML -- only the (few) failing tests carry their log, keeping the report small.
+def configure_junit_logging(config):
+    """Embed every test's captured log into its JUnit <system-out> so the Jenkins Test
+    Result page shows the log inline (for passing tests too), without the JUnit
+    Attachments plugin.
 
     Must run after the junitxml plugin has created its LogXML (we set xmlpath in
     setup_test_logging, which runs earlier in pytest_configure), so call from
@@ -123,13 +121,13 @@ def configure_junit_failure_logging(config):
     try:
         from _pytest.junitxml import LogXML
     except Exception as e:
-        log.debug(f'Could not import LogXML to configure JUnit failure logging: {e}')
+        log.debug(f'Could not import LogXML to configure JUnit logging: {e}')
         return
     for plugin in config.pluginmanager.get_plugins():
         if isinstance(plugin, LogXML):
-            plugin.logging = 'all'            # capture stdout/stderr + log records into the XML
-            plugin.log_passing_tests = False  # ...but only emit them for failing tests
-            log.debug('JUnit: failing tests will embed their log in <system-out>')
+            plugin.logging = 'all'           # capture stdout/stderr + log records into the XML
+            plugin.log_passing_tests = True  # ...for every test, including passing ones
+            log.debug('JUnit: tests will embed their log in <system-out>')
             return
 
 


### PR DESCRIPTION
**Overview:** Makes each test's log visible directly on Jenkins' Test Result page — clicking a test shows its full log inline, with no JUnit Attachments plugin required (that plugin isn't installed and can't be added). Pairs with librealsense-deploy PR #134, which publishes the pytest JUnit XML to Jenkins and aggregates it per-platform.

## Change
In `logging_setup.py`, configure the (built-in) pytest junitxml plugin so:
- `LogXML.logging = 'all'` — captured stdout/stderr + log records get written into each testcase's `<system-out>`.
- `LogXML.log_passing_tests = True` — for **every** test, including passing ones, so any test you click on the Test Result page shows its log (not just failures).

Wired via a new `pytest_sessionstart` hook (`conftest.py`), since the junitxml `LogXML` object is created after our `pytest_configure` sets `xmlpath`.

## Why this approach
- No new dependency — `_pytest/junitxml.py` ships inside pytest (already pinned in `unit-tests/requirements.txt`), and it rides the base Jenkins JUnit plugin already in use.
- We deliberately embed logs for **all** tests (not just failures), so the inline log is available on green tests too.

## Size impact (measured on a full run)
Validated on a full-suite libci run (#16927, 2446 cases): total embedded `<system-out>` ≈ **1.3 MB**, largest single test ≈ **83 KB**, full aggregated report ≈ 2.5 MB — comfortably handled by Jenkins. `logging='all'` does buffer captured output in memory per test, which is acceptable at this scale.

## Verified
- Local probe: a passing test's `<system-out>` contains its log; matching content shows on the Jenkins Test Result page.
- Full libci run #16927: all 302 passing tests carry their log inline; per-platform prefixing intact (Linux/Windows/Jetson_JP5/JP6/Image_Quality).

🤖 Generated by AI
