### PR TITLE
enable pytest-drops-on-set on D457 and D401

### DIFF
--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -97,6 +97,8 @@ def test_laser_power_frame_drops(test_device_wrapped):
     dev, ctx = test_device_wrapped
     product_line = dev.get_info(rs.camera_info.product_line)
     depth_sensor = dev.first_depth_sensor()
+    if not depth_sensor.supports(rs.option.laser_power):
+        pytest.skip("Device does not support laser power")
     depth_profile = next(p for p in depth_sensor.profiles if p.is_default())
     checker = FrameDropChecker(product_line, is_depth=True)
 

--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -1,8 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
-# Currently, we exclude D401 as it's failing
-
 import platform
 import pytest
 import pyrealsense2 as rs
@@ -12,7 +10,6 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device("D400*"),
-    pytest.mark.device_exclude("D401"),
     pytest.mark.context("nightly"),
 ]
 
@@ -146,14 +143,19 @@ def test_color_options_frame_drops(test_device_wrapped):
     product_line = dev.get_info(rs.camera_info.product_line)
     product_name = dev.get_info(rs.camera_info.name)
 
+    # D405 and D401 have no separate color sensor; their color options are registered on the depth sensor.
     try:
         color_sensor = dev.first_color_sensor()
     except RuntimeError:
-        if 'D421' in product_name or 'D405' in product_name:
+        if 'D405' in product_name or 'D401' in product_name:
+            color_sensor = dev.first_depth_sensor()
+        elif 'D421' in product_name:
             pytest.skip("No color sensor")
-        raise
+        else:
+            raise
 
-    color_profile = next(p for p in color_sensor.profiles if p.is_default())
+    color_profile = next(p for p in color_sensor.profiles
+                         if p.is_default() and p.stream_type() == rs.stream.color)
     checker = FrameDropChecker(product_line, is_depth=False)
 
     color_sensor.open(color_profile)

--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
-# Currently, we exclude D457 and D401 as it's failing
+# Currently, we exclude D401 as it's failing
 
 import platform
 import pytest
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device("D400*"),
-    pytest.mark.device_exclude("D457"),
     pytest.mark.device_exclude("D401"),
     pytest.mark.context("nightly"),
 ]
@@ -84,6 +83,10 @@ def run_option_changes(sensor, checker, product_line):
             if orig_opt_value.type in (rs.option_type.integer, rs.option_type.float):
                 old_value = orig_opt_value.value
                 opt_range = sensor.get_option_range(option)
+                # e.g. Exposure while AE is on reads as 0 but range starts at 1 — restoring old_value would throw
+                if not (opt_range.min <= old_value <= opt_range.max):
+                    log.debug(f"{option}: skipping, current {old_value} outside range [{opt_range.min}, {opt_range.max}]")
+                    continue
                 new_value = opt_range.min if old_value != opt_range.min else opt_range.max
                 log.debug(f"{option}: {old_value} -> {new_value}")
                 set_new_value(checker, sensor, option, new_value)

--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -9,7 +9,7 @@ import logging
 log = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.device("D400*"),
+    pytest.mark.device_each("D400*"),
     pytest.mark.context("nightly"),
 ]
 

--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -96,9 +96,10 @@ def test_laser_power_frame_drops(test_device_wrapped):
     """No frame drops when sweeping laser power through its full range."""
     dev, ctx = test_device_wrapped
     product_line = dev.get_info(rs.camera_info.product_line)
+    product_name = dev.get_info(rs.camera_info.name)
+    if 'D401' in product_name or 'D405' in product_name:
+        pytest.skip(f"{product_name} does not support laser power")
     depth_sensor = dev.first_depth_sensor()
-    if not depth_sensor.supports(rs.option.laser_power):
-        pytest.skip("Device does not support laser power")
     depth_profile = next(p for p in depth_sensor.profiles if p.is_default())
     checker = FrameDropChecker(product_line, is_depth=True)
 

--- a/unit-tests/live/options/pytest-drops-on-set.py
+++ b/unit-tests/live/options/pytest-drops-on-set.py
@@ -82,7 +82,7 @@ def run_option_changes(sensor, checker, product_line):
                 opt_range = sensor.get_option_range(option)
                 # e.g. Exposure while AE is on reads as 0 but range starts at 1 — restoring old_value would throw
                 if not (opt_range.min <= old_value <= opt_range.max):
-                    log.debug(f"{option}: skipping, current {old_value} outside range [{opt_range.min}, {opt_range.max}]")
+                    log.info(f"{option}: skipping, current {old_value} outside range [{opt_range.min}, {opt_range.max}]")
                     continue
                 new_value = opt_range.min if old_value != opt_range.min else opt_range.max
                 log.debug(f"{option}: {old_value} -> {new_value}")
@@ -157,8 +157,12 @@ def test_color_options_frame_drops(test_device_wrapped):
         else:
             raise
 
-    color_profile = next(p for p in color_sensor.profiles
-                         if p.is_default() and p.stream_type() == rs.stream.color)
+    color_profile = next(
+        (p for p in color_sensor.profiles
+         if p.is_default() and p.stream_type() == rs.stream.color),
+        None)
+    if color_profile is None:
+        pytest.fail(f"{product_name}: no default color-stream profile found on sensor")
     checker = FrameDropChecker(product_line, is_depth=False)
 
     color_sensor.open(color_profile)


### PR DESCRIPTION
Tracked by: LRS-610

**Overview:** Enables `unit-tests/live/options/pytest-drops-on-set.py` for D457 and D401, and hardens `run_option_changes` against options whose current value falls outside the driver's advertised range.

## Why
D457 and D401 were excluded because the color-sensor test failed.

- **D457**: post-HW-reset the V4L2 color driver has `AE=1` and reports `Exposure current = 0.0`, while the advertised range is `[1, 10000]`. Set-to-min succeeds (auto-disabling-control turns AE off), but writing `old_value=0` back trips `VALIDATE_RANGE` and throws `out of range value for argument "value"`.
- **D401**: has no separate color sensor; its color options are registered on the depth sensor (same as D405). Also does not support `laser_power`.

## Summary
- Drop `device_exclude("D457")` and `device_exclude("D401")` from `pytestmark`.
- In `run_option_changes`, skip any option whose current value falls outside `[opt_range.min, opt_range.max]` (logs the reason). Covers Exposure while AE is on, and any similar option in the future.
- In `test_color_options_frame_drops`, fall back to `first_depth_sensor()` on D401/D405 (following the pattern in `pytest-rgb-options-metadata-consistency.py`). D421 still skips — it has no color options at all.
- Filter the chosen profile to `stream_type() == rs.stream.color` so we stream on the color path even when the sensor is the shared depth sensor.
- `test_laser_power_frame_drops` now skips on D401 and D405 (by product name). Other devices still fail loudly if laser_power is missing.

## Test plan
- [x] `pytest live/options/pytest-drops-on-set.py --context nightly` on D457 — three tests pass, Exposure iteration is skipped with a debug log line.
- [x] Same file on D401 — `test_laser_power_frame_drops` skips; the other two pass with color options iterated on the depth sensor.
- [x] Same file on D405 — no regression (same code path as D401 now, previously skipped).
- [x] Same file on D455 / D435i — no behavior change (current values are inside their ranges).
- [x] Jenkins LibCI nightly.

---
🤖 Generated by AI

Nightly run  - all green - https://rsjenkins.realsenseai.com/view/LRS/job/LRS_libci_pipeline/17132/