### PR TITLE
Relax depth AE convergence: fast gating (single resolution) + nightly full-matrix

### DIFF
--- a/unit-tests/live/d400/pytest-depth-ae-convergence.py
+++ b/unit-tests/live/d400/pytest-depth-ae-convergence.py
@@ -113,12 +113,13 @@ def measure_convergence(sensor, profile, max_allowed=1.0, timeout=2.0):
     If the profile exposes no ACTUAL_EXPOSURE metadata (no frames recorded) the
     result is 'skipped' - so a separate metadata-probe streaming cycle is not needed.
     """
-    # Ensure streaming stopped, then let the USB endpoints settle before reopening
+    # Ensure streaming stopped before reopening. No settle needed here: every measurement
+    # exits with a settle, so a preceding cycle already left a gap, and nothing is streaming
+    # on the very first call.
     try:
         sensor.stop(); sensor.close()
     except Exception:
         pass
-    _settle()
 
     # Disable AE (while not streaming)
     sensor.set_option(rs.option.enable_auto_exposure, 0)
@@ -272,6 +273,9 @@ def _select_default_profile(depth_profiles):
     for p in depth_profiles:
         if p.fps() == DEFAULT_FPS:
             return p
+    vsp0 = depth_profiles[0].as_video_stream_profile()
+    log.warning(f"No {DEFAULT_WIDTH}x{DEFAULT_HEIGHT}@{DEFAULT_FPS} or any {DEFAULT_FPS}fps depth profile found; "
+                f"falling back to {vsp0.width()}x{vsp0.height()}@{depth_profiles[0].fps()}")
     return depth_profiles[0]
 
 
@@ -324,8 +328,6 @@ def _run_ae_convergence(sensor, supports_mode, depth_profiles):
             log.info(f"REGULAR [{fmt}] AE samples={details.get('samples')}")
             log.info(f"REGULAR [{fmt}] exposures: {format_list_abbrev(details.get('exposures', []))}")
             log.info(f"REGULAR [{fmt}] gains: {format_list_abbrev(details.get('gains', []))}")
-            log.info(f"REGULAR AE exposures [{fmt}]: {format_list_abbrev(details.get('exposures', []))}")
-            log.info(f"REGULAR AE gains [{fmt}]: {format_list_abbrev(details.get('gains', []))}")
 
             # ACCELERATED AE mode test (if supported)
             if supports_mode:
@@ -374,8 +376,13 @@ def _run_ae_convergence(sensor, supports_mode, depth_profiles):
                         log.info(f"ACCELERATED [{fmt}] AE samples={accel_details.get('samples')}")
                         log.info(f"ACCELERATED [{fmt}] exposures: {format_list_abbrev(accel_details.get('exposures', []))}")
                         log.info(f"ACCELERATED [{fmt}] gains: {format_list_abbrev(accel_details.get('gains', []))}")
-                        log.info(f"ACCELERATED AE exposures [{fmt}]: {format_list_abbrev(accel_details.get('exposures', []))}")
-                        log.info(f"ACCELERATED AE gains [{fmt}]: {format_list_abbrev(accel_details.get('gains', []))}")
+
+                    # Restore REGULAR mode so subsequent profiles measure the REGULAR baseline
+                    # in the correct mode (measure_convergence never resets auto_exposure_mode).
+                    try:
+                        sensor.set_option(rs.option.auto_exposure_mode, REGULAR)
+                    except Exception:
+                        pass
 
     # -----------------------------------------------------------------------------------------------
     # Evaluate Overall Test Results (10% failure threshold)
@@ -395,10 +402,13 @@ def _run_ae_convergence(sensor, supports_mode, depth_profiles):
             for name in failed_configs:
                 log.info(f"  - {name}")
 
-        # Apply 10% threshold: only fail if more than 10% of configs failed
-        FAILURE_THRESHOLD = 10.0  # 10%
+        # Base tolerance is 10%, which is meaningful for the nightly full-matrix run. With a
+        # tiny config count (e.g. the single-profile gating run has at most REGULAR+ACCELERATED)
+        # a flat 10% would hard-fail on a single flaky config, so scale the threshold up to allow
+        # one config to fail regardless of matrix size. Nightly (many configs) stays at 10%.
+        FAILURE_THRESHOLD = max(10.0, 100.0 / max(total_configs, 1))
         assert failure_rate <= FAILURE_THRESHOLD, \
-            f"Failure rate {failure_rate:.1f}% exceeds {FAILURE_THRESHOLD}% threshold ({failure_count}/{total_configs} configs failed)"
+            f"Failure rate {failure_rate:.1f}% exceeds {FAILURE_THRESHOLD:.1f}% threshold ({failure_count}/{total_configs} configs failed)"
     else:
         log.warning("No configurations were tested")
 

--- a/unit-tests/live/d400/pytest-depth-ae-convergence.py
+++ b/unit-tests/live/d400/pytest-depth-ae-convergence.py
@@ -68,11 +68,6 @@ TIMEOUT_ACCEL = max(ACCEL_MAX * 1.5, ACCEL_MAX + 0.5)
 # stop/close -> open storms can wedge the host USB controller on CI machines.
 SETTLE_DELAY = float(0.5)  # seconds
 
-# Default profile exercised by the gating (non-nightly) run
-DEFAULT_WIDTH = 640
-DEFAULT_HEIGHT = 480
-DEFAULT_FPS = 30
-
 # Available AE modes
 REGULAR = 0.0
 ACCELERATED = 1.0
@@ -263,19 +258,17 @@ def _prepare_depth_ae_sensor(dev):
     return sensor, supports_mode, depth_profiles
 
 
-def _select_default_profile(depth_profiles):
-    """Pick the default resolution for the gating run (prefer 640x480@30)."""
-    for p in depth_profiles:
-        vsp = p.as_video_stream_profile()
-        if vsp.width() == DEFAULT_WIDTH and vsp.height() == DEFAULT_HEIGHT and p.fps() == DEFAULT_FPS:
-            return p
-    # Fall back to any 30fps profile, otherwise the first candidate
-    for p in depth_profiles:
-        if p.fps() == DEFAULT_FPS:
-            return p
+def _select_default_profile(sensor, depth_profiles):
+    """Pick the depth sensor's default stream profile via the SDK's is_default() flag
+    (the camera's out-of-the-box resolution), mirroring how other live tests choose their
+    profile. Falls back to the first candidate profile if the sensor flags no default."""
+    default = next((p for p in sensor.profiles
+                    if p.stream_type() == rs.stream.depth and p.is_default()), None)
+    if default is not None:
+        return default
     vsp0 = depth_profiles[0].as_video_stream_profile()
-    log.warning(f"No {DEFAULT_WIDTH}x{DEFAULT_HEIGHT}@{DEFAULT_FPS} or any {DEFAULT_FPS}fps depth profile found; "
-                f"falling back to {vsp0.width()}x{vsp0.height()}@{depth_profiles[0].fps()}")
+    log.warning(f"Depth sensor flags no default profile; falling back to "
+                f"{vsp0.width()}x{vsp0.height()}@{depth_profiles[0].fps()}")
     return depth_profiles[0]
 
 
@@ -421,7 +414,7 @@ def test_depth_ae_convergence(test_device_wrapped):
     dev, _ = test_device_wrapped
     sensor, supports_mode, depth_profiles = _prepare_depth_ae_sensor(dev)
 
-    default_profile = _select_default_profile(depth_profiles)
+    default_profile = _select_default_profile(sensor, depth_profiles)
     vsp = default_profile.as_video_stream_profile()
     fmt = f"{vsp.width()}x{vsp.height()}@{default_profile.fps()}"
     log.info(f"Testing AE convergence on default depth profile [{fmt}]")

--- a/unit-tests/live/d400/pytest-depth-ae-convergence.py
+++ b/unit-tests/live/d400/pytest-depth-ae-convergence.py
@@ -1,8 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
-# CI timeout set to 10 minutes to accommodate comprehensive testing of all
-# supported depth profiles
+# CI timeout set to 10 minutes to accommodate the nightly full-profile sweep.
+# The default (gating) test only exercises a single resolution and is fast.
 
 """
 Depth Auto-Exposure (AE) Convergence Qualification Test
@@ -22,6 +22,12 @@ Method:
   6. Report convergence time (seconds & frames).
   7. If auto_exposure_mode option is supported, test both REGULAR (0) and ACCELERATED (1)
      modes, asserting accelerated convergence <= regular convergence * factor.
+
+Coverage:
+  - test_depth_ae_convergence: gating/default run, single default resolution only, so
+    the gate stays short and does not hammer the USB controller with reconfigurations.
+  - test_depth_ae_convergence_all_resolutions: nightly-only, sweeps the full depth
+    profile matrix.
 
 Pass / Fail (defaults):
   REGULAR mode must converge within 1.5s.
@@ -58,12 +64,26 @@ SPEED_FACTOR = float(1.15)  # regular >= accelerated * 1.15 expected
 TIMEOUT_REGULAR = max(REGULAR_MAX * 1.5, REGULAR_MAX + 0.5)
 TIMEOUT_ACCEL = max(ACCEL_MAX * 1.5, ACCEL_MAX + 0.5)
 
+# Let the USB endpoints tear down between stream reconfigurations. Back-to-back
+# stop/close -> open storms can wedge the host USB controller on CI machines.
+SETTLE_DELAY = float(0.5)  # seconds
+
+# Default profile exercised by the gating (non-nightly) run
+DEFAULT_WIDTH = 640
+DEFAULT_HEIGHT = 480
+DEFAULT_FPS = 30
+
 # Available AE modes
 REGULAR = 0.0
 ACCELERATED = 1.0
 
 # -----------------------------------------------------------------------------------------------
 # Helper Functions
+
+def _settle():
+    """Pause so USB endpoints fully tear down before the next open()."""
+    time.sleep(SETTLE_DELAY)
+
 
 def has_metadata(frame, md):
     try:
@@ -89,12 +109,16 @@ def measure_convergence(sensor, profile, max_allowed=1.0, timeout=2.0):
     Returns (status, details_dict)
       status: 'passed' | 'failed' | 'skipped'
       details_dict: contains timings, samples, reason (for skip/fail)
+
+    If the profile exposes no ACTUAL_EXPOSURE metadata (no frames recorded) the
+    result is 'skipped' - so a separate metadata-probe streaming cycle is not needed.
     """
-    # Ensure streaming stopped
+    # Ensure streaming stopped, then let the USB endpoints settle before reopening
     try:
         sensor.stop(); sensor.close()
     except Exception:
         pass
+    _settle()
 
     # Disable AE (while not streaming)
     sensor.set_option(rs.option.enable_auto_exposure, 0)
@@ -160,11 +184,12 @@ def measure_convergence(sensor, profile, max_allowed=1.0, timeout=2.0):
         if time.time() - enable_wall_time > mode_timeout:
             break
 
-    # Stop streaming
+    # Stop streaming, then let the USB endpoints settle before the next open
     try:
         sensor.stop(); sensor.close()
     except Exception:
         pass
+    _settle()
 
     # Prepare return details and always include collected samples
     base = {
@@ -210,55 +235,15 @@ def measure_convergence(sensor, profile, max_allowed=1.0, timeout=2.0):
     return ('passed' if converged_time is not None and converged_time <= max_allowed else 'failed'), base
 
 
-def check_metadata_availability(sensor, profile, timeout=2.0):
-    """Open the given profile briefly and confirm per-frame metadata is present."""
-    try:
-        # ensure sensor is not streaming
-        try:
-            sensor.stop(); sensor.close()
-        except Exception:
-            pass
-
-        ok = { 'frame_seen': False, 'has_exposure': False, 'has_gain': False }
-
-        def cb(f):
-            if not f.is_depth_frame():
-                return
-            ok['frame_seen'] = True
-            try:
-                ok['has_exposure'] = f.supports_frame_metadata(rs.frame_metadata_value.actual_exposure)
-            except Exception:
-                ok['has_exposure'] = False
-            try:
-                ok['has_gain'] = f.supports_frame_metadata(rs.frame_metadata_value.gain_level)
-            except Exception:
-                ok['has_gain'] = False
-
-        sensor.open(profile)
-        sensor.start(cb)
-
-        t0 = time.time()
-        while time.time() - t0 < timeout and not ok['frame_seen']:
-            time.sleep(0.02)
-
-        try:
-            sensor.stop(); sensor.close()
-        except Exception:
-            pass
-
-        return ok['frame_seen'] and ok['has_exposure']
-    except Exception:
-        try:
-            sensor.stop(); sensor.close()
-        except Exception:
-            pass
-        return False
-
 # -----------------------------------------------------------------------------------------------
-# Run Tests
+# Shared setup / execution
 
-def test_depth_ae_convergence(test_device_wrapped):
-    dev, _ = test_device_wrapped
+def _prepare_depth_ae_sensor(dev):
+    """Common setup: FW gate, depth sensor, AE support and the candidate profile list.
+
+    Skips the test (via pytest.skip) if the device can't run it.
+    Returns (sensor, supports_mode, depth_profiles).
+    """
     require_min_fw_version(dev, rsutils.version(5, 17, 0, 10), "AE convergence", inclusive=False)
 
     sensor = dev.first_depth_sensor()
@@ -269,24 +254,37 @@ def test_depth_ae_convergence(test_device_wrapped):
     supports_mode = sensor.supports(rs.option.auto_exposure_mode)
     log.info(f"Depth AE mode: [{supports_mode}]")
 
-    # Track all test results
-    test_results = []  # List of (config_name, passed: bool)
-
-    # Run AE convergence for all supported depth profiles (resolution + fps)
-    # Exclude profiles with frame rates lower than 15 fps from testing
+    # Candidate depth profiles (resolution + fps); exclude frame rates lower than 15 fps
     depth_profiles = [p for p in sensor.profiles if p.stream_type() == rs.stream.depth and p.fps() >= 15]
     if not depth_profiles:
-        pytest.skip('Requested depth profile 640x480@30 not found - exiting')
+        pytest.skip('No depth profiles >= 15fps found - exiting')
+
+    return sensor, supports_mode, depth_profiles
+
+
+def _select_default_profile(depth_profiles):
+    """Pick the default resolution for the gating run (prefer 640x480@30)."""
+    for p in depth_profiles:
+        vsp = p.as_video_stream_profile()
+        if vsp.width() == DEFAULT_WIDTH and vsp.height() == DEFAULT_HEIGHT and p.fps() == DEFAULT_FPS:
+            return p
+    # Fall back to any 30fps profile, otherwise the first candidate
+    for p in depth_profiles:
+        if p.fps() == DEFAULT_FPS:
+            return p
+    return depth_profiles[0]
+
+
+def _run_ae_convergence(sensor, supports_mode, depth_profiles):
+    """Run AE convergence over the given depth profiles and assert the overall result."""
+    # Track all test results
+    test_results = []  # List of (config_name, passed: bool)
 
     for prof in depth_profiles:
         fmt = f"{prof.as_video_stream_profile().width()}x{prof.as_video_stream_profile().height()}@{prof.fps()}"
         # Skip 60, 90 fps and 300 fps test cases
         if prof.fps() == 60 or prof.fps() == 90 or prof.fps() == 300:
             log.info(f"Skipping 60,90,300 fps test case: {fmt}")
-            continue
-        # Verify metadata is available for this profile before running the test
-        if not check_metadata_availability(sensor, prof):
-            log.info(f"Depth frames for profile {fmt} do not expose ACTUAL_EXPOSURE metadata - skipping profile")
             continue
         # Regular
         # Adjust allowed convergence time for low frame-rate profiles (e.g., 6fps)
@@ -403,3 +401,29 @@ def test_depth_ae_convergence(test_device_wrapped):
             f"Failure rate {failure_rate:.1f}% exceeds {FAILURE_THRESHOLD}% threshold ({failure_count}/{total_configs} configs failed)"
     else:
         log.warning("No configurations were tested")
+
+
+# -----------------------------------------------------------------------------------------------
+# Run Tests
+
+def test_depth_ae_convergence(test_device_wrapped):
+    """Gating/default run: exercise a single default resolution only, keeping the gate
+    short and avoiding a storm of USB stream reconfigurations."""
+    dev, _ = test_device_wrapped
+    sensor, supports_mode, depth_profiles = _prepare_depth_ae_sensor(dev)
+
+    default_profile = _select_default_profile(depth_profiles)
+    vsp = default_profile.as_video_stream_profile()
+    fmt = f"{vsp.width()}x{vsp.height()}@{default_profile.fps()}"
+    log.info(f"Testing AE convergence on default depth profile [{fmt}]")
+
+    _run_ae_convergence(sensor, supports_mode, [default_profile])
+
+
+@pytest.mark.context("nightly")
+def test_depth_ae_convergence_all_resolutions(test_device_wrapped):
+    """Nightly-only run: sweep the full depth profile matrix (resolution + fps)."""
+    dev, _ = test_device_wrapped
+    sensor, supports_mode, depth_profiles = _prepare_depth_ae_sensor(dev)
+
+    _run_ae_convergence(sensor, supports_mode, depth_profiles)

--- a/unit-tests/live/d400/pytest-depth-ae-convergence.py
+++ b/unit-tests/live/d400/pytest-depth-ae-convergence.py
@@ -402,13 +402,12 @@ def _run_ae_convergence(sensor, supports_mode, depth_profiles):
             for name in failed_configs:
                 log.info(f"  - {name}")
 
-        # Base tolerance is 10%, which is meaningful for the nightly full-matrix run. With a
-        # tiny config count (e.g. the single-profile gating run has at most REGULAR+ACCELERATED)
-        # a flat 10% would hard-fail on a single flaky config, so scale the threshold up to allow
-        # one config to fail regardless of matrix size. Nightly (many configs) stays at 10%.
-        FAILURE_THRESHOLD = max(10.0, 100.0 / max(total_configs, 1))
+        # Apply 10% threshold: only fail if more than 10% of configs failed. The SAME bar is
+        # used for the gating (single profile) and nightly (full matrix) runs — the only
+        # difference between them is how many profiles are exercised, not the pass criterion.
+        FAILURE_THRESHOLD = 10.0  # 10%
         assert failure_rate <= FAILURE_THRESHOLD, \
-            f"Failure rate {failure_rate:.1f}% exceeds {FAILURE_THRESHOLD:.1f}% threshold ({failure_count}/{total_configs} configs failed)"
+            f"Failure rate {failure_rate:.1f}% exceeds {FAILURE_THRESHOLD}% threshold ({failure_count}/{total_configs} configs failed)"
     else:
         log.warning("No configurations were tested")
 


### PR DESCRIPTION
**Overview:** The depth AE convergence test now runs a single default resolution on the gating build and the full profile matrix only on nightly, and adds a settle delay between stream reconfigurations — so it stops hammering the USB controller.

Tracked on [RSDSO-21717]

## Why
The test iterated over every depth profile (≥15fps) and performed three full `open → start → stop → close` streaming cycles per profile (metadata probe + REGULAR + ACCELERATED) with no settle time. On a D455 that is ~36 back-to-back UVC reconfigurations in one test. Rapid UVC STREAMOFF→STREAMON storms are a known trigger for xHCI host-controller lockups on Linux, and this test was observed several times in CI to wedge the USB controller and take the whole agent offline (not just fail the test).

## Summary
- Split into two tests:
  - `test_depth_ae_convergence` — always runs (gating + nightly), exercises the depth sensor's **default resolution** selected via the SDK `is_default()` profile (e.g. 848x480@30 on D455, 1280x720@30 on D415), with a fallback to the first ≥15fps profile if none is flagged. Drops gating from ~36 stream reconfigurations to ~2–4.
  - `test_depth_ae_convergence_all_resolutions` — `@pytest.mark.context("nightly")`, sweeps the full depth profile matrix. Only runs with `--context nightly`.
- Removed the redundant metadata-probe streaming cycle: `measure_convergence` already returns `skipped` ("No exposure metadata collected") when a profile exposes no `ACTUAL_EXPOSURE` metadata, so the separate `check_metadata_availability` open/stream/close cycle was unnecessary.
- Added a `SETTLE_DELAY` (0.5s) after every `stop(); close()` so USB endpoints tear down before the next `open()`.
- Same 10% failure threshold used for both gating and nightly — the only difference between the two is how many profiles are exercised, not the pass criterion.
- Extracted shared setup/run into `_prepare_depth_ae_sensor`, `_select_default_profile`, `_run_ae_convergence`.

## Test plan
- [x] Collection + context gating verified locally: gating test runs in any context; nightly test skips with "Requires --context nightly" unless `--context nightly` is passed.
- [x] Live path validated locally on hardware — D455 (default 848x480@30, gating + full nightly matrix) and D415 (default 1280x720@30, gating); default profile selection confirmed per-SKU via `is_default()`.
- [x] LibCI validated on benches across D455/D435/D457/D436/D401 (Windows/Linux/Jetson) — gating + nightly full-matrix.

---
🤖 Generated by AI
