### PR TITLE
Change transient temperature log level from ERROR to DEBUG

### DIFF
--- a/src/ds/ds-options.cpp
+++ b/src/ds/ds-options.cpp
@@ -90,7 +90,7 @@ namespace librealsense
         }
 
         if (0 == temperature_data.*is_valid_field)
-            LOG_ERROR(strong_ep->get_option_name(_option) << " value is not valid!");
+            LOG_DEBUG(strong_ep->get_option_name(_option) << " value is not valid!");
 
         return temperature_data.*field;
     }


### PR DESCRIPTION
Tracked on: [RSDSO-21551]

The "Asic Temperature value is not valid!" message is a transient firmware condition (FW fails to read its on-die PVT sensor and clears the valid flag for ~1s). librealsense only reports the flag and returns the last-valid value. It is benign and FW itself logs it as a warning, so ERROR severity is too high and spams logs. Lower to DEBUG.