### PR TITLE
Cherry-Pick MIPI color: raise RGB controls driver gate to 1.0.4.9 (#15342)

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -195,11 +195,11 @@ namespace librealsense
     {
         auto& color_ep = get_color_sensor();
 
-        // MIPI RGB controls require FW >= 5.17.3.15 and d4xx kernel driver >= 1.0.3.15.
+        // MIPI RGB controls require FW >= 5.17.3.15 and d4xx kernel driver >= 1.0.4.9.
         const bool mipi_rgb_controls_supported = _is_mipi_device
             && _fw_version >= firmware_version("5.17.3.15")
             && supports_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)
-            && rsutils::version(get_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)) >= rsutils::version("1.0.3.15");
+            && rsutils::version(get_info(RS2_CAMERA_INFO_MIPI_DRIVER_VERSION)) >= rsutils::version("1.0.4.9");
 
         if (!_is_mipi_device)
         {


### PR DESCRIPTION
**Overview:** Cherry-pick of #15342 onto `r/2.58.3`: raise the d4xx driver-version gate for MIPI RGB ISP controls from `1.0.3.15` to `1.0.4.9`.

Tracked on [RSDSO-21713]

## Why
The RGB ISP controls only exist in the driver from **1.0.4.9** (master lineage / release branch `r/58.3`, RSDEV-5918). The `1.0.3.15` threshold came from the driver's `dev` branch numbering; a `master` build such as `1.0.3.18` passes `>= 1.0.3.15` without the feature, so the SDK registered controls the driver never implemented → `xioctl EINVAL` (e.g. D401 option-test failures on Jetson).

## Summary
- `d400-color.cpp`: `mipi_rgb_controls_supported` now requires driver `>= 1.0.4.9` (matches the version that ships the controls and the existing `1.0.4.9` MIPI check in the same file).

Straight cherry-pick of the merged development commit — no code changes beyond the version constant.

---
🤖 Generated by AI
