### PR TITLE
D401 GMSL: route RGB controls to dedicated color v4l2 node

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -127,6 +127,24 @@ namespace librealsense
                 _color_device_idx = _depth_device_idx;
                 d400_device::_color_stream = _color_stream;
                 _separate_color = false;
+
+                // D401 GMSL exposes color through the depth sensor, but color streams from a dedicated
+                // v4l2 node (video-rs-color) that also owns the RGB controls (saturation, white balance,
+                // sharpness, ...) - the depth/front node does not. The depth sensor wraps all mi0 nodes in
+                // a multi_pins_uvc_device that routes every control to the front (depth) node, so RGB
+                // controls never reach the color node. Bind a raw endpoint to the color node for them.
+                if (_is_mipi_device && _pid == ds::RS401_GMSL_PID)
+                {
+                    auto color_node = std::find_if(color_devs_info_mi0.begin(), color_devs_info_mi0.end(),
+                        [](const platform::uvc_device_info& info) { return info.device_path.find("color") != std::string::npos; });
+                    if (color_node != color_devs_info_mi0.end())
+                    {
+                        auto color_uvc_node = get_backend()->create_uvc_device(*color_node);
+                        if (color_uvc_node)
+                            _raw_color_ep = std::make_shared<uvc_sensor>("Raw RGB Camera", color_uvc_node,
+                                std::unique_ptr<frame_timestamp_reader>(new ds_timestamp_reader()), this);
+                    }
+                }
             }
             else
                 throw invalid_value_exception( rsutils::string::from() << "RS4XX: RGB modules inconsistency - "
@@ -201,10 +219,12 @@ namespace librealsense
             // RGB controls registered for USB but not yet for MIPI (no FW/kernel support):
             //   RS2_OPTION_BRIGHTNESS, RS2_OPTION_CONTRAST, RS2_OPTION_GAMMA,
             //   RS2_OPTION_BACKLIGHT_COMPENSATION, RS2_OPTION_HUE
-            auto raw_color_ep = get_raw_color_sensor();
+            // For D401 GMSL the color node differs from the depth (front) node, so route the RGB
+            // controls to the dedicated color endpoint; other devices use the shared raw color sensor.
+            auto raw_color_ep = _raw_color_ep ? _raw_color_ep : get_raw_color_sensor();
 
-            color_ep.register_pu(RS2_OPTION_SATURATION);
-            color_ep.register_pu(RS2_OPTION_SHARPNESS);
+            color_ep.register_option(RS2_OPTION_SATURATION, std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_SATURATION));
+            color_ep.register_option(RS2_OPTION_SHARPNESS, std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_SHARPNESS));
 
             auto white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_WHITE_BALANCE);
             auto auto_white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);

--- a/src/ds/d400/d400-color.h
+++ b/src/ds/d400/d400-color.h
@@ -68,6 +68,9 @@ namespace librealsense
         friend class ds_color_common;
 
         bool _separate_color;
+        // For D401 GMSL the color shares the depth sensor but streams from its own v4l2 node.
+        // This raw endpoint is bound to that node so RGB controls reach it (see create_color_device).
+        std::shared_ptr< uvc_sensor > _raw_color_ep;
         rsutils::lazy< std::vector< uint8_t > > _color_calib_table_raw;
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _color_extrinsic;
     };

--- a/unit-tests/live/options/pytest-advanced-mode.py
+++ b/unit-tests/live/options/pytest-advanced-mode.py
@@ -8,7 +8,6 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D400*"),
-    pytest.mark.device_exclude("D401"),
     pytest.mark.device_each("D500*"),
     pytest.mark.context("nightly"),
 ]

--- a/unit-tests/live/options/pytest-presets.py
+++ b/unit-tests/live/options/pytest-presets.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D400*"),
-    pytest.mark.device_exclude("D401"),
     pytest.mark.device_each("D500*"),
     pytest.mark.context("nightly"),
     pytest.mark.flaky(retries=2),  # See FW stability issue RSDSO-18908
@@ -68,12 +67,16 @@ def test_setting_color_options(test_device_wrapped):
     product_name = dev.get_info(rs.camera_info.name)
     depth_sensor = dev.first_depth_sensor()
 
+    # D405 and D401 GMSL expose color through the depth sensor (no separate color sensor).
     try:
         color_sensor = dev.first_color_sensor()
     except RuntimeError:
-        if 'D421' in product_name or 'D405' in product_name:
+        if 'D405' in product_name or 'D401' in product_name:
+            color_sensor = dev.first_depth_sensor()
+        elif 'D421' in product_name:
             pytest.skip("No color sensor")
-        raise
+        else:
+            raise
 
     if not color_sensor.supports(rs.option.hue):
         pytest.skip("Color sensor does not support hue option")

--- a/unit-tests/live/options/pytest-presets.py
+++ b/unit-tests/live/options/pytest-presets.py
@@ -67,12 +67,14 @@ def test_setting_color_options(test_device_wrapped):
     product_name = dev.get_info(rs.camera_info.name)
     depth_sensor = dev.first_depth_sensor()
 
-    # D405 and D401 GMSL expose color through the depth sensor (no separate color sensor).
+    # D401 GMSL exposes color through the depth sensor (no separate color sensor).
     try:
         color_sensor = dev.first_color_sensor()
     except RuntimeError:
-        if 'D405' in product_name or 'D401' in product_name:
+        if 'D401' in product_name:
             color_sensor = dev.first_depth_sensor()
+        elif 'D405' in product_name:
+            pytest.skip("D405 default preset does not reset hue (see default_405 in presets.cpp)")
         elif 'D421' in product_name:
             pytest.skip("No color sensor")
         else:

--- a/unit-tests/live/options/pytest-rgb-options-metadata-consistency.py
+++ b/unit-tests/live/options/pytest-rgb-options-metadata-consistency.py
@@ -9,9 +9,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D400*"),
-    pytest.mark.device_exclude("D421"),
-    pytest.mark.device_exclude("D405"),
-    pytest.mark.device_exclude("D401"),
+    pytest.mark.device_exclude("D421"),  # no color sensor and no color options registered
     pytest.mark.device_each("D500*"),
     pytest.mark.context("nightly"),
 ]
@@ -55,7 +53,16 @@ def test_rgb_options_metadata_consistency(test_device):
     """For each color option, set min/max/default and verify get_option and frame metadata agree."""
     dev, ctx = test_device
 
-    color_sensor = dev.first_color_sensor()
+    # D405 and D401 GMSL expose color through the depth sensor (no separate color sensor),
+    # but the color options (saturation, sharpness, white_balance, ...) are registered there.
+    try:
+        color_sensor = dev.first_color_sensor()
+    except RuntimeError:
+        product_name = dev.get_info(rs.camera_info.name)
+        if 'D405' in product_name or 'D401' in product_name:
+            color_sensor = dev.first_depth_sensor()
+        else:
+            raise
 
     color_profile = next(
         (p for p in color_sensor.profiles


### PR DESCRIPTION
Tracked by: RSDSO-21631

**Overview:** On D401 GMSL, RGB controls (Saturation, Sharpness, White Balance, Auto WB) failed to take effect because they were being applied to the wrong v4l2 node.

## Why
D401 GMSL exposes color through the depth sensor (`_separate_color = false`), but color actually streams from a dedicated `video-rs-color` node that also owns the RGB controls — the depth/front node does not. The depth sensor wraps all mi0 nodes in a `multi_pins_uvc_device` that routes every control to the front (depth) node, so RGB controls never reached the color node.

## Summary
- In `d400_color::create_color_device`, when the device is MIPI with `RS401_GMSL_PID`, locate the `color` entry in `color_devs_info_mi0` and build a dedicated `uvc_sensor` (`_raw_color_ep`) bound to that node.
- In `register_options`, use `_raw_color_ep` (when set) as the target for Saturation and Sharpness — switching from `register_pu` to an explicit `uvc_pu_option` on the right endpoint — and for the existing White Balance / Auto WB options. Other devices keep using `get_raw_color_sensor()`.
- Adds the `_raw_color_ep` member to `d400_color.h` with a comment pointing back to `create_color_device`.
- `pytest-rgb-options-metadata-consistency.py`: drops `device_exclude` for D405 and D401, and falls back to `first_depth_sensor()` when `first_color_sensor()` throws — D405 and D401 GMSL expose color through the depth sensor.
- `pytest-advanced-mode.py`: drops `device_exclude("D401")` — advanced-mode is now expected to work on D401.
- `pytest-presets.py`: drops `device_exclude("D401")` and updates the `first_color_sensor()` fallback — D401 falls back to `first_depth_sensor()`, D405 skips with a hue-preservation reason (`default_405` in `presets.cpp` deliberately does not reset color hue on preset apply), D421 keeps its explicit "no color sensor" skip. On D401 GMSL the test skips cleanly at the `supports(rs.option.hue)` guard since HUE isn't registered on MIPI.

## Test plan
- [x] D401 GMSL: realsense-viewer — adjust Saturation/Sharpness/White Balance and confirm the streamed image responds.
- [x] D401 GMSL: toggle Auto White Balance on/off and confirm behavior.
- [x] D400 USB (e.g. D435): verify Saturation/Sharpness/WB still work (no regression — `_raw_color_ep` stays null, fallback path unchanged).
- [x] D401 GMSL: run `pytest-rgb-options-metadata-consistency.py` (nightly) — passes.
- [x] D405: run `pytest-rgb-options-metadata-consistency.py` (nightly) — passes.
- [x] D401 GMSL: run `pytest-advanced-mode.py` (nightly) — passes.
- [x] D401 GMSL: run `pytest-presets.py` (nightly) — passes.
- [x] D405: run `pytest-presets.py` (nightly) — `test_setting_color_options` skips with the hue-preservation reason; other tests in the file pass.
- [x] D401 GMSL: run `pytest-uvc-power-stress-test.py` (weekly, with `-r`) — passes.