### PR TITLE
unit-tests: reset pytest-timeout between pytest-retry attempts

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -449,16 +449,27 @@ def _reset_pytest_timeout_for_retry(item):
     fails and then retries can be killed ~110s into the retry with a
     `+++ Timeout +++` stack dump. Re-arming here gives each attempt a fresh
     budget while setup/teardown stay bounded by the outer protocol timer.
+
+    Fires on the *first* pytest_runtest_call too, not only on retries — a
+    deliberate side effect: setup time no longer counts against the call-phase
+    budget. In practice module_device_setup takes seconds; the previous
+    behaviour of setup eating into the 200s call budget was more of a footgun
+    than a feature. Setup itself is still bounded by the outer protocol timer
+    (which we cancel only after setup has completed and the call begins).
+
     Only applies when pytest-timeout is protocol-scoped (func_only=False,
     our default in pytest_configure); with func_only=True pytest-timeout
-    already re-arms per call itself.
+    already re-arms per call itself. `_get_item_settings` is a pytest-timeout
+    internal; a rename raises ImportError from the `from ... import` line
+    (or AttributeError if the module structure ever changes), both caught
+    below → helper degrades to no-op.
     """
     try:
         from pytest_timeout import _get_item_settings
-    except ImportError:
+    except (ImportError, AttributeError):
         return
     settings = _get_item_settings(item)
-    if not (settings.timeout and settings.timeout > 0 and settings.func_only is False):
+    if not (settings.timeout and settings.timeout > 0 and not settings.func_only):
         return
     hooks = item.config.pluginmanager.hook
     hooks.pytest_timeout_cancel_timer(item=item)

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -440,30 +440,9 @@ def pytest_runtest_makereport(item, call):
 
 
 def _reset_pytest_timeout_for_retry(item):
-    """Re-arm pytest-timeout's per-item timer so retries get a fresh --timeout budget.
-
-    pytest-timeout arms its timer in a `pytest_runtest_protocol` hookwrapper whose
-    yield covers setup + all call attempts + teardown. pytest-retry re-invokes
-    `pytest_runtest_call` from inside `pytest_runtest_makereport`, still under
-    that outer yield, so retries share the original budget — a 90s test that
-    fails and then retries can be killed ~110s into the retry with a
-    `+++ Timeout +++` stack dump. Re-arming here gives each attempt a fresh
-    budget while setup/teardown stay bounded by the outer protocol timer.
-
-    Fires on the *first* pytest_runtest_call too, not only on retries — a
-    deliberate side effect: setup time no longer counts against the call-phase
-    budget. In practice module_device_setup takes seconds; the previous
-    behaviour of setup eating into the 200s call budget was more of a footgun
-    than a feature. Setup itself is still bounded by the outer protocol timer
-    (which we cancel only after setup has completed and the call begins).
-
-    Only applies when pytest-timeout is protocol-scoped (func_only=False,
-    our default in pytest_configure); with func_only=True pytest-timeout
-    already re-arms per call itself. `_get_item_settings` is a pytest-timeout
-    internal; a rename raises ImportError from the `from ... import` line
-    (or AttributeError if the module structure ever changes), both caught
-    below → helper degrades to no-op.
-    """
+    """Re-arm pytest-timeout so each pytest-retry attempt gets a fresh --timeout budget
+    (the outer protocol yield otherwise makes retries share the first attempt's budget).
+    Also fires on first call: setup no longer counts against the call budget."""
     try:
         from pytest_timeout import _get_item_settings
     except (ImportError, AttributeError):

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -439,9 +439,36 @@ def pytest_runtest_makereport(item, call):
         log.debug(f"Test execution took {report.duration:.3f}s")
 
 
+def _reset_pytest_timeout_for_retry(item):
+    """Re-arm pytest-timeout's per-item timer so retries get a fresh --timeout budget.
+
+    pytest-timeout arms its timer in a `pytest_runtest_protocol` hookwrapper whose
+    yield covers setup + all call attempts + teardown. pytest-retry re-invokes
+    `pytest_runtest_call` from inside `pytest_runtest_makereport`, still under
+    that outer yield, so retries share the original budget — a 90s test that
+    fails and then retries can be killed ~110s into the retry with a
+    `+++ Timeout +++` stack dump. Re-arming here gives each attempt a fresh
+    budget while setup/teardown stay bounded by the outer protocol timer.
+    Only applies when pytest-timeout is protocol-scoped (func_only=False,
+    our default in pytest_configure); with func_only=True pytest-timeout
+    already re-arms per call itself.
+    """
+    try:
+        from pytest_timeout import _get_item_settings
+    except ImportError:
+        return
+    settings = _get_item_settings(item)
+    if not (settings.timeout and settings.timeout > 0 and settings.func_only is False):
+        return
+    hooks = item.config.pluginmanager.hook
+    hooks.pytest_timeout_cancel_timer(item=item)
+    hooks.pytest_timeout_set_timer(item=item, settings=settings)
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    """Surface pytest-check soft-check failures in the call phase.
+    """Reset pytest-timeout between retry attempts + surface pytest-check
+    soft-check failures in the call phase.
 
     pytest-check defers its failures to pytest_runtest_makereport. But pytest-retry
     reruns a test by invoking pytest_runtest_call directly and building the report
@@ -456,6 +483,8 @@ def pytest_runtest_call(item):
     one stays failed) and keeps them off the teardown report. Scoped to fire only for
     the buggy case; every other path is left to pytest-check unchanged.
     """
+    _reset_pytest_timeout_for_retry(item)
+
     outcome = yield
     try:
         from pytest_check import check_log

--- a/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
@@ -1,0 +1,25 @@
+# Exercises the pytest-timeout + pytest-retry interaction. Run under
+# --retries=1 --timeout=3.
+#
+# pytest-timeout arms its per-item timer in `pytest_runtest_protocol`, whose
+# yield covers setup + all call attempts + teardown. pytest-retry re-invokes
+# `pytest_runtest_call` from inside `pytest_runtest_makereport`, still under
+# that outer yield, so without a reset each retry shares the original --timeout
+# budget with the failed first attempt.
+#
+# This test consumes ~2s per attempt on a 3s budget. Without the conftest
+# reset, attempt 2 has ~1s of budget left after attempt 1 and gets killed
+# mid-sleep with a `+++ Timeout +++` banner (os._exit(1) → whole subprocess
+# dies). With the reset, each attempt gets a fresh 3s and the test passes on
+# attempt 2.
+import time
+
+_attempt = 0
+
+
+def test_timeout_resets_between_retry_attempts():
+    global _attempt
+    _attempt += 1
+    time.sleep(2.0)
+    if _attempt == 1:
+        assert False, "intentional first-attempt failure"

--- a/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
@@ -1,5 +1,5 @@
 # Exercises the pytest-timeout + pytest-retry interaction. Run under
-# --retries=1 --timeout=3.
+# --retries=1 --timeout=5.
 #
 # pytest-timeout arms its per-item timer in `pytest_runtest_protocol`, whose
 # yield covers setup + all call attempts + teardown. pytest-retry re-invokes
@@ -7,11 +7,11 @@
 # that outer yield, so without a reset each retry shares the original --timeout
 # budget with the failed first attempt.
 #
-# This test consumes ~2s per attempt on a 3s budget. Without the conftest
-# reset, attempt 2 has ~1s of budget left after attempt 1 and gets killed
+# This test consumes ~3s per attempt on a 5s budget. Without the conftest
+# reset, attempt 2 has ~2s of budget left after attempt 1 and gets killed
 # mid-sleep with a `+++ Timeout +++` banner (os._exit(1) → whole subprocess
-# dies). With the reset, each attempt gets a fresh 3s and the test passes on
-# attempt 2.
+# dies). With the reset, each attempt gets a fresh 5s and the test passes on
+# attempt 2. Margins chosen for slow CI: 2s of slack per attempt.
 import time
 
 _attempt = 0
@@ -20,6 +20,6 @@ _attempt = 0
 def test_timeout_resets_between_retry_attempts():
     global _attempt
     _attempt += 1
-    time.sleep(2.0)
+    time.sleep(3.0)
     if _attempt == 1:
         assert False, "intentional first-attempt failure"

--- a/unit-tests/infra-tests/test_e2e_retry_timeout.py
+++ b/unit-tests/infra-tests/test_e2e_retry_timeout.py
@@ -1,0 +1,31 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: pytest-timeout resets between pytest-retry attempts.
+
+pytest-timeout arms its per-item timer in `pytest_runtest_protocol`, whose
+yield covers setup + all call attempts + teardown. pytest-retry re-invokes
+`pytest_runtest_call` from `pytest_runtest_makereport`, still under that
+outer yield — so without a reset, retries share the original --timeout
+budget. A test that consumes most of the budget on attempt 1 gets killed
+mid-attempt-2 with a `+++ Timeout +++` stack dump. The conftest
+`_reset_pytest_timeout_for_retry` re-arms the timer at the start of every
+`pytest_runtest_call`. This test locks in the fixed behaviour.
+"""
+
+from helpers import run_e2e, parse_outcomes
+
+
+class TestRetryTimeoutReset:
+
+    def test_timeout_resets_between_retry_attempts(self):
+        """Attempt 1 sleeps 2s and fails; attempt 2 sleeps 2s and passes.
+        With --timeout=3, the shared-timer bug would kill attempt 2 at ~1s.
+        With the reset, each attempt gets a fresh 3s and the test PASSES."""
+        rc, out, *_ = run_e2e("pytest-retry-timeout.py",
+                               "--retries", "1", "--timeout", "3")
+        assert rc == 0, out
+        outcomes = parse_outcomes(out)
+        assert outcomes.get("passed") == 1, out
+        assert "+++ Timeout +++" not in out, out

--- a/unit-tests/infra-tests/test_e2e_retry_timeout.py
+++ b/unit-tests/infra-tests/test_e2e_retry_timeout.py
@@ -20,11 +20,12 @@ from helpers import run_e2e, parse_outcomes
 class TestRetryTimeoutReset:
 
     def test_timeout_resets_between_retry_attempts(self):
-        """Attempt 1 sleeps 2s and fails; attempt 2 sleeps 2s and passes.
-        With --timeout=3, the shared-timer bug would kill attempt 2 at ~1s.
-        With the reset, each attempt gets a fresh 3s and the test PASSES."""
+        """Attempt 1 sleeps 3s and fails; attempt 2 sleeps 3s and passes.
+        With --timeout=5, the shared-timer bug would kill attempt 2 at ~2s.
+        With the reset, each attempt gets a fresh 5s and the test PASSES.
+        2s slack per attempt tolerates slow CI scheduler jitter."""
         rc, out, *_ = run_e2e("pytest-retry-timeout.py",
-                               "--retries", "1", "--timeout", "3")
+                               "--retries", "1", "--timeout", "5")
         assert rc == 0, out
         outcomes = parse_outcomes(out)
         assert outcomes.get("passed") == 1, out

--- a/unit-tests/infra-tests/test_e2e_retry_timeout.py
+++ b/unit-tests/infra-tests/test_e2e_retry_timeout.py
@@ -29,4 +29,5 @@ class TestRetryTimeoutReset:
         assert rc == 0, out
         outcomes = parse_outcomes(out)
         assert outcomes.get("passed") == 1, out
+        assert outcomes.get("retried") == 1, f"expected exactly 1 retry: {out}"
         assert "+++ Timeout +++" not in out, out


### PR DESCRIPTION
**Overview:** Each `pytest-retry` attempt now gets a fresh `--timeout` budget instead of sharing the failed first attempt's leftover. Fixes the `+++ Timeout +++` cascade seen on the Jetson viewer-GUI retry in PR #15337.

## Why
`pytest-timeout` arms its per-item timer in a `pytest_runtest_protocol` hookwrapper — that wrapper's `yield` covers **setup + all call attempts + teardown**. `pytest-retry` re-invokes `pytest_runtest_call` from inside `pytest_runtest_makereport` (`retry_plugin.py:238`), still under the outer yield, so every retry shares the original `--timeout` budget with the failed first attempt.

Observed on the Jetson nightly (see PR #15337):
- Test parametrization entered at `05:22:31` → outer `pytest-timeout` (200 s) armed.
- Attempt 1 ran ~103 s, failed on a mem-leak assertion.
- Retry started at `05:24:14`, expected another ~90 s.
- Outer timer fired at `05:26:00` (209 s after item start), killing the retry mid-viewer with `+++ Timeout +++` and `os._exit(1)`.

The retry never had a chance — only ~97 s of the 200 s budget was left.

## Summary
- `unit-tests/conftest.py`: add `_reset_pytest_timeout_for_retry(item)` and call it at the start of the existing `pytest_runtest_call` hookwrapper. On each entry (first call *and* every retry) it invokes `pytest_timeout_cancel_timer` + `pytest_timeout_set_timer` so the item's timer is re-armed with a full `--timeout` budget. No-op when `pytest-timeout` is not installed, or when `func_only=True` is set (pytest-timeout already re-arms per call in that mode).
- `unit-tests/infra-tests/test_e2e_retry_timeout.py` + `e2e/pytest-retry-timeout.py`: regression test. Sleeps 2 s per attempt under `--retries=1 --timeout=3`; passes with the fix, fails with a `+++ Timeout +++` banner without it. Verified locally by stashing the conftest change and re-running.

## Test plan
- [ ] Local: `python -m pytest unit-tests/infra-tests/test_e2e_retry_timeout.py test_e2e_check_retry.py -v` — new + existing retry regression tests pass.
- [ ] LibCI Infra_Tests job stays green.
- [ ] Nightly Jetson viewer-GUI retry (once a legit failure occurs) sees the retry run its full 200 s budget instead of dying at ~90 s.

---
🤖 Generated by AI
