### PR TITLE
viewer: fix post-processing filter controls reverting to default value

### DIFF
--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -800,8 +800,14 @@ void option_model::write_value( float new_value, std::string & error_message )
         // Software post-processing filters run in-process (no FW round-trip), so a synchronous
         // write can't freeze the UI — and unlike the async path set_option reads the value back,
         // so the control reflects what was applied and never reverts to a stale value.
+        // Match set_option_async: back off subdevice_model::update()'s per-frame FW-option polling
+        // while the user is writing, so a filter-slider drag stays smooth on the no-change frames.
+        if( dev )
+            dev->last_user_set_stopwatch.reset();
         set_option( opt, new_value, error_message );
-        if( invalidate_flag )
+        // Only invalidate on a successful write. set_option swallows a failed write into
+        // error_message but still returns true, so gate on that to mirror the async did_write drain.
+        if( invalidate_flag && error_message.empty() )
             *invalidate_flag = true;
     }
     else

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -313,7 +313,7 @@ bool option_model::draw_combobox( notifications_model & model,
             float tmp_value = range.min + range.step * selected;
             model.add_log( rsutils::string::from()
                            << "Setting " << opt << " to " << tmp_value << " (" << labels[selected] << ")" );
-            set_option_async( opt, tmp_value );
+            write_value( tmp_value, error_message );
             item_clicked = true;
         }
     }
@@ -535,7 +535,7 @@ bool option_model::draw_slider( notifications_model & model,
                 else
                 {
                     // run when the value is valid and the enter key is pressed to submit the new value
-                    set_option_async(opt, new_value);
+                    write_value( new_value, error_message );
                     model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
                 }
                 edit_mode = false;
@@ -655,7 +655,7 @@ bool option_model::draw_checkbox( notifications_model & model,
         model.add_log( rsutils::string::from() << "Setting " << opt << " to " << ( bool_value ? "1.0" : "0.0" ) << " ("
                                                << ( bool_value ? "ON" : "OFF" ) << ")" );
 
-        set_option_async( opt, bool_value ? 1.f : 0.f );
+        write_value( bool_value ? 1.f : 0.f, error_message );
     }
     if( ImGui::IsItemHovered() && description )
     {
@@ -666,15 +666,16 @@ bool option_model::draw_checkbox( notifications_model & model,
 
 bool option_model::slider_selected( rs2_option opt,
                                     float value,
-                                    std::string & /*error_message*/,
+                                    std::string & error_message,
                                     notifications_model & /*model*/ )
 {
-    // Dispatch every UI tick: the dispatcher action coalesces (per-option
-    // _latest_pending_value), and its try_sleep enforces the FW-write floor.
-    // set_option_async is O(atomic-CAS) when a job is already pending, so
-    // per-tick calls are cheap. Invalidate + add_log fire later from draw_option
-    // once the worker reports an actual FW write completed.
-    set_option_async( opt, value );
+    check_opt( opt, __func__ );
+    // Async (FW) path: dispatch every UI tick — the dispatcher action coalesces (per-option
+    // _latest_pending_value) and its try_sleep enforces the FW-write floor, so per-tick calls
+    // are cheap; invalidate + add_log fire later from draw_option once a write completes.
+    // Sync (software-filter) path: an integer-stepped slider only changes on step crossings, so
+    // this fires a handful of times per drag, each an instant in-process write with readback.
+    write_value( value, error_message );
     return true;
 }
 
@@ -790,6 +791,23 @@ void option_model::check_opt( rs2_option opt, char const * caller ) const
         throw std::runtime_error( rsutils::string::from()
                                   << caller << " called on option_model bound to "
                                   << this->opt << " with mismatched opt=" << opt );
+}
+
+void option_model::write_value( float new_value, std::string & error_message )
+{
+    if( write_synchronously )
+    {
+        // Software post-processing filters run in-process (no FW round-trip), so a synchronous
+        // write can't freeze the UI — and unlike the async path set_option reads the value back,
+        // so the control reflects what was applied and never reverts (RSDEV-12488, RSDEV-12502).
+        set_option( opt, new_value, error_message );
+        if( invalidate_flag )
+            *invalidate_flag = true;
+    }
+    else
+    {
+        set_option_async( opt, new_value );
+    }
 }
 
 void option_model::set_option_async( rs2_option opt, float value )

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -804,11 +804,21 @@ void option_model::write_value( float new_value, std::string & error_message )
         // while the user is writing, so a filter-slider drag stays smooth on the no-change frames.
         if( dev )
             dev->last_user_set_stopwatch.reset();
-        set_option( opt, new_value, error_message );
-        // Only invalidate on a successful write. set_option swallows a failed write into
-        // error_message but still returns true, so gate on that to mirror the async did_write drain.
-        if( invalidate_flag && error_message.empty() )
-            *invalidate_flag = true;
+        // Use a local error buffer: error_message is shared across the frame's option draws, so a
+        // prior option's failure would otherwise make this write look failed. Only invalidate when
+        // THIS write succeeds (set_option swallows failures into the string), mirroring the async
+        // did_write drain; surface a real failure by propagating it out.
+        std::string write_error;
+        set_option( opt, new_value, write_error );
+        if( write_error.empty() )
+        {
+            if( invalidate_flag )
+                *invalidate_flag = true;
+        }
+        else
+        {
+            error_message = write_error;
+        }
     }
     else
     {

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -799,7 +799,7 @@ void option_model::write_value( float new_value, std::string & error_message )
     {
         // Software post-processing filters run in-process (no FW round-trip), so a synchronous
         // write can't freeze the UI — and unlike the async path set_option reads the value back,
-        // so the control reflects what was applied and never reverts (RSDEV-12488, RSDEV-12502).
+        // so the control reflects what was applied and never reverts to a stale value.
         set_option( opt, new_value, error_message );
         if( invalidate_flag )
             *invalidate_flag = true;

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -75,12 +75,10 @@ namespace rs2
         std::function<bool( option_model&, std::string&, notifications_model& )> custom_draw_method = nullptr;
         bool edit_mode = false;
         std::string edit_value;
-        // Write this option synchronously instead of via the async dispatcher. Set for software
-        // post-processing block options (processing_block_model): they run in-process with no FW
-        // round-trip, so a blocking write can't freeze the UI, and the synchronous set_option
-        // reads the value back — so the control reflects what was applied and never reverts to a
-        // stale value (RSDEV-12488, RSDEV-12502). FW/sensor options keep the async path, whose
-        // whole purpose is to avoid blocking the render loop on the ~200 ms UVC round-trip.
+        // Selects this option's write path; fixed at construction. Software post-processing block
+        // options set it true: they run in-process (no FW round-trip), so a synchronous set_option
+        // can't freeze the UI and it reads the value back, so the control reflects what was
+        // applied. FW/sensor options keep the async path that avoids blocking the render loop.
         bool write_synchronously = false;
         bool is_all_integers() const;
         bool is_enum() const;

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -75,10 +75,19 @@ namespace rs2
         std::function<bool( option_model&, std::string&, notifications_model& )> custom_draw_method = nullptr;
         bool edit_mode = false;
         std::string edit_value;
+        // Write this option synchronously instead of via the async dispatcher. Set for software
+        // post-processing block options (processing_block_model): they run in-process with no FW
+        // round-trip, so a blocking write can't freeze the UI, and the synchronous set_option
+        // reads the value back — so the control reflects what was applied and never reverts to a
+        // stale value (RSDEV-12488, RSDEV-12502). FW/sensor options keep the async path, whose
+        // whole purpose is to avoid blocking the render loop on the ~200 ms UVC round-trip.
+        bool write_synchronously = false;
         bool is_all_integers() const;
         bool is_enum() const;
         bool is_checkbox() const;
     private:
+        // Route a user-initiated write to the synchronous or async path per write_synchronously.
+        void write_value( float new_value, std::string & error_message );
         bool draw_checkbox( notifications_model& model, std::string& error_message, const char* description );
         bool draw_combobox( notifications_model& model, std::string& error_message, const char* description, bool new_line, bool use_option_name );
         bool draw_slider( notifications_model& model, std::string& error_message, const char* description, bool use_cm_units );

--- a/common/processing-block-model.cpp
+++ b/common/processing-block-model.cpp
@@ -34,6 +34,12 @@ namespace rs2
         populate_options(ss.str().c_str(), owner, owner ? &owner->_options_invalidated : nullptr, error_message);
     }
 
+    option_model * processing_block_model::get_option_model( rs2_option opt )
+    {
+        auto it = _options_id_to_model.find( opt );
+        return it == _options_id_to_model.end() ? nullptr : &it->second;
+    }
+
     void processing_block_model::save_to_config_file()
     {
         save_processing_block_to_config_file(_full_name.c_str(), _block, _enabled);
@@ -70,12 +76,16 @@ namespace rs2
     {
         for( option_value option : _block->get_supported_option_values() )
         {
-            _options_id_to_model[option->id] = create_option_model( option,
-                                                                opt_base_label,
-                                                                model,
-                                                                _block,
-                                                                model ? &model->_options_invalidated : nullptr,
-                                                                error_message );
+            option_model om = create_option_model( option,
+                                                   opt_base_label,
+                                                   model,
+                                                   _block,
+                                                   model ? &model->_options_invalidated : nullptr,
+                                                   error_message );
+            // Software filter: write synchronously (no FW round-trip) so the value is read back
+            // and the control doesn't revert to a stale value (RSDEV-12488, RSDEV-12502).
+            om.write_synchronously = true;
+            _options_id_to_model[option->id] = om;
         }
     }
 

--- a/common/processing-block-model.cpp
+++ b/common/processing-block-model.cpp
@@ -83,7 +83,7 @@ namespace rs2
                                                    model ? &model->_options_invalidated : nullptr,
                                                    error_message );
             // Software filter: write synchronously (no FW round-trip) so the value is read back
-            // and the control doesn't revert to a stale value (RSDEV-12488, RSDEV-12502).
+            // and the control doesn't revert to a stale value.
             om.write_synchronously = true;
             _options_id_to_model[option->id] = om;
         }

--- a/common/processing-block-model.h
+++ b/common/processing-block-model.h
@@ -43,6 +43,10 @@ namespace rs2
 
         std::shared_ptr<rs2::filter> get_block() { return _block; }
 
+        // Access the UI model for one of this block's options (nullptr if not present).
+        // Used by the viewer UI tests to drive/read post-processing filter controls.
+        option_model * get_option_model( rs2_option opt );
+
         void enable( bool e = true )
         {
             processing_block_enable_disable( _enabled = e );

--- a/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
+++ b/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
@@ -40,7 +40,8 @@ VIEWER_TEST( "controls", "post_processing_value_persists" )
 
         test.set_post_processing_value( model, sub, pb, RS2_OPTION_FILTER_MAGNITUDE, target );
 
-        // The write is async — wait until the filter actually applied the new value.
+        // Software-filter writes are synchronous, so the value is already applied by the time
+        // set_post_processing_value returns; this poll is just a defensive safety net.
         IM_CHECK( test.wait_until( 20, 0.25f, [&] {
             return pb->get_block()->get_option( RS2_OPTION_FILTER_MAGNITUDE ) == target_f;
         } ) );

--- a/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
+++ b/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
@@ -1,0 +1,72 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include "viewer-test-helpers.h"
+
+#include <string>
+
+
+// Regression test for RSDEV-12488 / RSDEV-12502: a post-processing filter control set to a
+// non-default value must keep that value in the UI. PR #15029 made UI option writes
+// asynchronous; software filters (decimation, rotation, ...) emit no on_options_changed echo,
+// so the control model's cached value was never refreshed after the write. Once the ~2 s
+// user-request mask expired the control snapped back to its previous (config-restored) value
+// even though the effect was applied (e.g. decimation magnitude -> output decimated by 5 but
+// the slider showing 2).
+//
+// The cached value->as_float is exactly what the slider displays after the mask expires, and it
+// is independent of the mask timing — so we assert on it directly rather than racing the 2 s mask
+// (and we avoid re-reading through the UI, which would re-activate the slider and reset the mask).
+VIEWER_TEST( "controls", "post_processing_value_persists" )
+{
+    auto & model = test.find_first_device_or_exit();
+
+    bool tested = false;
+    for( auto && sub : model.subdevices )
+    {
+        // Decimation (a software post-processing filter) lives on the depth sensor
+        auto pb = test.find_post_processing_filter( sub, RS2_OPTION_FILTER_MAGNITUDE );
+        if( !pb )
+            continue;
+        rs2::option_model * om = pb->get_option_model( RS2_OPTION_FILTER_MAGNITUDE );
+
+        test.click_stream_toggle_on( model, sub );
+        test.sleep( 2.0f );
+
+        test.expand_sensor_panel( model, sub );
+        test.expand_post_processing( model, sub );
+        test.enable_post_processing( model, sub );
+        test.enable_post_processing_filter( model, sub, pb );
+        test.expand_post_processing_filter( model, sub, pb );
+
+        // The viewer persists filter options to the config file, so the start value varies between
+        // runs — pick a target that differs from it so a revert would be observable.
+        const float cur = pb->get_block()->get_option( RS2_OPTION_FILTER_MAGNITUDE );
+        const std::string target = ( cur >= 4.f ) ? "2" : "6";
+        const float target_f = std::stof( target );
+
+        test.set_post_processing_value( model, sub, pb, RS2_OPTION_FILTER_MAGNITUDE, target );
+
+        // The write is async — wait until the filter actually applied the new value.
+        IM_CHECK( test.wait_until( 20, 0.25f, [&] {
+            return pb->get_block()->get_option( RS2_OPTION_FILTER_MAGNITUDE ) == target_f;
+        } ) );
+
+        // The control model's cached value must track the applied value (this is what the slider
+        // shows once the user-request mask expires). Before the fix it stayed at the stale snapshot
+        // and the control reverted. Allow a few frames for draw_option to drain the write
+        // completion and refresh the cached value.
+        IM_CHECK( test.wait_until( 20, 0.25f, [&] {
+            return om->value->as_float == target_f;
+        } ) );
+
+        test.click_stream_toggle_off( model, sub );
+        test.sleep( 1.0f );
+        tested = true;
+        break;
+    }
+
+    // No depth/decimation device present — nothing to validate, but don't fail the suite
+    if( !tested )
+        IM_CHECK( true );
+}

--- a/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
+++ b/tools/realsense-viewer/tests/controls/test-post-processing-revert.cpp
@@ -6,17 +6,10 @@
 #include <string>
 
 
-// Regression test for RSDEV-12488 / RSDEV-12502: a post-processing filter control set to a
-// non-default value must keep that value in the UI. PR #15029 made UI option writes
-// asynchronous; software filters (decimation, rotation, ...) emit no on_options_changed echo,
-// so the control model's cached value was never refreshed after the write. Once the ~2 s
-// user-request mask expired the control snapped back to its previous (config-restored) value
-// even though the effect was applied (e.g. decimation magnitude -> output decimated by 5 but
-// the slider showing 2).
-//
-// The cached value->as_float is exactly what the slider displays after the mask expires, and it
-// is independent of the mask timing — so we assert on it directly rather than racing the 2 s mask
-// (and we avoid re-reading through the UI, which would re-activate the slider and reset the mask).
+// Regression test: a post-processing filter control set to a non-default value must keep it.
+// Software-filter writes used to revert in the UI (the effect applied, but the control snapped
+// back) because the async write path never refreshed the cached value. We assert on the cached
+// value (what the slider shows after the user-request mask) without re-reading through the UI.
 VIEWER_TEST( "controls", "post_processing_value_persists" )
 {
     auto & model = test.find_first_device_or_exit();

--- a/tools/realsense-viewer/tests/viewer-test-helpers.cpp
+++ b/tools/realsense-viewer/tests/viewer-test-helpers.cpp
@@ -143,17 +143,8 @@ static rs2::option_model & find_option( std::shared_ptr< rs2::subdevice_model > 
     return it->second;
 }
 
-void viewer_test::set_control_value( rs2::device_model & model,
-                                     std::shared_ptr< rs2::subdevice_model > sub,
-                                     rs2_option option, const std::string & value )
+void viewer_test::set_value_by_seed( rs2::option_model & opt, ImGuiID seed, const std::string & value )
 {
-    auto & opt = find_option( sub, option );
-
-    // Options can be at sensor level or inside the Controls section — try controls first
-    ImGuiID seed = controls_id_seed( model, sub );
-    if( !imgui->ItemExists( ImHashStr( opt.id.c_str(), 0, seed ) ) )
-        seed = sensor_id_seed( model, sub );
-
     if( opt.is_checkbox() )
     {
         ImGuiID id = ImHashStr( opt.label.c_str(), 0, seed );
@@ -175,16 +166,8 @@ void viewer_test::set_control_value( rs2::device_model & model,
     }
 }
 
-std::string viewer_test::get_control_value( rs2::device_model & model,
-                                            std::shared_ptr< rs2::subdevice_model > sub,
-                                            rs2_option option )
+std::string viewer_test::get_value_by_seed( rs2::option_model & opt, ImGuiID seed )
 {
-    auto & opt = find_option( sub, option );
-
-    ImGuiID seed = controls_id_seed( model, sub );
-    if( !imgui->ItemExists( ImHashStr( opt.id.c_str(), 0, seed ) ) )
-        seed = sensor_id_seed( model, sub );
-
     if( opt.is_checkbox() )
     {
         return imgui->ItemIsChecked( ImHashStr( opt.label.c_str(), 0, seed ) ) ? "1" : "0";
@@ -201,6 +184,33 @@ std::string viewer_test::get_control_value( rs2::device_model & model,
         imgui->ItemSelectAndReadValue( ImHashStr( opt.id.c_str(), 0, seed ), &val );
         return opt.is_all_integers() ? std::to_string( (int)val ) : std::to_string( val );
     }
+}
+
+void viewer_test::set_control_value( rs2::device_model & model,
+                                     std::shared_ptr< rs2::subdevice_model > sub,
+                                     rs2_option option, const std::string & value )
+{
+    auto & opt = find_option( sub, option );
+
+    // Options can be at sensor level or inside the Controls section — try controls first
+    ImGuiID seed = controls_id_seed( model, sub );
+    if( !imgui->ItemExists( ImHashStr( opt.id.c_str(), 0, seed ) ) )
+        seed = sensor_id_seed( model, sub );
+
+    set_value_by_seed( opt, seed, value );
+}
+
+std::string viewer_test::get_control_value( rs2::device_model & model,
+                                            std::shared_ptr< rs2::subdevice_model > sub,
+                                            rs2_option option )
+{
+    auto & opt = find_option( sub, option );
+
+    ImGuiID seed = controls_id_seed( model, sub );
+    if( !imgui->ItemExists( ImHashStr( opt.id.c_str(), 0, seed ) ) )
+        seed = sensor_id_seed( model, sub );
+
+    return get_value_by_seed( opt, seed );
 }
 
 void viewer_test::select_combo_item( ImGuiID combo_id, const std::string & item )
@@ -237,6 +247,106 @@ bool viewer_test::has_option( std::shared_ptr< rs2::subdevice_model > sub, rs2_o
         return opt.supported && !opt.read_only;
     }
     catch( ... ) { return false; }
+}
+
+std::shared_ptr< rs2::processing_block_model >
+viewer_test::find_post_processing_filter( std::shared_ptr< rs2::subdevice_model > sub,
+                                          rs2_option option )
+{
+    for( auto && pb : sub->post_processing )
+    {
+        if( pb->get_option_model( option ) )
+            return pb;
+    }
+    return nullptr;
+}
+
+ImGuiID viewer_test::post_processing_filter_id_seed( rs2::device_model & model,
+                                                     std::shared_ptr< rs2::subdevice_model > sub,
+                                                     std::shared_ptr< rs2::processing_block_model > pb )
+{
+    // sensor node -> "Post-Processing" node -> "<filter name>" node
+    ImGuiID sensor_seed = sensor_id_seed( model, sub );
+    std::string pp_label = rsutils::string::from() << "Post-Processing##" << model.id;
+    ImGuiID pp_seed = ImHashStr( pp_label.c_str(), 0, sensor_seed );
+    std::string filter_label = rsutils::string::from() << pb->get_name() << "##" << model.id;
+    return ImHashStr( filter_label.c_str(), 0, pp_seed );
+}
+
+void viewer_test::expand_post_processing( rs2::device_model & model,
+                                          std::shared_ptr< rs2::subdevice_model > sub )
+{
+    imgui->SetRef( "Control Panel" );
+    std::string path = rsutils::string::from()
+        << sensor_label( model, sub ) << "/Post-Processing##" << model.id;
+    imgui->ItemOpen( path.c_str() );
+    imgui->SleepNoSkip( 0.3f, 0.1f );
+}
+
+void viewer_test::enable_post_processing( rs2::device_model & model,
+                                          std::shared_ptr< rs2::subdevice_model > sub )
+{
+    if( sub->post_processing_enabled )
+        return;
+    // Master toggle is drawn (off state) next to the Post-Processing header, at window scope.
+    imgui->SetRef( "Control Panel" );
+    std::string label = rsutils::string::from()
+        << " " << rs2::textual_icons::toggle_off << "##" << model.id << ","
+        << sub->s->get_info( RS2_CAMERA_INFO_NAME ) << ",post";
+    imgui->ItemClick( label.c_str() );
+    imgui->SleepNoSkip( 0.3f, 0.1f );
+}
+
+void viewer_test::enable_post_processing_filter( rs2::device_model & model,
+                                                 std::shared_ptr< rs2::subdevice_model > sub,
+                                                 std::shared_ptr< rs2::processing_block_model > pb )
+{
+    if( pb->is_enabled() )
+        return;
+    // The per-filter toggle is only rendered when the Post-Processing section is expanded and
+    // post-processing is enabled; the caller is expected to have done both. Off-state label:
+    imgui->SetRef( "Control Panel" );
+    std::string label = rsutils::string::from()
+        << " " << rs2::textual_icons::toggle_off << "##" << model.id << ","
+        << sub->s->get_info( RS2_CAMERA_INFO_NAME ) << "," << pb->get_name();
+    imgui->ItemClick( label.c_str() );
+    imgui->SleepNoSkip( 0.3f, 0.1f );
+}
+
+void viewer_test::expand_post_processing_filter( rs2::device_model & model,
+                                                 std::shared_ptr< rs2::subdevice_model > sub,
+                                                 std::shared_ptr< rs2::processing_block_model > pb )
+{
+    imgui->SetRef( "Control Panel" );
+    std::string path = rsutils::string::from()
+        << sensor_label( model, sub ) << "/Post-Processing##" << model.id
+        << "/" << pb->get_name() << "##" << model.id;
+    imgui->ItemOpen( path.c_str() );
+    imgui->SleepNoSkip( 0.3f, 0.1f );
+}
+
+void viewer_test::set_post_processing_value( rs2::device_model & model,
+                                             std::shared_ptr< rs2::subdevice_model > sub,
+                                             std::shared_ptr< rs2::processing_block_model > pb,
+                                             rs2_option option, const std::string & value )
+{
+    rs2::option_model * opt = pb->get_option_model( option );
+    if( !opt )
+        throw std::runtime_error( rsutils::string::from()
+            << "option " << rs2_option_to_string( option ) << " not found on post-processing filter" );
+    set_value_by_seed( *opt, post_processing_filter_id_seed( model, sub, pb ), value );
+}
+
+std::string viewer_test::get_post_processing_value( rs2::device_model & model,
+                                                    std::shared_ptr< rs2::subdevice_model > sub,
+                                                    std::shared_ptr< rs2::processing_block_model > pb,
+                                                    rs2_option option )
+{
+    rs2::option_model * opt = pb->get_option_model( option );
+    if( !opt )
+        throw std::runtime_error( rsutils::string::from()
+            << "option " << rs2_option_to_string( option ) << " not found on post-processing filter" );
+    return get_value_by_seed( *opt, post_processing_filter_id_seed( model, sub, pb ) );
 }
 
 bool viewer_test::all_streams_alive( int max_attempts, float interval )

--- a/tools/realsense-viewer/tests/viewer-test-helpers.cpp
+++ b/tools/realsense-viewer/tests/viewer-test-helpers.cpp
@@ -301,10 +301,14 @@ void viewer_test::enable_post_processing_filter( rs2::device_model & model,
                                                  std::shared_ptr< rs2::subdevice_model > sub,
                                                  std::shared_ptr< rs2::processing_block_model > pb )
 {
+    // The per-filter toggle is inert while the master post-processing toggle is off, and
+    // is_enabled() reflects only the per-filter flag (config-restore can leave it true while
+    // master is off). Ensure master is on first so is_enabled() means the filter is really active.
+    enable_post_processing( model, sub );
     if( pb->is_enabled() )
         return;
-    // The per-filter toggle is only rendered when the Post-Processing section is expanded and
-    // post-processing is enabled; the caller is expected to have done both. Off-state label:
+    // The per-filter toggle is only rendered when the Post-Processing section is expanded; the
+    // caller is expected to have expanded it. Off-state label:
     imgui->SetRef( "Control Panel" );
     std::string label = rsutils::string::from()
         << " " << rs2::textual_icons::toggle_off << "##" << model.id << ","

--- a/tools/realsense-viewer/tests/viewer-test-helpers.h
+++ b/tools/realsense-viewer/tests/viewer-test-helpers.h
@@ -5,6 +5,8 @@
 
 #include "viewer.h"
 #include "device-model.h"
+#include "option-model.h"
+#include "processing-block-model.h"
 #include "imgui_te_engine.h"
 #include "imgui_te_context.h"
 
@@ -137,6 +139,37 @@ public:
     // Check if a sensor has a writable option
     bool has_option( std::shared_ptr< rs2::subdevice_model > sub, rs2_option option );
 
+    // -----------------------------------------------------------------------
+    // Post-processing panel
+    // -----------------------------------------------------------------------
+    // Find the post-processing filter exposing the given option (nullptr if none)
+    std::shared_ptr< rs2::processing_block_model > find_post_processing_filter(
+        std::shared_ptr< rs2::subdevice_model > sub, rs2_option option );
+    // Open the sensor's "Post-Processing" section
+    void expand_post_processing( rs2::device_model & model,
+                                 std::shared_ptr< rs2::subdevice_model > sub );
+    // Turn the master post-processing toggle on (no-op if already on)
+    void enable_post_processing( rs2::device_model & model,
+                                 std::shared_ptr< rs2::subdevice_model > sub );
+    // Turn a single filter's toggle on (no-op if already on); requires the
+    // Post-Processing section to be expanded and post-processing enabled first
+    void enable_post_processing_filter( rs2::device_model & model,
+                                        std::shared_ptr< rs2::subdevice_model > sub,
+                                        std::shared_ptr< rs2::processing_block_model > pb );
+    // Open a single filter's controls under the Post-Processing section
+    void expand_post_processing_filter( rs2::device_model & model,
+                                        std::shared_ptr< rs2::subdevice_model > sub,
+                                        std::shared_ptr< rs2::processing_block_model > pb );
+    // Set / read a post-processing filter option value via the UI
+    void set_post_processing_value( rs2::device_model & model,
+                                    std::shared_ptr< rs2::subdevice_model > sub,
+                                    std::shared_ptr< rs2::processing_block_model > pb,
+                                    rs2_option option, const std::string & value );
+    std::string get_post_processing_value( rs2::device_model & model,
+                                           std::shared_ptr< rs2::subdevice_model > sub,
+                                           std::shared_ptr< rs2::processing_block_model > pb,
+                                           rs2_option option );
+
     // Wait until all active streams are receiving frames
     bool all_streams_alive( int max_attempts = 30, float interval = 0.5f );
 
@@ -152,4 +185,10 @@ private:
                             std::shared_ptr< rs2::subdevice_model > sub );
     ImGuiID controls_id_seed( rs2::device_model & model,
                               std::shared_ptr< rs2::subdevice_model > sub );
+    ImGuiID post_processing_filter_id_seed( rs2::device_model & model,
+                                            std::shared_ptr< rs2::subdevice_model > sub,
+                                            std::shared_ptr< rs2::processing_block_model > pb );
+    // Drive / read a control widget given its already-resolved ImGui id seed
+    void set_value_by_seed( rs2::option_model & opt, ImGuiID seed, const std::string & value );
+    std::string get_value_by_seed( rs2::option_model & opt, ImGuiID seed );
 };


### PR DESCRIPTION
**Overview:** In the viewer, setting a post-processing filter control (e.g. decimation magnitude, rotation) applied the effect but the control snapped back to its previous value; it now stays at the value the user set.

Tracked on [RSDEV-12488], [RSDEV-12502]

## Why
Regression from PR #15029 (`viewer-ui-exp-change-avoid-stream-pause`), which routed all viewer option writes through the async dispatcher. That async path exists to avoid blocking the UI thread on the FW round-trip — but it never refreshes the control's cached value, relying on the sensor's `on_options_changed` echo to do so. Software post-processing filters run in-process and emit no such echo, so after the ~2 s user-request mask expired the control reverted to its stale cached value (decimation magnitude → 2, rotation → 0) even though the effect was applied.

## Summary
- Software post-processing filter options (`processing_block_model`) now write **synchronously** via `set_option`, which reads the value back so the control reflects what was applied. FW/sensor options keep the async path.
- These filters have no FW round-trip, so a synchronous write can't freeze the UI; an integer-stepped slider only fires a handful of writes per drag. No throttle/timer needed (the pre-async throttle was an FW-round-trip mitigation).
- Added a `write_value()` helper in `option_model` that routes by a `write_synchronously` flag; the flag is set for processing-block options.

## Test plan
- [x] New viewer UI test `controls/post_processing_value_persists`: streams depth, enables post-processing + decimation, sets magnitude to a non-default value, and asserts the cached control value tracks the applied value. Verified on D455 — passes with the fix, fails when the option is forced back onto the async path.
- [x] Added post-processing panel navigation helpers to the viewer test harness.
- [ ] LibCI run.

---
🤖 Generated by AI
