### PR TITLE
Fix global timestamps stepping/slewing/reversing and depth-color splits at the HW clock wrap

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -7,6 +7,14 @@ using namespace std::chrono;
 
 namespace librealsense
 {
+    // Clock-sync sample admission, delay gate (see time_diff_keeper::update_diff_time).
+    // Each poll pairs a device-clock reading with a system time. If the control-transfer round-trip is
+    // much slower than the fastest seen, the device clock could have been read anywhere within that
+    // round-trip: the pairing is unreliable and a single such sample can shift the fit by seconds.
+    // Reject these, but not forever - after too many in a row accept one, to keep the fit from going stale.
+    static const double max_delay_over_min_ms = 15.;
+    static const unsigned int max_rejections_in_a_row = 10;
+
     CSample& CSample::operator-=(const CSample& other)
     {
         _x -= other._x;
@@ -174,6 +182,7 @@ namespace librealsense
         _users_count(0),
         _is_ready(false),
         _min_command_delay(1000),
+        _rejections_in_row(0),
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
@@ -205,6 +214,7 @@ namespace librealsense
             _is_ready = false;
             std::lock_guard< std::recursive_mutex > lock( _read_mtx );
             _coefs.reset();
+            _rejections_in_row = 0;
         }
     }
 
@@ -230,6 +240,33 @@ namespace librealsense
                 _coefs.add_const_y_coefs(command_delay - _min_command_delay);
                 _min_command_delay = command_delay;
             }
+            else if (command_delay - _min_command_delay > max_delay_over_min_ms)
+            {
+                // Delayed control transfer (e.g. USB congestion): the pairing is unreliable
+                // (see the delay-gate comment above max_delay_over_min_ms).
+                if (!_is_ready)
+                {
+                    // During warmup accept it anyway - rejecting could starve the fit before it is ever
+                    // ready, and enforce_monotonicity bounds the damage a noisy early fit can do.
+                    LOG_DEBUG("time_diff_keeper: accepting delayed clock sample during warmup: command delay "
+                              << command_delay << " ms exceeds minimal delay " << _min_command_delay
+                              << " ms by more than " << max_delay_over_min_ms << " ms");
+                }
+                else if (++_rejections_in_row <= max_rejections_in_a_row)
+                {
+                    LOG_DEBUG("time_diff_keeper: rejecting delayed clock sample: command delay " << command_delay
+                              << " ms exceeds minimal delay " << _min_command_delay << " ms by more than "
+                              << max_delay_over_min_ms << " ms");
+                    return false;
+                }
+                else
+                {
+                    LOG_WARNING("time_diff_keeper: accepting delayed clock sample (command delay " << command_delay
+                                << " ms, minimal delay " << _min_command_delay << " ms) after " << _rejections_in_row - 1
+                                << " consecutive rejections, to avoid a stale fit");
+                }
+            }
+            _rejections_in_row = 0;
             double system_time(system_time_finish - _min_command_delay);
             if (_is_ready)
             {
@@ -289,7 +326,9 @@ namespace librealsense
         _device_timestamp_reader(std::move(device_timestamp_reader)),
         _time_diff_keeper(timediff),
         _option_is_enabled(enable_option),
-        _ts_is_ready(false)
+        _ts_is_ready(false),
+        _last_hw_time_ms(-1),
+        _last_global_time_ms(0)
     {
     }
 
@@ -301,11 +340,55 @@ namespace librealsense
         {
             auto sp = _time_diff_keeper.lock();
             if (sp)
-                frame_time = sp->get_system_hw_time(frame_time, _ts_is_ready);
+            {
+                double hw_time = frame_time;
+                frame_time = sp->get_system_hw_time(hw_time, _ts_is_ready);
+                if (_ts_is_ready)
+                    frame_time = enforce_monotonicity(hw_time, frame_time);
+            }
             else
                 LOG_DEBUG("Notification: global_timestamp_reader - time_diff_keeper is being shut-down");
         }
         return frame_time;
+    }
+
+    // A frame that is later on the HW clock must never get an earlier global timestamp than the frame
+    // before it: a bad clock-sync sample can make the fit walk backwards faster than frames advance,
+    // reversing frame order in global time and breaking stream pairing downstream. When that happens,
+    // hold the last value. The clamp applies only while the HW clock advances continuously; on a HW
+    // rewind or a streaming gap the fit is trusted as-is and tracking restarts.
+    //
+    // The hold is bounded by max_monotonic_hold_ms so it bridges the small per-frame inversions it
+    // exists for, but a larger drop (the fit genuinely re-basing) is accepted as a single backward step
+    // rather than held. This trades one bounded ordering violation for never freezing a stream's
+    // timestamps at a stuck value - an unbounded hold could freeze a stream indefinitely, which is worse.
+    double global_timestamp_reader::enforce_monotonicity(double hw_time, double global_time)
+    {
+        static const double max_continuous_hw_gap_ms = 1000.;
+        static const double max_monotonic_hold_ms = 100.;
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+        double hw_gap = hw_time - _last_hw_time_ms;
+        if (_last_hw_time_ms >= 0 && hw_gap >= 0 && hw_gap < max_continuous_hw_gap_ms &&
+            global_time < _last_global_time_ms)
+        {
+            if (_last_global_time_ms - global_time > max_monotonic_hold_ms)
+            {
+                // Dropped further below the held value than the hold can bridge: the fit has re-based
+                // (or the held value was bad). Accept the computed value - one backward step - and
+                // resume tracking from it.
+                LOG_DEBUG("global_timestamp_reader: releasing monotonicity hold: computed global time "
+                          << global_time << " ms is more than " << max_monotonic_hold_ms
+                          << " ms below held value " << _last_global_time_ms
+                          << " ms; accepting one backward step");
+            }
+            else
+            {
+                global_time = _last_global_time_ms;
+            }
+        }
+        _last_hw_time_ms = hw_time;
+        _last_global_time_ms = global_time;
+        return global_time;
     }
 
 
@@ -323,6 +406,9 @@ namespace librealsense
     void global_timestamp_reader::reset()
     {
         _device_timestamp_reader->reset();
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+        _last_hw_time_ms = -1;
+        _last_global_time_ms = 0;
     }
 
     global_time_interface::global_time_interface() :

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -245,19 +245,26 @@ namespace librealsense
         _last_request_time = x;
     }
 
-    // Map a HW time onto the fit's current wrap epoch WITHOUT mutating shared state.
-    // The device clock is a 32-bit microsecond counter that wraps every ~71.6 minutes. Near a wrap,
-    // frames from different streams of the same device straddle the boundary (one reads ~2^32 us, the
-    // next ~0) and are converted interleaved. The fit is shared across those streams, so re-basing it
-    // per frame here would corrupt the others' conversions; instead just shift the queried value by
-    // whole wrap periods onto the samples' epoch and leave the fit untouched.
-    double CLinearCoefficients::to_fit_domain(double x) const
+    // Shift x by whole wrap periods onto the epoch of anchor. The device clock is a 32-bit
+    // microsecond counter that wraps every ~71.6 minutes; two readings of it can only be compared
+    // on a continuous axis after mapping them onto the same wrap epoch.
+    double CLinearCoefficients::align_to_epoch(double x, double anchor)
     {
         static const double max_device_time(pow(2, 32) * MICROSEC_TO_MILLISEC);
+        double k = std::round((anchor - x) / max_device_time);
+        return x + k * max_device_time;
+    }
+
+    // Map a HW time onto the fit's current wrap epoch WITHOUT mutating shared state.
+    // Near a wrap, frames from different streams of the same device straddle the boundary (one
+    // reads ~2^32 us, the next ~0) and are converted interleaved. The fit is shared across those
+    // streams, so re-basing it per frame here would corrupt the others' conversions; instead just
+    // shift the queried value onto the samples' epoch and leave the fit untouched.
+    double CLinearCoefficients::to_fit_domain(double x) const
+    {
         if (_last_values.empty())
             return x;
-        double k = std::round((_last_values.front()._x - x) / max_device_time);
-        return x + k * max_device_time;
+        return align_to_epoch(x, _last_values.front()._x);
     }
 
     time_diff_keeper::time_diff_keeper(global_time_interface* dev, const unsigned int sampling_interval_ms) :
@@ -368,7 +375,12 @@ namespace librealsense
                 if (std::fabs(innovation) > max_innovation_ms)
                 {
                     ++_innovation_rejections_in_row;
-                    _rejected_samples.push_front(CSample(sample_hw_time, system_time));
+                    // A rejection streak can span the HW clock wrap; keep the window on one wrap
+                    // epoch so refit_from_samples() gets a continuous x-axis.
+                    double rejected_x = sample_hw_time;
+                    if (!_rejected_samples.empty())
+                        rejected_x = CLinearCoefficients::align_to_epoch(rejected_x, _rejected_samples.front()._x);
+                    _rejected_samples.push_front(CSample(rejected_x, system_time));
                     if (_rejected_samples.size() > re_fit_window)
                         _rejected_samples.pop_back();
 

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -38,6 +38,9 @@ namespace librealsense
     // _min_command_delay sentinel before any sample was measured.
     static const double initial_min_command_delay_ms = 1000.;
 
+    // The device clock is a 32-bit microsecond counter; it wraps every 2^32 us (~71.6 minutes).
+    static const double max_device_time_ms = 4294967296. * MICROSEC_TO_MILLISEC;
+
     CSample& CSample::operator-=(const CSample& other)
     {
         _x -= other._x;
@@ -217,14 +220,13 @@ namespace librealsense
     // so that the global timestamp can be correctly computed
     bool CLinearCoefficients::update_samples_base(double x)
     {
-        static const double max_device_time(pow(2, 32) * MICROSEC_TO_MILLISEC);
         double base_x;
         if (_last_values.empty())
             return false;
-        if ((_last_values.front()._x - x) > max_device_time / 2)
-            base_x = max_device_time;
-        else if ((x - _last_values.front()._x) > max_device_time / 2)
-            base_x = -max_device_time;
+        if ((_last_values.front()._x - x) > max_device_time_ms / 2)
+            base_x = max_device_time_ms;
+        else if ((x - _last_values.front()._x) > max_device_time_ms / 2)
+            base_x = -max_device_time_ms;
         else
             return false;
         LOG_DEBUG(__FUNCTION__ << "(" << base_x << ")");
@@ -245,14 +247,12 @@ namespace librealsense
         _last_request_time = x;
     }
 
-    // Shift x by whole wrap periods onto the epoch of anchor. The device clock is a 32-bit
-    // microsecond counter that wraps every ~71.6 minutes; two readings of it can only be compared
-    // on a continuous axis after mapping them onto the same wrap epoch.
+    // Shift x by whole wrap periods onto the epoch of anchor. Two device-clock readings can only
+    // be compared on a continuous axis after mapping them onto the same wrap epoch.
     double CLinearCoefficients::align_to_epoch(double x, double anchor)
     {
-        static const double max_device_time(pow(2, 32) * MICROSEC_TO_MILLISEC);
-        double k = std::round((anchor - x) / max_device_time);
-        return x + k * max_device_time;
+        double k = std::round((anchor - x) / max_device_time_ms);
+        return x + k * max_device_time_ms;
     }
 
     // Map a HW time onto the fit's current wrap epoch WITHOUT mutating shared state.
@@ -370,6 +370,8 @@ namespace librealsense
                 // prediction for this device time. If this sample also improved _min_command_delay above,
                 // calc_value() still returns the pre-shift prediction (the shift is applied on the next
                 // recompute); that error is a few ms at most, negligible against the gate.
+                // update_samples_base above already re-based the fit into sample_hw_time's epoch, so
+                // calling calc_value with the raw value is in-domain (no to_fit_domain mapping needed).
                 double predicted_system_time = _coefs.calc_value(sample_hw_time);
                 double innovation = system_time - predicted_system_time;
                 if (std::fabs(innovation) > max_innovation_ms)
@@ -500,6 +502,11 @@ namespace librealsense
     // exists for, but a larger drop (the fit genuinely re-basing) is accepted as a single backward step
     // rather than held. This trades one bounded ordering violation for never freezing a stream's
     // timestamps at a stuck value - an unbounded hold could freeze a stream indefinitely, which is worse.
+    //
+    // Ownership: a global_timestamp_reader instance is per-sensor (only the time_diff_keeper is shared
+    // across the device), so depth and color frames never interleave through this state. Streams of the
+    // same sensor that do interleave with independent HW times (e.g. gyro+accel) hit the hw-rewind
+    // bypass below and simply restart tracking - no false hold.
     double global_timestamp_reader::enforce_monotonicity(double hw_time, double global_time)
     {
         static const double max_continuous_hw_gap_ms = 1000.;

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -1,7 +1,10 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 RealSense, Inc. All Rights Reserved.
 #include "global_timestamp_reader.h"
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <vector>
 
 using namespace std::chrono;
 
@@ -14,6 +17,26 @@ namespace librealsense
     // Reject these, but not forever - after too many in a row accept one, to keep the fit from going stale.
     static const double max_delay_over_min_ms = 15.;
     static const unsigned int max_rejections_in_a_row = 10;
+
+    // Clock-sync sample admission, value gate (innovation gate).
+    // The delay gate can't catch a sample that arrived quickly but carries a wrong device-clock reading.
+    // So each sample is also compared against the fit's own prediction: if the measured system time
+    // differs from the predicted one by more than max_innovation_ms it cannot be genuine clock drift
+    // (which is at most tens of ms between polls) and is rejected before it can move the fit.
+    //
+    // A rejected sample is not necessarily the wrong one, though - the fit may be. Two mechanisms keep a
+    // bad fit from rejecting good samples forever:
+    //  1. The fit is computed robustly (theil_sen_fit), so a minority of outlier samples can't skew it.
+    //  2. If the fit rejects every sample for max_consecutive_rejections polls in a row it is assumed
+    //     wrong (stale, or the device clock re-based) and rebuilt from the rejected samples themselves:
+    //     the last re_fit_window rejections are kept and passed to refit_from_samples(). This self-heals
+    //     within max_consecutive_rejections polls and never drops readiness.
+    static const double max_innovation_ms = 100.;
+    static const unsigned int max_consecutive_rejections = 60;
+    static const unsigned int re_fit_window = 15;
+
+    // _min_command_delay sentinel before any sample was measured.
+    static const double initial_min_command_delay_ms = 1000.;
 
     CSample& CSample::operator-=(const CSample& other)
     {
@@ -64,10 +87,57 @@ namespace librealsense
         }
     }
 
+    // Robust linear fit over a window of (x, y) samples: Theil-Sen - the median of all pairwise slopes,
+    // then the median of the intercepts that slope implies. Unlike least squares, a minority of outlier
+    // samples (up to ~29% of the window) can't move the result, which is why the fit tolerates the
+    // occasional bad clock reading. The window is small (<=16 samples) so the O(n^2) slope enumeration
+    // is cheap. Samples are centered on base_sample only for numerical conditioning; the result does not
+    // depend on that choice. Returns false without touching a, b if there aren't two samples with
+    // distinct x to form a slope.
+    bool CLinearCoefficients::theil_sen_fit(const std::deque<CSample>& values, const CSample& base_sample, double& a, double& b)
+    {
+        static const double min_dx_ms = 1e-6; // Guard degenerate/near-duplicate x pairs (would blow up the slope estimate).
+        std::vector<CSample> centered;
+        centered.reserve(values.size());
+        for (auto& s : values)
+        {
+            CSample c(s);
+            c -= base_sample;
+            centered.push_back(c);
+        }
+        size_t n = centered.size();
+        if (n < 2)
+            return false;
+        std::vector<double> slopes;
+        slopes.reserve(n * (n - 1) / 2);
+        for (size_t i = 0; i < n; ++i)
+        {
+            for (size_t j = i + 1; j < n; ++j)
+            {
+                double dx = centered[j]._x - centered[i]._x;
+                if (std::fabs(dx) < min_dx_ms)
+                    continue;
+                slopes.push_back((centered[j]._y - centered[i]._y) / dx);
+            }
+        }
+        if (slopes.empty())
+            return false;
+        std::sort(slopes.begin(), slopes.end());
+        size_t mid = slopes.size() / 2;
+        a = (slopes.size() % 2) ? slopes[mid] : (slopes[mid - 1] + slopes[mid]) / 2.0;
+
+        std::vector<double> intercepts;
+        intercepts.reserve(n);
+        for (auto& c : centered)
+            intercepts.push_back(c._y - a * c._x);
+        std::sort(intercepts.begin(), intercepts.end());
+        size_t imid = intercepts.size() / 2;
+        b = (intercepts.size() % 2) ? intercepts[imid] : (intercepts[imid - 1] + intercepts[imid]) / 2.0;
+        return true;
+    }
+
     void CLinearCoefficients::calc_linear_coefs()
     {
-        // Calculate linear coefficients, based on calculus described in: https://www.statisticshowto.datasciencecentral.com/probability-and-statistics/regression-analysis/find-a-linear-regression-equation/
-        // Calculate Std
         double n(static_cast<double>(_last_values.size()));
         double a(1);
         double b(0);
@@ -83,26 +153,7 @@ namespace librealsense
         }
         else
         {
-            double sum_x(0);
-            double sum_y(0);
-            double sum_xy(0);
-            double sum_x2(0);
-            for (auto sample = _last_values.begin(); sample != _last_values.end(); sample++)
-            {
-                CSample crnt_sample(*sample);
-                crnt_sample -= _base_sample;
-                sum_x += crnt_sample._x;
-                sum_y += crnt_sample._y;
-                sum_xy += (crnt_sample._x * crnt_sample._y);
-                sum_x2 += (crnt_sample._x * crnt_sample._x);
-            }
-            double denom = n * sum_x2 - sum_x * sum_x;
-            if( denom > std::numeric_limits< double >::epsilon() )
-            {
-                b = (sum_y * sum_x2 - sum_x * sum_xy) / denom;
-                a = (n * sum_xy - sum_x * sum_y) / denom;
-            }
-            else
+            if (!theil_sen_fit(_last_values, _base_sample, a, b))
             {
                 a = _dest_a;
                 b = _dest_b;
@@ -116,6 +167,25 @@ namespace librealsense
         _prev_b = _dest_b * dt + _prev_b * (1 - dt);
         _dest_a = a;
         _dest_b = b;
+        _prev_time = _last_request_time;
+    }
+
+    // Replace the fit outright from an explicit sample window, instead of blending a sample in gradually
+    // the way add_value() does. Used to rebuild the fit after it has been rejecting samples for too long
+    // (see max_consecutive_rejections), so a re-based device clock - or a fit that itself went bad - is
+    // corrected at once rather than over the next second. base_sample is re-anchored to the window so
+    // the fit is self-contained.
+    void CLinearCoefficients::refit_from_samples(const std::deque<CSample>& samples)
+    {
+        if (samples.empty())
+            return;
+        _last_values = samples;
+        _base_sample = samples.front();
+        double a(1), b(0);
+        theil_sen_fit(_last_values, _base_sample, a, b);
+        _dest_a = _prev_a = a;
+        _dest_b = _prev_b = b;
+        _last_request_time = samples.front()._x;
         _prev_time = _last_request_time;
     }
 
@@ -181,8 +251,9 @@ namespace librealsense
         _coefs(15),
         _users_count(0),
         _is_ready(false),
-        _min_command_delay(1000),
+        _min_command_delay(initial_min_command_delay_ms),
         _rejections_in_row(0),
+        _innovation_rejections_in_row(0),
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
@@ -215,6 +286,8 @@ namespace librealsense
             std::lock_guard< std::recursive_mutex > lock( _read_mtx );
             _coefs.reset();
             _rejections_in_row = 0;
+            _innovation_rejections_in_row = 0;
+            _rejected_samples.clear();
         }
     }
 
@@ -271,7 +344,43 @@ namespace librealsense
             if (_is_ready)
             {
                 _coefs.update_samples_base(sample_hw_time);
+                // Value gate (see max_innovation_ms): compare the measured system time against the fit's
+                // prediction for this device time. If this sample also improved _min_command_delay above,
+                // calc_value() still returns the pre-shift prediction (the shift is applied on the next
+                // recompute); that error is a few ms at most, negligible against the gate.
+                double predicted_system_time = _coefs.calc_value(sample_hw_time);
+                double innovation = system_time - predicted_system_time;
+                if (std::fabs(innovation) > max_innovation_ms)
+                {
+                    ++_innovation_rejections_in_row;
+                    _rejected_samples.push_front(CSample(sample_hw_time, system_time));
+                    if (_rejected_samples.size() > re_fit_window)
+                        _rejected_samples.pop_back();
+
+                    if (_innovation_rejections_in_row < max_consecutive_rejections)
+                    {
+                        LOG_DEBUG("time_diff_keeper: rejecting clock sample on value: measured system time "
+                                  << system_time << " ms vs. predicted " << predicted_system_time
+                                  << " ms; innovation " << innovation << " ms exceeds "
+                                  << max_innovation_ms << " ms (" << _innovation_rejections_in_row
+                                  << " consecutive rejections)");
+                        return false;
+                    }
+
+                    // Rejected every sample for max_consecutive_rejections polls in a row: the fit is no
+                    // longer trustworthy (the device clock re-based, or the fit went bad). Rebuild it from
+                    // the rejected samples - they are consistent readings the fit fails to match - and
+                    // resume. Never drops _is_ready; only stop() does that.
+                    _coefs.refit_from_samples(_rejected_samples);
+                    LOG_WARNING("time_diff_keeper: clock fit re-based from rejected-sample window after "
+                                << _innovation_rejections_in_row << " consecutive innovation-gate rejections");
+                    _innovation_rejections_in_row = 0;
+                    _rejected_samples.clear();
+                    return true;
+                }
             }
+            _innovation_rejections_in_row = 0;
+            _rejected_samples.clear();
             CSample crnt_sample(sample_hw_time, system_time);
             _coefs.add_value(crnt_sample);
             _is_ready = true;

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -245,6 +245,21 @@ namespace librealsense
         _last_request_time = x;
     }
 
+    // Map a HW time onto the fit's current wrap epoch WITHOUT mutating shared state.
+    // The device clock is a 32-bit microsecond counter that wraps every ~71.6 minutes. Near a wrap,
+    // frames from different streams of the same device straddle the boundary (one reads ~2^32 us, the
+    // next ~0) and are converted interleaved. The fit is shared across those streams, so re-basing it
+    // per frame here would corrupt the others' conversions; instead just shift the queried value by
+    // whole wrap periods onto the samples' epoch and leave the fit untouched.
+    double CLinearCoefficients::to_fit_domain(double x) const
+    {
+        static const double max_device_time(pow(2, 32) * MICROSEC_TO_MILLISEC);
+        if (_last_values.empty())
+            return x;
+        double k = std::round((_last_values.front()._x - x) / max_device_time);
+        return x + k * max_device_time;
+    }
+
     time_diff_keeper::time_diff_keeper(global_time_interface* dev, const unsigned int sampling_interval_ms) :
         _device(dev),
         _poll_intervals_ms(sampling_interval_ms),
@@ -421,9 +436,11 @@ namespace librealsense
         is_ready = _is_ready;
         if (_is_ready)
         {
-            _coefs.update_samples_base(crnt_hw_time);
-            _coefs.update_last_sample_time(crnt_hw_time);
-            return _coefs.calc_value(crnt_hw_time);
+            // Read-only wrap alignment: only the polling thread (update_diff_time) may
+            // re-base the fit; see to_fit_domain().
+            double x = _coefs.to_fit_domain(crnt_hw_time);
+            _coefs.update_last_sample_time(x);
+            return _coefs.calc_value(x);
         }
         else
             return crnt_hw_time;

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -85,6 +85,7 @@ namespace librealsense
         mutable std::recursive_mutex _enable_mtx; // Watch only 1 start/stop operation at a time.
         CLinearCoefficients _coefs;
         double _min_command_delay;
+        unsigned int _rejections_in_row; // Consecutive samples rejected for excessive command delay.
         bool _is_ready;
     };
 
@@ -101,11 +102,16 @@ namespace librealsense
         void reset() override;
 
     private:
+        double enforce_monotonicity(double hw_time, double global_time);
+
+    private:
         std::unique_ptr<frame_timestamp_reader> _device_timestamp_reader;
         std::weak_ptr<time_diff_keeper> _time_diff_keeper;
         mutable std::recursive_mutex _mtx;
         std::shared_ptr<global_time_option> _option_is_enabled;
         bool _ts_is_ready;
+        double _last_hw_time_ms;        // HW timestamp of the last frame (-1 if none yet).
+        double _last_global_time_ms;    // Global timestamp given to the last frame.
     };
 
     class global_time_interface

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -41,6 +41,7 @@ namespace librealsense
         void refit_from_samples(const std::deque<CSample>& samples);
         bool update_samples_base(double x);
         double to_fit_domain(double x) const;
+        static double align_to_epoch(double x, double anchor);
         void update_last_sample_time(double x);
         double calc_value(double x) const;
         bool is_full() const;

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -38,6 +38,7 @@ namespace librealsense
         void reset();
         void add_value(CSample val);
         void add_const_y_coefs(double dy);
+        void refit_from_samples(const std::deque<CSample>& samples);
         bool update_samples_base(double x);
         void update_last_sample_time(double x);
         double calc_value(double x) const;
@@ -46,6 +47,7 @@ namespace librealsense
     private:
         void calc_linear_coefs();
         void get_a_b(double x, double& a, double& b) const;
+        static bool theil_sen_fit(const std::deque<CSample>& values, const CSample& base_sample, double& a, double& b);
 
     private:
         unsigned int _buffer_size;
@@ -86,6 +88,8 @@ namespace librealsense
         CLinearCoefficients _coefs;
         double _min_command_delay;
         unsigned int _rejections_in_row; // Consecutive samples rejected for excessive command delay.
+        unsigned int _innovation_rejections_in_row; // Consecutive samples rejected for excessive innovation (value vs. fit prediction).
+        std::deque<CSample> _rejected_samples;   // Last re_fit_window (x, y) pairs rejected on value; refit source if rejections persist.
         bool _is_ready;
     };
 

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -40,6 +40,7 @@ namespace librealsense
         void add_const_y_coefs(double dy);
         void refit_from_samples(const std::deque<CSample>& samples);
         bool update_samples_base(double x);
+        double to_fit_domain(double x) const;
         void update_last_sample_time(double x);
         double calc_value(double x) const;
         bool is_full() const;

--- a/unit-tests/synchronization/test-timestamps.cpp
+++ b/unit-tests/synchronization/test-timestamps.cpp
@@ -5,6 +5,8 @@
 // which first demonstrated with a test that the 32-bit hardware-timestamp wrap-around breaks
 // the global-time linear fit; extended with an interleaved-stream wrap case.
 
+//#cmake: static!
+
 #include "../catch.h"
 #include <src/global_timestamp_reader.h>
 #include <vector>

--- a/unit-tests/synchronization/test-timestamps.cpp
+++ b/unit-tests/synchronization/test-timestamps.cpp
@@ -1,0 +1,114 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+// Adapted from https://github.com/IntelRealSense/librealsense/pull/7923 by thomas-slamcore,
+// which first demonstrated with a test that the 32-bit hardware-timestamp wrap-around breaks
+// the global-time linear fit; extended with an interleaved-stream wrap case.
+
+#include "../catch.h"
+#include <src/global_timestamp_reader.h>
+#include <vector>
+
+using namespace librealsense;
+
+constexpr uint64_t PERIOD_USEC = 20000;      // 50 Hz
+constexpr uint64_t WRAP_USEC = 1ULL << 32;   // HW timestamps wrap every 2^32 microseconds
+constexpr double USEC_TO_MSEC = 0.001;
+
+static double to_hw_ms( uint64_t ts_usec )
+{
+    return ( ts_usec % WRAP_USEC ) * USEC_TO_MSEC;
+}
+
+static double to_sys_ms( uint64_t ts_usec )
+{
+    return ts_usec * USEC_TO_MSEC;
+}
+
+// Feed a clock-sync sample the way time_diff_keeper::update_diff_time does: only the
+// sample-admission path may re-base the fit onto the current wrap epoch.
+static void add_sample( CLinearCoefficients & coefs, uint64_t ts_usec, bool is_ready )
+{
+    if( is_ready )
+        coefs.update_samples_base( to_hw_ms( ts_usec ) );
+    coefs.add_value( CSample( to_hw_ms( ts_usec ), to_sys_ms( ts_usec ) ) );
+}
+
+// Convert a frame's HW time the way time_diff_keeper::get_system_hw_time does: read-only
+// wrap alignment, never mutating the shared fit.
+static double query( CLinearCoefficients & coefs, uint64_t ts_usec )
+{
+    double x = coefs.to_fit_domain( to_hw_ms( ts_usec ) );
+    coefs.update_last_sample_time( x );
+    return coefs.calc_value( x );
+}
+
+// With zero-latency samples (hardware and system clocks advancing identically) the fit is
+// the identity mapping, so querying any fed timestamp must reproduce its system time -
+// including when the 32-bit hardware counter wraps mid-sequence.
+static void test_linear_coefficients( const uint64_t ts_offset )
+{
+    CLinearCoefficients coefs( 15 );
+
+    std::vector< uint64_t > timestamps;
+    for( size_t i = 0; i < 10; ++i )
+        timestamps.push_back( ts_offset + i * PERIOD_USEC );
+
+    bool is_ready = false;
+    for( auto ts : timestamps )
+    {
+        add_sample( coefs, ts, is_ready );
+        is_ready = true;
+    }
+
+    // It should be possible to query timestamps in the past - frames are converted some
+    // time after they were captured
+    for( auto ts : timestamps )
+        CHECK( query( coefs, ts ) == Catch::Approx( to_sys_ms( ts ) ).margin( 0.001 ) );
+}
+
+TEST_CASE( "linear_coefficients_simple", "[global-timestamp]" )
+{
+    test_linear_coefficients( 0 );
+}
+
+TEST_CASE( "linear_coefficients_timewrap", "[global-timestamp]" )
+{
+    // Start a little bit before the hardware wrap-around time
+    test_linear_coefficients( ( ( WRAP_USEC - 5 * PERIOD_USEC ) / PERIOD_USEC ) * PERIOD_USEC );
+}
+
+// Around the wrap instant, in-flight frames from different streams of one device straddle
+// the boundary (one stream still converting HW times near 2^32 us while another already
+// converts times near 0) and are converted interleaved through the shared fit. Per-frame
+// conversion used to re-base the fit on every such query, yanking it back and forth by a
+// full wrap period; it must be read-only and correct for both epochs.
+TEST_CASE( "linear_coefficients_interleaved_wrap", "[global-timestamp]" )
+{
+    CLinearCoefficients coefs( 15 );
+
+    // Bring the fit to steady state just before the wrap
+    uint64_t ts = WRAP_USEC - 8 * PERIOD_USEC;
+    bool is_ready = false;
+    for( int i = 0; i < 6; ++i, ts += PERIOD_USEC )
+    {
+        add_sample( coefs, ts, is_ready );
+        is_ready = true;
+    }
+
+    // Interleaved per-frame conversions from both sides of the wrap
+    const uint64_t pre_wrap = WRAP_USEC - PERIOD_USEC;
+    const uint64_t post_wrap = WRAP_USEC + PERIOD_USEC;
+    for( int i = 0; i < 10; ++i )
+    {
+        CHECK( query( coefs, pre_wrap ) == Catch::Approx( to_sys_ms( pre_wrap ) ).margin( 0.001 ) );
+        CHECK( query( coefs, post_wrap ) == Catch::Approx( to_sys_ms( post_wrap ) ).margin( 0.001 ) );
+    }
+
+    // The clock-sync loop keeps sampling across the wrap; the fit must still be intact
+    for( int i = 0; i < 8; ++i, ts += PERIOD_USEC )
+        add_sample( coefs, ts, is_ready );
+
+    for( uint64_t t = WRAP_USEC - 8 * PERIOD_USEC; t < ts; t += PERIOD_USEC )
+        CHECK( query( coefs, t ) == Catch::Approx( to_sys_ms( t ) ).margin( 0.001 ) );
+}

--- a/unit-tests/synchronization/test-timestamps.cpp
+++ b/unit-tests/synchronization/test-timestamps.cpp
@@ -114,3 +114,55 @@ TEST_CASE( "linear_coefficients_interleaved_wrap", "[global-timestamp]" )
     for( uint64_t t = WRAP_USEC - 8 * PERIOD_USEC; t < ts; t += PERIOD_USEC )
         CHECK( query( coefs, t ) == Catch::Approx( to_sys_ms( t ) ).margin( 0.001 ) );
 }
+
+TEST_CASE( "align_to_epoch", "[global-timestamp]" )
+{
+    const double wrap_ms = WRAP_USEC * USEC_TO_MSEC;
+    // Same epoch: unchanged
+    CHECK( CLinearCoefficients::align_to_epoch( 5000., 6000. ) == Catch::Approx( 5000. ).margin( 0.001 ) );
+    // Value just after the wrap, anchor just before it: shifted up one period
+    CHECK( CLinearCoefficients::align_to_epoch( 20., wrap_ms - 20. ) == Catch::Approx( wrap_ms + 20. ).margin( 0.001 ) );
+    // Value just before the wrap, anchor just after it: shifted down one period
+    CHECK( CLinearCoefficients::align_to_epoch( wrap_ms - 20., 20. ) == Catch::Approx( -20. ).margin( 0.001 ) );
+}
+
+// A long innovation-rejection streak ends with the fit rebuilt from the rejected-sample window
+// (refit_from_samples). The window is collected on a single wrap epoch (see update_diff_time),
+// so a streak that spans the wrap instant must still rebuild a valid fit for both epochs.
+TEST_CASE( "refit_from_samples_across_wrap", "[global-timestamp]" )
+{
+    CLinearCoefficients coefs( 15 );
+
+    // Pre-existing fit state from well before the wrap
+    uint64_t ts = WRAP_USEC - 100 * PERIOD_USEC;
+    bool is_ready = false;
+    for( int i = 0; i < 6; ++i, ts += PERIOD_USEC )
+    {
+        add_sample( coefs, ts, is_ready );
+        is_ready = true;
+    }
+
+    // Rejection window straddling the wrap, collected the way update_diff_time collects it:
+    // each sample epoch-aligned onto the window before being stored (newest at front)
+    std::deque< CSample > window;
+    for( uint64_t t = WRAP_USEC - 7 * PERIOD_USEC; t <= WRAP_USEC + 7 * PERIOD_USEC; t += PERIOD_USEC )
+    {
+        double x = to_hw_ms( t );
+        if( ! window.empty() )
+            x = CLinearCoefficients::align_to_epoch( x, window.front()._x );
+        window.push_front( CSample( x, to_sys_ms( t ) ) );
+    }
+
+    coefs.refit_from_samples( window );
+
+    // The rebuilt fit must be valid on both sides of the wrap
+    for( uint64_t t = WRAP_USEC - 7 * PERIOD_USEC; t <= WRAP_USEC + 7 * PERIOD_USEC; t += PERIOD_USEC )
+        CHECK( query( coefs, t ) == Catch::Approx( to_sys_ms( t ) ).margin( 0.001 ) );
+
+    // And the clock-sync loop must be able to keep extending it
+    for( uint64_t t = WRAP_USEC + 8 * PERIOD_USEC; t <= WRAP_USEC + 12 * PERIOD_USEC; t += PERIOD_USEC )
+    {
+        add_sample( coefs, t, true );
+        CHECK( query( coefs, t ) == Catch::Approx( to_sys_ms( t ) ).margin( 0.001 ) );
+    }
+}


### PR DESCRIPTION
**Overview:** Fixes global timestamps that could step by seconds, slew, or run backwards, and that permanently split depth from color at the ~71.6-minute hardware-clock wrap. Both failures are host-side and affect the whole D400/D500 family, not just multi-camera D585S rigs.

Tracked on [ANTHILLTRB-8172]

## Why
Two long-standing defects in the shared camera-to-host clock model (`global_timestamp_reader` / `time_diff_keeper`), each with a D400-family paper trail going back to 2019:

- **Per-frame wrap handling corrupts the shared fit.** Per-frame conversion mutated the device's one shared clock fit to handle the 32-bit microsecond wrap. Frames from different streams straddling the wrap re-base the fit back and forth by a full wrap period, corrupting it — killing aligned depth/color at a camera's *second* wrap (~2.4 h uptime), curable only by restart. (cf. [#7922](https://github.com/IntelRealSense/librealsense/issues/7922), [#10775](https://github.com/IntelRealSense/librealsense/issues/10775), [#11320](https://github.com/IntelRealSense/librealsense/issues/11320))
- **Bad clock readings poison the fit.** Under shared-USB load the device answers the periodic clock probe late, or promptly but with a value wrong by ±0.8–3.7 s. A least-squares fit seeded on these (common at multi-camera stream start) gets a wrong *slope* and diverges from reality forever; downstream, global timestamps step, slew, or run backwards and split framesets in the syncer. (cf. [#4505](https://github.com/IntelRealSense/librealsense/issues/4505), [#6715](https://github.com/IntelRealSense/librealsense/issues/6715), [#9131](https://github.com/IntelRealSense/librealsense/issues/9131))

## Summary
- **Read-only per-frame wrap alignment** (`to_fit_domain`): frame conversion now maps the HW value onto the fit's current wrap epoch arithmetically and never mutates shared state; only the single-threaded polling loop may re-base the fit.
- **Delay gate + bounded monotonicity**: a reading whose round-trip is much longer than the best observed is rejected (with an escape hatch so the fit can't go stale); a frame's global time can no longer run backwards while the HW clock advances, with a bounded release so a legitimate re-base can't freeze a stream.
- **Innovation gate + robust fit**: a reading disagreeing with the model's own prediction by >100 ms is rejected; the fit is now Theil–Sen (robust to outlier bursts) instead of ordinary least squares; if the fit rejects every reading for ~1 minute it is rebuilt from the rejected window.
- Adds a wrap regression test (`unit-tests/synchronization/test-timestamps.cpp`) **adapted with credit from the never-merged [PR #7923](https://github.com/IntelRealSense/librealsense/pull/7923) by @thomas-slamcore (Slamcore)**, extended with an interleaved two-stream wrap case.

## Test plan
- [ ] `test-synchronization-timestamps` (built with `-DBUILD_UNIT_TESTS=ON`) — single-stream wrap and interleaved two-stream wrap cases pass.
- [ ] 6.8 h four-camera D585S soak under shared-USB load: zero timestamp jumps, zero backwards time, zero timestamp-domain flapping, zero duplicate frames.
- [ ] Full ROS stack across two wrap points: all depth/aligned topics steady at 30 Hz, where the unfixed library degraded at wrap 1 and died at wrap 2.

---
🤖 Generated by AI
