### PR TITLE
viewer: split depth/IR resolution UI gated on embedded decimation (always on for D585S)

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -534,6 +534,7 @@ namespace rs2
 
             if (ui.is_multiple_resolutions)
             {
+                apply_decimation_resolution_defaults();
                 for (auto it = ui.selected_stream_to_res.begin(); it != ui.selected_stream_to_res.end(); ++it)
                 {
                     if (!is_selected_combination_supported())
@@ -1569,39 +1570,28 @@ namespace rs2
 
     bool subdevice_model::is_multiple_resolutions_supported() const
     {
-        if( !dev.supports( RS2_CAMERA_INFO_PRODUCT_LINE ) || !s->supports( RS2_CAMERA_INFO_NAME ) )
+        if( ! dev.supports( RS2_CAMERA_INFO_PRODUCT_LINE ) || ! s->supports( RS2_CAMERA_INFO_NAME ) )
             return false;
+        if( std::string( dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE ) ) != "D500" ) return false;
+        if( std::string( s->get_info( RS2_CAMERA_INFO_NAME ) ) != "Stereo Module" ) return false;
 
-        std::string product_line = dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE );
-        std::string sensor_name = s->get_info( RS2_CAMERA_INFO_NAME );
-
-        if( product_line != "D500" || sensor_name != "Stereo Module" )
-            return false;
-
-        // D585S runs the embedded decimation filter permanently in FW and doesn't expose
-        // it as a UI option, so depth is always at a lower resolution than IR — the split
-        // UI must always be shown.
-        if( dev.supports( RS2_CAMERA_INFO_NAME )
-            && std::string( dev.get_info( RS2_CAMERA_INFO_NAME ) ).find( "D585S" ) != std::string::npos )
+        // D585S: FW-side decimation always on, option not exposed.
+        if( dev.supports( RS2_CAMERA_INFO_PRODUCT_ID )
+            && std::string( dev.get_info( RS2_CAMERA_INFO_PRODUCT_ID ) ) == "0B6B" )
             return true;
 
-        // Other D500 devices: depth and IR share a single sensor, so their resolution is
-        // only decoupled when the embedded decimation filter is ON — depth is decimated
-        // on-camera while IR is not. Otherwise both streams stream at the same resolution
-        // and the split UI is redundant.
-        return is_embedded_decimation_enabled();
-    }
-
-    bool subdevice_model::is_embedded_decimation_enabled() const
-    {
+        // Other D500: show split UI only when the user-toggleable decimation is enabled.
+        // Read the cached is_enabled() (kept fresh via on_options_changed) so this stays
+        // cheap on the per-frame draw path.
         for( auto & ef : embedded_filters )
         {
             auto filter = ef->get_filter();
             if( ! filter || filter->get_type() != RS2_EMBEDDED_FILTER_TYPE_DECIMATION )
                 continue;
+            // Filter present without the ENABLED option => permanently on in FW.
             if( ! filter->supports( RS2_OPTION_EMBEDDED_FILTER_ENABLED ) )
-                return false;
-            return filter->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ) != 0.f;
+                return true;
+            return ef->is_enabled();
         }
         return false;
     }
@@ -1617,7 +1607,8 @@ namespace rs2
         if( desired )
         {
             // Switching ON: seed the per-stream map from the current single-resolution
-            // selection, keeping it where the stream supports that resolution.
+            // selection, then force the FW-mandated decimation defaults (depth 640x360,
+            // IR 1280x720) so the combo boxes land on values the pipeline will accept.
             std::pair< int, int > current_res{ 0, 0 };
             if( ui.selected_res_id >= 0 && ui.selected_res_id < static_cast< int >( res_values.size() ) )
                 current_res = res_values[ui.selected_res_id];
@@ -1630,6 +1621,7 @@ namespace rs2
                 auto it = std::find( options.begin(), options.end(), current_res );
                 ui.selected_stream_to_res[res_array.first] = ( it != options.end() ) ? *it : options.back();
             }
+            apply_decimation_resolution_defaults();
         }
         else
         {
@@ -1652,6 +1644,26 @@ namespace rs2
 
         ui.is_multiple_resolutions = desired;
         last_valid_ui = ui;
+    }
+
+    void subdevice_model::apply_decimation_resolution_defaults()
+    {
+        // Viewer-only convenience for the split-resolution UI: the embedded decimation
+        // filter (FW-side) only accepts depth at 640x360 and pairs it with IR at 1280x720.
+        // Landing the combo boxes on these values here avoids the streaming-time error
+        // in avoid_streaming_on_embedded_filters_not_matching_configuration().
+        static const std::pair< int, int > DEPTH_RES{ 640, 360 };
+        static const std::pair< int, int > IR_RES{ 1280, 720 };
+
+        auto force = [&]( rs2_stream stream, const std::pair< int, int > & res ) {
+            auto it = resolutions_per_stream.find( stream );
+            if( it == resolutions_per_stream.end() ) return;
+            auto & options = it->second;
+            if( std::find( options.begin(), options.end(), res ) == options.end() ) return;
+            ui.selected_stream_to_res[stream] = res;
+        };
+        force( RS2_STREAM_DEPTH, DEPTH_RES );
+        force( RS2_STREAM_INFRARED, IR_RES );
     }
 
     std::pair<int, int> subdevice_model::get_max_resolution(rs2_stream stream) const

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -1087,6 +1087,10 @@ namespace rs2
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 10);
         bool res = false;
 
+        // The split depth/IR resolution UI only makes sense when the embedded decimation
+        // filter is ON; re-evaluate here so toggling the filter switches modes live.
+        refresh_multiple_resolutions_state();
+
         std::string label = rsutils::string::from()
             << "Stream Selection Columns##" << dev.get_info(RS2_CAMERA_INFO_NAME)
             << s->get_info(RS2_CAMERA_INFO_NAME);
@@ -1571,7 +1575,83 @@ namespace rs2
         std::string product_line = dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE );
         std::string sensor_name = s->get_info( RS2_CAMERA_INFO_NAME );
 
-        return product_line == "D500" && sensor_name == "Stereo Module";
+        if( product_line != "D500" || sensor_name != "Stereo Module" )
+            return false;
+
+        // D585S runs the embedded decimation filter permanently in FW and doesn't expose
+        // it as a UI option, so depth is always at a lower resolution than IR — the split
+        // UI must always be shown.
+        if( dev.supports( RS2_CAMERA_INFO_NAME )
+            && std::string( dev.get_info( RS2_CAMERA_INFO_NAME ) ).find( "D585S" ) != std::string::npos )
+            return true;
+
+        // Other D500 devices: depth and IR share a single sensor, so their resolution is
+        // only decoupled when the embedded decimation filter is ON — depth is decimated
+        // on-camera while IR is not. Otherwise both streams stream at the same resolution
+        // and the split UI is redundant.
+        return is_embedded_decimation_enabled();
+    }
+
+    bool subdevice_model::is_embedded_decimation_enabled() const
+    {
+        for( auto & ef : embedded_filters )
+        {
+            auto filter = ef->get_filter();
+            if( ! filter || filter->get_type() != RS2_EMBEDDED_FILTER_TYPE_DECIMATION )
+                continue;
+            if( ! filter->supports( RS2_OPTION_EMBEDDED_FILTER_ENABLED ) )
+                return false;
+            return filter->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ) != 0.f;
+        }
+        return false;
+    }
+
+    void subdevice_model::refresh_multiple_resolutions_state()
+    {
+        const bool desired = is_multiple_resolutions_supported();
+        if( desired == ui.is_multiple_resolutions ) return;
+        // Don't toggle the mode mid-stream — the streaming pipeline was configured with
+        // the current selection layout. It will re-sync on the next stop/start.
+        if( streaming ) return;
+
+        if( desired )
+        {
+            // Switching ON: seed the per-stream map from the current single-resolution
+            // selection, keeping it where the stream supports that resolution.
+            std::pair< int, int > current_res{ 0, 0 };
+            if( ui.selected_res_id >= 0 && ui.selected_res_id < static_cast< int >( res_values.size() ) )
+                current_res = res_values[ui.selected_res_id];
+
+            for( auto & res_array : resolutions_per_stream )
+            {
+                auto & options = res_array.second;
+                if( options.empty() )
+                    continue;
+                auto it = std::find( options.begin(), options.end(), current_res );
+                ui.selected_stream_to_res[res_array.first] = ( it != options.end() ) ? *it : options.back();
+            }
+        }
+        else
+        {
+            // Switching OFF: map depth's per-stream resolution back into res_values, so the
+            // single-resolution combo lands on the same choice the user was seeing.
+            std::pair< int, int > target{ 0, 0 };
+            auto it = ui.selected_stream_to_res.find( RS2_STREAM_DEPTH );
+            if( it != ui.selected_stream_to_res.end() )
+                target = it->second;
+
+            int idx = -1;
+            for( int i = 0; i < static_cast< int >( res_values.size() ); ++i )
+            {
+                if( res_values[i] == target ) { idx = i; break; }
+            }
+            if( idx < 0 && ! res_values.empty() )
+                idx = static_cast< int >( res_values.size() ) - 1;
+            ui.selected_res_id = idx;
+        }
+
+        ui.is_multiple_resolutions = desired;
+        last_valid_ui = ui;
     }
 
     std::pair<int, int> subdevice_model::get_max_resolution(rs2_stream stream) const

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -260,8 +260,8 @@ namespace rs2
         bool draw_formats_combo_box_multiple_resolutions(std::string& error_message, std::string& label, std::function<void()> streaming_tooltip, float col0, float col1,
             rs2_stream stream_type);
         bool is_multiple_resolutions_supported() const;
-        bool is_embedded_decimation_enabled() const;
         void refresh_multiple_resolutions_state();
+        void apply_decimation_resolution_defaults();
         int get_res_id_in_resolutions_array(const std::vector<const char*>& res_chars, const std::pair<int, int>& res) const;
         std::pair<int, int> get_resolution_from_res_chars_id(const std::vector<const char*>& res_chars, int id_in_res_chars) const;
         std::pair<int, int> get_max_resolution(rs2_stream stream) const;

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -260,6 +260,8 @@ namespace rs2
         bool draw_formats_combo_box_multiple_resolutions(std::string& error_message, std::string& label, std::function<void()> streaming_tooltip, float col0, float col1,
             rs2_stream stream_type);
         bool is_multiple_resolutions_supported() const;
+        bool is_embedded_decimation_enabled() const;
+        void refresh_multiple_resolutions_state();
         int get_res_id_in_resolutions_array(const std::vector<const char*>& res_chars, const std::pair<int, int>& res) const;
         std::pair<int, int> get_resolution_from_res_chars_id(const std::vector<const char*>& res_chars, int id_in_res_chars) const;
         std::pair<int, int> get_max_resolution(rs2_stream stream) const;

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -124,19 +124,6 @@ namespace librealsense
         return _hw_monitor_response->hwmon_error2str(opcode);
     }
 
-    bool d500_device::contradicts( const stream_profile_interface * a, const std::vector< stream_profile > & others ) const
-    {
-        if( auto vid_a = dynamic_cast< const video_stream_profile_interface * >( a ) )
-        {
-            for( auto request : others )
-            {
-                if( a->get_framerate() != 0 && request.fps != 0 && ( a->get_framerate() != request.fps ) )
-                    return true;
-            }
-        }
-        return false;
-    }
-
     d500_depth_sensor::d500_depth_sensor( d500_device * owner,std::shared_ptr<uvc_sensor> uvc_sensor)
         : synthetic_sensor(ds::DEPTH_STEREO, uvc_sensor, owner, d500_depth_fourcc_to_rs2_format, d500_depth_fourcc_to_rs2_stream)
         , _owner(owner)

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -120,7 +120,6 @@ namespace librealsense
         void update_flash(const std::vector<uint8_t>& image, rs2_update_progress_callback_sptr callback, int update_mode) override;
         bool check_fw_compatibility( const std::vector<uint8_t>& image ) const override { return true; };
         std::string get_opcode_string(int opcode) const override;
-        bool contradicts( const stream_profile_interface * a, const std::vector< stream_profile > & others ) const override;
 
     protected:
         std::shared_ptr<ds_device_common> _ds_device_common;

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -254,6 +254,8 @@ namespace librealsense
     };
     
 
+    // Local to this translation unit; method bodies kept inline to match sibling classes
+    // in this file (rs555_device, rs585_legacy_device, etc.).
     class rs585s_device
         : public d500_active
         , public d500_color

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -314,6 +314,22 @@ namespace librealsense
 
             return tags;
         };
+
+        // D585S runs embedded decimation filter transparently in FW, so depth and IR
+        // can be auto-completed at different resolutions from the same sensor — only fps
+        // has to agree. Other D500 devices keep the base rule (matching w/h/fps).
+        bool contradicts( const stream_profile_interface * a, const std::vector< stream_profile > & others ) const override
+        {
+            if( dynamic_cast< const video_stream_profile_interface * >( a ) )
+            {
+                for( auto request : others )
+                {
+                    if( a->get_framerate() != 0 && request.fps != 0 && ( a->get_framerate() != request.fps ) )
+                        return true;
+                }
+            }
+            return false;
+        }
     };
     
 

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -315,9 +315,8 @@ namespace librealsense
             return tags;
         };
 
-        // D585S runs embedded decimation filter transparently in FW, so depth and IR
-        // can be auto-completed at different resolutions from the same sensor — only fps
-        // has to agree. Other D500 devices keep the base rule (matching w/h/fps).
+        // FW-side decimation lets pipeline auto-complete depth and IR at different
+        // resolutions from the same sensor; only fps must agree.
         bool contradicts( const stream_profile_interface * a, const std::vector< stream_profile > & others ) const override
         {
             if( dynamic_cast< const video_stream_profile_interface * >( a ) )


### PR DESCRIPTION
**Overview:** On D500 devices, the viewer only shows the split depth vs. IR resolution UI when the embedded decimation filter is enabled — the one case where depth and IR arrive at different resolutions from the same sensor. D585S, which runs decimation transparently in FW, keeps the split UI unconditionally. When the split UI activates, the viewer forces depth to 640x360 and IR to 1280x720 to match the FW-side decimation constraint.

## Why
The split resolution UI was previously shown for all D500 Stereo Module sensors, but it is only meaningful when depth is decimated on-camera while IR is not. In every other case both streams stream at the same resolution and the split combo boxes were misleading.

## Summary
- `subdevice_model::is_multiple_resolutions_supported()` now also requires the embedded decimation filter to be enabled. Uses the cached `embedded_filter_model::is_enabled()` (kept fresh via `on_options_changed`) so the per-frame draw path stays cheap. D585S is short-circuited to `true` via `RS2_CAMERA_INFO_PRODUCT_ID == "0B6B"` because it runs decimation transparently in FW without exposing the option. If a decimation filter is present without the ENABLED option, treats it as permanently on (same semantic as D585S).
- New `refresh_multiple_resolutions_state()` runs each frame from `draw_stream_selection()` so toggling the filter switches the UI live, syncing between `ui.selected_res_id` and `ui.selected_stream_to_res` without losing the current selection. Skipped mid-stream.
- New `apply_decimation_resolution_defaults()` viewer-only helper forces depth=640x360 and IR=1280x720 when the split UI activates (both on the ON transition and at construction if the split UI is active from the start), so the combo boxes land on values the FW-side decimation accepts.
- Moved the pipeline `contradicts()` override that loosens auto-completion to fps-only (allowing per-stream resolutions) from the shared `d500_device` base to `rs585s_device`. Only D585S actually guarantees the sensor can deliver depth and IR at different resolutions, so other D500 devices now fall back to the base rule (matching w/h/fps) — preventing `rs2::pipeline::start()` with wildcards from auto-completing inconsistent depth/IR resolutions.

## Test plan
- [ ] D585S: split depth/IR resolution combo boxes visible on connect, defaulting to depth 640x360 / IR 1280x720; streaming succeeds.
- [ ] D555 (or other D500 without D585S): default view shows a single resolution combo; toggling the embedded decimation filter ON reveals per-stream combos and forces depth 640x360 / IR 1280x720; toggling OFF collapses back to the single combo without losing the depth selection.
- [ ] `rs2::pipeline::start()` on a non-D585S D500 with a wildcard IR request auto-completes at the same resolution as depth (base contradicts rule).
- [ ] `rs2::pipeline::start()` on D585S with wildcards still auto-completes depth/IR at different resolutions (fps-only rule preserved).

---
🤖 Generated by AI