### PR TITLE
viewer: fix hang on close while FW logs are active

### DIFF
--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -105,7 +105,7 @@ void output_model::thread_loop()
                 }
             }
 
-            while( enable_firmware_logs )
+            while( enable_firmware_logs && ! to_stop )
             {
                 for( auto & it : loggers )
                 {
@@ -146,7 +146,7 @@ void output_model::thread_loop()
                                 add_log( message.get_severity(), __FILE__, 0, ss.str() );
                             }
 
-                            if( !enable_firmware_logs && fwlogger.get_number_of_fw_logs() == 0 )
+                            if( ( !enable_firmware_logs || to_stop ) && fwlogger.get_number_of_fw_logs() == 0 )
                                 break;
                         }
                     }

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -146,7 +146,7 @@ void output_model::thread_loop()
                                 add_log( message.get_severity(), __FILE__, 0, ss.str() );
                             }
 
-                            if( ( !enable_firmware_logs || to_stop ) && fwlogger.get_number_of_fw_logs() == 0 )
+                            if( ! enable_firmware_logs || to_stop )
                                 break;
                         }
                     }
@@ -160,16 +160,19 @@ void output_model::thread_loop()
                 }
                                     
                 // FW define the logs polling intervals to be no less than 100msec to cope with limited resources.
-                // At the same time 100 msec should guarantee no log drops
-                std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+                // At the same time 100 msec should guarantee no log drops.
+                // Sleep in 10 ms chunks so shutdown (to_stop) doesn't wait a full 100 ms.
+                for( int i = 0; i < 10 && ! to_stop; ++i )
+                    std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
             }
 
-            // User dectivated FW logs. Stop collecting logs.
+            // FW logs deactivated (user toggle or shutdown). Stop collecting logs.
             for( auto & fwlogger : loggers )
                 fwlogger.first.stop_collecting();
         }
 
-        std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+        for( int i = 0; i < 10 && ! to_stop; ++i )
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
     }
 }
 

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -150,7 +150,7 @@ namespace rs2
         animated< int > default_dashboard_w { 0 };
         bool is_dashboard_open = true;
 
-        bool enable_firmware_logs = false;
+        std::atomic< bool > enable_firmware_logs { false };
 
         bool errors_selected = false;
         bool warnings_selected = false;


### PR DESCRIPTION
Tracked by: RSDEV-12564

**Overview:** In realsense-viewer, opening the FW-logs panel and then closing the window caused the process to hang. Reproduces even with no device connected. Regression introduced in v2.56.1 vs. v2.55.1.

## Why
The FW-logger worker thread in `output_model::thread_loop()` was refactored in v2.56.1 into a nested loop. The inner `while( enable_firmware_logs )` polls FW logs but never re-checks `to_stop`. On viewer shutdown, `~output_model()` sets `to_stop = 1` and calls `fw_logger.join()`, but the worker is trapped in the inner loop — nothing turns `enable_firmware_logs` off during shutdown — so the join blocks forever.

## Summary
- Inner FW-log poll loop now honors `to_stop`, so the worker exits on viewer close even while FW logs are active.
- Drain break inside `get_firmware_log` now exits immediately on shutdown or user toggle-off (drops any queued messages — acceptable for a viewer; `stop_collecting()` runs right after anyway).
- Both 100 ms `sleep_for` calls broken into 10×10 ms chunks that watch `to_stop`, so close-latency drops from ~100 ms to ~10 ms without changing the FW polling cadence.
- `enable_firmware_logs` is now `std::atomic<bool>` — it's written from the UI thread and read from the FW-log thread; the previous plain `bool` was a data race exposed more by the new shutdown-aware loop.

## Test plan
- [x] Local Windows build of `realsense-viewer` succeeds.
- [ ] Open realsense-viewer, click FW-logs icon, close the window — process exits cleanly (no hang), with and without a device connected.
- [ ] Regression check: open FW-logs, disable FW-logs via the icon, verify logs stop collecting as before.

---
🤖 Generated by AI