### PR TITLE
DFU device can reset after update without waiting for status query

### DIFF
--- a/src/ds/d400/d400-fw-update-device.cpp
+++ b/src/ds/d400/d400-fw-update-device.cpp
@@ -61,17 +61,6 @@ ds_d400_update_device::ds_d400_update_device(
         return it->second;
     }
 
-    std::string ds_d400_update_device::parse_serial_number(const std::vector<uint8_t>& buffer) const
-    {
-        if (buffer.size() != sizeof(serial_number_data))
-            throw std::runtime_error("DFU - failed to parse serial number!");
-
-        std::stringstream rv;
-        for (auto i = 0; i < ds::module_serial_size; i++)
-            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(buffer[i]);
-
-        return rv.str();
-    }
     float ds_d400_update_device::compute_progress(float progress, float start, float end, float threshold) const
     {
         return (progress*100);

--- a/src/ds/d400/d400-fw-update-device.h
+++ b/src/ds/d400/d400-fw-update-device.h
@@ -20,7 +20,5 @@ namespace librealsense
         std::string get_firmware_min_version() const override;
 
         float compute_progress(float progress, float start, float end, float threshold) const override;
-    private:
-        std::string parse_serial_number(const std::vector<uint8_t>& buffer) const;
     };
 }

--- a/src/ds/d500/d500-fw-update-device.cpp
+++ b/src/ds/d500/d500-fw-update-device.cpp
@@ -7,6 +7,9 @@
 
 namespace librealsense
 {
+    // update_device::parse_serial_number iterates sizeof(serial_number_data::serial); keep it aligned with the ds constant.
+    static_assert( sizeof( serial_number_data::serial ) == ds::module_serial_size, "serial number field size mismatch" );
+
 ds_d500_update_device::ds_d500_update_device( std::shared_ptr< const device_info > const & dev_info,
                                     std::shared_ptr< platform::usb_device > const & usb_device )
     : update_device( dev_info, usb_device, "D500" )

--- a/src/ds/d500/d500-fw-update-device.cpp
+++ b/src/ds/d500/d500-fw-update-device.cpp
@@ -23,18 +23,6 @@ ds_d500_update_device::ds_d500_update_device( std::shared_ptr< const device_info
         return true;
     }
 
-    std::string ds_d500_update_device::parse_serial_number(const std::vector<uint8_t>& buffer) const
-    {
-        if (buffer.size() != sizeof(serial_number_data))
-            throw std::runtime_error("DFU - failed to parse serial number!");
-
-        std::stringstream rv;
-        for (auto i = 0; i < ds::module_serial_size; i++)
-            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(buffer[i]);
-
-        return rv.str();
-    }
-
     void ds_d500_update_device::update(const void* fw_image, int fw_image_size, rs2_update_progress_callback_sptr update_progress_callback) const
     {
         update_device::update( fw_image, fw_image_size, update_progress_callback );
@@ -137,11 +125,5 @@ ds_d500_update_device::ds_d500_update_device( std::shared_ptr< const device_info
         }
         else
             std::this_thread::sleep_for(std::chrono::seconds(required_dfu_time));
-    }
-    float ds_d500_update_device::compute_progress(float progress, float start, float end, float threshold) const
-    {
-        if( threshold > 1.f )
-            progress = ceil( progress * threshold ) / threshold;
-        return start + progress * ( end - start );
     }
 }

--- a/src/ds/d500/d500-fw-update-device.cpp
+++ b/src/ds/d500/d500-fw-update-device.cpp
@@ -117,25 +117,8 @@ ds_d500_update_device::ds_d500_update_device( std::shared_ptr< const device_info
         if (!wait_for_manifest_completion(messenger, RS2_DFU_STATE_DFU_MANIFEST, std::chrono::seconds(200), update_progress_callback))
             throw std::runtime_error("Firmware manifest completion failed");
 
-
-        // After the zero length DFU_DNLOAD request terminates the Transfer
-        // phase, the device is ready to manifest the new firmware. As described
-        // previously, some devices may accumulate the firmware image and perform
-        // the entire reprogramming operation at one time. Others may have only a
-        // small amount remaining to be reprogrammed, and still others may have
-        // none. Regardless, the device enters the dfuMANIFEST-SYNC state and
-        // awaits the solicitation of the status report by the host. Upon receipt
-        // of the anticipated DFU_GETSTATUS, the device enters the dfuMANIFEST
-        // state, where it completes its reprogramming operations.
-
-        // WaitForDFU state sends several DFU_GETSTATUS requests, until we hit
-        // either RS2_DFU_STATE_DFU_MANIFEST_WAIT_RESET or RS2_DFU_STATE_DFU_ERROR status.
-        // This command also reset the device
         if (_is_dfu_monitoring_enabled)
-        {
-            if (!wait_for_state(messenger, RS2_DFU_STATE_DFU_MANIFEST_WAIT_RESET, 20000))
-                throw std::runtime_error("Firmware manifest failed");
-        }
+            update_device::dfu_manifest_phase(messenger, update_progress_callback);
     }
 
     void ds_d500_update_device::report_progress_and_wait_for_fw_burn(rs2_update_progress_callback_sptr update_progress_callback, int required_dfu_time) const

--- a/src/ds/d500/d500-fw-update-device.h
+++ b/src/ds/d500/d500-fw-update-device.h
@@ -19,10 +19,8 @@ namespace librealsense
         bool wait_for_manifest_completion(std::shared_ptr<platform::usb_messenger> messenger, const rs2_dfu_state state,
             std::chrono::seconds timeout_seconds, rs2_update_progress_callback_sptr update_progress_callback) const;
         virtual void dfu_manifest_phase(const platform::rs_usb_messenger& messenger, rs2_update_progress_callback_sptr update_progress_callback) const override;
-        float compute_progress(float progress, float start, float end, float threshold) const override;
 
     private:
-        std::string parse_serial_number(const std::vector<uint8_t>& buffer) const;
         void report_progress_and_wait_for_fw_burn(rs2_update_progress_callback_sptr update_progress_callback, int required_dfu_time) const;
         // The following data member _is_dfu_monitoring_enabled is needed to perform DFU when
         // the DFU monitoring is not enabled by FW, for D500 device.

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -160,7 +160,6 @@ namespace librealsense
 
     float update_device::compute_progress(float progress, float start, float end, float threshold) const
     {
-        // NOTE: this is usually overriden; see derived classes!
         if( threshold > 1.f )
             progress = ceil( progress * threshold ) / threshold;
         return start + progress * (end - start);

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -11,6 +11,7 @@
 #include <rsutils/time/stopwatch.h>
 
 #include <chrono>
+#include <iomanip>
 #include <stdexcept>
 #include <algorithm>
 #include <thread>
@@ -93,6 +94,18 @@ namespace librealsense
                   << "\n\tDFU version is: " << payload.dfu_version
                   << "\n\tPrevious version: " << _last_fw_version
                   << "\n\tHighest ever installed: " << _highest_fw_version );
+    }
+
+    std::string update_device::parse_serial_number(const std::vector<uint8_t>& buffer) const
+    {
+        if (buffer.size() != sizeof(serial_number_data))
+            throw std::runtime_error("DFU - failed to parse serial number!");
+
+        std::stringstream rv;
+        for (size_t i = 0; i < sizeof(serial_number_data::serial); i++)
+            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(buffer[i]);
+
+        return rv.str();
     }
 
     std::ostream & operator<<( std::ostream & os, rs2_dfu_state state )

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -279,21 +279,27 @@ namespace librealsense
 
     void update_device::dfu_manifest_phase(const platform::rs_usb_messenger& messenger, rs2_update_progress_callback_sptr update_progress_callback) const
     {
-        // After the zero length DFU_DNLOAD request terminates the Transfer
-        // phase, the device is ready to manifest the new firmware. As described
-        // previously, some devices may accumulate the firmware image and perform
-        // the entire reprogramming operation at one time. Others may have only a
-        // small amount remaining to be reprogrammed, and still others may have
-        // none. Regardless, the device enters the dfuMANIFEST-SYNC state and
-        // awaits the solicitation of the status report by the host. Upon receipt
-        // of the anticipated DFU_GETSTATUS, the device enters the dfuMANIFEST
-        // state, where it completes its reprogramming operations.
+        // Manifestation phase: the device programs the new firmware, then either holds dfuMANIFEST-WAIT-RESET (manifestation-tolerant)
+        // or resets itself immediately (per USB DFU 1.1). Reaching WAIT_RESET or losing the device (control-transfer failure)
+        // both mean success; only an explicit DFU error state is a failure.
+        auto start = std::chrono::system_clock::now();
+        while (true)
+        {
+            dfu_status_payload status;
+            uint32_t transferred = 0;
+            auto sts = messenger->control_transfer(0xa1 /*DFU_GETSTATUS_PACKET*/, RS2_DFU_GET_STATUS, 0, 0, (uint8_t*)&status, sizeof(status), transferred, 5000);
 
-        // WaitForDFU state sends several DFU_GETSTATUS requests, until we hit
-        // either RS2_DFU_STATE_DFU_MANIFEST_WAIT_RESET or RS2_DFU_STATE_DFU_ERROR status.
-        // This command also reset the device
-        if (!wait_for_state(messenger, RS2_DFU_STATE_DFU_MANIFEST_WAIT_RESET, 20000))
-            throw std::runtime_error("Firmware manifest failed");
+            if (sts != platform::RS2_USB_STATUS_SUCCESS)   // device reset after manifestation
+                return;
+            if (status.is_in_state(RS2_DFU_STATE_DFU_MANIFEST_WAIT_RESET))
+                return;
+            if (status.is_error_state())
+                throw std::runtime_error("Firmware manifest failed with an error");
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(DEFAULT_TIMEOUT));
+            if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start) >= std::chrono::milliseconds(20000))
+                throw std::runtime_error("Firmware manifest failed. Timeout waiting for device reset.");
+        }
     }
 
     void update_device::update_mipi(const void* fw_image, int fw_image_size, rs2_update_progress_callback_sptr update_progress_callback) const

--- a/src/fw-update/fw-update-device.h
+++ b/src/fw-update/fw-update-device.h
@@ -161,6 +161,7 @@ namespace librealsense
         bool wait_for_state(std::shared_ptr<platform::usb_messenger> messenger, const rs2_dfu_state state, size_t timeout = 1000) const;
         virtual void dfu_manifest_phase(const platform::rs_usb_messenger& messenger, rs2_update_progress_callback_sptr update_progress_callback) const;
         void read_device_info(std::shared_ptr<platform::usb_messenger> messenger);
+        std::string parse_serial_number(const std::vector<uint8_t>& buffer) const;
 
         const std::string & get_name() const { return _name; }
         const std::string & get_product_line() const { return _product_line; }


### PR DESCRIPTION
Tracked on [RSDEV-12696]

According to DFU spec 1.1 it is valid for a device to reset without waiting for next status query from host
