### PR TITLE
changed window state config update

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -37,6 +37,8 @@ void glfw_error_callback(int error, const char* description)
     std::cerr << "GLFW Driver Error: " << description << "\n";
 }
 
+constexpr double window_settle_ms = 300.0;
+
 namespace rs2
 {
     void GLAPIENTRY MessageCallback(GLenum source,
@@ -360,23 +362,29 @@ namespace rs2
             glDebugMessageCallback(MessageCallback, 0);
         }
 
+        glfwSetWindowUserPointer(_win, this);
+
         glfwSetWindowPosCallback(_win, [](GLFWwindow* w, int x, int y)
         {
-            config_file::instance().set(configurations::window::saved_pos, true);
-            config_file::instance().set(configurations::window::position_x, x);
-            config_file::instance().set(configurations::window::position_y, y);
+            auto self = reinterpret_cast<ux_window*>(glfwGetWindowUserPointer(w));
+            if (!self) return;
+            self->_pending_pos_x = x;
+            self->_pending_pos_y = y;
+            self->_pending_pos_dirty = true;
+            self->_window_moved_timer.reset();
         });
 
-        glfwSetWindowSizeCallback( _win, []( GLFWwindow * window, int width, int height ) {
-            if( width > 0 && height > 0 )
-            {
-                config_file::instance().set( configurations::window::saved_size, true );
-                config_file::instance().set( configurations::window::width, width );
-                config_file::instance().set( configurations::window::height, height );
-                config_file::instance().set( configurations::window::maximized,
-                                             glfwGetWindowAttrib( window, GLFW_MAXIMIZED ) );
-            }
-        } );
+        glfwSetWindowSizeCallback(_win, [](GLFWwindow* w, int width, int height)
+        {
+            if (width <= 0 || height <= 0) return;
+            auto self = reinterpret_cast<ux_window*>(glfwGetWindowUserPointer(w));
+            if (!self) return;
+            self->_pending_win_width = width;
+            self->_pending_win_height = height;
+            self->_pending_maximized = glfwGetWindowAttrib(w, GLFW_MAXIMIZED);
+            self->_pending_size_dirty = true;
+            self->_window_resized_timer.reset();
+        });
 
         setup_icon();
 
@@ -396,9 +404,6 @@ namespace rs2
         imgui_easy_theming(_font_dynamic, _font_18, _monofont, font_size);
 
         // Register for UI-controller events
-        glfwSetWindowUserPointer(_win, this);
-
-
         glfwSetCursorPosCallback(_win, [](GLFWwindow* w, double cx, double cy)
         {
             ImGui_ImplGlfw_CursorPosCallback(w, cx, cy); // Forward the cursor position to ImGui
@@ -689,9 +694,30 @@ namespace rs2
         glfwTerminate();
     }
 
+    void ux_window::flush_pending_window_state()
+    {
+        if (_pending_pos_dirty && _window_moved_timer.get_elapsed_ms() > window_settle_ms)
+        {
+            config_file::instance().set(configurations::window::saved_pos, true);
+            config_file::instance().set(configurations::window::position_x, _pending_pos_x);
+            config_file::instance().set(configurations::window::position_y, _pending_pos_y);
+            _pending_pos_dirty = false;
+        }
+        if (_pending_size_dirty && _window_resized_timer.get_elapsed_ms() > window_settle_ms)
+        {
+            config_file::instance().set(configurations::window::saved_size, true);
+            config_file::instance().set(configurations::window::width, _pending_win_width);
+            config_file::instance().set(configurations::window::height, _pending_win_height);
+            config_file::instance().set(configurations::window::maximized, _pending_maximized);
+            _pending_size_dirty = false;
+        }
+    }
+
     void ux_window::begin_frame()
     {
         glfwPollEvents();
+
+        flush_pending_window_state();
 
         int state = glfwGetKey(_win, GLFW_KEY_F8);
         if (state == GLFW_PRESS)

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -37,7 +37,6 @@ void glfw_error_callback(int error, const char* description)
     std::cerr << "GLFW Driver Error: " << description << "\n";
 }
 
-constexpr double window_settle_ms = 300.0;
 
 namespace rs2
 {
@@ -370,8 +369,8 @@ namespace rs2
             if (!self) return;
             self->_pending_pos_x = x;
             self->_pending_pos_y = y;
-            self->_pending_pos_dirty = true;
-            self->_window_moved_timer.reset();
+            self->_pending_window_state = true;
+            self->_window_state_timer.start();
         });
 
         glfwSetWindowSizeCallback(_win, [](GLFWwindow* w, int width, int height)
@@ -382,8 +381,8 @@ namespace rs2
             self->_pending_win_width = width;
             self->_pending_win_height = height;
             self->_pending_maximized = glfwGetWindowAttrib(w, GLFW_MAXIMIZED);
-            self->_pending_size_dirty = true;
-            self->_window_resized_timer.reset();
+            self->_pending_window_state = true;
+            self->_window_state_timer.start();
         });
 
         setup_icon();
@@ -696,20 +695,16 @@ namespace rs2
 
     void ux_window::flush_pending_window_state()
     {
-        if (_pending_pos_dirty && _window_moved_timer.get_elapsed_ms() > window_settle_ms)
+        if (_pending_window_state && _window_state_timer.has_expired())
         {
             config_file::instance().set(configurations::window::saved_pos, true);
             config_file::instance().set(configurations::window::position_x, _pending_pos_x);
             config_file::instance().set(configurations::window::position_y, _pending_pos_y);
-            _pending_pos_dirty = false;
-        }
-        if (_pending_size_dirty && _window_resized_timer.get_elapsed_ms() > window_settle_ms)
-        {
             config_file::instance().set(configurations::window::saved_size, true);
             config_file::instance().set(configurations::window::width, _pending_win_width);
             config_file::instance().set(configurations::window::height, _pending_win_height);
             config_file::instance().set(configurations::window::maximized, _pending_maximized);
-            _pending_size_dirty = false;
+            _pending_window_state = false;
         }
     }
 

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -14,6 +14,7 @@
 #include "rendering.h"
 #include <atomic>
 #include <memory>
+#include <rsutils/time/timer.h>
 
 namespace rs2
 {
@@ -148,13 +149,10 @@ namespace rs2
 
         int                      _pending_pos_x = 0;
         int                      _pending_pos_y = 0;
-        bool                     _pending_pos_dirty = false;
-        rsutils::time::stopwatch _window_moved_timer;
-
         int                      _pending_win_width = 0;
         int                      _pending_win_height = 0;
         bool                     _pending_maximized = false;
-        bool                     _pending_size_dirty = false;
-        rsutils::time::stopwatch _window_resized_timer;
+        bool                     _pending_window_state = false;
+        rsutils::time::timer     _window_state_timer{ std::chrono::milliseconds( 300 ) };
     };
 }

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -93,6 +93,8 @@ namespace rs2
 
         void setup_icon();
 
+        void flush_pending_window_state();
+
         void imgui_config_push();
         void imgui_config_pop();
 
@@ -143,5 +145,16 @@ namespace rs2
         context                  &_ctx;
 
         bool                     _is_ui_aligned = false;
+
+        int                      _pending_pos_x = 0;
+        int                      _pending_pos_y = 0;
+        bool                     _pending_pos_dirty = false;
+        rsutils::time::stopwatch _window_moved_timer;
+
+        int                      _pending_win_width = 0;
+        int                      _pending_win_height = 0;
+        bool                     _pending_maximized = false;
+        bool                     _pending_size_dirty = false;
+        rsutils::time::stopwatch _window_resized_timer;
     };
 }


### PR DESCRIPTION
## Summary

- The viewer config file was being written on every pixel of movement while dragging the window, because `glfwSetWindowPosCallback` / `glfwSetWindowSizeCallback` called `config_file::instance().set()` directly and GLFW fires these callbacks at the OS event rate.
- Replace the immediate writes with a 300 ms debounce: callbacks now store the incoming position/size into pending member variables and reset a stopwatch; the new `flush_pending_window_state()` method — called each frame from `begin_frame()` — commits to config only once the window has been still for 300 ms.
- Move `glfwSetWindowUserPointer` to before the callback registrations so `this` is available in all GLFW callbacks from the point they are registered.

## Changes

- `common/ux-window.h` — add six private members (`_pending_pos_x/y`, `_pending_pos_dirty`, `_window_moved_timer`, and the size equivalents); declare `flush_pending_window_state()`.
- `common/ux-window.cpp` — rewrite the two GLFW callbacks to store pending state; add `flush_pending_window_state()`; call it from `begin_frame()`; introduce file-scope `constexpr double window_settle_ms = 300.0`.
