### PR TITLE
sw-update: match device names with or without Intel prefix

### DIFF
--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -296,12 +296,25 @@ namespace rs2
 
         }
 
+        // Device names historically carried an "Intel " prefix; newer SDKs drop it.
+        // Normalize so DB entries and reported names match regardless of the prefix.
+        static std::string strip_intel_prefix(const std::string &name)
+        {
+            static const std::string prefix = "Intel ";
+            if (0 == name.compare(0, prefix.size(), prefix))
+                return name.substr(prefix.size());
+            return name;
+        }
+
         bool versions_db_manager::is_device_name_equal(const std::string &str_from_db, const std::string &str_compared, bool allow_wildcard)
         {
+            const std::string db = strip_intel_prefix(str_from_db);
+            const std::string cmp = strip_intel_prefix(str_compared);
+
             if (allow_wildcard)
-                return (0 == str_from_db.compare(0, str_from_db.find('*'), str_compared, 0, str_from_db.find('*')));
+                return (0 == db.compare(0, db.find('*'), cmp, 0, db.find('*')));
             else
-                return (str_from_db == str_compared);
+                return (db == cmp);
         }
     }
 

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -298,7 +298,9 @@ namespace rs2
 
         // Device names historically carried an "Intel " prefix; newer SDKs drop it.
         // Normalize so DB entries and reported names match regardless of the prefix.
-        static std::string strip_intel_prefix(const std::string &name)
+        // The prefix casing is a guaranteed invariant: the DB always uses exactly
+        // "Intel ", so a case-sensitive match is intentional here.
+        std::string versions_db_manager::strip_intel_prefix(const std::string &name)
         {
             static const std::string prefix = "Intel ";
             if (0 == name.compare(0, prefix.size(), prefix))
@@ -308,11 +310,16 @@ namespace rs2
 
         bool versions_db_manager::is_device_name_equal(const std::string &str_from_db, const std::string &str_compared, bool allow_wildcard)
         {
+            // Strip the legacy "Intel " prefix from both sides so comparisons are
+            // prefix-agnostic regardless of which side (DB or runtime) carries it.
             const std::string db = strip_intel_prefix(str_from_db);
             const std::string cmp = strip_intel_prefix(str_compared);
 
             if (allow_wildcard)
-                return (0 == db.compare(0, db.find('*'), cmp, 0, db.find('*')));
+            {
+                const auto wildcard_pos = db.find('*');
+                return (0 == db.compare(0, wildcard_pos, cmp, 0, wildcard_pos));
+            }
             else
                 return (db == cmp);
         }

--- a/common/sw-update/versions-db-manager.h
+++ b/common/sw-update/versions-db-manager.h
@@ -83,6 +83,7 @@ namespace rs2
             void parse_versions_data(const std::stringstream &ver_data);
             bool get_version_data_common(const component_part_type component, const version& version, const std::string& req_field, std::string& out);
             bool is_device_name_equal(const std::string &str_from_db, const std::string &str_compared, bool allow_wildcard);
+            static std::string strip_intel_prefix(const std::string &name);
 
 
             bool init();


### PR DESCRIPTION
**Overview:** The software-update version DB lookup now matches a device name whether or not it carries the legacy `Intel ` prefix, so newer SDK builds (which drop the prefix) still find their update entries against DB files that still use `Intel RealSense ...`.

Tracked on [RSDEV-12506]

## Why
The SDK previously reported device names with an `Intel ` prefix (e.g. `Intel RealSense D455`), matching the DB JSON. Newer SDKs drop the prefix (`RealSense D455`), so `is_device_name_equal` no longer matched the DB entries and update lookups failed.

## Summary
- `is_device_name_equal` normalizes both the DB value and the reported name by stripping an optional leading `Intel ` before comparing (wildcard logic preserved).
- DB JSON is intentionally left with the `Intel RealSense ...` prefix so already-shipped older SDKs keep matching; the new SDK matches with or without it.

## Test plan
- [ ] Unit test lookup with DB `Intel RealSense D455` vs reported `RealSense D455` and vice versa.
- [x] Confirm wildcard entries still match.


<img width="166" height="84" alt="image" src="https://github.com/user-attachments/assets/91821a67-dbde-4e83-9018-70cc3845621e" />


---
🤖 Generated by AI
