### PR TITLE
Unity: detect L5 device by substring, not Intel-prefix StartsWith

### DIFF
--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsProcessingPipe.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsProcessingPipe.cs
@@ -50,7 +50,7 @@ public class RsProcessingPipe : RsFrameProvider
         if (ActiveProfile != null)
         {
             string devName = ActiveProfile.Device.Info.GetInfo(CameraInfo.Name);
-            if (!string.IsNullOrEmpty(devName) && devName.StartsWith("Intel RealSense L5", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(devName) && devName.IndexOf("L5", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 GameObject pbPanel = GameObject.Find("ProcessingBlocks/ScrollRect/Viewport/Content");
                 if (pbPanel != null)


### PR DESCRIPTION
**Overview:** Fix L5 device detection in the Unity processing-blocks panel after the recent rename that dropped the `Intel` prefix from camera names.

## Why
`RsProcessingPipe.OnSourceStart` used `devName.StartsWith("Intel RealSense L5", ...)` to disable non-temporal processing blocks for L5 cameras. Since the `Intel` prefix was dropped from `RS2_CAMERA_INFO_NAME` (#15178), device names now start with `RealSense ...` and the check never matched — the L5 processing-blocks UI was silently broken.

## Summary
- Replace `StartsWith("Intel RealSense L5", OrdinalIgnoreCase)` with `IndexOf("L5", OrdinalIgnoreCase) >= 0` so the check is prefix-agnostic and matches both legacy and current names, consistent with how the rest of the codebase detects models (`find("D555")`, `find("D457")`, etc.).

## Test plan
- [ ] Load the Unity PointCloudProcessingBlocks scene with an L5-series device and verify only the Temporal Filter remains enabled.
- [ ] Verify on a non-L5 device (e.g. D435) that all processing blocks stay enabled.

---
🤖 Generated by AI