### PR TITLE
Fix use-after-free in DDS device notification teardown

### DIFF
--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -706,6 +706,11 @@ void dds_device::impl::create_notifications_reader()
     _notifications_reader->on_data_available(
         [&]()
         {
+            // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
+            // if a notification handler drops the device's last reference.
+            auto self = weak_from_this().lock();
+            if( ! self )
+                return;
             topics::flexible_msg notification;
             dds_sample sample;
             while( topics::flexible_msg::take_next( *_notifications_reader, &notification, &sample ) )

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -743,6 +743,11 @@ void dds_device::impl::create_metadata_reader()
     _metadata_reader->on_data_available(
         [this]()
         {
+            // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
+            // if a metadata handler drops the device's last reference.
+            auto self = weak_from_this().lock();
+            if( ! self )
+                return;
             topics::flexible_msg message;
             while( topics::flexible_msg::take_next( *_metadata_reader, &message ) )
             {

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -27,7 +27,7 @@ class dds_topic_writer;
 class dds_subscriber;
 
 
-class dds_device::impl
+class dds_device::impl : public std::enable_shared_from_this< dds_device::impl >
 {
 public:
     enum class state_t

--- a/unit-tests/dds/pytest-control-reply.py
+++ b/unit-tests/dds/pytest-control-reply.py
@@ -151,3 +151,6 @@ else:
         check.equal( reply_count[device.guid()], dev1_replies + 1 )
         check.equal( reply_count[device2.guid()], dev2_replies + 1 )
 
+        # free the participant now so it can't linger on the domain into the next module
+        del notification2_subscription, notification_subscription, device2, device, participant
+

--- a/unit-tests/dds/pytest-control-reply.py
+++ b/unit-tests/dds/pytest-control-reply.py
@@ -151,6 +151,4 @@ else:
         check.equal( reply_count[device.guid()], dev1_replies + 1 )
         check.equal( reply_count[device2.guid()], dev2_replies + 1 )
 
-        # free the participant now so it can't linger on the domain into the next module
-        del notification2_subscription, notification_subscription, device2, device, participant
 


### PR DESCRIPTION
**Root cause:** `dds_device::impl`'s notification reader dispatch (`on_data_available`) captures the impl by reference and runs a `take_next` loop calling `on_notification`. If a handler drops the device's last reference, `~impl` runs on that same reader thread and frees the impl mid-loop → use-after-free at teardown. On Windows the freed heap is reused/poisoned (fatal, surfaces as an access violation in an unrelated thread); on Linux it survives silently — hence the Windows-only `Win_SH_Py_DDS_CI` crashes.

**Fix:** make `dds_device::impl` `enable_shared_from_this` and pin it via `weak_from_this().lock()` for the duration of each dispatch, so it cannot be freed mid-loop.

Also removes the earlier test-level `del` workaround from `pytest-control-reply` — the C++ fix makes it unnecessary.

**Validation:** full DDS suite, CI-exact flags (`--debug -s --not-live --context "dds windows" --tag dds`), locally:
- without fix: **6/12 runs crash** (access violation, matches CI)
- with fix: **0/12**