### PR TITLE
viewer: skip resize/maximize when saved window size is zero

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -345,8 +345,9 @@ namespace rs2
         {
             int w = config_file::instance().get(configurations::window::width);
             int h = config_file::instance().get(configurations::window::height);
-            // Guard against a corrupt/legacy config with zero dimensions: XConfigureWindow
-            // rejects 0 width/height with BadValue, aborting the viewer under Xvfb (no WM).
+            // Guard against a corrupt/legacy config with zero dimensions: XConfigureWindow rejects
+            // 0 width/height with BadValue. A normal desktop's window manager clamps such requests,
+            // but CI runs the viewer under Xvfb (headless X server, no WM) where Xlib aborts.
             if (w > 0 && h > 0)
                 glfwSetWindowSize(_win, w, h);
             else

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -348,12 +348,13 @@ namespace rs2
             // Guard against a corrupt/legacy config with zero dimensions: XConfigureWindow
             // rejects 0 width/height with BadValue, aborting the viewer under Xvfb (no WM).
             if (w > 0 && h > 0)
-            {
                 glfwSetWindowSize(_win, w, h);
+            else
+                rs2::log(RS2_LOG_SEVERITY_WARN,
+                    "Ignoring persisted window size (width/height <= 0); falling back to monitor default");
 
-                if (config_file::instance().get(configurations::window::maximized))
-                    glfwMaximizeWindow(_win);
-            }
+            if (config_file::instance().get(configurations::window::maximized))
+                glfwMaximizeWindow(_win);
         }
 
         glfwMakeContextCurrent(_win);

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -345,10 +345,15 @@ namespace rs2
         {
             int w = config_file::instance().get(configurations::window::width);
             int h = config_file::instance().get(configurations::window::height);
-            glfwSetWindowSize(_win, w, h);
-            
-            if (config_file::instance().get(configurations::window::maximized))
-                glfwMaximizeWindow(_win);
+            // Guard against a corrupt/legacy config with zero dimensions: XConfigureWindow
+            // rejects 0 width/height with BadValue, aborting the viewer under Xvfb (no WM).
+            if (w > 0 && h > 0)
+            {
+                glfwSetWindowSize(_win, w, h);
+
+                if (config_file::instance().get(configurations::window::maximized))
+                    glfwMaximizeWindow(_win);
+            }
         }
 
         glfwMakeContextCurrent(_win);


### PR DESCRIPTION
**Overview:** Add a load-side guard so a stale or legacy `realsense-config.json` with `saved_size=true, width/height=0` no longer aborts the viewer at startup under Xvfb.

## Why
`test_realsense_viewer_gui` failed deterministically in CI (LibCI x86_64 static Release) with:

```
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  12 (X_ConfigureWindow)
  Value in failed request:  0x0
```

The viewer crashed ~275 ms into launch, before any test ran. Root cause: `common/ux-window.cpp` reads persisted window size from `~/.realsense-config.json` and calls `glfwSetWindowSize(_win, w, h)` unconditionally. If the file contains `saved_size=true` with `width=0/height=0` (possible from a very old build predating the write-side guard, or from a corrupted file on the CI slave), the resulting `XConfigureWindow` request violates the X11 protocol and Xlib's default handler kills the process. Under Xvfb there is no window manager to sanitize the request.

The write callback has guarded against zero since 2021 (commit 6852dd766); this mirrors that check on the load side so a poisoned config no longer bricks every subsequent run on the same agent.

## Summary
- `common/ux-window.cpp`: skip `glfwSetWindowSize` / `glfwMaximizeWindow` when the persisted width or height is `<= 0`. Falls back to the monitor-derived default (already computed above).

## Test plan
- [ ] LibCI nightly `test_realsense_viewer_gui` passes on Linux (Xvfb) with a clean and with a poisoned `realsense-config.json`.
- [ ] Local sanity: launch `realsense-viewer` on a machine with a normal saved size — window still restores to the saved dimensions.

---
🤖 Generated by AI