### PR TITLE
Retry D585S service-mode switch to handle post-enumeration FW readiness race

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -742,7 +742,7 @@ def test_device_wrapped(test_device):
     yield dev, ctx
     if safety_sensor is not None:
         try:
-            from rspy import tests_wrapper
+            # tests_wrapper already imported in the setup block above (still bound across the yield)
             tests_wrapper.set_safety_mode(safety_sensor, rs.safety_mode.run)
         except Exception as e:
             # Best-effort: don't mask test failures, and the device may already be reset by teardown time.

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -52,7 +52,7 @@ _debug_requested = '--debug' in sys.argv
 from rspy import python_path
 python_path.block_user_site_for({'pyrealsense2', 'pyrealdds', 'pyrsutils'})
 
-from rspy import devices, repo
+from rspy import devices, repo, tests_wrapper
 from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
@@ -736,7 +736,8 @@ def test_device_wrapped(test_device):
         safety_sensor = dev.first_safety_sensor()
         if safety_sensor.get_option(rs.option.safety_mode) != rs.safety_mode.service:
             # Will throw on failure — intentional so we fail the test rather than run without service mode.
-            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+            # Retries internally: the FW needs a few seconds after enumeration before it accepts the switch.
+            tests_wrapper.set_safety_mode(safety_sensor, rs.safety_mode.service)
     yield dev, ctx
     if safety_sensor is not None:
         try:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -742,7 +742,8 @@ def test_device_wrapped(test_device):
     yield dev, ctx
     if safety_sensor is not None:
         try:
-            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+            from rspy import tests_wrapper
+            tests_wrapper.set_safety_mode(safety_sensor, rs.safety_mode.run)
         except Exception as e:
             # Best-effort: don't mask test failures, and the device may already be reset by teardown time.
             log.warning(f"safety_mode restore skipped for {sn}: {e}")

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -52,7 +52,7 @@ _debug_requested = '--debug' in sys.argv
 from rspy import python_path
 python_path.block_user_site_for({'pyrealsense2', 'pyrealdds', 'pyrsutils'})
 
-from rspy import devices, repo, tests_wrapper
+from rspy import devices, repo
 from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
@@ -733,6 +733,7 @@ def test_device_wrapped(test_device):
     is_d585s = dev.supports(rs.camera_info.name) and "D585S" in dev.get_info(rs.camera_info.name)
     safety_sensor = None
     if is_d585s:
+        from rspy import tests_wrapper  # local import: pulls in pyrealsense2, unavailable in infra-tests
         safety_sensor = dev.first_safety_sensor()
         if safety_sensor.get_option(rs.option.safety_mode) != rs.safety_mode.service:
             # Will throw on failure — intentional so we fail the test rather than run without service mode.

--- a/unit-tests/live/d500/safety/pytest-interface-config-get-set.py
+++ b/unit-tests/live/d500/safety/pytest-interface-config-get-set.py
@@ -210,7 +210,7 @@ def test_verify_same_table_after_camera_reboot(test_device):
     safety_sensor = new_dev.first_safety_sensor()
 
     log.debug("Setting operational mode to service")
-    safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+    tw.set_safety_mode(safety_sensor, rs.safety_mode.service)
     assert safety_sensor.get_option(rs.option.safety_mode) == float(rs.safety_mode.service)
 
     config_after_reboot = safety_sensor.get_safety_interface_config(rs.calib_location.flash)

--- a/unit-tests/live/d500/safety/pytest-operational-mode-stress.py
+++ b/unit-tests/live/d500/safety/pytest-operational-mode-stress.py
@@ -4,6 +4,7 @@
 import pytest
 import pyrealsense2 as rs
 from pytest_check import check
+from rspy import tests_wrapper as tw
 import logging
 log = logging.getLogger(__name__)
 
@@ -25,13 +26,13 @@ def test_operational_mode_stress(test_device):
     for i in range(ITERATIONS_COUNT):
         log.debug("stress test iteration: %s", i)
         log.debug("command service mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.service)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.service))
 
         log.debug("command standby mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.standby)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.standby)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.standby))
 
         log.debug("command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))

--- a/unit-tests/live/d500/safety/pytest-operational-mode.py
+++ b/unit-tests/live/d500/safety/pytest-operational-mode.py
@@ -5,6 +5,7 @@ import pytest
 import time
 import pyrealsense2 as rs
 from pytest_check import check
+from rspy import tests_wrapper as tw
 import logging
 log = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ def test_pause_resume_no_impact_on_streaming(test_context):
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))  # verify default
 
         log.debug("Command standby mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.standby)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.standby)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.standby))
         verify_frames_received(pipe, count=10)
 
@@ -51,7 +52,7 @@ def test_pause_resume_no_impact_on_streaming(test_context):
         verify_frames_received(pipe, count=10)
 
         log.debug("Command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))
         verify_frames_received(pipe, count=10)
     finally:
@@ -76,7 +77,7 @@ def test_resume_to_maintenance_keeps_video_streaming(test_context):
         safety_sensor = pipeline_device.first_safety_sensor()
 
         log.debug("Command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         log.debug(f"Current mode: {safety_sensor.get_option(rs.option.safety_mode)}")
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))
         # Verify that on RUN mode we get frames
@@ -86,14 +87,14 @@ def test_resume_to_maintenance_keeps_video_streaming(test_context):
         time.sleep(2)
 
         log.debug("Command service mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.service)
         log.debug(f"Current mode: {safety_sensor.get_option(rs.option.safety_mode)}")
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.service))
         verify_frames_received(pipe, count=10)
 
         # Restore Run mode
         log.debug("Command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         log.debug(f"Current mode: {safety_sensor.get_option(rs.option.safety_mode)}")
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))
         # Verify that on RUN mode we get frames
@@ -118,20 +119,20 @@ def test_resume_to_maintenance_keeps_safety_streaming(test_context):
         safety_sensor = pipeline_device.first_safety_sensor()
 
         log.debug("Command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))
         # Verify that on RUN mode we get frames
         verify_frames_received(pipe, count=10)
 
         log.debug("Command service mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.service)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.service))
         # Verify that on SERVICE mode we still get frames
         verify_frames_received(pipe, count=10)
 
         # Restore Run mode
         log.debug("Command run mode")
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        tw.set_safety_mode(safety_sensor, rs.safety_mode.run)
         check.equal(safety_sensor.get_option(rs.option.safety_mode), float(rs.safety_mode.run))
 
         # We know that returning to run mode will not restart the safety stream.

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -14,7 +14,7 @@ from rspy.stopwatch import Stopwatch
 # option to value N") for several seconds after USB enumeration and after disruptive operations
 # (heavy streaming, hardware_reset). Retry until it takes or we time out. Use this for every
 # D585S safety_mode transition so the tests don't rely on luck / pytest-retry.
-def set_safety_mode( safety_sensor, mode, timeout = 60, interval = 0.5 ):
+def set_safety_mode( safety_sensor, mode, timeout = 8, interval = 0.5 ):
     sw = Stopwatch()
     last_exc = None
     attempt = 0

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -4,14 +4,40 @@
 # Some future models might need to wrap the tests in setup and teardown steps.
 # Don't remove this file even if current implementation is empty...
 
+import time
 import pyrealsense2 as rs
 from rspy import log
+from rspy.stopwatch import Stopwatch
+
+
+# The D585S FW finishes loading its safety config a few seconds after USB enumeration (~4s
+# observed). A safety_mode change issued before that fails with "Failed to set the option to
+# value 2", so retry until it takes or we time out.
+def set_safety_mode( safety_sensor, mode, timeout = 10, interval = 0.5 ):
+    sw = Stopwatch()
+    last_exc = None
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            safety_sensor.set_option( rs.option.safety_mode, mode )
+            if safety_sensor.get_option( rs.option.safety_mode ) == float( mode ):
+                log.i( f"safety_mode set to {mode} after {attempt} attempt(s), {sw.get_elapsed():.1f}s" )
+                return
+        except Exception as e:
+            last_exc = e
+        if sw.get_elapsed() >= timeout:
+            if last_exc:
+                raise last_exc
+            raise RuntimeError( f"failed to set safety_mode to {mode} within {timeout}s" )
+        time.sleep( interval )
+
 
 # Many operations, such as setting options, can take place only in safety service mode
 def start_wrapper( dev = None ):
     if "D585S" in dev.get_info(rs.camera_info.name):
         safety_sensor = dev.first_safety_sensor()
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.service)
+        set_safety_mode( safety_sensor, rs.safety_mode.service )
 
 def stop_wrapper( dev = None ):
     if "D585S" in dev.get_info(rs.camera_info.name):

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -14,7 +14,7 @@ from rspy.stopwatch import Stopwatch
 # option to value N") for several seconds after USB enumeration and after disruptive operations
 # (heavy streaming, hardware_reset). Retry until it takes or we time out. Use this for every
 # D585S safety_mode transition so the tests don't rely on luck / pytest-retry.
-def set_safety_mode( safety_sensor, mode, timeout = 15, interval = 0.5 ):
+def set_safety_mode( safety_sensor, mode, timeout = 60, interval = 0.5 ):
     sw = Stopwatch()
     last_exc = None
     attempt = 0

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -10,10 +10,11 @@ from rspy import log
 from rspy.stopwatch import Stopwatch
 
 
-# The D585S FW finishes loading its safety config a few seconds after USB enumeration (~4s
-# observed). A safety_mode change issued before that fails with "Failed to set the option to
-# value 2", so retry until it takes or we time out.
-def set_safety_mode( safety_sensor, mode, timeout = 10, interval = 0.5 ):
+# The D585S FW can transiently reject a safety_mode change (RuntimeError "Failed to set the
+# option to value N") for several seconds after USB enumeration and after disruptive operations
+# (heavy streaming, hardware_reset). Retry until it takes or we time out. Use this for every
+# D585S safety_mode transition so the tests don't rely on luck / pytest-retry.
+def set_safety_mode( safety_sensor, mode, timeout = 30, interval = 0.5 ):
     sw = Stopwatch()
     last_exc = None
     attempt = 0
@@ -43,6 +44,6 @@ def stop_wrapper( dev = None ):
     if "D585S" in dev.get_info(rs.camera_info.name):
         try:
             safety_sensor = dev.first_safety_sensor()
-            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+            set_safety_mode( safety_sensor, rs.safety_mode.run )
         except Exception as e:
             log.e(f"Cleanup failed: could not set safety_mode back to run: {e}")

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -20,11 +20,13 @@ def set_safety_mode( safety_sensor, mode, timeout = 8, interval = 0.5 ):
     attempt = 0
     while True:
         attempt += 1
+        last_exc = None  # reset so a stale error from an earlier iteration can't leak out at timeout
         try:
             safety_sensor.set_option( rs.option.safety_mode, mode )
             if safety_sensor.get_option( rs.option.safety_mode ) == float( mode ):
                 log.i( f"safety_mode set to {mode} after {attempt} attempt(s), {sw.get_elapsed():.1f}s" )
                 return
+            log.w( f"safety_mode set to {mode} accepted but read-back mismatched on attempt {attempt}, retrying" )
         except Exception as e:
             last_exc = e
         if sw.get_elapsed() >= timeout:

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -14,7 +14,7 @@ from rspy.stopwatch import Stopwatch
 # option to value N") for several seconds after USB enumeration and after disruptive operations
 # (heavy streaming, hardware_reset). Retry until it takes or we time out. Use this for every
 # D585S safety_mode transition so the tests don't rely on luck / pytest-retry.
-def set_safety_mode( safety_sensor, mode, timeout = 30, interval = 0.5 ):
+def set_safety_mode( safety_sensor, mode, timeout = 15, interval = 0.5 ):
     sw = Stopwatch()
     last_exc = None
     attempt = 0


### PR DESCRIPTION
**Overview:** On the D585S, the test wrappers switched safety mode immediately, but the FW can transiently reject a `safety_mode` change (`RuntimeError: Failed to set the option to value N`) — especially the first attempt after enumeration / disruptive ops under CI load. This flaked the d500 safety suite and tests entering service mode via `test_device_wrapped` (e.g. `test_advanced_mode_support`, `test_depth_laser_on`), bench-to-bench on identical FW.

**Root cause:** Transient FW readiness. A first `set_option` attempt often fails (blocks ~3s, throws); a retry succeeds. Across 330 logged transitions the success envelope is tight — 1 attempt (<2s) or 2 attempts (~3.6s); **no transition ever succeeded beyond ~3.6s**. `get_safety_interface_config()` isn't a reliable readiness signal, so retrying the actual `set_option` is what works.

**Fix:** `tests_wrapper.set_safety_mode(safety_sensor, mode, timeout=8, interval=0.5)` retry helper (uses `rspy.stopwatch.Stopwatch`, logs `safety_mode set to <mode> after N attempt(s), Xs`), routed through every D585S safety-mode transition:
- `rspy/tests_wrapper.py` → `start_wrapper` / `stop_wrapper`
- `conftest.py` → `test_device_wrapped` (enter + teardown)
- `pytest-operational-mode.py`, `pytest-operational-mode-stress.py`, `pytest-interface-config-get-set.py` (post-reboot)

Timeout is 8s (~2× the 3.6s worst observed success); larger values were tried but never recovered anything a small retry didn't — the rare truly-stuck transition recovers only via a full test rerun, tracked separately in **RSDEV-12512** (module-scoped `test_device_wrapped` can't re-setup on pytest-retry → hard error). D585S-only; other devices untouched.

**CI verification (vtglnx163 + D585S 333622320169):**
- #14451 (`-r d500 --repeat 3`, 261 tests): 0 retries.
- #14455 (full suite, 846 tests): 0 retries, 0 failures.
- Final D585S-only full nightly at 8s: in progress.

**Jira:** RSDEV-12509 (fix), RSDEV-12512 (fixture-retry fragility), RSDEV-12232 (FW-side, closed)

🤖 Generated by AI
