### PR TITLE
MIPI color: raise RGB controls driver gate to 1.0.4.9

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -195,11 +195,11 @@ namespace librealsense
     {
         auto& color_ep = get_color_sensor();
 
-        // MIPI RGB controls require FW >= 5.17.3.15 and d4xx kernel driver >= 1.0.3.15.
+        // MIPI RGB controls require FW >= 5.17.3.15 and d4xx kernel driver >= 1.0.4.9.
         const bool mipi_rgb_controls_supported = _is_mipi_device
             && _fw_version >= firmware_version("5.17.3.15")
             && supports_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)
-            && rsutils::version(get_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)) >= rsutils::version("1.0.3.15");
+            && rsutils::version(get_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)) >= rsutils::version("1.0.4.9");
 
         if (!_is_mipi_device)
         {


### PR DESCRIPTION
**Overview:** On MIPI/GMSL D400 cameras, raise the d4xx driver-version threshold that gates the RGB ISP controls (Auto White Balance, White Balance, Saturation, Sharpness, Power Line Frequency) from `1.0.3.15` to `1.0.4.9`.

Tracked on [RSDSO-21713]

## Why
The RGB ISP controls only exist in the driver from **1.0.4.9** on the master lineage (release branch `r/58.3`, feature RSDEV-5918). The old `1.0.3.15` threshold came from the *dev* branch's independent numbering (PR #451 bumped dev `1.0.3.12→1.0.3.15`). Master reached `1.0.3.18` (r/58.2) **without** the feature, so any master build in `1.0.3.15..1.0.4.8` passed the gate, the SDK registered controls the driver never implemented, and every get/set failed with `xioctl EINVAL` — e.g. 5 D401 option-test failures in `LRS_jetson_compile_pipeline #17522`.

## Summary
- `d400-color.cpp`: `mipi_rgb_controls_supported` now requires driver `>= 1.0.4.9` (matches the version that ships the controls, and the existing `1.0.4.9` MIPI check elsewhere in the same file).

## Test plan
- [ ] Jetson CI with a driver `>= 1.0.4.9` (r/58.3): RGB option tests pass on D401.
- [ ] Jetson CI with driver `1.0.3.18`: controls are no longer registered → no `EINVAL` failures (tests skip cleanly).

---
🤖 Generated by AI
