### PR TITLE
Fix flaky D555 temperatures-xu-vs-hwmc test (post-reboot XU warm-up)

### DIFF
--- a/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
+++ b/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
@@ -101,13 +101,8 @@ def test_temperatures_xu_vs_hwmc(test_device):
     # Since PVT in XU is different sensor than PVT in HMC, we increase the tolerance to 3 deg
     tolerance = 3.0
 
-    # On DDS devices (e.g. D555) the XU temperature options return the last value
-    # pushed by the camera over DDS. Right after the camera reboots it announces
-    # these options with their default (~30 deg) and only pushes the first real
-    # reading ~2 sec after the device enumerates, while the HWMC GTEMP command
-    # returns a real value immediately. Poll until the two paths converge (or
-    # until a short timeout) so the test does not flake on this warm-up window.
-    warmup_timeout = 10  # seconds (observed warm-up ~2 sec, with margin)
+    # Allow the system some time to read the correct value after power up
+    warmup_timeout = 10  # seconds
     timer = Timer(warmup_timeout)
     timer.start()
     while True:

--- a/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
+++ b/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
@@ -3,6 +3,7 @@
 
 # Not frequently changing, no need to test for each commit
 
+import time
 import pytest
 import pyrealsense2 as rs
 from pytest_check import check
@@ -25,17 +26,9 @@ def test_temperatures_xu_vs_hwmc(test_device):
     ########################################  HELPERS  ##########################################
 
     def get_temperatures_from_xu():
-        nonlocal is_projector_option_supported
-        pvt_temp = -10
-        ohm_temp = -10
-        proj_temp = -10
-
-        check.is_true(depth_sensor.supports(rs.option.soc_pvt_temperature))
-        check.is_true(depth_sensor.supports(rs.option.ohm_temperature))
-        is_projector_option_supported = depth_sensor.supports(rs.option.projector_temperature)
-
         pvt_temp = depth_sensor.get_option(rs.option.soc_pvt_temperature)
         ohm_temp = depth_sensor.get_option(rs.option.ohm_temperature)
+        proj_temp = -10
         if is_projector_option_supported:
             proj_temp = depth_sensor.get_option(rs.option.projector_temperature)
 
@@ -98,11 +91,32 @@ def test_temperatures_xu_vs_hwmc(test_device):
         return pvt_temp, ohm_temp, proj_temp
 
 
-    pvt_temp_xu, ohm_temp_xu, projector_temp_xu = get_temperatures_from_xu()
-    pvt_temp_hwm, ohm_temp_hwm, projector_temp_hwm = get_temperatures_from_hwm()
+    check.is_true(depth_sensor.supports(rs.option.soc_pvt_temperature))
+    check.is_true(depth_sensor.supports(rs.option.ohm_temperature))
+    is_projector_option_supported = depth_sensor.supports(rs.option.projector_temperature)
 
     # Since PVT in XU is different sensor than PVT in HMC, we increase the tolerance to 3 deg
     tolerance = 3.0
+
+    # On DDS devices (e.g. D555) the XU temperature options return the last value
+    # pushed by the camera over DDS. Right after the camera reboots it announces
+    # these options with their default (~30 deg) and only pushes the first real
+    # reading ~2 sec after the device enumerates, while the HWMC GTEMP command
+    # returns a real value immediately. Poll until the two paths converge (or
+    # until a short timeout) so the test does not flake on this warm-up window.
+    warmup_timeout = 10  # seconds (observed warm-up ~2 sec, with margin)
+    start_time = time.time()
+    while True:
+        pvt_temp_xu, ohm_temp_xu, projector_temp_xu = get_temperatures_from_xu()
+        pvt_temp_hwm, ohm_temp_hwm, projector_temp_hwm = get_temperatures_from_hwm()
+        converged = (abs(pvt_temp_xu - pvt_temp_hwm) <= tolerance
+                     and abs(ohm_temp_xu - ohm_temp_hwm) <= tolerance
+                     and (not is_projector_option_supported
+                          or abs(projector_temp_xu - projector_temp_hwm) <= tolerance))
+        if converged or time.time() - start_time >= warmup_timeout:
+            break
+        time.sleep(1)
+
     check.almost_equal(pvt_temp_xu, pvt_temp_hwm, abs=tolerance)
     check.almost_equal(ohm_temp_xu, ohm_temp_hwm, abs=tolerance)
     if is_projector_option_supported:

--- a/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
+++ b/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
@@ -7,6 +7,7 @@ import time
 import pytest
 import pyrealsense2 as rs
 from pytest_check import check
+from rspy.timer import Timer
 import logging
 log = logging.getLogger(__name__)
 
@@ -105,7 +106,8 @@ def test_temperatures_xu_vs_hwmc(test_device):
     # returns a real value immediately. Poll until the two paths converge (or
     # until a short timeout) so the test does not flake on this warm-up window.
     warmup_timeout = 10  # seconds (observed warm-up ~2 sec, with margin)
-    start_time = time.time()
+    timer = Timer(warmup_timeout)
+    timer.start()
     while True:
         pvt_temp_xu, ohm_temp_xu, projector_temp_xu = get_temperatures_from_xu()
         pvt_temp_hwm, ohm_temp_hwm, projector_temp_hwm = get_temperatures_from_hwm()
@@ -113,7 +115,7 @@ def test_temperatures_xu_vs_hwmc(test_device):
                      and abs(ohm_temp_xu - ohm_temp_hwm) <= tolerance
                      and (not is_projector_option_supported
                           or abs(projector_temp_xu - projector_temp_hwm) <= tolerance))
-        if converged or time.time() - start_time >= warmup_timeout:
+        if converged or timer.has_expired():
             break
         time.sleep(1)
 

--- a/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
+++ b/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
@@ -27,9 +27,12 @@ def test_temperatures_xu_vs_hwmc(test_device):
     ########################################  HELPERS  ##########################################
 
     def get_temperatures_from_xu():
+        pvt_temp = -10
+        ohm_temp = -10
+        proj_temp = -10
+
         pvt_temp = depth_sensor.get_option(rs.option.soc_pvt_temperature)
         ohm_temp = depth_sensor.get_option(rs.option.ohm_temperature)
-        proj_temp = -10
         if is_projector_option_supported:
             proj_temp = depth_sensor.get_option(rs.option.projector_temperature)
 

--- a/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
+++ b/unit-tests/live/d500/pytest-temperatures-xu-vs-hwmc.py
@@ -23,10 +23,9 @@ def test_temperatures_xu_vs_hwmc(test_device):
     depth_sensor = dev.first_depth_sensor()
     dp_device = dev.as_debug_protocol()
 
-    is_projector_option_supported = True
     ########################################  HELPERS  ##########################################
 
-    def get_temperatures_from_xu():
+    def get_temperatures_from_xu(depth_sensor, is_projector_option_supported):
         pvt_temp = -10
         ohm_temp = -10
         proj_temp = -10
@@ -70,7 +69,7 @@ def test_temperatures_xu_vs_hwmc(test_device):
         return temperatures_list
 
 
-    def get_temperatures_from_hwm():
+    def get_temperatures_from_hwm(dp_device, is_projector_option_supported):
         gtemp_opcode = 0x2a
 
         # getting all the available temperatures
@@ -112,8 +111,10 @@ def test_temperatures_xu_vs_hwmc(test_device):
     timer = Timer(warmup_timeout)
     timer.start()
     while True:
-        pvt_temp_xu, ohm_temp_xu, projector_temp_xu = get_temperatures_from_xu()
-        pvt_temp_hwm, ohm_temp_hwm, projector_temp_hwm = get_temperatures_from_hwm()
+        pvt_temp_xu, ohm_temp_xu, projector_temp_xu = get_temperatures_from_xu(
+            depth_sensor, is_projector_option_supported)
+        pvt_temp_hwm, ohm_temp_hwm, projector_temp_hwm = get_temperatures_from_hwm(
+            dp_device, is_projector_option_supported)
         converged = (abs(pvt_temp_xu - pvt_temp_hwm) <= tolerance
                      and abs(ohm_temp_xu - ohm_temp_hwm) <= tolerance
                      and (not is_projector_option_supported


### PR DESCRIPTION
**Overview:** Make `test_temperatures_xu_vs_hwmc` robust to the D555's post-reboot warm-up so it stops flaking in CI.

Tracked on [RSDEV-12361]

## Why
On DDS devices (D555) `get_option()` returns the last value the camera pushed over DDS, not a live read. Right after the camera reboots it announces the temperature options at their default (~30 °C) and only pushes the first real reading ~2 s after the device enumerates, while the HWMC `GTEMP` command returns a real value immediately. If the test reads inside that window it compares XU `30.0` against HWMC `~21 °C` and fails the 3 °C tolerance. This flaked `LRS_windows_compile_pipeline` (passed on retry).

Reproduced on bench rsdsk255 via a cold PoE power-cycle of the D555: at enumeration both XU temps read exactly `30.000` while HWMC read ~23 °C; the XU values converged with HWMC ~2 s later.

## Summary
- Poll until the XU and HWMC paths agree within the existing 3 °C tolerance (10 s timeout) before asserting; the loop exits immediately once converged, so steady-state cost is zero.
- Move the one-time `supports()` checks out of the per-read helper.
- No longer relies on the framework `--retry` (which interacted badly with `pytest_check`).

## Test plan
- [ ] Nightly run of `temperatures-xu-vs-hwmc` on D555/D585S (`--context nightly`) passes.
- [ ] No regression on D585S (USB XU path, unaffected by the warm-up).

---
🤖 Generated by AI
