### PR TITLE
Skip slow first clock-read in global-time (startup actual_fps jitter)

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -276,6 +276,7 @@ namespace librealsense
         _min_command_delay(initial_min_command_delay_ms),
         _rejections_in_row(0),
         _innovation_rejections_in_row(0),
+        _first_sample_dropped(false),
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
@@ -305,6 +306,7 @@ namespace librealsense
             LOG_DEBUG("time_diff_keeper::stop: stop object.");
             _active_object.stop();
             _is_ready = false;
+            _first_sample_dropped = false;
             std::lock_guard< std::recursive_mutex > lock( _read_mtx );
             _coefs.reset();
             _rejections_in_row = 0;
@@ -328,6 +330,14 @@ namespace librealsense
             double sample_hw_time = _device->get_device_time_ms();
             double system_time_finish = duration<double, std::milli>(system_clock::now().time_since_epoch()).count();
             double command_delay = (system_time_finish-system_time_start)/2;
+
+            // Drop the first clock read if it's slow - it can skew the few-point fit for ~2s.
+            if( ! _first_sample_dropped )
+            {
+                _first_sample_dropped = true;
+                if( command_delay > 10. )
+                    return false;
+            }
 
             std::lock_guard<std::recursive_mutex> lock(_read_mtx);
             if (command_delay < _min_command_delay)

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -305,9 +305,9 @@ namespace librealsense
         {
             LOG_DEBUG("time_diff_keeper::stop: stop object.");
             _active_object.stop();
+            std::lock_guard< std::recursive_mutex > lock( _read_mtx );
             _is_ready = false;
             _first_sample_dropped = false;
-            std::lock_guard< std::recursive_mutex > lock( _read_mtx );
             _coefs.reset();
             _rejections_in_row = 0;
             _innovation_rejections_in_row = 0;
@@ -331,6 +331,7 @@ namespace librealsense
             double system_time_finish = duration<double, std::milli>(system_clock::now().time_since_epoch()).count();
             double command_delay = (system_time_finish-system_time_start)/2;
 
+            std::lock_guard<std::recursive_mutex> lock(_read_mtx);
             // Drop the first clock read if it's slow - it can skew the few-point fit for ~2s.
             if( ! _first_sample_dropped )
             {
@@ -339,7 +340,6 @@ namespace librealsense
                     return false;
             }
 
-            std::lock_guard<std::recursive_mutex> lock(_read_mtx);
             if (command_delay < _min_command_delay)
             {
                 _coefs.add_const_y_coefs(command_delay - _min_command_delay);

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -93,6 +93,7 @@ namespace librealsense
         unsigned int _innovation_rejections_in_row; // Consecutive samples rejected for excessive innovation (value vs. fit prediction).
         std::deque<CSample> _rejected_samples;   // Last re_fit_window (x, y) pairs rejected on value; refit source if rejections persist.
         bool _is_ready;
+        bool _first_sample_dropped; // the first (often slow) clock read after start is dropped
     };
 
     class global_timestamp_reader : public frame_timestamp_reader

--- a/unit-tests/live/frames/pytest-actual-fps-startup.py
+++ b/unit-tests/live/frames/pytest-actual-fps-startup.py
@@ -8,7 +8,6 @@ import time
 
 pytestmark = [
     pytest.mark.device_each("D455"),
-    pytest.mark.context("weekly"),
 ]
 
 FPS = 30

--- a/unit-tests/live/frames/pytest-actual-fps-startup.py
+++ b/unit-tests/live/frames/pytest-actual-fps-startup.py
@@ -1,0 +1,40 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import pytest
+import pyrealsense2 as rs
+from pytest_check import check
+import time
+
+pytestmark = [
+    pytest.mark.device_each("D455"),
+    pytest.mark.context("weekly"),
+]
+
+FPS = 30
+DURATION = 10.0
+
+def test_actual_fps_within_tolerance_from_startup(module_device_setup):
+    cfg = rs.config()
+    cfg.enable_stream(rs.stream.depth, 848, 480, rs.format.z16, FPS)
+    pipe = rs.pipeline()
+    pipe.start(cfg)  # global time on by default - no warmup sleep on purpose
+
+    md = rs.frame_metadata_value.actual_fps
+    frames = 0
+    out_of_band = []
+    start = time.time()
+    try:
+        while time.time() - start < DURATION:
+            f = pipe.wait_for_frames().get_depth_frame()
+            if not f or not f.supports_frame_metadata(md):  # first frame has no actual_fps
+                continue
+            frames += 1
+            fps = f.get_frame_metadata(md) / 1000.0
+            if not 0.9 * FPS <= fps <= 1.1 * FPS:
+                out_of_band.append((f.get_frame_number(), round(fps, 2)))
+    finally:
+        pipe.stop()
+
+    check.greater(frames, 0, "no frames with actual_fps metadata were collected")
+    check.equal(out_of_band, [], f"actual_fps outside +/-10% of {FPS}: {out_of_band[:20]}")


### PR DESCRIPTION
Tracked on: [RSDEV-7815]

`actual_fps` deviated more than ±10% of the set FPS for the first ~2s of streaming on D455, while the camera cadence was actually steady. Cause: the first device-clock read after stream start is slow, which skews the global-time regression that `actual_fps` is derived from. Fix: while the time-sync fit is still converging, skip an outlier-slow clock read. D455 now converges like D435 — flat `actual_fps` from frame 1; steady-state unchanged.

Verified on D455 + D435 (depth 848x480@30). LibCI 16981 green.