### PR TITLE
added comma that was missing

### DIFF
--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -1251,7 +1251,7 @@ namespace rs2
             "OSSD2_A_present",
             "OSSD2_A status : Raised / Idle",
             "OSSD2_B_present",
-            "OSSD2_B status : Raised / Idle"
+            "OSSD2_B status : Raised / Idle",
             "Device_Ready_present",
             "Device_Ready on / off",
             "Error signal present",


### PR DESCRIPTION
# Added missing comma

## Problem
In common/stream-model.cpp, the meanings vector that decodes the RS2_FRAME_METADATA_SAFETY_NON_FUSA_GPIO_OUT bitmap was missing a comma between two adjacent string literals. C++ concatenated the two literals into a single element, so the vector had 7 entries instead of 8 and every bit from index 4 onward was mislabelled.

## Solution
- Add the missing comma