### PR TITLE
viewer: terminal fix and enhancement

### DIFF
--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -21,7 +21,8 @@ bool output_model::cycle_autocomplete(bool forward)
 {
     if (command_line.empty())
         return false;
-    if (autocomplete.empty() || !starts_with(to_lower(autocomplete.front()), to_lower(command_line)))
+    std::string lower_cmd = to_lower(command_line);
+    if (autocomplete.empty() || !starts_with(lower_cmd, autocomplete_prefix))
     {
         std::string commands_xml = config_file::instance().get(configurations::viewer::commands_xml);
         std::ifstream f(commands_xml.c_str());
@@ -29,12 +30,13 @@ bool output_model::cycle_autocomplete(bool forward)
         {
             std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
             autocomplete.clear();
+            autocomplete_prefix = lower_cmd;
             std::regex exp("Command Name=\"(\\w+)\"");
             std::smatch res;
             std::string::const_iterator searchStart(str.cbegin());
             while (regex_search(searchStart, str.cend(), res, exp))
             {
-                if (starts_with(to_lower(res[1]), to_lower(command_line)))
+                if (starts_with(to_lower(res[1]), lower_cmd))
                     autocomplete.push_back(res[1]);
                 searchStart = res.suffix().first;
             }
@@ -703,6 +705,7 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
             history_offset = -1;
             history_draft = "";
             autocomplete.clear();
+            autocomplete_prefix = "";
             command_focus = true;
         }
         if (!command_focus && !new_log) command_line = buff;
@@ -712,6 +715,7 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
         {
             command_line = "";
             autocomplete.clear();
+            autocomplete_prefix = "";
         }
 
         float child_height = 0;

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -631,8 +631,6 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
         ImGui::SetCursorPos(ImVec2(30, h - ImGui::GetTextLineHeightWithSpacing() - 4));
 
 
-        const int MAX_HISTORY_SIZE = 100;
-
         ImGui::PushFont(win.get_monofont());
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
         ImGui::PushItemWidth( w - get_dashboard_width() - 30 );
@@ -647,10 +645,14 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
                 if (!self->commands_histroy.empty())
                 {
                     if (data->EventKey == ImGuiKey_UpArrow)
+                    {
+                        if (self->history_offset == -1)
+                            self->history_draft = self->command_line;
                         self->history_offset = std::min(self->history_offset + 1, (int)self->commands_histroy.size() - 1);
+                    }
                     else if (data->EventKey == ImGuiKey_DownArrow && self->history_offset > -1)
                         self->history_offset--;
-                    self->command_line = self->history_offset >= 0 ? self->commands_histroy[self->history_offset] : "";
+                    self->command_line = self->history_offset >= 0 ? self->commands_histroy[self->history_offset] : self->history_draft;
                 }
             }
             else if (data->EventFlag == ImGuiInputTextFlags_CallbackCompletion)
@@ -659,6 +661,12 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
             }
             else if (data->EventFlag == ImGuiInputTextFlags_CallbackAlways)
             {
+                // Reset history navigation if the user edits the buffer mid-browse
+                if (self->history_offset >= 0 && self->command_line != self->commands_histroy[self->history_offset])
+                {
+                    self->history_offset = -1;
+                    self->history_draft = "";
+                }
                 // Shift+Tab cycles autocomplete backwards (CallbackCompletion only fires on plain Tab)
                 if (!ImGui::IsKeyPressed(ImGuiKey_Tab) || !ImGui::GetIO().KeyShift)
                     return 0;
@@ -693,13 +701,18 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
             run_command(command_line, device_models);
             command_line = "";
             history_offset = -1;
+            history_draft = "";
+            autocomplete.clear();
             command_focus = true;
         }
         if (!command_focus && !new_log) command_line = buff;
         ImGui::PopStyleColor(2);
         ImGui::PopFont();
         if (ImGui::IsWindowFocused() && ImGui::IsKeyPressed(ImGuiKey_Escape))
+        {
             command_line = "";
+            autocomplete.clear();
+        }
 
         float child_height = 0;
         for( auto && dash : dashboards )

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -17,6 +17,47 @@
 using namespace rs2;
 using namespace rsutils::string;
 
+bool output_model::cycle_autocomplete(bool forward)
+{
+    if (command_line.empty())
+        return false;
+    if (autocomplete.empty() || !starts_with(to_lower(autocomplete.front()), to_lower(command_line)))
+    {
+        std::string commands_xml = config_file::instance().get(configurations::viewer::commands_xml);
+        std::ifstream f(commands_xml.c_str());
+        if (f.good())
+        {
+            std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+            autocomplete.clear();
+            std::regex exp("Command Name=\"(\\w+)\"");
+            std::smatch res;
+            std::string::const_iterator searchStart(str.cbegin());
+            while (regex_search(searchStart, str.cend(), res, exp))
+            {
+                if (starts_with(to_lower(res[1]), to_lower(command_line)))
+                    autocomplete.push_back(res[1]);
+                searchStart = res.suffix().first;
+            }
+        }
+    }
+    if (autocomplete.empty())
+        return false;
+    if (forward)
+    {
+        auto temp = autocomplete.front();
+        autocomplete.pop_front();
+        autocomplete.push_back(temp);
+    }
+    else
+    {
+        auto temp = autocomplete.back();
+        autocomplete.pop_back();
+        autocomplete.push_front(temp);
+    }
+    command_line = autocomplete.front();
+    return true;
+}
+
 void output_model::thread_loop()
 {
     while (!to_stop)
@@ -590,94 +631,75 @@ void output_model::draw(ux_window& win, rect view_rect, device_models_list & dev
         ImGui::SetCursorPos(ImVec2(30, h - ImGui::GetTextLineHeightWithSpacing() - 4));
 
 
+        const int MAX_HISTORY_SIZE = 100;
+
         ImGui::PushFont(win.get_monofont());
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
         ImGui::PushItemWidth( w - get_dashboard_width() - 30 );
 
-        bool force_refresh = false;
-        if (ImGui::IsWindowFocused() && (ImGui::GetIO().KeysDown[ImGuiKey_UpArrow] || ImGui::GetIO().KeysDown[ImGuiKey_DownArrow]))
+        auto terminal_cb = [](ImGuiInputTextCallbackData* data) -> int
         {
-            if (commands_histroy.size())
-            {
-                if (ImGui::GetIO().KeysDown[ImGuiKey_UpArrow]) history_offset = (history_offset + 1) % commands_histroy.size();
-                if (ImGui::GetIO().KeysDown[ImGuiKey_DownArrow]) history_offset = (history_offset - 1 + (int)commands_histroy.size()) % commands_histroy.size();
-                command_line = commands_histroy[history_offset];
+            auto* self = static_cast<output_model*>(data->UserData);
+            self->command_line = std::string(data->Buf, data->BufTextLen);
 
-                force_refresh = true;
-            }
-        }
-
-        if (ImGui::IsWindowFocused() && ImGui::GetIO().KeysDown[GLFW_KEY_TAB])
-        {
-            if (!autocomplete.size() || !starts_with(to_lower(autocomplete.front()), to_lower(command_line)))
+            if (data->EventFlag == ImGuiInputTextFlags_CallbackHistory)
             {
-                std::string commands_xml = config_file::instance().get(configurations::viewer::commands_xml);
-                std::ifstream f(commands_xml.c_str());
-                if (f.good())
+                if (!self->commands_histroy.empty())
                 {
-                    std::string str((std::istreambuf_iterator<char>(f)),
-                        std::istreambuf_iterator<char>());
-
-                    autocomplete.clear();
-                    std::regex exp("Command Name=\"(\\w+)\"");
-                    std::smatch res;
-                    std::string::const_iterator searchStart(str.cbegin());
-                    while (regex_search(searchStart, str.cend(), res, exp))
-                    {
-                        if (starts_with(to_lower(res[1]), to_lower(command_line)))
-                            autocomplete.push_back(res[1]);
-                        searchStart = res.suffix().first;
-                    }
+                    if (data->EventKey == ImGuiKey_UpArrow)
+                        self->history_offset = std::min(self->history_offset + 1, (int)self->commands_histroy.size() - 1);
+                    else if (data->EventKey == ImGuiKey_DownArrow && self->history_offset > -1)
+                        self->history_offset--;
+                    self->command_line = self->history_offset >= 0 ? self->commands_histroy[self->history_offset] : "";
                 }
             }
-            if (autocomplete.size())
+            else if (data->EventFlag == ImGuiInputTextFlags_CallbackCompletion)
             {
-                auto temp = autocomplete.front();
-                autocomplete.pop_front();
-                autocomplete.push_back(temp);
-
-                if (starts_with(to_lower(temp), command_line))
-                    command_line = to_lower(autocomplete.front());
-                else
-                    command_line = autocomplete.front();
-                force_refresh = true;
+                self->cycle_autocomplete(true);
             }
-        }
+            else if (data->EventFlag == ImGuiInputTextFlags_CallbackAlways)
+            {
+                // Shift+Tab cycles autocomplete backwards (CallbackCompletion only fires on plain Tab)
+                if (!ImGui::IsKeyPressed(ImGuiKey_Tab) || !ImGui::GetIO().KeyShift)
+                    return 0;
+                self->cycle_autocomplete(false);
+            }
+
+            data->DeleteChars(0, data->BufTextLen);
+            data->InsertChars(0, self->command_line.c_str());
+            data->CursorPos = data->BufTextLen;
+            return 0;
+        };
 
         memcpy(buff, command_line.c_str(), command_line.size());
         buff[command_line.size()] = 0;
 
-        int flags = ImGuiInputTextFlags_EnterReturnsTrue;
-        if (force_refresh)
-        {
-            flags = ImGuiInputTextFlags_ReadOnly;
-        }
+        int flags = ImGuiInputTextFlags_EnterReturnsTrue
+                  | ImGuiInputTextFlags_CallbackCompletion
+                  | ImGuiInputTextFlags_CallbackHistory
+                  | ImGuiInputTextFlags_CallbackAlways;
 
         ImGui::PushStyleColor(ImGuiCol_FrameBg, scrollbar_bg);
-        if (ImGui::InputText("##TerminalCommand", buff, 1023, flags))
+        if (command_focus || new_log || (ImGui::IsWindowFocused() && !ImGui::IsAnyItemActive()))
+            ImGui::SetKeyboardFocusHere();
+        command_focus = false;
+        if (ImGui::InputText("##TerminalCommand", buff, sizeof(buff) - 1, flags, terminal_cb, this))
         {
-
-        }
-        if (!command_focus && !new_log) command_line = buff;
-        ImGui::PopStyleColor();
-        if (command_focus || new_log) ImGui::SetKeyboardFocusHere();
-        ImGui::PopFont();
-        ImGui::PopStyleColor();
-
-        if (ImGui::IsWindowFocused() && (ImGui::GetIO().KeysDown[GLFW_KEY_ENTER] || ImGui::GetIO().KeysDown[GLFW_KEY_KP_ENTER]))
-        {
-            if (commands_histroy.size() > 100) commands_histroy.pop_back();
-            commands_histroy.push_front(command_line);
+            if (!command_line.empty() && (commands_histroy.empty() || commands_histroy.front() != command_line))
+            {
+                if (commands_histroy.size() > MAX_HISTORY_SIZE) commands_histroy.pop_back();
+                commands_histroy.push_front(command_line);
+            }
             run_command(command_line, device_models);
             command_line = "";
+            history_offset = -1;
             command_focus = true;
         }
-        else command_focus = false;
-
-        if (ImGui::IsWindowFocused() && ImGui::GetIO().KeysDown[GLFW_KEY_ESCAPE])
-        {
+        if (!command_focus && !new_log) command_line = buff;
+        ImGui::PopStyleColor(2);
+        ImGui::PopFont();
+        if (ImGui::IsWindowFocused() && ImGui::IsKeyPressed(ImGuiKey_Escape))
             command_line = "";
-        }
 
         float child_height = 0;
         for( auto && dash : dashboards )

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -177,8 +177,11 @@ namespace rs2
         std::mutex devices_mutex;
         std::vector<rs2::device> devices;
 
+        static constexpr int MAX_HISTORY_SIZE = 100;
+
         std::string search_line { "" };
         std::string command_line { "" };
+        std::string history_draft { "" };
         std::deque<std::string> commands_histroy;
         int history_offset = -1;
         bool command_focus = true;

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -180,7 +180,7 @@ namespace rs2
         std::string search_line { "" };
         std::string command_line { "" };
         std::deque<std::string> commands_histroy;
-        int history_offset = 0;
+        int history_offset = -1;
         bool command_focus = true;
 
         std::vector<std::shared_ptr<stream_dashboard>> dashboards;
@@ -190,5 +190,6 @@ namespace rs2
         std::thread fw_logger;
 
         void thread_loop();
+        bool cycle_autocomplete(bool forward);
     };
 }

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -173,6 +173,7 @@ namespace rs2
         size_t max_notifications_kept = 1000;
 
         std::deque<std::string> autocomplete;
+        std::string autocomplete_prefix;
 
         std::mutex devices_mutex;
         std::vector<rs2::device> devices;


### PR DESCRIPTION
## Fix command terminal input bugs and refactor autocomplete

### Summary

- **Tab no longer fires repeatedly while held** — moved to `ImGuiInputTextFlags_CallbackCompletion` which fires once per keypress instead of reading `KeysDown` every frame
- **Up/Down no longer steal focus** — `ImGuiInputTextFlags_CallbackHistory` claims ownership of arrow keys, preventing ImGui's nav system from consuming them
- **History navigation no longer skips the most recent command** — `history_offset` initialised and reset to `-1` (sentinel for "not browsing") instead of `0`; first Up press now correctly lands at index 0
- **Enter no longer adds empty strings to history** — submit logic moved inside `if (InputText(...))` which returns true exactly once per press
- **Tab no longer autocompletes on an empty command line** — early-out added
- **`SetKeyboardFocusHere()` moved before `InputText`** — was incorrectly placed after, focusing the next widget instead
- **Shift+Tab added for reverse autocomplete cycling** — implemented via `ImGuiInputTextFlags_CallbackAlways` + `IsKeyPressed(Tab) && KeyShift`, since `CallbackCompletion` only fires on plain Tab
- **Autocomplete preserves XML casing** — removed spurious `to_lower` from display path; case folding only applies during matching
- **Duplicate consecutive commands no longer added to history** — same as bash behaviour

### Refactoring

- Extracted `cycle_autocomplete(bool forward)` — eliminates a duplicated ~20-line XML loading + cycling block that existed separately in the Tab and Shift+Tab branches
- `PopStyleColor()` + `PopFont()` + `PopStyleColor()` collapsed to `PopStyleColor(2)` + `PopFont()`
- History size limit `100` extracted to `MAX_HISTORY_SIZE` local constant
- `InputText` buffer size changed from hardcoded `1023` to `sizeof(buff) - 1` to keep it derived from the array declaration
