### PR TITLE
d500: add Emitter Always On option to D585/D535 5x5 devices

### DIFF
--- a/src/ds/d500/d500-active.cpp
+++ b/src/ds/d500/d500-active.cpp
@@ -31,10 +31,14 @@ namespace librealsense
         _ds_active_common->register_options();
 
         // Emitter Always On (Laser Always On) - projector control common to all D500 active SKUs.
-        // D555 uses the legacy LASERONCONST opcode; newer 5x5 / D585 SKUs use the APM_STROBE opcodes.
-        bool is_legacy_emitter_opcode = ( get_pid() == D555_PID );
-        auto emitter_get_opcode = is_legacy_emitter_opcode ? LASERONCONST : APM_STROBE_GET;
-        auto emitter_set_opcode = is_legacy_emitter_opcode ? LASERONCONST : APM_STROBE_SET;
+        // Newer 5x5 / D585 SKUs use the APM_STROBE opcodes; D555 uses the legacy LASERONCONST opcode.
+        fw_cmd emitter_get_opcode = APM_STROBE_GET;
+        fw_cmd emitter_set_opcode = APM_STROBE_SET;
+        if( get_pid() == D555_PID )
+        {
+            emitter_get_opcode = LASERONCONST;
+            emitter_set_opcode = LASERONCONST;
+        }
         auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( _hw_monitor, emitter_get_opcode, emitter_set_opcode );
         get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
     }

--- a/src/ds/d500/d500-active.cpp
+++ b/src/ds/d500/d500-active.cpp
@@ -29,5 +29,13 @@ namespace librealsense
             _device_capabilities, _hw_monitor, _fw_version);
 
         _ds_active_common->register_options();
+
+        // Emitter Always On (Laser Always On) - projector control common to all D500 active SKUs.
+        // D555 uses the legacy LASERONCONST opcode; newer 5x5 / D585 SKUs use the APM_STROBE opcodes.
+        bool is_legacy_emitter_opcode = ( get_pid() == D555_PID );
+        auto emitter_get_opcode = is_legacy_emitter_opcode ? LASERONCONST : APM_STROBE_GET;
+        auto emitter_set_opcode = is_legacy_emitter_opcode ? LASERONCONST : APM_STROBE_SET;
+        auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( _hw_monitor, emitter_get_opcode, emitter_set_opcode );
+        get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
     }
 }

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -123,6 +123,9 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
+
+            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
+            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -173,6 +176,9 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
+
+            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
+            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
 
             // Improved Close Range Depth - USB toggle
             register_feature( std::make_shared< close_range_filter_feature >(
@@ -226,6 +232,9 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
+
+            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
+            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -123,9 +123,6 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
-
-            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
-            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -176,9 +173,6 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
-
-            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
-            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
 
             // Improved Close Range Depth - USB toggle
             register_feature( std::make_shared< close_range_filter_feature >(
@@ -232,9 +226,6 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
-
-            auto emitter_always_on_opt = std::make_shared< emitter_always_on_option >( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
-            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -293,9 +284,6 @@ namespace librealsense
             versions[1] = get_info( RS2_CAMERA_INFO_SMCU_FW_VERSION );
             set_expected_source_versions( std::move( versions ) );
 
-            auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( d500_device::_hw_monitor, ds::APM_STROBE_GET, ds::APM_STROBE_SET );
-            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
-
             // Note - requirement to gate depth options was removed to allow validation checks. Gated by FW only.
             // This should be last as we wish to protect the depth options setting when not in service safety mode
             // d500_safety::gate_depth_options();
@@ -353,10 +341,6 @@ namespace librealsense
             auto & depth_sensor = get_depth_sensor();
             group_multiple_fw_calls(depth_sensor, [&]()
             {
-                auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( d500_device::_hw_monitor,
-                                                                                         ds::LASERONCONST, ds::LASERONCONST);
-                depth_sensor.register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
-
                 auto thermal_compensation_toggle = std::make_shared< d500_thermal_compensation_option >( d500_device::_hw_monitor );
 
                 // Monitoring SOC PVT (not OHM) because it correlates to D400 ASIC temperature and we keep the model the same.


### PR DESCRIPTION
**Overview:** Adds the missing "Emitter Always On" (Laser Always On) depth-control toggle to the D585/D535 5x5 device variants, so it shows up in the Viewer's Depth Control tab.

Tracked on [RSDEV-12581]

## Why
On D585 the "Emitter Always On" toggle was missing from the Depth Control tab. FW supports the control (validated via HWM command); only the SDK was not exposing it. D555 and D585S already registered the option, but the other D585/D535 5x5 SKUs did not.

## Summary
- Register `RS2_OPTION_EMITTER_ALWAYS_ON` on `rs5x5_device`, `rs5x5_dedicated_color_device`, and `rs585_legacy_device`.
- Uses the new `APM_STROBE_GET`/`APM_STROBE_SET` opcodes, matching `rs585s_device`.

## Test plan
- [x] Core library (`realsense2`) builds on Windows/MSVC.
- [x] Verified the "Emitter Always On" toggle appears and functions in the Viewer on a D585 device.

---
🤖 Generated by AI
