### PR TITLE
Enable pytest-fps-manual-exposure test

### DIFF
--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -22,6 +22,8 @@ pytestmark = [
 TESTED_FPS =          [5,   6,   15,  30,  60,  90]
 TIME_TO_TEST_FPS =    [25,  20,  13,  10,  5,   4]
 
+fps_helper.TIME_FOR_STEADY_STATE = 1.2  # t2ff KPI is 1 second + some extra
+
 
 def set_exposure_half_frame_time(sensor, requested_fps):
     """Set sensor exposure to half the frame time for the given requested_fps.
@@ -130,14 +132,10 @@ def test_color_fps_manual_exposure(test_device):
     for i in range(len(TESTED_FPS)):
         requested_fps = TESTED_FPS[i]
         try:
-            candidates = [p for p in cs.profiles
-                          if p.fps() == requested_fps
-                          and p.stream_type() == rs.stream.color
-                          and p.format() == rs.format.rgb8]
-            if not candidates:
-                raise StopIteration
-            candidates.sort(key=lambda pr: pr.as_video_stream_profile().width() * pr.as_video_stream_profile().height())
-            cp = candidates[len(candidates)//2]
+            cp = next(p for p in cs.profiles
+                      if p.fps() == requested_fps
+                      and p.stream_type() == rs.stream.color
+                      and p.format() == rs.format.rgb8)
         except StopIteration:
             log.info(f"Requested fps: {requested_fps:.1f} [Hz], not supported")
             continue

--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -134,9 +134,11 @@ def test_color_fps_manual_exposure(test_device):
             cs.set_option(rs.option.auto_exposure_priority, 0)
 
     failures = []
+    tested_count = 0
     for i in range(len(TESTED_FPS)):
         requested_fps = TESTED_FPS[i]
         try:
+            # Pick the first matching profile; resolution does not affect FPS accuracy
             cp = next(p for p in cs.profiles
                       if p.fps() == requested_fps
                       and p.stream_type() == rs.stream.color
@@ -145,6 +147,7 @@ def test_color_fps_manual_exposure(test_device):
             log.info(f"Requested fps: {requested_fps:.1f} [Hz], not supported")
             continue
 
+        tested_count += 1
         exposure_val = set_exposure_half_frame_time(cs, requested_fps)
         fps_helper.TIME_TO_COUNT_FRAMES = TIME_TO_TEST_FPS[i]
         fps_dict = fps_helper.measure_fps({cs: [cp]})
@@ -154,4 +157,5 @@ def test_color_fps_manual_exposure(test_device):
         if not (fps >= requested_fps - delta_Hz and fps <= requested_fps + delta_Hz):
             failures.append(f"Color {requested_fps}Hz: got {fps:.1f}Hz")
 
+    assert tested_count > 0, f"No color profiles found on {product_name} — test ran no FPS checks"
     assert not failures, "Color FPS out of tolerance:\n" + "\n".join(failures)

--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -108,12 +108,18 @@ def test_color_fps_manual_exposure(test_device):
     product_name = dev.get_info(rs.camera_info.name)
     os_name = platform.system()
 
-    if any(model in product_name for model in ['D421', 'D405']):
-        pytest.skip(f"Device {product_name} has no color sensor")
-
     log.info(f"Testing color fps (manual exposure) {product_line} device - {os_name} OS")
 
-    cs = dev.first_color_sensor()
+    # D405 and D401 expose color through the depth sensor (no separate color sensor)
+    try:
+        cs = dev.first_color_sensor()
+    except RuntimeError:
+        if 'D405' in product_name or 'D401' in product_name:
+            cs = dev.first_depth_sensor()
+        elif 'D421' in product_name:
+            pytest.skip(f"Device {product_name} has no color sensor")
+        else:
+            raise
     if product_line == "D400":
         if cs.supports(rs.option.enable_auto_exposure):
             cs.set_option(rs.option.enable_auto_exposure, 0)

--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -8,9 +8,11 @@ Mirrors fps-single-stream but disables auto-exposure and sets exposure to half f
 
 import pytest
 import pyrealsense2 as rs
+import pyrsutils as rsutils
 import fps_helper
 import platform
 import logging
+from rspy.pytest.device_helpers import require_min_fw_version
 log = logging.getLogger(__name__)
 
 pytestmark = [
@@ -109,6 +111,8 @@ def test_color_fps_manual_exposure(test_device):
     product_line = dev.get_info(rs.camera_info.product_line)
     product_name = dev.get_info(rs.camera_info.name)
     os_name = platform.system()
+
+    require_min_fw_version(dev, rsutils.version(5, 17, 4, 6), "color manual exposure FPS")
 
     log.info(f"Testing color fps (manual exposure) {product_line} device - {os_name} OS")
 

--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -17,7 +17,6 @@ pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
     pytest.mark.device_exclude("D555"),
-    pytest.mark.skip(reason="Test disabled (donotrun)"),
 ]
 
 TESTED_FPS =          [5,   6,   15,  30,  60,  90]

--- a/unit-tests/live/frames/pytest-fps-manual-exposure.py
+++ b/unit-tests/live/frames/pytest-fps-manual-exposure.py
@@ -112,7 +112,8 @@ def test_color_fps_manual_exposure(test_device):
     product_name = dev.get_info(rs.camera_info.name)
     os_name = platform.system()
 
-    require_min_fw_version(dev, rsutils.version(5, 17, 4, 6), "color manual exposure FPS")
+    if product_line == "D400":
+        require_min_fw_version(dev, rsutils.version(5, 17, 4, 6), "color manual exposure FPS")
 
     log.info(f"Testing color fps (manual exposure) {product_line} device - {os_name} OS")
 


### PR DESCRIPTION
**Overview:** Re-enables `pytest-fps-manual-exposure.py` and makes it robust for devices without a separate color sensor and for older firmwares that suffer from RSDSO-20502.

## Why
- Test was gated by an unconditional `pytest.mark.skip`, so it never ran on any device.
- D405/D401 have no separate color sensor — color is exposed through the depth sensor — so the color test needs the same fallback pattern used in `pytest-rgb-options-metadata-consistency.py`.
- On D436 with older FW (RSDSO-20502: "Actual FPS is Lower Than Reported FPS When Auto Exposure is Disabled") the color test intermittently fails. RSDSO-20502 was fixed and the color test is reliable from FW **5.17.4.6** onward.

## Summary
- Drop the `pytest.mark.skip` from `pytestmark`. `device_each("D400*" / "D500*")` and `device_exclude("D555")` markers stay.
- `test_color_fps_manual_exposure`: try `first_color_sensor()`; on `RuntimeError`, fall back to `first_depth_sensor()` for D405/D401, skip on D421, re-raise otherwise.
- Mirror `pytest-fps-single-stream`: pick the first matching color profile with `next()`, and set `fps_helper.TIME_FOR_STEADY_STATE = 1.2`.
- `test_color_fps_manual_exposure`: `require_min_fw_version(dev, rsutils.version(5, 17, 4, 6), "color manual exposure FPS")` so the test skips on older FW where RSDSO-20502 is still present.

## Test plan
- [ ] `pytest-fps-manual-exposure.py` executes (not skipped) on D400 and D500 targets in LibCI
- [ ] Still excluded on D555 via the existing marker
- [ ] Color test runs against depth sensor on D405/D401 and reports FPS in tolerance
- [ ] Color test still skips cleanly on D421
- [ ] Color test skips with an FW-min message on D436 running FW < 5.17.4.6
- [ ] Color test passes on D436 running FW >= 5.17.4.6 (Windows + JP5)

---
🤖 Generated by AI

Jenkins all green - https://rsjenkins.realsenseai.com/view/LRS/job/LRS_libci_pipeline/17277/