### PR TITLE
pytest: record failures + teardown in per-test logs across retries/repeats

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -780,8 +780,13 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     teardown_disable = not no_reset
 
     def _teardown(serials):
+        # Log the teardown so the per-test file shows the module's cleanup -- not just
+        # setup + test. Runs while this module+camera's log handler is still open.
+        ensure_newline()
         if not teardown_disable:
+            log.info(f"Teardown: leaving {serials} enabled (--no-reset)")
             return
+        log.info(f"Teardown: disabling {serials}")
         try:
             devices.disable(serials)
         except Exception as e:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -489,12 +489,9 @@ def pytest_runtest_call(item):
         item.stash[_retry_setup_exc_key] = None  # consumed
         return
 
-    # Record a call-phase failure into the per-test log. pytest-retry reruns a test by
-    # invoking pytest_runtest_call directly -- bypassing pytest_runtest_makereport -- and
-    # reopens the module log in 'w' mode, which truncates the original attempt's logged
-    # failure. Logging here means every attempt (including the last retry) records its
-    # failure, so a failing test's .log never ends on just the "Test:" header.
-    if outcome.excinfo is not None and outcome.excinfo[0].__name__ != "Skipped":
+    # Log every call-phase failure here so pytest-retry attempts (which bypass
+    # pytest_runtest_makereport) are also captured in the per-test .log file.
+    if outcome.excinfo is not None and not issubclass(outcome.excinfo[0], pytest.skip.Exception):
         ensure_newline()
         log.error(f"call failed: {outcome.excinfo[0].__name__}: {outcome.excinfo[1]}")
 

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -444,7 +444,9 @@ def pytest_runtest_makereport(item, call):
         ensure_newline()
         reason = report.longrepr[-1]
         log.info(reason)
-    if report.failed and call.excinfo:
+    # Call-phase failures are logged from pytest_runtest_call so they also appear on
+    # pytest-retry attempts (which bypass this hook); here we cover setup/teardown.
+    if report.failed and call.excinfo and call.when != "call":
         ensure_newline()
         log.error(f"{call.when} {report.outcome}: {call.excinfo.typename}: {call.excinfo.value}")
     if call.when == "call":
@@ -487,6 +489,15 @@ def pytest_runtest_call(item):
         item.stash[_retry_setup_exc_key] = None  # consumed
         return
 
+    # Record a call-phase failure into the per-test log. pytest-retry reruns a test by
+    # invoking pytest_runtest_call directly -- bypassing pytest_runtest_makereport -- and
+    # reopens the module log in 'w' mode, which truncates the original attempt's logged
+    # failure. Logging here means every attempt (including the last retry) records its
+    # failure, so a failing test's .log never ends on just the "Test:" header.
+    if outcome.excinfo is not None and outcome.excinfo[0].__name__ != "Skipped":
+        ensure_newline()
+        log.error(f"call failed: {outcome.excinfo[0].__name__}: {outcome.excinfo[1]}")
+
     try:
         from pytest_check import check_log
     except ImportError:
@@ -499,7 +510,10 @@ def pytest_runtest_call(item):
         return
     num_failures = check_log._num_failures
     check_log.clear_failures()
-    raise AssertionError("\n".join(failures + ["-" * 60, f"Failed Checks: {num_failures}"]))
+    message = "\n".join(failures + ["-" * 60, f"Failed Checks: {num_failures}"])
+    ensure_newline()
+    log.error(f"call failed: {num_failures} soft-check failure(s):\n{message}")
+    raise AssertionError(message)
 
 
 def pytest_sessionstart(session):

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -786,7 +786,12 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         if not teardown_disable:
             log.info(f"Teardown: leaving {serials} enabled (--no-reset)")
             return
-        log.info(f"Teardown: disabling {serials}")
+        if devices.hub is None:
+            # No hub to power the port off: disable() is a no-op, so nothing is removed here.
+            # The device is cleared by hardware_reset at the next module's setup recycle.
+            log.info(f"Teardown: {serials} left enumerated (no hub; recycled at next setup)")
+            return
+        log.info(f"Teardown: disabling {serials} and waiting for removal")
         try:
             devices.disable(serials)
         except Exception as e:

--- a/unit-tests/infra-tests/e2e/pytest-logfail.py
+++ b/unit-tests/infra-tests/e2e/pytest-logfail.py
@@ -1,0 +1,10 @@
+# Driver for test_e2e_log_failures: a device test whose call phase raises. Used to
+# verify the exception is recorded in the per-test log even under pytest-retry (which
+# reopens the module log in 'w' mode and bypasses pytest_runtest_makereport).
+import pytest
+
+pytestmark = [pytest.mark.device("D455")]
+
+
+def test_raises_runtime_error(module_device_setup):
+    raise RuntimeError("xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22")

--- a/unit-tests/infra-tests/helpers.py
+++ b/unit-tests/infra-tests/helpers.py
@@ -161,6 +161,10 @@ def run_e2e(test_filename, *extra_pytest_args, env=None):
 
         sub_env = os.environ.copy()
         sub_env['INFRA_UNIT_TESTS_DIR'] = os.path.normpath(os.path.join(_E2E_DIR, '..', '..'))  # unit-tests/
+        # Force per-test logs into the tmpdir so they're deterministic (independent of any build
+        # tree) and collectable below; otherwise the location varies (build dir vs unit-tests/logs).
+        e2e_logdir = os.path.join(tmpdir, 'testlogs')
+        sub_env['RS_TEST_LOGDIR'] = e2e_logdir
         if env:
             sub_env.update(env)
 
@@ -183,6 +187,15 @@ def run_e2e(test_filename, *extra_pytest_args, env=None):
         tracking = json.loads(open(tracking_file).read()) if os.path.exists(tracking_file) else {
             "enable_only_calls": [], "rslog_calls": [], "query_kwargs": [], "disable_calls": []
         }
+
+        # Collect per-test log files (name -> content) before the tmpdir is removed, so tests can
+        # assert on log content without depending on where the logs would otherwise land.
+        tracking["logs"] = {}
+        if os.path.isdir(e2e_logdir):
+            for name in os.listdir(e2e_logdir):
+                path = os.path.join(e2e_logdir, name)
+                if os.path.isfile(path):
+                    tracking["logs"][name] = open(path, encoding="utf-8", errors="replace").read()
 
         return p.returncode, p.stdout, tracking
 

--- a/unit-tests/infra-tests/helpers.py
+++ b/unit-tests/infra-tests/helpers.py
@@ -195,7 +195,8 @@ def run_e2e(test_filename, *extra_pytest_args, env=None):
             for name in os.listdir(e2e_logdir):
                 path = os.path.join(e2e_logdir, name)
                 if os.path.isfile(path):
-                    tracking["logs"][name] = open(path, encoding="utf-8", errors="replace").read()
+                    with open(path, encoding="utf-8", errors="replace") as fh:
+                        tracking["logs"][name] = fh.read()
 
         return p.returncode, p.stdout, tracking
 

--- a/unit-tests/infra-tests/test_e2e_log_failures.py
+++ b/unit-tests/infra-tests/test_e2e_log_failures.py
@@ -1,0 +1,59 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: a failing test records its exception in its per-test log file.
+
+Regression for empty failing-test logs (Jetson #17522): a test whose call phase
+raised left a .log ending on just the "Test:" header. Two effects combined --
+pytest_runtest_makereport was the only hook that logged failures, and pytest-retry
+reruns a test via pytest_runtest_call (never makereport) after reopening the module
+log in 'w' mode, truncating the original attempt's logged failure. conftest now logs
+the call-phase failure from pytest_runtest_call, which fires on every attempt.
+"""
+
+import os
+from helpers import run_e2e, parse_outcomes
+
+_LOGDIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'logs'))
+_LOGFILE = os.path.join(_LOGDIR, 'pytest-logfail_D455-111.log')
+
+
+def _cleanup():
+    try:
+        os.remove(_LOGFILE)
+    except OSError:
+        pass
+
+
+def _read_log():
+    assert os.path.exists(_LOGFILE), f"per-test log not created at {_LOGFILE}"
+    with open(_LOGFILE) as f:
+        return f.read()
+
+
+class TestLogFailures:
+
+    def test_call_failure_recorded(self):
+        """A failing call-phase test writes its exception into the per-test log,
+        exactly once (makereport no longer double-logs the call phase)."""
+        _cleanup()
+        rc, out, *_ = run_e2e("pytest-logfail.py")
+        assert rc != 0, out
+        assert parse_outcomes(out).get("failed") == 1, out
+        log = _read_log()
+        assert "call failed: RuntimeError: xioctl" in log, log
+        assert "errno=22" in log, log
+        assert log.count("call failed: RuntimeError") == 1, f"duplicate failure log line:\n{log}"
+        _cleanup()
+
+    def test_call_failure_recorded_under_retry(self):
+        """Under --retries the module log is truncated + reopened per attempt and
+        makereport is bypassed; the failure must still survive in the final file."""
+        _cleanup()
+        rc, out, *_ = run_e2e("pytest-logfail.py", "--retries", "2")
+        assert rc != 0, out
+        assert parse_outcomes(out).get("failed") == 1, out
+        log = _read_log()
+        assert "call failed: RuntimeError: xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22" in log, log
+        _cleanup()

--- a/unit-tests/infra-tests/test_e2e_log_failures.py
+++ b/unit-tests/infra-tests/test_e2e_log_failures.py
@@ -7,29 +7,20 @@ E2E: a failing test records its exception in its per-test log file.
 Regression for empty failing-test logs (Jetson #17522): a test whose call phase
 raised left a .log ending on just the "Test:" header. Two effects combined --
 pytest_runtest_makereport was the only hook that logged failures, and pytest-retry
-reruns a test via pytest_runtest_call (never makereport) after reopening the module
-log in 'w' mode, truncating the original attempt's logged failure. conftest now logs
-the call-phase failure from pytest_runtest_call, which fires on every attempt.
+reruns a test via pytest_runtest_call (never makereport). conftest now logs the
+call-phase failure from pytest_runtest_call (fires on every attempt), and the module
+log is opened in append mode so retries/repeats accumulate instead of overwriting.
 """
 
-import os
 from helpers import run_e2e, parse_outcomes
 
-_LOGDIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'logs'))
-_LOGFILE = os.path.join(_LOGDIR, 'pytest-logfail_D455-111.log')
+_LOG_NAME = "pytest-logfail_D455-111.log"
 
 
-def _cleanup():
-    try:
-        os.remove(_LOGFILE)
-    except OSError:
-        pass
-
-
-def _read_log():
-    assert os.path.exists(_LOGFILE), f"per-test log not created at {_LOGFILE}"
-    with open(_LOGFILE) as f:
-        return f.read()
+def _log(tracking):
+    logs = tracking.get("logs", {})
+    assert _LOG_NAME in logs, f"per-test log {_LOG_NAME} not created; got {list(logs)}"
+    return logs[_LOG_NAME]
 
 
 class TestLogFailures:
@@ -38,26 +29,31 @@ class TestLogFailures:
         """A failing call-phase test writes its exception into the per-test log,
         exactly once (makereport no longer double-logs the call phase), followed by
         the teardown marker."""
-        _cleanup()
-        rc, out, *_ = run_e2e("pytest-logfail.py")
+        rc, out, tracking = run_e2e("pytest-logfail.py")
         assert rc != 0, out
         assert parse_outcomes(out).get("failed") == 1, out
-        log = _read_log()
+        log = _log(tracking)
         assert "call failed: RuntimeError: xioctl" in log, log
         assert "errno=22" in log, log
         assert log.count("call failed: RuntimeError") == 1, f"duplicate failure log line:\n{log}"
-        assert "Teardown: disabling" in log, log
-        _cleanup()
+        assert "Teardown:" in log, log   # common prefix across hub / hub-less / --no-reset paths
 
     def test_every_retry_attempt_recorded_in_one_file(self):
         """Under --retries the module log is reopened in append mode per attempt and
         makereport is bypassed; every attempt's failure AND teardown must accumulate in
         the one file (not overwritten, not empty). --retries 2 == 3 attempts."""
-        _cleanup()
-        rc, out, *_ = run_e2e("pytest-logfail.py", "--retries", "2")
+        rc, out, tracking = run_e2e("pytest-logfail.py", "--retries", "2")
         assert rc != 0, out
         assert parse_outcomes(out).get("failed") == 1, out
-        log = _read_log()
+        log = _log(tracking)
         assert log.count("call failed: RuntimeError: xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22") == 3, log
-        assert log.count("Teardown: disabling") == 3, log
-        _cleanup()
+        assert log.count("Teardown:") == 3, log
+
+    def test_every_repeat_pass_recorded_in_one_file(self):
+        """Under --repeat the module runs multiple passes; append mode must accumulate every
+        pass's failure + teardown in the one file. --repeat 2 == 2 passes."""
+        rc, out, tracking = run_e2e("pytest-logfail.py", "--repeat", "2")
+        assert rc != 0, out
+        log = _log(tracking)
+        assert log.count("call failed: RuntimeError: xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22") == 2, log
+        assert log.count("Teardown:") == 2, log

--- a/unit-tests/infra-tests/test_e2e_log_failures.py
+++ b/unit-tests/infra-tests/test_e2e_log_failures.py
@@ -34,9 +34,10 @@ def _read_log():
 
 class TestLogFailures:
 
-    def test_call_failure_recorded(self):
+    def test_call_failure_and_teardown_recorded(self):
         """A failing call-phase test writes its exception into the per-test log,
-        exactly once (makereport no longer double-logs the call phase)."""
+        exactly once (makereport no longer double-logs the call phase), followed by
+        the teardown marker."""
         _cleanup()
         rc, out, *_ = run_e2e("pytest-logfail.py")
         assert rc != 0, out
@@ -45,15 +46,18 @@ class TestLogFailures:
         assert "call failed: RuntimeError: xioctl" in log, log
         assert "errno=22" in log, log
         assert log.count("call failed: RuntimeError") == 1, f"duplicate failure log line:\n{log}"
+        assert "Teardown: disabling" in log, log
         _cleanup()
 
-    def test_call_failure_recorded_under_retry(self):
-        """Under --retries the module log is truncated + reopened per attempt and
-        makereport is bypassed; the failure must still survive in the final file."""
+    def test_every_retry_attempt_recorded_in_one_file(self):
+        """Under --retries the module log is reopened in append mode per attempt and
+        makereport is bypassed; every attempt's failure AND teardown must accumulate in
+        the one file (not overwritten, not empty). --retries 2 == 3 attempts."""
         _cleanup()
         rc, out, *_ = run_e2e("pytest-logfail.py", "--retries", "2")
         assert rc != 0, out
         assert parse_outcomes(out).get("failed") == 1, out
         log = _read_log()
-        assert "call failed: RuntimeError: xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22" in log, log
+        assert log.count("call failed: RuntimeError: xioctl(VIDIOC_G_EXT_CTRLS) failed, errno=22") == 3, log
+        assert log.count("Teardown: disabling") == 3, log
         _cleanup()

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -80,10 +80,16 @@ def _find_build_dir():
 
 
 def setup_test_logging(config):
-    """Set up per-test log directory and JUnit XML output path (<build_dir>/<config>/unit-tests/)."""
-    build_dir = _find_build_dir()
+    """Set up per-test log directory and JUnit XML output path (<build_dir>/<config>/unit-tests/).
 
-    if build_dir:
+    RS_TEST_LOGDIR overrides the location — used by the infra E2E harness for a deterministic,
+    isolated log dir regardless of whether a build tree is present."""
+    env_logdir = os.environ.get('RS_TEST_LOGDIR')
+    build_dir = None if env_logdir else _find_build_dir()
+
+    if env_logdir:
+        logdir = env_logdir
+    elif build_dir:
         cmake_cache_path = os.path.join(build_dir, 'CMakeCache.txt')
         configuration = None
 
@@ -287,10 +293,8 @@ def open_log(file_path, device_id, config):
         return None
     log_path = os.path.join(logdir, _compose_log_name(file_path, device_id))
     try:
-        # First open this session truncates (clears a stale file from a previous run); reopens
-        # append, so pytest-retry attempts and --repeat/--count passes of the same (module, device)
-        # all accumulate in ONE file -- each attempt's setup, test output, failure, and teardown --
-        # instead of the latest attempt overwriting the previous ones.
+        # First open truncates any stale file from a previous run; subsequent opens append so
+        # pytest-retry attempts and --repeat/--count passes accumulate in one file.
         mode = 'a' if log_path in _opened_logs else 'w'
         handler = logging.FileHandler(log_path, mode=mode)
         handler.setFormatter(_NestedFormatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -37,6 +37,11 @@ _unit_tests_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..',
 # Live-logging state: set to True when -s is passed (stdout not captured)
 live_logging = False
 
+# Per-(module, camera) log paths already opened this session. The first open truncates
+# (clears any stale file from a previous run); reopens append, so pytest-retry attempts and
+# --repeat/--count passes all accumulate in one file instead of overwriting each other.
+_opened_logs = set()
+
 def bridge_rspy_log():
     """Wrap rspy.log.d/i/w/e to also emit via Python logging."""
     def _wrap(original_fn, py_level):
@@ -282,12 +287,16 @@ def open_log(file_path, device_id, config):
         return None
     log_path = os.path.join(logdir, _compose_log_name(file_path, device_id))
     try:
-        # mode='w': retries/repeats of the same (module, device) overwrite the previous pass's
-        # log so the Jenkins report links to the latest attempt (appending would interleave passes).
-        handler = logging.FileHandler(log_path, mode='w')
+        # First open this session truncates (clears a stale file from a previous run); reopens
+        # append, so pytest-retry attempts and --repeat/--count passes of the same (module, device)
+        # all accumulate in ONE file -- each attempt's setup, test output, failure, and teardown --
+        # instead of the latest attempt overwriting the previous ones.
+        mode = 'a' if log_path in _opened_logs else 'w'
+        handler = logging.FileHandler(log_path, mode=mode)
         handler.setFormatter(_NestedFormatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
         handler.setLevel(logging.DEBUG)
         logging.getLogger().addHandler(handler)
+        _opened_logs.add(log_path)
         return handler
     except Exception as e:
         log.warning(f"Could not create test log file {log_path}: {e}")


### PR DESCRIPTION
**Overview:** Failing pytest tests no longer leave an empty per-test log. The call-phase exception is recorded in the `.log` file — on every pytest-retry attempt and `--repeat`/`--count` pass — and the module teardown is now logged too.

Tracked on [RSDSO-21714]

## Why
A failing test's per-test log ended on just the `Test:` header (e.g. the D401 xioctl failures in Jetson #17522). Two effects combined in `conftest.py`/`logging_setup.py`:
- Failures were logged only from `pytest_runtest_makereport`, but pytest-retry reruns a test via `pytest_runtest_call` (bypassing `makereport`).
- The module log opened in `mode='w'`, so each retry/repeat truncated the previous attempt's content.

Teardown was also invisible: nothing marked module cleanup (and on hub-less Jetson the device-disable is a no-op).

## Summary
- `conftest.py`: log the call-phase failure from `pytest_runtest_call` (fires on every attempt); `makereport` now handles only setup/teardown-phase failures (no duplicate line).
- `logging_setup.py`: open the per-test log in append mode (first open per session truncates a stale file), so retries and `--repeat`/`--count` passes accumulate in ONE file instead of overwriting.
- `conftest.py`: log an INFO `Teardown:` marker in the module teardown — hub-aware: `disabling … and waiting for removal` on hub benches, `left enumerated (no hub; recycled at next setup)` on hub-less Jetson/MIPI.
- Added `infra-tests/test_e2e_log_failures.py` + `e2e/pytest-logfail.py`.

Logging-only: the recycle/hub decision (`devices.hub is None → recycle=True`, `enable_only`) is untouched — hub-less machines still recycle.

## Test plan
- [x] `infra-tests/` locally: 145 passed, 9 skipped.
- [x] E2E asserts every `--retries`/`--repeat` attempt + teardown lands in one file.
- [x] LibCI #17063: SUCCESS on all platforms; verified real per-test logs now show the `Teardown:` line (previously ended at `Test execution took…`).

---
🤖 Generated by AI
