### PR TITLE
pytest: unmask real setup error when pytest-retry reruns a failed module-fixture setup

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -20,6 +20,7 @@ import sys
 import os
 import re
 import logging
+from _pytest.stash import StashKey
 
 # Defense against ROS 2 launch.logging: when ROS is sourced, launch_testing's
 # pytest entry-point transitively imports launch.logging, which installs a
@@ -421,6 +422,19 @@ def _test_log_banner(request):
     ensure_newline()
 
 
+# Stash a retry-setup-phase failure so pytest_runtest_call can surface the real error
+# instead of the masking KeyError (see pytest_runtest_call for the full story).
+_retry_setup_exc_key = StashKey()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    """Record whether the setup phase failed, so pytest_runtest_call can recover the real
+    error if pytest-retry then runs the call phase on a failed retry-setup."""
+    outcome = yield
+    item.stash[_retry_setup_exc_key] = outcome.excinfo[1] if outcome.excinfo else None
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Log test duration and any failures/errors."""
@@ -455,8 +469,22 @@ def pytest_runtest_call(item):
     on every attempt (a genuinely flaky soft-check test passes on retry; a persistent
     one stays failed) and keeps them off the teardown report. Scoped to fire only for
     the buggy case; every other path is left to pytest-check unchanged.
+
+    Also unmasks a pytest-retry bug: pytest-retry reruns a test by calling pytest_runtest_setup
+    then pytest_runtest_call unconditionally (retry_plugin ~L237-238), ignoring whether the
+    retry-setup failed. When it did, funcargs lack the fixture and pytest_pyfunc_call raises
+    `KeyError: '<fixture>'`, hiding the real setup error and confusing the retry decision.
+    We swap that KeyError back for the recorded setup exception so the failure is
+    diagnosable and pytest-retry sees the true (retryable) error.
     """
     outcome = yield
+
+    setup_exc = item.stash.get(_retry_setup_exc_key, None)
+    if (setup_exc is not None and outcome.excinfo is not None
+            and outcome.excinfo[0] is KeyError):
+        outcome.force_exception(setup_exc)
+        return
+
     try:
         from pytest_check import check_log
     except ImportError:

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -20,7 +20,6 @@ import sys
 import os
 import re
 import logging
-from _pytest.stash import StashKey
 
 # Defense against ROS 2 launch.logging: when ROS is sourced, launch_testing's
 # pytest entry-point transitively imports launch.logging, which installs a
@@ -424,7 +423,7 @@ def _test_log_banner(request):
 
 # Stash a retry-setup-phase failure so pytest_runtest_call can surface the real error
 # instead of the masking KeyError (see pytest_runtest_call for the full story).
-_retry_setup_exc_key = StashKey()
+_retry_setup_exc_key = pytest.StashKey()
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -479,10 +479,13 @@ def pytest_runtest_call(item):
     """
     outcome = yield
 
+    # Match only the fixture-missing KeyError pytest injects, not a test-body KeyError.
     setup_exc = item.stash.get(_retry_setup_exc_key, None)
     if (setup_exc is not None and outcome.excinfo is not None
-            and outcome.excinfo[0] is KeyError):
+            and outcome.excinfo[0] is KeyError
+            and str(outcome.excinfo[1]).strip("'\"") in item.fixturenames):
         outcome.force_exception(setup_exc)
+        item.stash[_retry_setup_exc_key] = None  # consumed
         return
 
     try:

--- a/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
@@ -1,0 +1,23 @@
+# A module-scoped fixture (autouse-dependency chain) that fails its first two setup
+# attempts. pytest-retry reruns setup+call unconditionally; on the failed re-setup the
+# call phase would raise KeyError('<fixture>'), masking the real error. The conftest guard
+# surfaces the real error instead, so the retry sees the true (retryable) exception.
+import pytest
+pytestmark = [pytest.mark.device_each("D455")]
+_base = 0
+_dep = 0
+
+@pytest.fixture(scope="module", autouse=True)
+def base_module_fixture():
+    global _base; _base += 1
+    yield _base
+
+@pytest.fixture(scope="module")
+def dependent_module_fixture(base_module_fixture):
+    global _dep; _dep += 1
+    if _dep <= 2:
+        raise RuntimeError("intentional module-fixture setup failure attempt %d" % _dep)
+    yield _dep
+
+def test_recovers_without_keyerror(dependent_module_fixture):
+    assert dependent_module_fixture >= 3

--- a/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
@@ -3,7 +3,6 @@
 # call phase would raise KeyError('<fixture>'), masking the real error. The conftest guard
 # surfaces the real error instead, so the retry sees the true (retryable) exception.
 import pytest
-pytestmark = [pytest.mark.device_each("D455")]
 _base = 0
 _dep = 0
 

--- a/unit-tests/infra-tests/test_e2e_retry_setup_fail.py
+++ b/unit-tests/infra-tests/test_e2e_retry_setup_fail.py
@@ -1,0 +1,27 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: a module-scoped fixture that fails setup under pytest-retry must surface the REAL
+error, not a masking KeyError.
+
+pytest-retry reruns a test by calling pytest_runtest_setup then pytest_runtest_call
+unconditionally (retry_plugin ~L237-238); it ignores whether the retry-setup failed. When it
+did, funcargs lack the fixture and pytest_pyfunc_call raises `KeyError: '<fixture>'`, hiding
+the real setup error. conftest's pytest_runtest_setup/pytest_runtest_call guard swaps that
+KeyError back for the recorded setup exception. Verified: without the guard this test sees
+`KeyError` in the output; with it, the real RuntimeError is reported and the retry recovers.
+"""
+
+from helpers import run_e2e, parse_outcomes
+
+
+class TestRetrySetupFail:
+
+    def test_module_fixture_setup_fail_surfaces_real_error(self):
+        """Fixture fails setup on attempts 1 & 2 (real RuntimeError) and recovers on attempt 3.
+        The retry must never leak pytest-retry's masking KeyError."""
+        rc, out, *_ = run_e2e("pytest-retry-module-setup-fail.py", "--retries", "2")
+        assert parse_outcomes(out).get("passed") == 1, out
+        assert "KeyError" not in out, f"pytest-retry KeyError leaked:\n{out}"
+        assert "intentional module-fixture setup failure" in out, out


### PR DESCRIPTION
**Overview:** When pytest-retry reruns a test whose module-scoped fixture fails setup, it no longer masks the real error with `KeyError: '<fixture>'` — the true (retryable) setup exception is surfaced instead.

Tracked on [RSDEV-12512]

## Why
pytest-retry reruns a test by calling `pytest_runtest_setup` then `pytest_runtest_call` unconditionally (retry_plugin ~L237-238), ignoring whether the retry-setup failed. When it did, `funcargs` lack the fixture and `pytest_pyfunc_call` raises `KeyError: '<fixture>'`, which hides the real setup error and confuses the retry decision. Reproduced on a live D585S: `test_device_wrapped` setup failed transiently, and every retry then reported `KeyError: 'test_device_wrapped'` instead of the real error, erroring out a recoverable transient.

## Summary
- `conftest.py`: a `pytest_runtest_setup` hookwrapper stashes any setup-phase exception; `pytest_runtest_call` detects the masking `KeyError` after a stashed setup failure and swaps in the real exception via `outcome.force_exception(...)`.
- Added `infra-tests/test_e2e_retry_setup_fail.py` + `e2e/pytest-retry-module-setup-fail.py` (a module fixture that fails its first two setup attempts). Verified the test fails without the guard (KeyError leaks) and passes with it.

## Test plan
- [x] `infra-tests/` locally: full suite green.
- [x] New regression test asserts recovery with no `KeyError` leak.
- [x] Live D585S: persistent module-fixture setup failure now reports the real error on every attempt instead of `KeyError`.

---
🤖 Generated by AI
