### PR TITLE
Migrate test-rotation-filter.py to pytest

### DIFF
--- a/unit-tests/post-processing/pytest-rotation-filter.py
+++ b/unit-tests/post-processing/pytest-rotation-filter.py
@@ -1,10 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2024 RealSense, Inc. All Rights Reserved.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
-#temporary fix to prevent the test from running on Win_SH_Py_DDS_CI
-#test:donotrun:dds
-
-from rspy import test, repo
 import pyrealsense2 as rs
 import numpy as np
 
@@ -85,11 +81,11 @@ def validate_rotation_results(filtered_frame, angle):
     expected_list = expected_data.flatten().tolist()
 
     # Compare the flattened lists
-    test.check_equal_lists(rotated_list, expected_list)
+    assert rotated_list == expected_list
 
 
 ################################################################################################
-with test.closure("Test rotation filter"):
+def test_rotation_filter():
     # Set up software device and depth sensor
     sw_dev = rs.software_device()
     depth_sensor = sw_dev.add_sensor("Depth")
@@ -126,6 +122,3 @@ with test.closure("Test rotation filter"):
         # Stop and close the sensor after each angle test
         depth_sensor.stop()
         depth_sensor.close()
-
-################################################################################################
-test.print_results_and_exit()


### PR DESCRIPTION
**Overview:** Migrates the rotation-filter post-processing test from the legacy `rspy.test` framework to native pytest.

Tracked on [RSDSO-21680]

## Why
Part of the ongoing effort to move legacy `test-*.py` scripts to native `pytest-*.py`.

## Summary
- `git mv test-rotation-filter.py pytest-rotation-filter.py` (history preserved).
- Wrapped the `test.closure` body in `def test_rotation_filter()`; helper functions and module-level parameters kept as-is.
- `test.check_equal_lists(...)` → `assert ... == ...`; dropped `test.print_results_and_exit`.
- Dropped `#test:donotrun:dds`: under pytest the DDS CI runs with `--tag dds` and only collects dds-tagged tests, so this software-only test never runs there — the directive is a no-op.
- Dropped unused `test`/`repo` imports. Software-device only, no hardware.

## Test plan
- [x] `pytest -v unit-tests/post-processing/pytest-rotation-filter.py` — 1 passed locally (no hardware needed).
- [ ] LibCI green on all platforms.

---
🤖 Generated by AI
