### PR TITLE
Cherry-Pick sw-update: match device names with or without Intel prefix (#15340)

### DIFF
--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -296,12 +296,32 @@ namespace rs2
 
         }
 
+        // Device names historically carried an "Intel " prefix; newer SDKs drop it.
+        // Normalize so DB entries and reported names match regardless of the prefix.
+        // The prefix casing is a guaranteed invariant: the DB always uses exactly
+        // "Intel ", so a case-sensitive match is intentional here.
+        std::string versions_db_manager::strip_intel_prefix(const std::string &name)
+        {
+            static const std::string prefix = "Intel ";
+            if (0 == name.compare(0, prefix.size(), prefix))
+                return name.substr(prefix.size());
+            return name;
+        }
+
         bool versions_db_manager::is_device_name_equal(const std::string &str_from_db, const std::string &str_compared, bool allow_wildcard)
         {
+            // Strip the legacy "Intel " prefix from both sides so comparisons are
+            // prefix-agnostic regardless of which side (DB or runtime) carries it.
+            const std::string db = strip_intel_prefix(str_from_db);
+            const std::string cmp = strip_intel_prefix(str_compared);
+
             if (allow_wildcard)
-                return (0 == str_from_db.compare(0, str_from_db.find('*'), str_compared, 0, str_from_db.find('*')));
+            {
+                const auto wildcard_pos = db.find('*');
+                return (0 == db.compare(0, wildcard_pos, cmp, 0, wildcard_pos));
+            }
             else
-                return (str_from_db == str_compared);
+                return (db == cmp);
         }
     }
 

--- a/common/sw-update/versions-db-manager.h
+++ b/common/sw-update/versions-db-manager.h
@@ -83,6 +83,7 @@ namespace rs2
             void parse_versions_data(const std::stringstream &ver_data);
             bool get_version_data_common(const component_part_type component, const version& version, const std::string& req_field, std::string& out);
             bool is_device_name_equal(const std::string &str_from_db, const std::string &str_compared, bool allow_wildcard);
+            static std::string strip_intel_prefix(const std::string &name);
 
 
             bool init();


### PR DESCRIPTION
**Overview:** Cherry-pick of #15340 into `r/2.58.3` — the software-update version DB lookup now matches a device name whether or not it carries the legacy `Intel ` prefix, so newer SDK builds (which drop the prefix) still find their update entries against DB files that still use `Intel RealSense ...`.

Tracked on [RSDEV-12506]

## Why
Newer SDKs report device names without the `Intel ` prefix (`RealSense D455` instead of `Intel RealSense D455`), so `is_device_name_equal` no longer matched the DB entries and update lookups failed. This needs to ship on the `r/2.58.3` release branch as well.

## Summary
- Cherry-pick of #15340 (merged to `development`).
- `is_device_name_equal` normalizes both the DB value and the reported name by stripping an optional leading `Intel ` before comparing (wildcard logic preserved).
- DB JSON intentionally keeps the `Intel RealSense ...` prefix so already-shipped older SDKs keep matching; the new SDK matches with or without it.

## Test plan
- [x] Built realsense-viewer from this branch and validated locally against a connected D455. The device reports `RealSense D455` (no prefix); pointed the viewer at a local versions DB whose entries keep the `Intel ` prefix and confirmed both update notifications appeared:
  - Recommended SW matched the wildcard entry `Intel RealSense D4*` (wildcard + prefix-strip).
  - Recommended FW matched the exact entry `Intel RealSense D455` (exact + prefix-strip).
  - Both match only with this fix; on the old code neither would match.
- [ ] Unit test for `is_device_name_equal` deferred (follow-up on `development`).

---
🤖 Generated by AI
