### PR TITLE
fix(macos): D555 Ethernet/DDS on Apple Silicon (shared FastDDS + C++14)

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -52,6 +52,10 @@ function(get_fastdds)
     #   more fragile with FetchContent and still couples singleton lifetime to
     #   the host binary. Shared FastDDS matches normal dylib dependency practice.
     if(APPLE)
+        # Function-scoped; does not leak to the caller. Of FastDDS's bundled
+        # third-parties only fastrtps/fastcdr become dylibs — foonathan_memory
+        # is built by its vendor project and stays a static archive
+        # (libfoonathan_memory-*.a), verified in the installed prefix.
         set(BUILD_SHARED_LIBS ON)
         message(STATUS "FastDDS: shared libraries (required for macOS librealsense2.dylib + DDS)")
     else()

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -41,7 +41,15 @@ function(get_fastdds)
     set(NO_TLS ON CACHE INTERNAL "" FORCE)
 
     # Set special values for FastDDS sub directory
-    set(BUILD_SHARED_LIBS OFF)
+    # On Apple Silicon, static FastDDS linked into librealsense2.dylib makes
+    # DomainParticipantFactory::create_participant crash (null call). Building
+    # FastDDS as shared dylibs avoids the broken static-in-shared singleton path.
+    # (rs-dds-sniffer, fully static, works; rs-enumerate-devices via dylib does not.)
+    if(APPLE)
+        set(BUILD_SHARED_LIBS ON)
+    else()
+        set(BUILD_SHARED_LIBS OFF)
+    endif()
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install) 
     set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)  
 

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -41,12 +41,19 @@ function(get_fastdds)
     set(NO_TLS ON CACHE INTERNAL "" FORCE)
 
     # Set special values for FastDDS sub directory
-    # On Apple Silicon, static FastDDS linked into librealsense2.dylib makes
-    # DomainParticipantFactory::create_participant crash (null call). Building
-    # FastDDS as shared dylibs avoids the broken static-in-shared singleton path.
-    # (rs-dds-sniffer, fully static, works; rs-enumerate-devices via dylib does not.)
+    #
+    # Link model (important on Apple):
+    # - Default (Linux/Windows): static FastDDS, as upstream historically does.
+    # - APPLE: build FastDDS as *shared* dylibs. Archiving FastDDS into
+    #   librealsense2.dylib breaks DomainParticipantFactory::create_participant
+    #   at runtime (EXC_BAD_ACCESS / null PC). Fully-static tools (rs-dds-sniffer)
+    #   still work; anything that loads librealsense2 as a shared library does not.
+    #   Alternative not chosen: force_load of static archives into the dylib —
+    #   more fragile with FetchContent and still couples singleton lifetime to
+    #   the host binary. Shared FastDDS matches normal dylib dependency practice.
     if(APPLE)
         set(BUILD_SHARED_LIBS ON)
+        message(STATUS "FastDDS: shared libraries (required for macOS librealsense2.dylib + DDS)")
     else()
         set(BUILD_SHARED_LIBS OFF)
     endif()
@@ -74,11 +81,28 @@ function(get_fastdds)
 
     add_definitions(-DBUILD_WITH_DDS)
 
-    install(TARGETS dds fastrtps eProsima_atomic EXPORT realsense2Targets)
-    
+    if(APPLE)
+        # Runtime search path so tools/python next to / under lib find fastrtps without DYLD_LIBRARY_PATH
+        foreach(_dds_tgt fastrtps fastcdr)
+            if(TARGET ${_dds_tgt})
+                set_target_properties(${_dds_tgt} PROPERTIES
+                    BUILD_RPATH "@loader_path"
+                    INSTALL_RPATH "@loader_path"
+                    MACOSX_RPATH ON
+                    INSTALL_NAME_DIR "@rpath")
+            endif()
+        endforeach()
+    endif()
+
+    # Keep dds INTERFACE in the export set (realdds depends on it) on all platforms.
+    install(TARGETS dds fastrtps eProsima_atomic EXPORT realsense2Targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     # fastcdr is installed separately because it cannot be exported to realsense2Targets - it is already exported in fastdds
-    # install in order to set ARCHIVE DESTINATION - to put libfastcdr.a into the x86_64 folder
-    install(TARGETS fastcdr 
+    install(TARGETS fastcdr
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     message(CHECK_PASS "Done")
 endfunction()

--- a/CMake/external_pybind11.cmake
+++ b/CMake/external_pybind11.cmake
@@ -72,7 +72,18 @@ function(get_pybind11)
       set( PYTHON_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
     else()
       find_package(Python REQUIRED COMPONENTS Interpreter Development)
-      set( PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+      # Default: system/venv site-packages (historical).
+      # On Apple + DDS we prefer a *prefix-relative* layout so pyrealsense2,
+      # librealsense2, and shared FastDDS stay under CMAKE_INSTALL_PREFIX and
+      # resolve via @loader_path (no DYLD_LIBRARY_PATH, no polluting Homebrew).
+      if(APPLE AND BUILD_WITH_DDS)
+        set( _pyrealsense2_default_install_dir
+             "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/pyrealsense2" )
+      else()
+        set( _pyrealsense2_default_install_dir "${Python_SITEARCH}/pyrealsense2" )
+      endif()
+      set( PYTHON_INSTALL_DIR "${_pyrealsense2_default_install_dir}"
+           CACHE PATH "Installation directory for Python bindings")
     endif()
 
     message( STATUS #CHECK_PASS

--- a/CMake/external_pybind11.cmake
+++ b/CMake/external_pybind11.cmake
@@ -77,6 +77,11 @@ function(get_pybind11)
       # librealsense2, and shared FastDDS stay under CMAKE_INSTALL_PREFIX and
       # resolve via @loader_path (no DYLD_LIBRARY_PATH, no polluting Homebrew).
       if(APPLE AND BUILD_WITH_DDS)
+        # CMAKE_INSTALL_LIBDIR is only defined by GNUInstallDirs; without it the
+        # path below would silently start at the filesystem root.
+        if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+          include(GNUInstallDirs)
+        endif()
         set( _pyrealsense2_default_install_dir
              "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/pyrealsense2" )
       else()

--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -103,9 +103,11 @@ macro(global_target_config)
             PRIVATE ${USB_INCLUDE_DIRS}
     )
 
-    # macOS: resolve librealsense2 + (when DDS) libfastrtps/libfastcdr via @rpath
-    # so install/build trees work without DYLD_LIBRARY_PATH.
-    if(APPLE)
+    # macOS + DDS: resolve librealsense2 + libfastrtps/libfastcdr via @rpath so
+    # install/build trees work without DYLD_LIBRARY_PATH. Single source of truth
+    # for ${LRS_TARGET} rpath properties; os_target_config() (unix_config.cmake)
+    # only sets the CMAKE_* defaults inherited by tools / bindings created later.
+    if(APPLE AND BUILD_WITH_DDS)
         set_target_properties(${LRS_TARGET} PROPERTIES
             MACOSX_RPATH ON
             BUILD_RPATH "@loader_path"

--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -103,6 +103,15 @@ macro(global_target_config)
             PRIVATE ${USB_INCLUDE_DIRS}
     )
 
+    # macOS: resolve librealsense2 + (when DDS) libfastrtps/libfastcdr via @rpath
+    # so install/build trees work without DYLD_LIBRARY_PATH.
+    if(APPLE)
+        set_target_properties(${LRS_TARGET} PROPERTIES
+            MACOSX_RPATH ON
+            BUILD_RPATH "@loader_path"
+            INSTALL_RPATH "@loader_path"
+            INSTALL_NAME_DIR "@rpath")
+    endif()
 
 endmacro()
 

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -112,4 +112,26 @@ macro(os_set_flags)
 endmacro()
 
 macro(os_target_config)
+    # When FastDDS is shared on Apple (BUILD_WITH_DDS), tools and the Python
+    # module must find librealsense2 + fastrtps via @rpath without DYLD_LIBRARY_PATH.
+    # Build tree: all outputs under CMAKE_RUNTIME_OUTPUT_DIRECTORY / lib next to each other.
+    # Install tree: binaries in bin/, libs in lib/ → @loader_path/../lib.
+    if(APPLE AND BUILD_WITH_DDS)
+        set(_lrs_install_rpath "@loader_path;@loader_path/../lib")
+        set(_lrs_build_rpath "@loader_path")
+        # Global defaults for executables/modules created after this point
+        set(CMAKE_BUILD_RPATH "${_lrs_build_rpath}")
+        set(CMAKE_INSTALL_RPATH "${_lrs_install_rpath}")
+        set(CMAKE_MACOSX_RPATH ON)
+        set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+        # Librealsense core (already created) + any later tools
+        if(TARGET ${LRS_TARGET})
+            set_target_properties(${LRS_TARGET} PROPERTIES
+                BUILD_RPATH "${_lrs_build_rpath}"
+                INSTALL_RPATH "@loader_path"
+                MACOSX_RPATH ON
+                INSTALL_NAME_DIR "@rpath")
+        endif()
+    endif()
 endmacro()

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -125,13 +125,7 @@ macro(os_target_config)
         set(CMAKE_MACOSX_RPATH ON)
         set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
         set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-        # Librealsense core (already created) + any later tools
-        if(TARGET ${LRS_TARGET})
-            set_target_properties(${LRS_TARGET} PROPERTIES
-                BUILD_RPATH "${_lrs_build_rpath}"
-                INSTALL_RPATH "@loader_path"
-                MACOSX_RPATH ON
-                INSTALL_NAME_DIR "@rpath")
-        endif()
+        # ${LRS_TARGET} rpath properties are set once in global_config.cmake;
+        # here we only provide the CMAKE_* defaults for later executables/modules.
     endif()
 endmacro()

--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -15,7 +15,9 @@ sudo examples/rs-depth
 
 **Current Limitations:**
 - **RealSense Viewer is not supported** on macOS in the current release
-- **Motion sensors (IMU) are disabled** on macOS in the current release
+- **Motion sensors (IMU) are disabled** on macOS in the current release (USB path; D555 over DDS exposes motion when the device publishes it)
+
+**D555 (PoE / Ethernet + DDS):** see **[installation_osx_d555_dds.md](installation_osx_d555_dds.md)** for network (MTU 9000), `BUILD_WITH_DDS=ON`, shared FastDDS on Apple, `sw_only` enumeration, and Python notes.
 
 ## Building from Source
 

--- a/doc/installation_osx_d555_dds.md
+++ b/doc/installation_osx_d555_dds.md
@@ -1,0 +1,172 @@
+# macOS + D555 Ethernet / DDS (Apple Silicon)
+
+This guide covers **Intel RealSense D555 (PoE / Ethernet + DDS)** on **macOS arm64**.
+USB D4xx cameras still use the classic RSUSB backend; D555 is **not** USB video —
+it speaks **DDS (FastDDS)** over Ethernet.
+
+> Status: verified with librealsense **2.58.x**, macOS 15+/26 arm64, D555 factory IP
+> `192.168.11.55`, host Ethernet first in service order (Wi‑Fi may stay enabled).
+
+---
+
+## Network (host)
+
+| Setting | Recommended |
+|---------|-------------|
+| Link | Direct Ethernet (or PoE injector). Switch optional. |
+| Host IPv4 | Manual, e.g. `192.168.11.100` |
+| Subnet | `255.255.255.0` (`/24`) |
+| Camera IP | Factory default **`192.168.11.55`** (ping should succeed) |
+| **MTU** | **Jumbo 9000** (required for stable high-res streams) |
+| Speed | 1000baseT full-duplex is fine |
+| Service order | **Ethernet above Wi‑Fi** (System Settings → Network) |
+| Multi-homed | OK if Ethernet is preferred for `192.168.11.0/24` routes |
+
+Check:
+
+```bash
+ifconfig en0 | grep -E 'inet |mtu|media'
+ping -c 2 192.168.11.55
+route -n get 192.168.11.55   # interface should be en0 (or your Ethernet)
+```
+
+---
+
+## Build (source)
+
+Dependencies:
+
+```bash
+brew install cmake libusb pkg-config openssl
+export OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
+```
+
+Configure **with DDS** (required for D555):
+
+```bash
+git clone https://github.com/realsenseai/librealsense.git
+cd librealsense
+mkdir build && cd build
+
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_WITH_DDS=ON \
+  -DBUILD_TOOLS=ON \
+  -DBUILD_PYTHON_BINDINGS=ON \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_GRAPHICAL_EXAMPLES=OFF \
+  -DFORCE_RSUSB_BACKEND=ON \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_INSTALL_PREFIX="$HOME/librealsense-d555" \
+  -DPYTHON_EXECUTABLE="$(which python3)"
+
+cmake --build . -j"$(sysctl -n hw.ncpu)"
+cmake --install .
+```
+
+### Why `BUILD_WITH_DDS=ON` and shared FastDDS on Apple?
+
+- D555 is discovered and streamed only through the **DDS** path (`realdds` + FastDDS).
+- On **macOS**, FastDDS is built as **shared** libraries (`libfastrtps`, `libfastcdr`) and linked into `librealsense2.dylib`.
+- Archiving FastDDS **statically** into `librealsense2.dylib` has been observed to crash inside
+  `DomainParticipantFactory::create_participant` (null PC). Fully static tools (e.g. `rs-dds-sniffer`)
+  can still work; anything that **loads** `librealsense2` as a dylib does not.
+- Install/RPATH: libraries use `@loader_path` so **`DYLD_LIBRARY_PATH` is not required** after `cmake --install`.
+
+---
+
+## Runtime config
+
+Optional `~/.realsense-config.json`:
+
+```json
+{
+  "context": {
+    "dds": {
+      "enabled": true,
+      "domain": 0
+    }
+  }
+}
+```
+
+| Key | Notes |
+|-----|--------|
+| **domain** | Default **0**. Must match camera / site policy. |
+| **enabled** | `true` for Ethernet D555. |
+| **sw_only** | DDS devices are software-backed; tools often need SW product-line bits. |
+
+### Enumerate
+
+```bash
+# After install (prefix/bin on PATH, prefix/lib via rpath):
+export PATH="$HOME/librealsense-d555/bin:$PATH"
+
+rs-dds-sniffer -d 0 --participants -s
+# expect: ... D555_<serial>
+
+# DDS devices: use --sw-only (includes RS2_PRODUCT_LINE_SW_ONLY)
+rs-enumerate-devices --sw-only -s
+```
+
+Without `--sw-only`, USB-only masks may hide DDS devices even when the sniffer sees the participant.
+
+### Python
+
+```bash
+# If pyrealsense2 was installed into the prefix lib:
+export PYTHONPATH="$HOME/librealsense-d555/lib:$PYTHONPATH"
+# (or install the extension into a venv that can load prefix/lib via rpath)
+
+python3 - <<'PY'
+import json, time
+import pyrealsense2 as rs
+
+settings = {
+    "dds": {
+        "enabled": True,
+        "domain": 0,
+        "query-devices-max": 12,
+        "query-devices-min": 4,
+        "device-initialization-timeout-ms": 15000,
+    },
+    "device-mask": 511,  # any + sw bits; see product_line in API
+    "partial-device-allowed": True,
+}
+ctx = rs.context(json.dumps(settings))
+mask = int(rs.product_line.any_intel) | int(rs.product_line.sw_only) | int(rs.product_line.non_intel)
+for _ in range(15):
+    devs = ctx.query_devices(mask)
+    if len(devs):
+        d = devs[0]
+        print(d.get_info(rs.camera_info.name), d.get_info(rs.camera_info.serial_number))
+        break
+    time.sleep(1)
+else:
+    raise SystemExit("no D555")
+PY
+```
+
+### Stream notes
+
+- Prefer **native profiles** from the device (e.g. color/depth **1280×800**). Arbitrary 640×480 may fail with “Couldn't resolve requests”.
+- First handshake can take several seconds on multi-homed hosts; allow `query-devices-min/max` time.
+
+---
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| `ping` OK, sniffer empty | MTU 9000? Domain ID? PoE power? |
+| Sniffer sees D555, `query_devices` empty | Use `sw_only` / `device-mask` including SW; wait longer |
+| `create_participant` crash | Rebuild with `BUILD_WITH_DDS=ON` on Apple (shared FastDDS path) |
+| `Couldn't resolve requests` | List `sensor.profiles` and enable those width/height/format/fps |
+| Need `DYLD_LIBRARY_PATH` after install | RPATH not applied; reinstall with the Apple DDS rpath cmake, or run from install `lib`/`bin` layout |
+
+---
+
+## Related
+
+- Base macOS build notes: [installation_osx.md](installation_osx.md)
+- CMake option: `BUILD_WITH_DDS` in `CMake/lrs_options.cmake`

--- a/doc/installation_osx_d555_dds.md
+++ b/doc/installation_osx_d555_dds.md
@@ -48,6 +48,10 @@ git clone https://github.com/realsenseai/librealsense.git
 cd librealsense
 mkdir build && cd build
 
+PY="$(which python3)"
+PY_VER="$("$PY" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PREFIX="$HOME/librealsense-d555"
+
 cmake .. \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_WITH_DDS=ON \
@@ -57,12 +61,15 @@ cmake .. \
   -DBUILD_GRAPHICAL_EXAMPLES=OFF \
   -DFORCE_RSUSB_BACKEND=ON \
   -DCMAKE_OSX_ARCHITECTURES=arm64 \
-  -DCMAKE_INSTALL_PREFIX="$HOME/librealsense-d555" \
-  -DPYTHON_EXECUTABLE="$(which python3)"
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DPYTHON_EXECUTABLE="$PY" \
+  -DPYTHON_INSTALL_DIR="lib/python${PY_VER}/site-packages/pyrealsense2"
 
 cmake --build . -j"$(sysctl -n hw.ncpu)"
 cmake --install .
 ```
+
+On Apple + DDS, CMake defaults `PYTHON_INSTALL_DIR` under the **install prefix** (not Homebrew `site-packages`) so the extension and dylibs stay co-located for `@loader_path`.
 
 ### Why `BUILD_WITH_DDS=ON` and shared FastDDS on Apple?
 
@@ -111,13 +118,17 @@ rs-enumerate-devices --sw-only -s
 
 Without `--sw-only`, USB-only masks may hide DDS devices even when the sniffer sees the participant.
 
+### Environment (production)
+
+```bash
+export PATH="$PREFIX/bin:$PATH"
+export PYTHONPATH="$PREFIX/lib/python${PY_VER}/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+# Do not set DYLD_LIBRARY_PATH — tools and the extension use @rpath/@loader_path.
+```
+
 ### Python
 
 ```bash
-# If pyrealsense2 was installed into the prefix lib:
-export PYTHONPATH="$HOME/librealsense-d555/lib:$PYTHONPATH"
-# (or install the extension into a venv that can load prefix/lib via rpath)
-
 python3 - <<'PY'
 import json, time
 import pyrealsense2 as rs

--- a/doc/installation_osx_d555_dds.md
+++ b/doc/installation_osx_d555_dds.md
@@ -27,8 +27,13 @@ Check:
 ```bash
 ifconfig en0 | grep -E 'inet |mtu|media'
 ping -c 2 192.168.11.55
-route -n get 192.168.11.55   # interface should be en0 (or your Ethernet)
 ```
+
+> Note: `route -n get 192.168.11.55` can be misleading on multi-homed hosts —
+> the camera link is a gateway-less *scoped* route, so `route get` may report
+> the default-route interface (Wi‑Fi) even though traffic correctly uses the
+> Ethernet. Trust `ifconfig` (which interface owns the camera's subnet), not
+> `route get`.
 
 ---
 
@@ -103,6 +108,33 @@ Optional `~/.realsense-config.json`:
 | **enabled** | `true` for Ethernet D555. |
 | **sw_only** | DDS devices are software-backed; tools often need SW product-line bits. |
 
+### Multi-interface hosts: pin discovery with a whitelist
+
+With several active interfaces (Wi‑Fi holding the default route, VPN `utun`,
+Thunderbolt bridges), FastDDS discovery can bind to the wrong interface and
+**silently find no device even though `ping` works**. Pin discovery to the
+host IP on the camera's subnet:
+
+```json
+{
+  "context": {
+    "dds": {
+      "enabled": true,
+      "domain": 0,
+      "udp": {
+        "whitelist": [ "192.168.11.100" ]
+      }
+    }
+  }
+}
+```
+
+`context.dds.udp.whitelist` maps to the FastDDS transport `interfaceWhiteList`
+and is honored by every librealsense context (`rs-enumerate-devices`,
+`rs-dds-sniffer`, `pyrealsense2`, apps). Re-check it whenever the host IP
+changes. The same key can be passed per-context in the settings JSON
+(`"dds": { "udp": { "whitelist": [...] } }`).
+
 ### Enumerate
 
 ```bash
@@ -133,7 +165,12 @@ Python minor version. If `python3` is Homebrew 3.14 but you built with 3.12 you 
 ModuleNotFoundError: No module named 'pyrealsense2.pyrealsense2'
 ```
 
-Use the same interpreter as at configure time (`python3.12`, or the build script’s `d555-python` wrapper).
+Use the same interpreter as at configure time. `d555-python` below refers to a
+small wrapper script that pins the build-time interpreter and prefix
+`PYTHONPATH`; a ready-made version ships with the packaging scripts at
+[bilims/d555-ethernet-macos](https://github.com/bilims/d555-ethernet-macos)
+(`scripts/build-and-install-macos-dds.sh` generates it into `PREFIX/bin`).
+Plain `python3.12` with the `PYTHONPATH` above works identically.
 
 ### Python
 
@@ -180,7 +217,7 @@ PY
 
 | Symptom | Check |
 |---------|--------|
-| `ping` OK, sniffer empty | MTU 9000? Domain ID? PoE power? |
+| `ping` OK, sniffer empty | **Multi-interface host? Set `dds.udp.whitelist`** (see above). MTU 9000? Domain ID? PoE power? |
 | Sniffer sees D555, `query_devices` empty | Use `sw_only` / `device-mask` including SW; wait longer |
 | `create_participant` crash | Rebuild with `BUILD_WITH_DDS=ON` on Apple (shared FastDDS path) |
 | `Couldn't resolve requests` | List `sensor.profiles` and enable those width/height/format/fps |

--- a/doc/installation_osx_d555_dds.md
+++ b/doc/installation_osx_d555_dds.md
@@ -126,10 +126,21 @@ export PYTHONPATH="$PREFIX/lib/python${PY_VER}/site-packages${PYTHONPATH:+:$PYTH
 # Do not set DYLD_LIBRARY_PATH — tools and the extension use @rpath/@loader_path.
 ```
 
+**Python ABI:** the extension is tagged e.g. `cpython-312-darwin.so`. It **only** loads in that
+Python minor version. If `python3` is Homebrew 3.14 but you built with 3.12 you will see:
+
+```text
+ModuleNotFoundError: No module named 'pyrealsense2.pyrealsense2'
+```
+
+Use the same interpreter as at configure time (`python3.12`, or the build script’s `d555-python` wrapper).
+
 ### Python
 
 ```bash
-python3 - <<'PY'
+# Correct interpreter (must match build, e.g. 3.12):
+python3.12 - <<'PY'
+# or: d555-python - <<'PY'
 import json, time
 import pyrealsense2 as rs
 

--- a/src/dds/rs-dds-embedded-close-range-filter.cpp
+++ b/src/dds/rs-dds-embedded-close-range-filter.cpp
@@ -12,6 +12,13 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14: static constexpr data members are not implicitly inline (that's C++17),
+    // so ODR-used members need out-of-line definitions or the link fails
+    constexpr const char * rs_dds_embedded_close_range_filter::ENABLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::DOWNSCALE_RATIO_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::DISPARITY_SHIFT_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::THRESHOLD_OPTION_NAME;
+
     rs_dds_embedded_close_range_filter::rs_dds_embedded_close_range_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/src/dds/rs-dds-embedded-decimation-filter.cpp
+++ b/src/dds/rs-dds-embedded-decimation-filter.cpp
@@ -15,6 +15,12 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14: static constexpr data members are not implicitly inline (that's C++17),
+    // so ODR-used members need out-of-line definitions or the link fails
+    constexpr const char * rs_dds_embedded_decimation_filter::TOGGLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_decimation_filter::MAGNITUDE_OPTION_NAME;
+    constexpr int32_t rs_dds_embedded_decimation_filter::DECIMATION_MAGNITUDE;
+
     rs_dds_embedded_decimation_filter::rs_dds_embedded_decimation_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/src/dds/rs-dds-embedded-temporal-filter.cpp
+++ b/src/dds/rs-dds-embedded-temporal-filter.cpp
@@ -15,6 +15,14 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14: static constexpr data members are not implicitly inline (that's C++17),
+    // so ODR-used members need out-of-line definitions or the link fails
+    constexpr const char * rs_dds_embedded_temporal_filter::TOGGLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::ALPHA_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::DELTA_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::PERSISTENCY_OPTION_NAME;
+    constexpr int32_t rs_dds_embedded_temporal_filter::PERSISTENCY_MAX_LEN;
+
     rs_dds_embedded_temporal_filter::rs_dds_embedded_temporal_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -118,7 +118,12 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
         if( ! _participant->is_valid() )
         {
             realdds::dds_participant::qos qos( participant_name );  // default settings
-            
+
+            // FastDDS flow-controllers + fastdds.max_message_size currently crash on Apple Silicon
+            // (null call during DomainParticipantFactory/XML profile path when creating the
+            // participant from rsdds_device_factory). rs-dds-sniffer works with a plain qos.
+            // Keep the advanced QoS for non-Apple platforms only until fixed upstream.
+#if ! defined( __APPLE__ )
             // As a client, we send messages to a server; sometimes big messages. E.g., for DFU these may be up to
             // 20MB... flexible messages are up to 4K. The UDP protocol is supposed to break messages (by default, up to
             // 64K) into fragmented packed, but the server may not be able to handle these; certain hardware cannot
@@ -141,6 +146,7 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
             // Further override with settings from device/dfu
             realdds::override_flow_controller_from_json( *dfu_flow_control, dds_settings.nested( "device", "dfu" ) );
             qos.flow_controllers().push_back( dfu_flow_control );
+#endif
 
             // qos will get further overriden with the settings we pass in
             _participant->init( domain_id, qos, dds_settings.default_object() );

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -119,16 +119,11 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
         {
             realdds::dds_participant::qos qos( participant_name );  // default settings
 
-            // FastDDS flow-controllers + fastdds.max_message_size currently crash on Apple Silicon
-            // (null call during DomainParticipantFactory/XML profile path when creating the
-            // participant from rsdds_device_factory). rs-dds-sniffer works with a plain qos.
-            // Keep the advanced QoS for non-Apple platforms only until fixed upstream.
-#if ! defined( __APPLE__ )
             // As a client, we send messages to a server; sometimes big messages. E.g., for DFU these may be up to
             // 20MB... flexible messages are up to 4K. The UDP protocol is supposed to break messages (by default, up to
             // 64K) into fragmented packed, but the server may not be able to handle these; certain hardware cannot
             // handle more than 1500 bytes!
-            // 
+            //
             // FastDDS does provide a 'udp/max-message-size' setting (as of v2.10.4), but this applies to both send and
             // receive. We want to only limit sends! So we use a new property of FastDDS:
             qos.properties().properties().emplace_back( "fastdds.max_message_size", "1470" );
@@ -146,7 +141,6 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
             // Further override with settings from device/dfu
             realdds::override_flow_controller_from_json( *dfu_flow_control, dds_settings.nested( "device", "dfu" ) );
             qos.flow_controllers().push_back( dfu_flow_control );
-#endif
 
             // qos will get further overriden with the settings we pass in
             _participant->init( domain_id, qos, dds_settings.default_object() );

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -708,7 +708,15 @@ void dds_device::impl::create_notifications_reader()
         {
             // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
             // if a notification handler drops the device's last reference.
-            auto self = weak_from_this().lock();
+            // weak_from_this() is C++17; realdds targets C++14. This reader is created from
+            // the impl constructor, so data can arrive before the impl is shared-owned, where
+            // shared_from_this() throws instead of returning empty — treat both as "not ready".
+            std::shared_ptr< impl > self;
+            try
+            {
+                self = shared_from_this();
+            }
+            catch( std::bad_weak_ptr const & ) {}
             if( ! self )
                 return;
             topics::flexible_msg notification;
@@ -745,7 +753,13 @@ void dds_device::impl::create_metadata_reader()
         {
             // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
             // if a metadata handler drops the device's last reference.
-            auto self = weak_from_this().lock();
+            // weak_from_this() is C++17; realdds targets C++14 — see create_notifications_reader()
+            std::shared_ptr< impl > self;
+            try
+            {
+                self = shared_from_this();
+            }
+            catch( std::bad_weak_ptr const & ) {}
             if( ! self )
                 return;
             topics::flexible_msg message;

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -244,6 +244,9 @@ void dds_participant::init( dds_domain_id domain_id, qos & pqos, rsutils::json c
     // https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/entity/entity.html#listener
     // We need none of the standard callbacks at this level: these can be enabled on a per-reader/-writer basis!
     StatusMask const par_mask = StatusMask::none();
+    // On Apple Silicon, FastDDS must be linked as shared libraries into librealsense2
+    // (see CMake/external_fastdds.cmake). Static FastDDS inside librealsense2.dylib
+    // makes create_participant crash (null call); rs-dds-sniffer (fully static) was fine.
     _participant_factory = DomainParticipantFactory::get_shared_instance();
     _participant
         = DDS_API_CALL( _participant_factory->create_participant( domain_id, pqos, _domain_listener.get(), par_mask ) );

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -244,9 +244,7 @@ void dds_participant::init( dds_domain_id domain_id, qos & pqos, rsutils::json c
     // https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/entity/entity.html#listener
     // We need none of the standard callbacks at this level: these can be enabled on a per-reader/-writer basis!
     StatusMask const par_mask = StatusMask::none();
-    // On Apple Silicon, FastDDS must be linked as shared libraries into librealsense2
-    // (see CMake/external_fastdds.cmake). Static FastDDS inside librealsense2.dylib
-    // makes create_participant crash (null call); rs-dds-sniffer (fully static) was fine.
+    // Apple links FastDDS shared — rationale in CMake/external_fastdds.cmake
     _participant_factory = DomainParticipantFactory::get_shared_instance();
     _participant
         = DDS_API_CALL( _participant_factory->create_participant( domain_id, pqos, _domain_listener.get(), par_mask ) );

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -39,7 +39,9 @@ void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, size_
                    "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
                        + std::to_string( profiles.size() ) + " stream profiles" );
 
-    auto self = weak_from_this();
+    // weak_from_this() is C++17; Apple clang builds realdds as C++14 (cxx_std_14).
+    // Equivalent C++14 form keeps DDS stream init working on macOS arm64.
+    auto self = std::weak_ptr< dds_stream_base >( shared_from_this() );
     for( auto const & profile : profiles )
     {
         check_profile( profile );

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -39,8 +39,12 @@ void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, size_
                    "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
                        + std::to_string( profiles.size() ) + " stream profiles" );
 
-    // weak_from_this() is C++17; Apple clang builds realdds as C++14 (cxx_std_14).
-    // Equivalent C++14 form keeps DDS stream init working on macOS arm64.
+    // weak_from_this() is C++17; realdds targets C++14 (cxx_std_14), where strict
+    // compilers (e.g. Apple Clang, or GCC/Clang with -pedantic-errors) reject it.
+    // Note shared_from_this() throws std::bad_weak_ptr if the object is not owned by a
+    // shared_ptr, while weak_from_this() would return an empty weak_ptr. Streams are
+    // always created via std::make_shared (see dds-device-impl.cpp), so a throw here
+    // means an ownership bug upstream and failing loudly is the desired behavior.
     auto self = std::weak_ptr< dds_stream_base >( shared_from_this() );
     for( auto const & profile : profiles )
     {

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -34,10 +34,14 @@ set_target_properties( pyrealsense2
         FOLDER Library/Python
     )
 if(APPLE AND BUILD_WITH_DDS)
-    # Extension loads librealsense2 (and via it, libfastrtps) from the same lib dir.
+    # Build tree: all dylibs next to the extension (@loader_path).
+    # Install tree (prefix layout):
+    #   lib/librealsense2.dylib
+    #   lib/pythonX.Y/site-packages/pyrealsense2/*.so
+    # → climb three levels: site-packages/pyrealsense2 → lib
     set_target_properties(pyrealsense2 PROPERTIES
         BUILD_RPATH "@loader_path"
-        INSTALL_RPATH "@loader_path;@loader_path/../lib"
+        INSTALL_RPATH "@loader_path;@loader_path/../../.."
         MACOSX_RPATH ON)
 endif()
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -34,13 +34,15 @@ set_target_properties( pyrealsense2
         FOLDER Library/Python
     )
 if(APPLE AND BUILD_WITH_DDS)
-    # Build tree: all dylibs next to the extension (@loader_path).
+    # Build tree: the extension lives in wrappers/python/ while librealsense2
+    # and shared FastDDS live elsewhere in the build tree, so @loader_path alone
+    # is not enough — add the actual build-tree lib locations.
     # Install tree (prefix layout):
     #   lib/librealsense2.dylib
     #   lib/pythonX.Y/site-packages/pyrealsense2/*.so
     # → climb three levels: site-packages/pyrealsense2 → lib
     set_target_properties(pyrealsense2 PROPERTIES
-        BUILD_RPATH "@loader_path"
+        BUILD_RPATH "@loader_path;${CMAKE_BINARY_DIR};${CMAKE_BINARY_DIR}/fastdds/fastdds_install/lib"
         INSTALL_RPATH "@loader_path;@loader_path/../../.."
         MACOSX_RPATH ON)
 endif()

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -33,6 +33,13 @@ set_target_properties( pyrealsense2
     PROPERTIES
         FOLDER Library/Python
     )
+if(APPLE AND BUILD_WITH_DDS)
+    # Extension loads librealsense2 (and via it, libfastrtps) from the same lib dir.
+    set_target_properties(pyrealsense2 PROPERTIES
+        BUILD_RPATH "@loader_path"
+        INSTALL_RPATH "@loader_path;@loader_path/../lib"
+        MACOSX_RPATH ON)
+endif()
 
 set(RAW_RS
     pybackend.cpp


### PR DESCRIPTION
## Summary
Enable **D555 PoE/Ethernet (DDS)** on **macOS Apple Silicon** with production-oriented build/install notes.

### Changes
1. **FastDDS link model (Apple):** build FastDDS as **shared** dylibs when `APPLE && BUILD_WITH_DDS`. Static FastDDS archived into `librealsense2.dylib` crashes in `DomainParticipantFactory::create_participant` (null PC). Fully-static tools (`rs-dds-sniffer`) were fine; Python/`rs-enumerate-devices` were not. Documented alternative (`force_load`) and why shared is preferred.
2. **realdds C++14:** `weak_from_this()` → `std::weak_ptr(shared_from_this())` (realdds uses `cxx_std_14`).
3. **QoS:** DFU flow-controller + `fastdds.max_message_size` restored on **all** platforms (including Apple) after shared FastDDS fix.
4. **RPATH:** `@loader_path` / `@loader_path/../lib` for librealsense2, tools, Python module, and FastDDS so **install works without `DYLD_LIBRARY_PATH`**.
5. **Docs:** `doc/installation_osx_d555_dds.md` + link from `installation_osx.md` (MTU 9000, Ethernet service order, domain 0, `sw_only`, PoE, multi-homed, Python).

## Hardware verification (macOS arm64)
- Host `192.168.11.100/24`, MTU **9000**, Ethernet first (Wi‑Fi may stay on), D555 `192.168.11.55` via PoE injector
- `rs-enumerate-devices --sw-only -s` → `Intel RealSense D555` / SN `342622303310` (**no DYLD_LIBRARY_PATH** after install)
- Pipeline: color+depth frames (e.g. 640×360 and 1280×800), depth distance OK
- Flow-controller path: `STREAM_OK_WITH_FLOW_CONTROLLER`

## Test plan
- [x] Configure `-DBUILD_WITH_DDS=ON` on arm64
- [x] Live D555 sniffer + enumerate + Python open + stream
- [x] Install prefix + run tools without `DYLD_LIBRARY_PATH`
- [ ] CI: configure-only macOS job (optional follow-up)
- [ ] Linux regression: static FastDDS path unchanged