### PR TITLE
hw-reset stress: re-acquire live device handle before each reset

### DIFF
--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -32,7 +32,6 @@ STRESS_ITERATIONS_DDS          =  50
 STRESS_ITERATIONS_NIGHTLY      =  10
 STRESS_ITERATIONS_NIGHTLY_DDS  =   5
 REMOVAL_TIMEOUT        = 10   # [sec] max wait for any device event after reset
-RESET_SETTLE           = 1    # [sec] let the device settle before each reset - a fast reconnect can leave the control channel not-yet-ready
 
 dev             = None   # current live handle - used for hardware_reset() and serial-number matching
 device_removed  = False
@@ -41,17 +40,41 @@ target_sn       = None   # serial number of the device under test - set once, ne
 
 
 def device_changed( info ):
-    global dev, device_removed, device_added
+    global device_removed, device_added
     if dev and info.was_removed( dev ):
         device_removed = True
     for candidate in info.get_new_devices():
         try:
             if candidate.get_info( rs.camera_info.serial_number ) == target_sn:
-                # We replace the device handle after each reset, to be sure we're always referring to the current live instance.
-                dev          = candidate
                 device_added = True
         except RuntimeError:
             continue
+
+
+def wait_for_live_device( ctx, sn, timeout ):
+    # Re-acquire a freshly-enumerated handle for 'sn' from the context. After a fast "OS race"
+    # reconnect the device node can still be churning, so a handle latched from a change-event may
+    # already be dead (hardware_reset() then fails with "Cannot open /dev/videoN"). Require the
+    # device present on two consecutive polls so we don't grab one that is about to disappear.
+    t = Timer( timeout )
+    t.start()
+    stable  = 0
+    current = None
+    while not t.has_expired():
+        found = None
+        for d in ctx.query_devices():
+            try:
+                if d.get_info( rs.camera_info.serial_number ) == sn:
+                    found = d
+                    break
+            except RuntimeError:
+                continue
+        current = found
+        stable  = stable + 1 if found else 0
+        if stable >= 2:
+            return current
+        time.sleep( 0.2 )
+    return current
 
 
 def test_hw_reset_stress( test_device, test_context_var ):
@@ -81,7 +104,14 @@ def test_hw_reset_stress( test_device, test_context_var ):
         device_removed   = False
         device_added     = False
 
-        time.sleep( RESET_SETTLE )  # let the (re)connected device settle before resetting
+        # Always reset a freshly-queried, stably-enumerated handle - never one left over from a
+        # previous cycle's change-event, which may already be dead after an OS-race reconnect.
+        dev = wait_for_live_device( ctx, target_sn, REMOVAL_TIMEOUT )
+        if dev is None:
+            log.error( f"[{i}/{iterations}] device {target_sn} not enumerated before reset" )
+            failed_reconnect.append( i )
+            break
+
         log.debug( f"[{i}/{iterations}] Sending HW-reset" )
         sw = Stopwatch()
         dev.hardware_reset()

--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -32,6 +32,8 @@ STRESS_ITERATIONS_DDS          =  50
 STRESS_ITERATIONS_NIGHTLY      =  10
 STRESS_ITERATIONS_NIGHTLY_DDS  =   5
 REMOVAL_TIMEOUT        = 10   # [sec] max wait for any device event after reset
+HW_RESET_RETRIES       = 5    # attempts for a single reset - a fast reconnect can leave the control channel not-yet-ready
+HW_RESET_RETRY_BACKOFF = 0.3  # [sec] base backoff between retries (escalates: 0.3, 0.6, 0.9, ...)
 
 dev             = None   # current live handle - used for hardware_reset() and serial-number matching
 device_removed  = False
@@ -51,6 +53,24 @@ def device_changed( info ):
                 device_added = True
         except RuntimeError:
             continue
+
+
+def hardware_reset_with_retry( device, i, iterations ):
+    # A fast "OS race" reconnect can re-enumerate the device before its control channel is ready;
+    # hardware_reset() (an XU control transfer) then fails with
+    # "xioctl(UVCIOC_CTRL_QUERY) ... Protocol error". The device is still up, so retry with an
+    # escalating backoff until the channel accepts the command.
+    for attempt in range( 1, HW_RESET_RETRIES + 1 ):
+        try:
+            device.hardware_reset()
+            return
+        except RuntimeError as e:
+            if attempt == HW_RESET_RETRIES:
+                raise
+            backoff = HW_RESET_RETRY_BACKOFF * attempt
+            log.warning( f"[{i}/{iterations}] hardware_reset attempt {attempt} failed ({e}); "
+                         f"retrying in {backoff:.1f} [sec]" )
+            time.sleep( backoff )
 
 
 def test_hw_reset_stress( test_device, test_context_var ):
@@ -84,7 +104,7 @@ def test_hw_reset_stress( test_device, test_context_var ):
 
         log.debug( f"[{i}/{iterations}] Sending HW-reset" )
         sw = Stopwatch()
-        dev.hardware_reset()
+        hardware_reset_with_retry( dev, i, iterations )
 
         # --- wait for removal OR addition (whichever comes first) ---
         # Use the sum of both timeouts: in the OS-race case (no removal event), the addition

--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -32,51 +32,49 @@ STRESS_ITERATIONS_DDS          =  50
 STRESS_ITERATIONS_NIGHTLY      =  10
 STRESS_ITERATIONS_NIGHTLY_DDS  =   5
 REMOVAL_TIMEOUT        = 10   # [sec] max wait for any device event after reset
-POLL_INTERVAL          = 0.2  # [sec] between consecutive ctx.query_devices() stability polls
+POLL_INTERVAL          = 0.2  # [sec] between ctx.query_devices() polls while waiting for a quiet bus
+QUIET_WINDOW           = 1.5  # [sec] required lull with no add/remove events before the next reset
 
 dev             = None   # current live handle - used for hardware_reset() and serial-number matching
 device_removed  = False
 device_added    = False
 target_sn       = None   # serial number of the device under test - set once, never changes
+last_event_ts   = 0.0    # perf_counter() of the most recent add/remove callback event for target_sn
 
 
 def device_changed( info ):
-    global device_removed, device_added
+    global device_removed, device_added, last_event_ts
     current_dev = dev  # snapshot: dev is reassigned on the test thread between iterations
     if current_dev and info.was_removed( current_dev ):
         device_removed = True
+        last_event_ts  = time.perf_counter()
     for candidate in info.get_new_devices():
         try:
             if candidate.get_info( rs.camera_info.serial_number ) == target_sn:
-                device_added = True
+                device_added  = True
+                last_event_ts = time.perf_counter()
         except RuntimeError:
             continue
 
 
-def wait_for_live_device( ctx, sn, timeout ):
-    # Re-acquire a freshly-enumerated handle for 'sn' from the context. After a fast "OS race"
-    # reconnect the device node can still be churning, so a handle latched from a change-event may
-    # already be dead (hardware_reset() then fails with "Cannot open /dev/videoN"). Require the
-    # device present on two consecutive polls so we don't grab one that is about to disappear.
+def wait_until_quiet( ctx, sn, quiet, timeout ):
+    # Reset only once the bus has settled: require 'sn' currently enumerated AND no add/remove
+    # callback event for 'quiet' seconds. On a flaky bench the device can re-enumerate repeatedly
+    # (double "device added", missed removals); resetting a handle mid-churn fails with
+    # "Protocol error" / "Cannot send after transport endpoint shutdown" / "Cannot open /dev/videoN".
+    # The event lull is measured from the callback (which sees every transition), not from polling.
     t = Timer( timeout )
     t.start()
-    stable  = 0
-    current = None
     while not t.has_expired():
-        found = None
-        for d in ctx.query_devices():
-            try:
-                if d.get_info( rs.camera_info.serial_number ) == sn:
-                    found = d
-                    break
-            except RuntimeError:
-                continue
-        current = found
-        stable  = stable + 1 if found else 0
-        if stable >= 2:
-            return current
+        if time.perf_counter() - last_event_ts >= quiet:
+            for d in ctx.query_devices():
+                try:
+                    if d.get_info( rs.camera_info.serial_number ) == sn:
+                        return d
+                except RuntimeError:
+                    continue
         time.sleep( POLL_INTERVAL )
-    return current if stable >= 2 else None
+    return None
 
 
 def test_hw_reset_stress( test_device, test_context_var ):
@@ -103,16 +101,18 @@ def test_hw_reset_stress( test_device, test_context_var ):
     skipped_removal  = 0
 
     for i in range( 1, iterations + 1 ):
-        device_removed   = False
-        device_added     = False
-
-        # Always reset a freshly-queried, stably-enumerated handle - never one left over from a
-        # previous cycle's change-event, which may already be dead after an OS-race reconnect.
-        dev = wait_for_live_device( ctx, target_sn, REMOVAL_TIMEOUT )
+        # Wait for a settled bus, then acquire a fresh handle - never reset one left over from a
+        # previous cycle's change-event, which may be dead or mid-re-enumeration on a flaky bench.
+        dev = wait_until_quiet( ctx, target_sn, QUIET_WINDOW, REMOVAL_TIMEOUT )
         if dev is None:
-            log.error( f"[{i}/{iterations}] device {target_sn} not enumerated before reset" )
+            log.error( f"[{i}/{iterations}] device {target_sn} never settled ({QUIET_WINDOW}s quiet) before reset" )
             failed_reconnect.append( i )
             break
+
+        # Clear the event flags only now (after settling) so removal/reconnect timing reflects
+        # this reset alone, not churn observed while waiting for the bus to go quiet.
+        device_removed = False
+        device_added   = False
 
         log.debug( f"[{i}/{iterations}] Sending HW-reset" )
         sw = Stopwatch()

--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -32,6 +32,7 @@ STRESS_ITERATIONS_DDS          =  50
 STRESS_ITERATIONS_NIGHTLY      =  10
 STRESS_ITERATIONS_NIGHTLY_DDS  =   5
 REMOVAL_TIMEOUT        = 10   # [sec] max wait for any device event after reset
+POLL_INTERVAL          = 0.2  # [sec] between consecutive ctx.query_devices() stability polls
 
 dev             = None   # current live handle - used for hardware_reset() and serial-number matching
 device_removed  = False
@@ -41,7 +42,8 @@ target_sn       = None   # serial number of the device under test - set once, ne
 
 def device_changed( info ):
     global device_removed, device_added
-    if dev and info.was_removed( dev ):
+    current_dev = dev  # snapshot: dev is reassigned on the test thread between iterations
+    if current_dev and info.was_removed( current_dev ):
         device_removed = True
     for candidate in info.get_new_devices():
         try:
@@ -73,8 +75,8 @@ def wait_for_live_device( ctx, sn, timeout ):
         stable  = stable + 1 if found else 0
         if stable >= 2:
             return current
-        time.sleep( 0.2 )
-    return current
+        time.sleep( POLL_INTERVAL )
+    return current if stable >= 2 else None
 
 
 def test_hw_reset_stress( test_device, test_context_var ):

--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -32,8 +32,7 @@ STRESS_ITERATIONS_DDS          =  50
 STRESS_ITERATIONS_NIGHTLY      =  10
 STRESS_ITERATIONS_NIGHTLY_DDS  =   5
 REMOVAL_TIMEOUT        = 10   # [sec] max wait for any device event after reset
-HW_RESET_RETRIES       = 5    # attempts for a single reset - a fast reconnect can leave the control channel not-yet-ready
-HW_RESET_RETRY_BACKOFF = 0.3  # [sec] base backoff between retries (escalates: 0.3, 0.6, 0.9, ...)
+RESET_SETTLE           = 1    # [sec] let the device settle before each reset - a fast reconnect can leave the control channel not-yet-ready
 
 dev             = None   # current live handle - used for hardware_reset() and serial-number matching
 device_removed  = False
@@ -55,24 +54,6 @@ def device_changed( info ):
             continue
 
 
-def hardware_reset_with_retry( device, i, iterations ):
-    # A fast "OS race" reconnect can re-enumerate the device before its control channel is ready;
-    # hardware_reset() (an XU control transfer) then fails with
-    # "xioctl(UVCIOC_CTRL_QUERY) ... Protocol error". The device is still up, so retry with an
-    # escalating backoff until the channel accepts the command.
-    for attempt in range( 1, HW_RESET_RETRIES + 1 ):
-        try:
-            device.hardware_reset()
-            return
-        except RuntimeError as e:
-            if attempt == HW_RESET_RETRIES:
-                raise
-            backoff = HW_RESET_RETRY_BACKOFF * attempt
-            log.warning( f"[{i}/{iterations}] hardware_reset attempt {attempt} failed ({e}); "
-                         f"retrying in {backoff:.1f} [sec]" )
-            time.sleep( backoff )
-
-
 def test_hw_reset_stress( test_device, test_context_var ):
     global dev, target_sn, device_removed, device_added
 
@@ -92,8 +73,6 @@ def test_hw_reset_stress( test_device, test_context_var ):
     log.info( f"Running {iterations} HW-reset iterations on {conn_type} device "
               f"({'weekly' if is_weekly else 'nightly'} context, max reconnect time: {max_enum} [sec])" )
 
-    time.sleep( 1 )  # let the device settle before the first reset
-
     failed_removal   = []
     failed_reconnect = []
     skipped_removal  = 0
@@ -102,9 +81,10 @@ def test_hw_reset_stress( test_device, test_context_var ):
         device_removed   = False
         device_added     = False
 
+        time.sleep( RESET_SETTLE )  # let the (re)connected device settle before resetting
         log.debug( f"[{i}/{iterations}] Sending HW-reset" )
         sw = Stopwatch()
-        hardware_reset_with_retry( dev, i, iterations )
+        dev.hardware_reset()
 
         # --- wait for removal OR addition (whichever comes first) ---
         # Use the sum of both timeouts: in the OS-race case (no removal event), the addition

--- a/unit-tests/live/hw-reset/pytest-stress.py
+++ b/unit-tests/live/hw-reset/pytest-stress.py
@@ -66,10 +66,13 @@ def wait_until_quiet( ctx, sn, quiet, timeout ):
     t = Timer( timeout )
     t.start()
     while not t.has_expired():
-        if time.perf_counter() - last_event_ts >= quiet:
+        quiet_since = last_event_ts  # snapshot: detect a churn during the query below
+        if time.perf_counter() - quiet_since >= quiet:
             for d in ctx.query_devices():
                 try:
                     if d.get_info( rs.camera_info.serial_number ) == sn:
+                        if last_event_ts != quiet_since:
+                            break  # a callback fired while querying - bus churned, re-wait for quiet
                         return d
                 except RuntimeError:
                     continue


### PR DESCRIPTION
**Overview:** Makes the weekly hw-reset stress test robust to fast device re-enumeration after `hardware_reset()`, which was causing intermittent failures on Linux.

Tracked on RSDSO-21727

## Why
After `hardware_reset()` the device can re-enumerate very fast — sometimes reappearing with no removal event, sometimes flapping (repeated add events, missed removals). The test then issued the next reset on a handle that was stale or not yet control-ready, so `hardware_reset()` failed with `xioctl(UVCIOC_CTRL_QUERY) ... Protocol error`, `Cannot open /dev/videoN`, or `Cannot send after transport endpoint shutdown`. Observed on Linux (D455 and D435); Windows and Jetson were unaffected.

## Summary
- Before each reset, wait for the bus to settle — no add/remove callback event for a quiet window (1.5 s) **and** the device currently enumerated — then acquire a fresh handle. Never reset a handle left over from a previous cycle's change-event.
- Re-wait if a device event fires during the handle query (closes a residual race).
- The devices-changed callback no longer reassigns to a transient handle; it only tracks add/remove events and their timestamps.

## Test plan
- [x] `pytest-live-hw-reset-stress` weekly (100 iterations): passed 100/100 on D455 and D435 on the Linux bench that previously failed.
- [x] hw-reset suite green on Windows and Jetson JP5.

## Note
The failing Linux bench also exhibits intermittent **physical** USB instability (continuous re-enumeration / transport-endpoint shutdown), tracked separately in RSDSO-21733. If the device flaps past the timeout, the test now fails **cleanly** ("device never settled") instead of crashing mid-command — but a genuinely unstable bench can still fail until the hardware is addressed.

---
🤖 Generated by AI
