### PR TITLE
Migrate test-filters.py to pytest

### DIFF
--- a/unit-tests/live/CMakeLists.txt
+++ b/unit-tests/live/CMakeLists.txt
@@ -29,3 +29,21 @@ dl_file( ${PP_Rosbag_Recordings_URL} recordings d455_all_streams_imu_native_ros2
 # for rec-play/pytest-playback-step.py
 dl_file( ${PP_Rosbag_Recordings_URL} recordings d455_depth_non_native.db3 OFF )
 
+# Post-processing filters reference dataset (post-processing/pytest-filters.py).
+# Shipped as a single zip (308 small files) so a build downloads it once instead of the
+# test doing hundreds of per-file requests at runtime.
+set( PP_Filters_Dataset_ZIP post_processing_tests_2018_ww18.zip )
+dl_file( https://librealsense.realsenseai.com/rs-tests recordings ${PP_Filters_Dataset_ZIP} OFF )
+get_filename_component( PP_Recordings_Dir recordings ABSOLUTE BASE_DIR ${CMAKE_CURRENT_BINARY_DIR} )
+# Extract once; sentinel is one of the dataset files (first sequence's metadata).
+if( EXISTS "${PP_Recordings_Dir}/${PP_Filters_Dataset_ZIP}" AND NOT EXISTS "${PP_Recordings_Dir}/1551257764229.0.Output.csv" )
+    message( STATUS "Extracting ${PP_Filters_Dataset_ZIP}" )
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xf "${PP_Recordings_Dir}/${PP_Filters_Dataset_ZIP}"
+        WORKING_DIRECTORY "${PP_Recordings_Dir}"
+        RESULT_VARIABLE PP_Filters_Extract_Result )
+    if( PP_Filters_Extract_Result )
+        message( SEND_ERROR "Failed to extract ${PP_Filters_Dataset_ZIP}: ${PP_Filters_Extract_Result}" )
+    endif()
+endif()
+

--- a/unit-tests/post-processing/pytest-filters.py
+++ b/unit-tests/post-processing/pytest-filters.py
@@ -1,15 +1,15 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2024 RealSense, Inc. All Rights Reserved.
-
-#temporary fix to prevent the test from running on Win_SH_Py_DDS_CI
-#test:donotrun:dds
-#test:donotrun:!nightly
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 import pyrealsense2 as rs, os, random, csv
-from rspy import test, repo
+import pytest
+from pytest_check import check
+from rspy import repo
 import urllib.request
 from urllib.error import URLError, HTTPError
 import platform
+
+pytestmark = [pytest.mark.context("nightly")]
 
 def download_file(url, subdir, filename):
     destination = os.path.join(subdir, filename)
@@ -71,33 +71,36 @@ def produce_sequence_extensions(source, target):
     sequence_length = get_sequence_length(contents)
     return [f".{i}" for i in range(sequence_length)]
 
-print(f"Preparing to download Post-processing tests dataset...\nRemote server: {PP_TESTS_URL}\nTarget Location: {Deployment_Location}")
 
-for test_pattern in PP_Tests_List:
-    sequence_meta_file = f"{test_pattern}.0.Output.csv"
-    source = sequence_meta_file
-    destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
-    sequence_extensions = produce_sequence_extensions(source, destination)
+@pytest.fixture(scope="module", autouse=True)
+def download_dataset():
+    print(f"Preparing to download Post-processing tests dataset...\nRemote server: {PP_TESTS_URL}\nTarget Location: {Deployment_Location}")
 
-    for ext in PP_Test_extensions_List:
-        for idx in sequence_extensions:
-            test_file_name = f"{test_pattern}{idx}{ext}"
-            source = test_file_name
-            destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
-            download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
+    for test_pattern in PP_Tests_List:
+        sequence_meta_file = f"{test_pattern}.0.Output.csv"
+        source = sequence_meta_file
+        destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
+        sequence_extensions = produce_sequence_extensions(source, destination)
 
-for test_pattern in PP_Tests_List:
-    sequence_meta_file = f"{test_pattern}.0.Output.csv"
-    source = sequence_meta_file
-    destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
-    sequence_extensions = produce_sequence_extensions(source, destination)
+        for ext in PP_Test_extensions_List:
+            for idx in sequence_extensions:
+                test_file_name = f"{test_pattern}{idx}{ext}"
+                source = test_file_name
+                destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
+                download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
 
-    for ext in PP_Test_extensions_List:
-        for idx in sequence_extensions:
-            test_file_name = f"{test_pattern}{idx}{ext}"
-            source = test_file_name
-            destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
-            download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
+    for test_pattern in PP_Tests_List:
+        sequence_meta_file = f"{test_pattern}.0.Output.csv"
+        source = sequence_meta_file
+        destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
+        sequence_extensions = produce_sequence_extensions(source, destination)
+
+        for ext in PP_Test_extensions_List:
+            for idx in sequence_extensions:
+                test_file_name = f"{test_pattern}{idx}{ext}"
+                source = test_file_name
+                destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
+                download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
 
 ################################################################################################
 frame_metadata_count = 43
@@ -262,52 +265,52 @@ def attrib_from_csv(file_path):
 
 
 def check_load_test_configuration(test_config):
-    test.check(test_config.name)
-    test.check(test_config.input_res_x)
-    test.check(test_config.input_res_y)
+    check.is_true(test_config.name)
+    check.is_true(test_config.input_res_x)
+    check.is_true(test_config.input_res_y)
 
     for i in range(test_config.frames_sequence_size):
-        test.check(len(test_config._input_frames[i]))
-        test.check(len(test_config._output_frames[i]))
+        check.is_true(len(test_config._input_frames[i]))
+        check.is_true(len(test_config._output_frames[i]))
 
     _padded_width = int((test_config.input_res_x // test_config.downsample_scale) + 3) // 4 * 4
     _padded_height = int((test_config.input_res_y // test_config.downsample_scale) + 3) // 4 * 4
 
-    test.check_equal(test_config.output_res_x, _padded_width)
-    test.check_equal(test_config.output_res_y, _padded_height)
-    test.check(test_config.input_res_x > 0)
-    test.check(test_config.input_res_y > 0)
-    test.check(test_config.output_res_x > 0)
-    test.check(test_config.output_res_y > 0)
-    test.check(abs(test_config.stereo_baseline_mm) > 0)
-    test.check(test_config.depth_units > 0)
-    test.check(test_config.focal_length > 0)
-    test.check(test_config.frames_sequence_size > 0)
+    check.equal(test_config.output_res_x, _padded_width)
+    check.equal(test_config.output_res_y, _padded_height)
+    check.is_true(test_config.input_res_x > 0)
+    check.is_true(test_config.input_res_y > 0)
+    check.is_true(test_config.output_res_x > 0)
+    check.is_true(test_config.output_res_y > 0)
+    check.is_true(abs(test_config.stereo_baseline_mm) > 0)
+    check.is_true(test_config.depth_units > 0)
+    check.is_true(test_config.focal_length > 0)
+    check.is_true(test_config.frames_sequence_size > 0)
 
     for i in range(test_config.frames_sequence_size):
-        test.check_equal(test_config.input_res_x * test_config.input_res_y * 2, len(test_config._input_frames[i]))
-        test.check_equal(test_config.output_res_x * test_config.output_res_y * 2,len(test_config._output_frames[i]))
+        check.equal(test_config.input_res_x * test_config.input_res_y * 2, len(test_config._input_frames[i]))
+        check.equal(test_config.output_res_x * test_config.output_res_y * 2,len(test_config._output_frames[i]))
 
     # The following tests use assumption about the filters intrinsic
     # Note that the specific parameter threshold are verified as of April 2018
     if test_config.spatial_filter:
-        test.check(test_config.spatial_alpha >= 0.25)
-        test.check(test_config.spatial_alpha <= 1.0)
-        test.check(test_config.spatial_delta >= 1)
-        test.check(test_config.spatial_delta <= 50)
-        test.check(test_config.spatial_iterations >= 1)
-        test.check(test_config.spatial_iterations <= 5)
+        check.is_true(test_config.spatial_alpha >= 0.25)
+        check.is_true(test_config.spatial_alpha <= 1.0)
+        check.is_true(test_config.spatial_delta >= 1)
+        check.is_true(test_config.spatial_delta <= 50)
+        check.is_true(test_config.spatial_iterations >= 1)
+        check.is_true(test_config.spatial_iterations <= 5)
 
     if test_config.temporal_filter:
-        test.check(test_config.temporal_alpha >= 0)
-        test.check(test_config.temporal_alpha <= 1.0)
-        test.check(test_config.temporal_delta >= 1)
-        test.check(test_config.temporal_delta <= 100)
-        test.check(test_config.temporal_persistence >= 0)
+        check.is_true(test_config.temporal_alpha >= 0)
+        check.is_true(test_config.temporal_alpha <= 1.0)
+        check.is_true(test_config.temporal_delta >= 1)
+        check.is_true(test_config.temporal_delta <= 100)
+        check.is_true(test_config.temporal_persistence >= 0)
 
     if test_config.holes_filter:
-        test.check(test_config.holes_filling_mode >= 0)
-        test.check(test_config.holes_filling_mode <= 2)
+        check.is_true(test_config.holes_filling_mode >= 0)
+        check.is_true(test_config.holes_filling_mode <= 2)
 
     return True
 
@@ -323,7 +326,7 @@ def load_test_configuration(test_name, test_config):
 
     #checking all the files are present
     for test_name in test_file_names.values():
-        test.check(os.path.exists(base_name+test_name))
+        assert os.path.exists(base_name+test_name)
 
     #Prepare the configuration data set
     test_config.reset()
@@ -366,7 +369,7 @@ def profile_diffs(distances, max_allowed_std, outlier):
         return
 
     max_value = max(distances)
-    test.check_equal(max_value, 0)
+    check.equal(max_value, 0)
 
     e = 0
     inverse = 1/len(distances)
@@ -374,8 +377,8 @@ def profile_diffs(distances, max_allowed_std, outlier):
         e += (distance - mean) ** 2
     standard_deviation = (inverse * e) ** 0.5
 
-    test.check(standard_deviation <= max_allowed_std)
-    test.check(abs(max_value) <= outlier)
+    check.is_true(standard_deviation <= max_allowed_std)
+    check.is_true(abs(max_value) <= outlier)
 
     return (abs(max_value) <= outlier) and (standard_deviation <= max_allowed_std)
 
@@ -384,13 +387,13 @@ def validate_ppf_results(result_depth, reference_data, frame_idx):
 
     domain_transform_only = (reference_data.downsample_scale == 1) and (not reference_data.spatial_filter) and (not reference_data.temporal_filter)
     result_profile = result_depth.get_profile().as_video_stream_profile()
-    test.check_equal(result_profile.width(), reference_data.output_res_x)
-    test.check_equal(result_profile.height(), reference_data.output_res_y)
+    check.equal(result_profile.width(), reference_data.output_res_x)
+    check.equal(result_profile.height(), reference_data.output_res_y)
 
     #Pixel-by-pixel comparison of the resulted filtered depth vs data encoded with external tool
     v1 = bytearray(result_depth.get_data())
     v2 = (reference_data._output_frames[frame_idx])
-    test.check_equal(len(v1), len(v2))
+    check.equal(len(v1), len(v2))
     diff2ref = [abs(byte1 - byte2) for byte1, byte2 in zip(v1, v2)]
 
     #Validate the filters
@@ -401,7 +404,7 @@ def compare_frame_md(origin_depth, result_depth):
     for i in range(frame_metadata_count):
         origin_supported = origin_depth.supports_frame_metadata(rs.frame_metadata_value(i))
         result_supported = result_depth.supports_frame_metadata(rs.frame_metadata_value(i))
-        test.check_equal(origin_supported, result_supported)
+        check.equal(origin_supported, result_supported)
         if origin_supported and result_supported:
             #FRAME_TIMESTAMP and SENSOR_TIMESTAMP metadatas are not included in post proccesing frames,
             #TIME_OF_ARRIVAL continues to increase  after post proccesing
@@ -410,7 +413,7 @@ def compare_frame_md(origin_depth, result_depth):
 
             origin_val = origin_depth.get_frame_metadata(rs.frame_metadata_value(i))
             result_val = result_depth.get_frame_metadata(rs.frame_metadata_value(i))
-            test.check_equal(origin_val, result_val)
+            check.equal(origin_val, result_val)
 
 def create_depth_intrinsics(test_cfg):
     depth_intrinsics = rs.intrinsics()
@@ -451,7 +454,7 @@ def create_frame(test_cfg, depth_stream_profile, index):
 
 
 ################################################################################################
-with test.closure("Post-Processing Filters sequence validation"):
+def test_filters_sequence_validation():
     test_cfg = ppf_test_config()
     for first_element, second_element in ppf_test_cases:
         # Load the data from configuration and raw frame files
@@ -491,8 +494,10 @@ with test.closure("Post-Processing Filters sequence validation"):
 
         depth_sensor.stop()
         depth_sensor.close()
+
+
 ################################################################################################
-with test.closure("Post-Processing Filters metadata validation"):
+def test_filters_metadata_validation():
     test_cfg = ppf_test_config()
     for first_element, second_element in ppf_test_cases:
         # Load the data from configuration and raw frame files
@@ -536,5 +541,3 @@ with test.closure("Post-Processing Filters metadata validation"):
 
         depth_sensor.stop()
         depth_sensor.close()
-################################################################################################
-test.print_results_and_exit()

--- a/unit-tests/post-processing/pytest-filters.py
+++ b/unit-tests/post-processing/pytest-filters.py
@@ -2,103 +2,13 @@
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 import pyrealsense2 as rs, os, random, csv
-import pytest
 from pytest_check import check
 from rspy import repo
-import urllib.request
-from urllib.error import URLError, HTTPError
-import platform
 
-def download_file(url, subdir, filename):
-    destination = os.path.join(subdir, filename)
-    try:
-        if not os.path.exists(subdir):
-            os.makedirs(subdir, exist_ok=True)
-            print(f"Created directory: {subdir}")
-
-        if not os.path.exists(destination):
-            print(f"Downloading {url}/{filename} to {destination}")
-            try:
-                req = urllib.request.Request(url)
-                with urllib.request.urlopen(req) as response, open(destination, 'wb') as out_file:
-                    out_file.write(response.read())
-                print(f"Downloaded {filename} successfully.")
-            except (URLError, HTTPError) as e:
-                print(f"Failed to download {url}/{filename}: {e.reason}")
-                return False
-    except OSError as e:
-        print(f"Failed to create directory {subdir}: {e.strerror}")
-        return False
-
-    return True
-
-RECORDINGS_FOLDER = os.path.join(repo.build, 'unit-tests', 'recordings')
-
-if platform.system() == 'Windows':
-    Deployment_Location = os.getenv('TESTDATA_LOCATION', os.getenv('TEMP', 'C:\\Temp'))
-else:
-    Deployment_Location = os.getenv('TESTDATA_LOCATION', '/tmp/')
-
-PP_Tests_List = [
-    "1551257764229", "1551257812956", "1551257880762", "1551257882796",
-    "1551257884097", "1551257987255", "1551259481873", "1551261946511",
-    "1551262153516", "1551262256875", "1551262841203", "1551262772964",
-    "1551262971309", "1551263177558"
-]
-
-# Extensions for post-processing test files
-PP_Test_extensions_List = [".Input.raw", ".Input.csv", ".Output.raw", ".Output.csv"]
-
-PP_TESTS_URL = "https://librealsense.realsenseai.com/rs-tests/post_processing_tests_2018_ww18/"
-
-def get_sequence_length(contents):
-    sequence_length = 1
-    for line in contents.split('\n'):
-        if "Frames sequence length" in line:
-            parts = line.split(',')
-            if len(parts) > 1 and parts[1].isdigit():
-                sequence_length = int(parts[1])
-                break
-    return sequence_length
-
-def produce_sequence_extensions(source, target):
-    if not os.path.exists(target):
-        download_file(PP_TESTS_URL + source, RECORDINGS_FOLDER, source)
-    with open(target, 'r') as f:
-        contents = f.read()
-    sequence_length = get_sequence_length(contents)
-    return [f".{i}" for i in range(sequence_length)]
-
-
-@pytest.fixture(scope="module", autouse=True)
-def download_dataset():
-    print(f"Preparing to download Post-processing tests dataset...\nRemote server: {PP_TESTS_URL}\nTarget Location: {Deployment_Location}")
-
-    for test_pattern in PP_Tests_List:
-        sequence_meta_file = f"{test_pattern}.0.Output.csv"
-        source = sequence_meta_file
-        destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
-        sequence_extensions = produce_sequence_extensions(source, destination)
-
-        for ext in PP_Test_extensions_List:
-            for idx in sequence_extensions:
-                test_file_name = f"{test_pattern}{idx}{ext}"
-                source = test_file_name
-                destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
-                download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
-
-    for test_pattern in PP_Tests_List:
-        sequence_meta_file = f"{test_pattern}.0.Output.csv"
-        source = sequence_meta_file
-        destination = os.path.join(RECORDINGS_FOLDER, sequence_meta_file)
-        sequence_extensions = produce_sequence_extensions(source, destination)
-
-        for ext in PP_Test_extensions_List:
-            for idx in sequence_extensions:
-                test_file_name = f"{test_pattern}{idx}{ext}"
-                source = test_file_name
-                destination = os.path.join(RECORDINGS_FOLDER, test_file_name)
-                download_file(PP_TESTS_URL + test_file_name, RECORDINGS_FOLDER, test_file_name)
+# The post-processing reference dataset (the 1551*.Input/.Output .raw/.csv files) is
+# provisioned at build time by CMake (unit-tests/live/CMakeLists.txt downloads
+# post_processing_tests_2018_ww18.zip and extracts it into the recordings dir), so the
+# test just reads it from repo.build like the other recording-based tests.
 
 ################################################################################################
 frame_metadata_count = 43

--- a/unit-tests/post-processing/pytest-filters.py
+++ b/unit-tests/post-processing/pytest-filters.py
@@ -9,8 +9,6 @@ import urllib.request
 from urllib.error import URLError, HTTPError
 import platform
 
-pytestmark = [pytest.mark.context("nightly")]
-
 def download_file(url, subdir, filename):
     destination = os.path.join(subdir, filename)
     try:


### PR DESCRIPTION
**Overview:** Migrates the post-processing filters test (sequence + metadata validation against a reference dataset) to native pytest.

Tracked on [RSDSO-21678]

## Why
Part of the ongoing effort to move legacy `test-*.py` scripts to native `pytest-*.py`.

## Summary
- `git mv test-filters.py pytest-filters.py` (history preserved).
- Split the two `test.closure` blocks into `test_filters_sequence_validation()` and `test_filters_metadata_validation()`.
- `test.check`/`test.check_equal` in validation paths → `pytest_check.check.*` (soft, so all frames/configs report); file-existence precondition → `assert`. Dropped `test.print_results_and_exit`.
- Dropped `#test:donotrun:dds` (no-op under pytest's `--tag dds` DDS CI) and the `#test:donotrun:!nightly` gate — this is a not-live software test, so it now runs on the GHA not-live jobs (Win + Linux).
- **Dataset provisioning moved to build time.** The legacy script downloaded the reference dataset (308 small files) at runtime via hundreds of sequential HTTPS requests, which blew the 200s per-test timeout on slow runners. Now `unit-tests/live/CMakeLists.txt` downloads a single `post_processing_tests_2018_ww18.zip` (~16 MiB) via `dl_file` and extracts it with `cmake -E tar` into the recordings dir — one request, at configure time, outside the test timeout. The test just reads the files like the other recording-based tests; all download/unpack logic removed from `pytest-filters.py`.

## Notes for reviewer
- `load_test_configuration` reuses its `test_name` parameter as the loop variable in the file-existence check (pre-existing shadowing); left as-is.
- New dataset zip is hosted at `librealsense.realsenseai.com/rs-tests/post_processing_tests_2018_ww18.zip` (sibling of the existing per-file folder).

## Test plan
- [x] `pytest -v unit-tests/post-processing/pytest-filters.py` — 2 passed locally.
- [x] Verified `dl_file` URL resolves and `cmake -E tar xf` extracts all 308 files flat into the recordings dir.
- [ ] GHA not-live green (Win_ST_Py_CI + U22_SH_Py_CI) with the new build-time provisioning.

---
🤖 Generated by AI
