### PR TITLE
align D5x5 visual preset to D585S values

### DIFF
--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -159,15 +159,6 @@ namespace librealsense
             case ds::RS455_PID:
             case ds::RS457_PID:
             case ds::D555_PID:
-            case ds::D585_LEGACY_PID:
-            case ds::D535_2C_PID:
-            case ds::D585_2C_PID:
-            case ds::D585_2C_PROTO_PID:
-            case ds::D535_3C_PID:
-            case ds::D535F_PID:
-            case ds::D585_3C_PID:
-            case ds::D585F_PID:
-            case ds::D585_3C_PROTO_PID:
                 default_450_mid_low_res( p );
                 switch( res )
                 {
@@ -186,6 +177,15 @@ namespace librealsense
                 }
                 break;
             case ds::D585S_PID:
+            case ds::D585_LEGACY_PID:
+            case ds::D535_2C_PID:
+            case ds::D585_2C_PID:
+            case ds::D585_2C_PROTO_PID:
+            case ds::D535_3C_PID:
+            case ds::D535F_PID:
+            case ds::D585_3C_PID:
+            case ds::D585F_PID:
+            case ds::D585_3C_PROTO_PID:
                 default_585S( p );
                 break;
             case ds::RS405U_PID:


### PR DESCRIPTION
**Overview:** The Default visual preset for the D585/D535 camera family now applies the D585S safety depth preset values instead of the D400-derived defaults.

Tracked on [RSDEV-11506]

## Why
PR #15232 originally made this change but was reverted (c71829344) while the target preset was still undecided. Per RSDEV-11506, the D585 safety depth preset was selected for the ES0 validation cycle.

## Summary
- Move the D585/D535 family PIDs from `default_450_mid_low_res` to `default_585S` in `advanced_mode.cpp`. D555 stays on the D450 default.

## Test plan
- [ ] Apply Default preset on a D585/D535 device and confirm it loads the D585S values.

---
🤖 Generated by AI
