### PR TITLE
Fix DDS handling for unsupported compressed encodings

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -87,6 +87,7 @@ rs2_intrinsics to_rs2_intrinsics( const realdds::video_intrinsics & intrinsics )
 static rs2_video_stream to_rs2_video_stream( rs2_stream const stream_type,
                                              sid_index const & sidx,
                                              std::shared_ptr< realdds::dds_video_stream_profile > const & profile,
+                                             rs2_format const format,
                                              const std::set< realdds::video_intrinsics > & intrinsics )
 {
     rs2_video_stream prof;
@@ -96,7 +97,7 @@ static rs2_video_stream to_rs2_video_stream( rs2_stream const stream_type,
     prof.width = profile->width();
     prof.height = profile->height();
     prof.fps = profile->frequency();
-    prof.fmt = static_cast< rs2_format >( profile->encoding().to_rs2() );
+    prof.fmt = format;
 
     // Handle intrinsics
     auto intr = std::find_if( intrinsics.begin(),
@@ -109,6 +110,23 @@ static rs2_video_stream to_rs2_video_stream( rs2_stream const stream_type,
     }
 
     return prof;
+}
+
+
+static bool try_to_rs2_format( realdds::dds_video_encoding const & encoding, rs2_format & format )
+{
+    if( encoding.to_string() == "h264" )
+        return false;
+
+    try
+    {
+        format = static_cast< rs2_format >( encoding.to_rs2() );
+        return true;
+    }
+    catch( std::exception const & )
+    {
+        return false;
+    }
 }
 
 
@@ -290,8 +308,15 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
                     if( video_stream )
                     {
                         auto video_profile = std::static_pointer_cast< realdds::dds_video_stream_profile >( profile );
+                        rs2_format format;
+                        if( ! try_to_rs2_format( video_profile->encoding(), format ) )
+                        {
+                            LOG_WARNING( "Skipping unsupported DDS encoding '" << video_profile->encoding().to_string()
+                                                                               << "' in stream " << stream->name() );
+                            continue;
+                        }
                         auto raw_stream_profile = sensor.add_video_stream(
-                            to_rs2_video_stream( stream_type, sidx, video_profile, video_stream->get_intrinsics() ),
+                            to_rs2_video_stream( stream_type, sidx, video_profile, format, video_stream->get_intrinsics() ),
                             profile == default_profile, stream->name() );
                         _stream_name_to_profiles[stream->name()].push_back( raw_stream_profile );
                     }
@@ -643,11 +668,12 @@ void dds_device_proxy::tag_default_profile_of_stream(
     const std::shared_ptr< const realdds::dds_stream > & stream ) const
 {
     auto const & dds_default_profile = stream->default_profile();
-    int target_format;
+    rs2_format target_format = RS2_FORMAT_ANY;
     auto dds_vsp = std::dynamic_pointer_cast< realdds::dds_video_stream_profile >( dds_default_profile );
     if( dds_vsp )
     {
-        target_format = dds_vsp->encoding().to_rs2();
+        if( ! try_to_rs2_format( dds_vsp->encoding(), target_format ) )
+            return;
         switch( target_format )
         {
         case RS2_FORMAT_YUYV:

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -52,6 +52,29 @@ using rsutils::json;
 namespace librealsense {
 
 
+static bool try_to_rs2_format( realdds::dds_video_encoding const & encoding, rs2_format & format )
+{
+    if( encoding.to_string() == "h264" )
+        return false;
+
+    try
+    {
+        format = static_cast< rs2_format >( encoding.to_rs2() );
+        return true;
+    }
+    catch( std::exception const & )
+    {
+        return false;
+    }
+}
+
+
+static bool is_variable_size_video_format( rs2_format format )
+{
+    return format == RS2_FORMAT_MJPEG;
+}
+
+
 dds_sensor_proxy::dds_sensor_proxy( std::string const & sensor_name,
                                     software_device * owner,
                                     std::shared_ptr< realdds::dds_device > const & dev )
@@ -132,12 +155,18 @@ void dds_sensor_proxy::register_converters()
         for( auto & profile : stream.second->profiles() )
         {
             if( auto vsp = std::dynamic_pointer_cast< realdds::dds_video_stream_profile >( profile ) )
-                if( vsp->encoding().to_rs2() == RS2_FORMAT_Y8 )
+            {
+                rs2_format format;
+                if( ! try_to_rs2_format( vsp->encoding(), format ) )
+                    continue;
+
+                if( format == RS2_FORMAT_Y8 )
                     y8_indexes.insert( stream.first.index );
-                else if( vsp->encoding().to_rs2() == RS2_FORMAT_Y16 )
+                else if( format == RS2_FORMAT_Y16 )
                     y16_indexes.insert( stream.first.index );
-                else if( vsp->encoding().to_rs2() == RS2_FORMAT_MJPEG )
+                else if( format == RS2_FORMAT_MJPEG )
                     jpeg_indexes.insert( stream.first.index );
+            }
         }
     }
 
@@ -391,12 +420,13 @@ void dds_sensor_proxy::handle_video_data( std::vector< uint8_t > && buffer,
     if( ! vid_profile )
         throw invalid_value_exception( "non-video profile provided to on_video_frame" );
 
+    auto format = vid_profile->get_format();
     auto height = vid_profile->get_height();
     auto width = vid_profile->get_width();
-    auto stride = static_cast< int >(height > 0 ? data.raw_size / height : data.raw_size );
-    auto expected_bpp = get_image_bpp(vid_profile->get_format()) / 8;
-    auto expected_size = height * width * expected_bpp;
-    if( data.raw_size != expected_size )
+    auto expected_bpp = get_image_bpp( format ) / 8;
+    auto stride = static_cast< int >( width > 0 ? width * expected_bpp : data.raw_size );
+    auto expected_size = static_cast< size_t >( height ) * static_cast< size_t >( width ) * expected_bpp;
+    if( ! is_variable_size_video_format( format ) && data.raw_size != expected_size )
         throw invalid_value_exception( rsutils::string::from() << "Received frame with unexpected size " << data.raw_size << ", expected " << expected_size );
 
     auto new_frame_interface = allocate_new_video_frame( vid_profile, stride, expected_bpp, std::move( data ) );    

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -209,7 +209,8 @@ dds_video_stream_profile::dds_video_stream_profile( rsutils::json const & j, int
 
 bool dds_video_stream_profile::is_compressed_encoding() const
 {
-    return _encoding.to_rs2() == RS2_FORMAT_MJPEG;
+    auto const encoding = _encoding.to_string();
+    return encoding == "jpeg" || encoding == "h264";
 }
 
 


### PR DESCRIPTION
Summary
- Skip DDS video profiles whose encoding cannot be mapped to an rs2_format, such as h264, instead of throwing while constructing the DDS device or registering converters.
- Keep h264 marked as a compressed DDS stream so discovery can parse the profile, while older SDK code simply omits it from exposed RealSense profiles.
- Treat DDS MJPEG frames as variable-size compressed payloads instead of requiring width * height * bpp, which allows CompColor to use the actual CompressedImage.data_length.

Firmware context
- Reproduced with firmware PR RealSenseAI-Internal/soc-rs-soc-device-mgr#342 plus dependencies RealSenseAI-Internal/soc-rs-soc-io-drivers#359, RealSenseAI-Internal/soc-rs-hkr-apps#166, and RealSenseAI-Internal/soc-rs-soc-enc-mw#7.
- Root cause was SDK-side: the new DDS Color/h264 profile could throw Invalid encoding 'h264', and PR #359 correctly sends JPEG data_length as the encoded size, which the DDS SDK path previously rejected as an unexpected fixed raw frame size.

Validation
- cmake --build build-h264-compat --target rs-enumerate-devices pyrealsense2 -j32
- D555 SN 343122300393 raw MJPEG Color(1) 896x504@30: 83 frames in 3 seconds.
- D555 SN 343122300393 converted RGB8 Color(1) 896x504@30: 83 frames in 3 seconds.
- Val: python3 Tool/StreamMetaData/StreamingTestRunner.py -p COLOR1_896_504_RGB8_30 -m 1 -t 30 -sn 343122300393 --no-report: PASS, 923 frames, 30.00 FPS, 0 drops.