### PR TITLE
viewer: fix preset requiring two clicks to update Advanced Controls

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2030,7 +2030,8 @@ namespace rs2
                                             << "Setting " << opt_model.opt << " to " << new_val << " ("
                                             << labels[selected] << ")");
 
-                                        opt_model.set_option_async(opt_model.opt, static_cast<float>(new_val));
+                                        // Sync: get_curr_advanced_controls below reads back the FW state set by the preset.
+                                        opt_model.set_option_sync(static_cast<float>(new_val));
 
                                         // Only apply preset to GUI if set_option was succesful
                                         selected_file_preset = "";


### PR DESCRIPTION
**Overview:** Selecting a depth-sensor preset in realsense-viewer updates Stereo Module > Advanced Controls > Depth Controls on the first click again.

Tracked on [RSDEV-12231]

## Why
PR #15029 moved option writes to an async dispatcher. The preset combo-box code then sets `get_curr_advanced_controls = true` and sleeps 20 ms before re-reading depth controls from FW — but the FW write was still queued, so the read returned the previous preset's values. The UI only caught up on the next click.

## Summary
- Use `set_option_sync` instead of `set_option_async` for preset selection at `common/device-model.cpp:2033`, so the FW has applied the preset before `get_curr_advanced_controls` reads it back. Async writes remain for sliders/checkboxes (the high-frequency paths PR #15029 targeted).

## Test plan
- [x] Launch realsense-viewer, open Stereo Module > Advanced Controls > Depth Controls, switch presets and confirm values update on the first click.

---
🤖 Generated by AI