### PR TITLE
Inference and some embedded filters are mutual exclusive

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -383,6 +383,27 @@ namespace rs2
         }
     }
 
+    bool device_model::is_inference_streaming()
+    {
+        for( auto const & sub : subdevices )
+            if( sub->streaming && subdevice_has_inference_stream_enabled( *sub ) )
+                return true;
+        return false;
+    }
+
+    bool device_model::is_inference_blocking_filter_enabled() const
+    {
+        for( auto const & sub : subdevices )
+            for( auto const & ef : sub->embedded_filters )
+            {
+                auto type = ef->get_filter()->get_type();
+                if( ( type == RS2_EMBEDDED_FILTER_TYPE_DECIMATION || type == RS2_EMBEDDED_FILTER_TYPE_TEMPORAL )
+                    && ef->is_enabled() )
+                    return true;
+            }
+        return false;
+    }
+
     void device_model::play_defaults(viewer_model& viewer)
     {
         if (!dev_syncer)
@@ -2523,8 +2544,11 @@ namespace rs2
                         }
                         if (can_stream)
                         {
-                            // Disable the start button for inference streams unless color and depth are already streaming.
-                            bool disable_inference = subdevice_has_inference_stream_enabled( *sub ) && ! are_color_and_depth_streaming();
+                            // Disable the start button for inference streams unless color and depth are already
+                            // streaming, and while a decimation/temporal embedded filter is enabled (mutually exclusive).
+                            bool sub_has_inference = subdevice_has_inference_stream_enabled( *sub );
+                            bool blocking_filter_enabled = sub_has_inference && is_inference_blocking_filter_enabled();
+                            bool disable_inference = ( sub_has_inference && ! are_color_and_depth_streaming() ) || blocking_filter_enabled;
                             if( disable_inference )
                                 ImGui::BeginDisabled();
 
@@ -2565,7 +2589,9 @@ namespace rs2
                             {
                                 ImGui::EndDisabled();
                                 if( ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
-                                    RsImGui::CustomTooltip( "Color and Depth streams must be streaming before starting inference" );
+                                    RsImGui::CustomTooltip( blocking_filter_enabled
+                                        ? "Disable the decimation/temporal embedded filter before starting inference (cannot run together)"
+                                        : "Color and Depth streams must be streaming before starting inference" );
                             }
                             else if (ImGui::IsItemHovered())
                             {
@@ -3031,7 +3057,13 @@ namespace rs2
                         ImGui::SetCursorPos({ windows_width - 42, pos.y - 3 });
 
                         const bool pb_available = pb->is_available();
-                        disable_guard dg( !pb_available );
+                        // Block turning a decimation/temporal filter on while inference streams (mutually exclusive).
+                        auto ef_type = pb->get_filter()->get_type();
+                        const bool block_enable_while_inference = !pb->is_enabled()
+                            && ( ef_type == RS2_EMBEDDED_FILTER_TYPE_DECIMATION
+                              || ef_type == RS2_EMBEDDED_FILTER_TYPE_TEMPORAL )
+                            && is_inference_streaming();
+                        disable_guard dg( !pb_available || block_enable_while_inference );
                         try
                         {
                             ImGui::PushFont(window.get_font());
@@ -3089,6 +3121,8 @@ namespace rs2
                             if( !pb_available && !pb->unavailable_tooltip.empty()
                                 && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
                                 RsImGui::CustomTooltip( "%s", pb->unavailable_tooltip.c_str() );
+                            else if( block_enable_while_inference && ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
+                                RsImGui::CustomTooltip( "Stop the inference stream before enabling this filter (cannot run together)" );
 
                             ImGui::PopStyleColor(5);
                             ImGui::PopFont();

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -343,7 +343,7 @@ namespace rs2
         }
     }
 
-    bool device_model::subdevice_has_inference_stream_enabled( const subdevice_model & sub )
+    bool device_model::subdevice_has_inference_stream_enabled( const subdevice_model & sub ) const
     {
         for( auto const & kv : sub.stream_enabled )
         {
@@ -383,7 +383,7 @@ namespace rs2
         }
     }
 
-    bool device_model::is_inference_streaming()
+    bool device_model::is_inference_streaming() const
     {
         for( auto const & sub : subdevices )
             if( sub->streaming && subdevice_has_inference_stream_enabled( *sub ) )

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -361,11 +361,11 @@ namespace rs2
 
         bool show_advanced_mode_popup = false;
         
-        bool subdevice_has_inference_stream_enabled( const subdevice_model & sub );
+        bool subdevice_has_inference_stream_enabled( const subdevice_model & sub ) const;
         bool are_color_and_depth_streaming() const;
         void stop_inference_if_video_stopped( viewer_model & viewer );
         // Inference and the decimation/temporal embedded filters are mutually exclusive.
-        bool is_inference_streaming();
+        bool is_inference_streaming() const;
         bool is_inference_blocking_filter_enabled() const;
 
         void draw_info_icon(ux_window& window, ImFont* font, const ImVec2& size);

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -364,6 +364,9 @@ namespace rs2
         bool subdevice_has_inference_stream_enabled( const subdevice_model & sub );
         bool are_color_and_depth_streaming() const;
         void stop_inference_if_video_stopped( viewer_model & viewer );
+        // Inference and the decimation/temporal embedded filters are mutually exclusive.
+        bool is_inference_streaming();
+        bool is_inference_blocking_filter_enabled() const;
 
         void draw_info_icon(ux_window& window, ImFont* font, const ImVec2& size);
         int draw_seek_bar();

--- a/src/dds/rs-dds-embedded-decimation-filter.cpp
+++ b/src/dds/rs-dds-embedded-decimation-filter.cpp
@@ -65,6 +65,9 @@ namespace librealsense {
                 json option_with_value = dds_option_to_name_and_value_json(option, value);
                 // validate values
                 validate_filter_option(option_with_value);
+                // Let owner reject turning the filter on, or add some other pre-activation logic
+                if (_activation_guard && option->get_name() == TOGGLE_OPTION_NAME && value.get<double>() != 0.)
+                    _activation_guard();
                 // set updated options to the remote device
                 _set_ef_cb(option_with_value);
                 // Delegate to DDS filter

--- a/src/dds/rs-dds-embedded-filter.h
+++ b/src/dds/rs-dds-embedded-filter.h
@@ -24,12 +24,17 @@ class rs_dds_embedded_filter
 public:
     typedef std::function< void( rsutils::json value ) > set_embedded_filter_callback;
     typedef std::function< rsutils::json() > query_embedded_filter_callback;
+    // Invoked right before the filter is turned on, lets the owner reject activation.
+    typedef std::function< void() > activation_guard_callback;
     virtual void add_option(std::shared_ptr< realdds::dds_option > option) = 0;
+
+    void set_activation_guard( activation_guard_callback cb ) { _activation_guard = std::move( cb ); }
 
 protected:
     std::shared_ptr< realdds::dds_embedded_filter > _dds_ef;
     set_embedded_filter_callback _set_ef_cb;
     query_embedded_filter_callback _query_ef_cb;
+    activation_guard_callback _activation_guard;
 
 public:
     rs_dds_embedded_filter( const std::shared_ptr< realdds::dds_embedded_filter > & dds_embedded_filter, 

--- a/src/dds/rs-dds-embedded-temporal-filter.cpp
+++ b/src/dds/rs-dds-embedded-temporal-filter.cpp
@@ -72,6 +72,9 @@ namespace librealsense {
                 json option_with_value = dds_option_to_name_and_value_json( option, value );
                 // validate values
                 validate_filter_option( option_with_value );
+                // Let owner reject turning the filter on, or add some other pre-activation logic
+                if( _activation_guard && option->get_name() == TOGGLE_OPTION_NAME && value.get< double >() != 0. )
+                    _activation_guard();
                 // set updated options to the remote device
                 _set_ef_cb( option_with_value );
                 // Delegate to DDS filter

--- a/src/dds/rs-dds-inference-sensor-proxy.h
+++ b/src/dds/rs-dds-inference-sensor-proxy.h
@@ -12,7 +12,7 @@ namespace librealsense {
 // For cases when checking if this is< inference_sensor >
 class dds_inference_sensor_proxy
     : public dds_sensor_proxy
-    , public inference_sensor
+    , public virtual inference_sensor
 {
 public:
     dds_inference_sensor_proxy( std::string const & sensor_name,

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -321,8 +321,10 @@ void dds_sensor_proxy::open( const stream_profiles & profiles )
 {
     if( Is< inference_sensor >( this ) )
     {
-        if( auto dev = dynamic_cast< device * >( &get_device() ) )
-            dev->throw_if_inference_blocking_filter_enabled();
+        auto dev = dynamic_cast< device * >( &get_device() );
+        if( ! dev )
+            throw invalid_value_exception( "inference sensor's owner is not a device" );
+        dev->throw_if_inference_blocking_filter_enabled();
     }
 
     _active_converted_profiles = profiles;
@@ -1010,12 +1012,11 @@ void dds_sensor_proxy::add_embedded_filter( std::shared_ptr< realdds::dds_embedd
             {
                 return _dev->query_embedded_filter(embedded_filter);
             });
-        filter->set_activation_guard(
-            [this]()
-            {
-                if( auto dev = dynamic_cast< device * >( &get_device() ) )
-                    dev->throw_if_inference_active();
-            } );
+        // Capture the owning device (which outlives this sensor, hence the filter) rather than 'this'.
+        auto owning_device = dynamic_cast< device * >( &get_device() );
+        if( ! owning_device )
+            throw invalid_value_exception( "embedded filter's owner is not a device" );
+        filter->set_activation_guard( [owning_device]() { owning_device->throw_if_inference_active(); } );
         rs_embedded_filter = filter;
     }
     else if (auto temporal_filter = std::dynamic_pointer_cast< dds_temporal_filter >(embedded_filter))
@@ -1031,12 +1032,11 @@ void dds_sensor_proxy::add_embedded_filter( std::shared_ptr< realdds::dds_embedd
             {
                 return _dev->query_embedded_filter(embedded_filter);
             });
-        filter->set_activation_guard(
-            [this]()
-            {
-                if( auto dev = dynamic_cast< device * >( &get_device() ) )
-                    dev->throw_if_inference_active();
-            } );
+        // Capture the owning device (which outlives this sensor, hence the filter) rather than 'this'.
+        auto owning_device = dynamic_cast< device * >( &get_device() );
+        if( ! owning_device )
+            throw invalid_value_exception( "embedded filter's owner is not a device" );
+        filter->set_activation_guard( [owning_device]() { owning_device->throw_if_inference_active(); } );
         rs_embedded_filter = filter;
     }
     else if (auto close_range_filter = std::dynamic_pointer_cast< dds_close_range_filter >(embedded_filter))

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -319,6 +319,12 @@ realdds::dds_stream_profiles dds_sensor_proxy::find_dds_profiles( const libreals
 
 void dds_sensor_proxy::open( const stream_profiles & profiles )
 {
+    if( Is< inference_sensor >( this ) )
+    {
+        if( auto dev = dynamic_cast< device * >( &get_device() ) )
+            dev->throw_if_inference_blocking_filter_enabled();
+    }
+
     _active_converted_profiles = profiles;
     auto source_profiles = profiles; // Start with user requested profiles
     if( get_format_conversion() != format_conversion::raw )
@@ -993,7 +999,7 @@ void dds_sensor_proxy::add_embedded_filter( std::shared_ptr< realdds::dds_embedd
     std::shared_ptr< embedded_filter_interface > rs_embedded_filter = nullptr;
     if (auto decimation_filter = std::dynamic_pointer_cast< dds_decimation_filter >(embedded_filter) )
     {
-        rs_embedded_filter = std::make_shared< rs_dds_embedded_decimation_filter >(
+        auto filter = std::make_shared< rs_dds_embedded_decimation_filter >(
             embedded_filter,
             [=](json options_value)
             {
@@ -1004,10 +1010,17 @@ void dds_sensor_proxy::add_embedded_filter( std::shared_ptr< realdds::dds_embedd
             {
                 return _dev->query_embedded_filter(embedded_filter);
             });
+        filter->set_activation_guard(
+            [this]()
+            {
+                if( auto dev = dynamic_cast< device * >( &get_device() ) )
+                    dev->throw_if_inference_active();
+            } );
+        rs_embedded_filter = filter;
     }
     else if (auto temporal_filter = std::dynamic_pointer_cast< dds_temporal_filter >(embedded_filter))
     {
-        rs_embedded_filter = std::make_shared< rs_dds_embedded_temporal_filter >(
+        auto filter = std::make_shared< rs_dds_embedded_temporal_filter >(
             embedded_filter,
             [=](json options_value)
             {
@@ -1018,6 +1031,13 @@ void dds_sensor_proxy::add_embedded_filter( std::shared_ptr< realdds::dds_embedd
             {
                 return _dev->query_embedded_filter(embedded_filter);
             });
+        filter->set_activation_guard(
+            [this]()
+            {
+                if( auto dev = dynamic_cast< device * >( &get_device() ) )
+                    dev->throw_if_inference_active();
+            } );
+        rs_embedded_filter = filter;
     }
     else if (auto close_range_filter = std::dynamic_pointer_cast< dds_close_range_filter >(embedded_filter))
     {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -140,6 +140,10 @@ bool device::is_inference_active() const
             continue;
         if( s.is_streaming() )
             return true;
+        // An inference sensor that is opened but not yet streaming is already "active" for our purposes
+        auto sb = dynamic_cast< const sensor_base * >( &s );  // is_opened() is not on sensor_interface
+        if( sb && sb->is_opened() )
+            return true;
     }
     return false;
 }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -10,6 +10,10 @@
 #include "sync.h"
 #include "context.h"  // rs2_device_info
 #include "core/sensor-interface.h"
+#include "sensor.h"  // sensor_base::is_opened
+#include "inference-sensor.h"
+#include "core/supported-embedded-filters-interface.h"
+#include "librealsense-exception.h"
 
 #include <rsutils/string/from.h>
 #include <rsutils/json.h>
@@ -125,6 +129,52 @@ sensor_interface& device::get_sensor(size_t subdevice)
     {
         throw invalid_value_exception("invalid subdevice value");
     }
+}
+
+bool device::is_inference_active() const
+{
+    for( size_t i = 0; i < _sensors.size(); ++i )
+    {
+        auto & s = *_sensors[i];
+        if( ! Is< inference_sensor >( &s ) )
+            continue;
+        if( s.is_streaming() )
+            return true;
+    }
+    return false;
+}
+
+bool device::is_inference_blocking_filter_enabled() const
+{
+    for( size_t i = 0; i < _sensors.size(); ++i )
+    {
+        auto supported = As< supported_embedded_filters_interface >( _sensors[i].get() );
+        if( ! supported )
+            continue;
+        for( auto & filter : supported->get_supported_embedded_filters() )
+        {
+            auto type = filter->get_type();
+            if( type != RS2_EMBEDDED_FILTER_TYPE_DECIMATION && type != RS2_EMBEDDED_FILTER_TYPE_TEMPORAL )
+                continue;
+            if( filter->supports_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED )
+                && filter->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ).query() != 0.f )
+                return true;
+        }
+    }
+    return false;
+}
+
+void device::throw_if_inference_active() const
+{
+    if( is_inference_active() )
+        throw wrong_api_call_sequence_exception( "Cannot enable the embedded filter while inference stream is active" );
+}
+
+void device::throw_if_inference_blocking_filter_enabled() const
+{
+    if( is_inference_blocking_filter_enabled() )
+        throw wrong_api_call_sequence_exception( "Cannot start inference stream while embedded decimation or temporal filter is enabled; "
+            "they cannot run at the same time. Disable the embedded filter first." );
 }
 
 size_t device::find_sensor_idx(const sensor_interface& s) const

--- a/src/device.h
+++ b/src/device.h
@@ -92,6 +92,12 @@ public:
 
     format_conversion get_format_conversion() const;
 
+    // Inference and some embedded filters cannot run at the same time. These functions help reject the conflicting combination.
+    bool is_inference_active() const;
+    bool is_inference_blocking_filter_enabled() const;
+    void throw_if_inference_active() const;
+    void throw_if_inference_blocking_filter_enabled() const;
+
 protected:
     int add_sensor(const std::shared_ptr<sensor_interface>& sensor_base);
     int assign_sensor(const std::shared_ptr<sensor_interface>& sensor_base, uint8_t idx);

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -119,6 +119,8 @@ namespace librealsense
 
     void d500_object_detection_sensor::start( rs2_frame_callback_sptr callback )
     {
+        // Inference and some embedded filters are mutually exclusive and cannot run together.
+        _owner->throw_if_inference_blocking_filter_enabled();
         // TODO: FW does not yet support the Align_Depth XU — re-enable once FW is ready.
         // set_align_depth_xu( _owner->get_raw_depth_sensor(), true );
         synthetic_sensor::start( callback );

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -117,10 +117,15 @@ namespace librealsense
         catch( ... )                       { LOG_WARNING( "Align_Depth XU: unknown exception" ); }
     }
 
+    void d500_object_detection_sensor::open( const stream_profiles & requests )
+    {
+        // Inference and some embedded filters cannot run together. Reject here before the device is touched.
+        _owner->throw_if_inference_blocking_filter_enabled();
+        synthetic_sensor::open( requests );
+    }
+
     void d500_object_detection_sensor::start( rs2_frame_callback_sptr callback )
     {
-        // Inference and some embedded filters are mutually exclusive and cannot run together.
-        _owner->throw_if_inference_blocking_filter_enabled();
         // TODO: FW does not yet support the Align_Depth XU — re-enable once FW is ready.
         // set_align_depth_xu( _owner->get_raw_depth_sensor(), true );
         synthetic_sensor::start( callback );

--- a/src/ds/d500/d500-object-detection.h
+++ b/src/ds/d500/d500-object-detection.h
@@ -47,6 +47,7 @@ namespace librealsense
         }
 
         stream_profiles init_stream_profiles() override;
+        void open( const stream_profiles & requests ) override;
         void start( rs2_frame_callback_sptr callback ) override;
         void stop() override;
 

--- a/src/inference-sensor.h
+++ b/src/inference-sensor.h
@@ -18,7 +18,7 @@ MAP_EXTENSION( RS2_EXTENSION_INFERENCE_SENSOR, librealsense::inference_sensor );
 
 
 
-class object_detection_sensor
+class object_detection_sensor : public virtual inference_sensor
 {
 public:
     virtual ~object_detection_sensor() = default;

--- a/unit-tests/live/d500/pytest-mutual-exclusions.py
+++ b/unit-tests/live/d500/pytest-mutual-exclusions.py
@@ -127,6 +127,24 @@ def test_blocking_filter_rejected_when_inference_active(depth_sensor, inference_
     embedded_filter.set_option( ENABLED, 0.0 )
 
 
+@pytest.mark.parametrize( "filter_type", BLOCKING_FILTERS )
+def test_blocking_filter_rejected_when_inference_opened_not_streaming(depth_sensor, inference_sensor,
+                                                                      inference_profile, filter_type):
+    # Covers the open()->start() window: the inference sensor is opened but not yet streaming. Enabling a blocking
+    # filter in that window must still be rejected, otherwise the subsequent start() would leave both active.
+    embedded_filter = get_embedded_filter_or_skip( depth_sensor, filter_type )
+    try:
+        inference_sensor.open( inference_profile )  # opened, not started
+    except RuntimeError as e:
+        pytest.skip( f"Inference stream not openable on this device: {e}" )
+    try:
+        with pytest.raises( RuntimeError ):
+            embedded_filter.set_option( ENABLED, 1.0 )
+        check.equal( embedded_filter.get_option( ENABLED ), 0.0 )
+    finally:
+        inference_sensor.close()
+
+
 @pytest.mark.parametrize( "filter_type", NON_BLOCKING_FILTERS )
 def test_non_blocking_filter_and_inference_coexist(depth_sensor, inference_sensor, inference_profile, filter_type):
     embedded_filter = get_embedded_filter_or_skip( depth_sensor, filter_type )

--- a/unit-tests/live/d500/pytest-mutual-exclusions.py
+++ b/unit-tests/live/d500/pytest-mutual-exclusions.py
@@ -1,0 +1,147 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Mutual exclusion between the inference stream and embedded filters.
+#
+# The decimation and temporal embedded filters cannot run at the same time as the
+# inference stream, so the SDK rejects the conflicting combination in either order with
+# a user-friendly (wrong-api-call-sequence) error, surfaced as a RuntimeError through
+# the Python API. Other ("non-blocking") embedded filters, e.g. improved close range,
+# are not restricted and can run alongside inference.
+#
+# The test adapts to the device at runtime: it skips when the inference stream or a
+# given embedded filter is not present, rather than gating on firmware versions.
+
+import pytest
+import pyrealsense2 as rs
+from pytest_check import check
+import logging
+log = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.device_each( "D555", "D585" ),
+    pytest.mark.context( "nightly" ),
+]
+
+
+# Embedded filters that are mutually exclusive with the inference stream.
+BLOCKING_FILTERS = [
+    rs.embedded_filter_type.decimation,
+    rs.embedded_filter_type.temporal,
+]
+
+# Embedded filters that may run alongside the inference stream.
+NON_BLOCKING_FILTERS = [
+    rs.embedded_filter_type.improved_close_range_depth,
+]
+
+ENABLED = rs.option.embedded_filter_enabled
+
+
+@pytest.fixture
+def depth_sensor(test_device):
+    dev, _ = test_device
+    return dev.first_depth_sensor()
+
+
+@pytest.fixture
+def inference_sensor(test_device):
+    dev, _ = test_device
+    try:
+        return dev.first_inference_sensor()  # throws if the device has no inference sensor
+    except RuntimeError:
+        pytest.skip( "Device has no inference sensor" )
+
+
+@pytest.fixture
+def inference_profile(inference_sensor):
+    profile = next( ( p for p in inference_sensor.get_stream_profiles()
+                      if p.stream_type() == rs.stream.object_detection ), None )
+    if profile is None:
+        pytest.skip( "Inference sensor has no object-detection profile" )
+    return profile
+
+
+def get_embedded_filter_or_skip(depth_sensor, filter_type):
+    # get_embedded_filter throws (rather than returning falsy) when the filter is not present.
+    try:
+        return depth_sensor.get_embedded_filter( filter_type )
+    except Exception:
+        pytest.skip( f"Embedded filter {filter_type} not present on this device" )
+
+
+def require_inference_openable(inference_sensor, inference_profile):
+    # The rejection tests are only meaningful if the inference stream opens standalone;
+    # otherwise we cannot tell our guard apart from an unrelated open failure.
+    try:
+        inference_sensor.open( inference_profile )
+        inference_sensor.close()
+    except RuntimeError as e:
+        pytest.skip( f"Inference stream not openable on this device: {e}" )
+
+
+def require_inference_started(inference_sensor, inference_profile):
+    # An inference sensor that exists must be startable - a failure here is a real error, not a skip.
+    inference_sensor.open( inference_profile )
+    try:
+        inference_sensor.start( lambda f: None )
+    except Exception:
+        inference_sensor.close()  # start never took effect; undo the open before propagating
+        raise
+
+
+@pytest.mark.parametrize( "filter_type", BLOCKING_FILTERS )
+def test_inference_rejected_when_blocking_filter_enabled(depth_sensor, inference_sensor, inference_profile, filter_type):
+    require_inference_openable( inference_sensor, inference_profile )
+    embedded_filter = get_embedded_filter_or_skip( depth_sensor, filter_type )
+
+    embedded_filter.set_option( ENABLED, 1.0 )
+    try:
+        # The guard runs before the device is touched, so opening must fail here.
+        with pytest.raises( RuntimeError ):
+            inference_sensor.open( inference_profile )
+    finally:
+        embedded_filter.set_option( ENABLED, 0.0 )
+
+    # With the filter disabled the same open succeeds again - proving the filter was the cause.
+    inference_sensor.open( inference_profile )
+    inference_sensor.close()
+
+
+@pytest.mark.parametrize( "filter_type", BLOCKING_FILTERS )
+def test_blocking_filter_rejected_when_inference_active(depth_sensor, inference_sensor, inference_profile, filter_type):
+    embedded_filter = get_embedded_filter_or_skip( depth_sensor, filter_type )
+    require_inference_started( inference_sensor, inference_profile )
+    try:
+        # Enabling the filter while inference streams is rejected, and the value stays off.
+        with pytest.raises( RuntimeError ):
+            embedded_filter.set_option( ENABLED, 1.0 )
+        check.equal( embedded_filter.get_option( ENABLED ), 0.0 )
+    finally:
+        inference_sensor.stop()
+        inference_sensor.close()
+
+    # Once inference stops, enabling the filter is allowed again.
+    embedded_filter.set_option( ENABLED, 1.0 )
+    embedded_filter.set_option( ENABLED, 0.0 )
+
+
+@pytest.mark.parametrize( "filter_type", NON_BLOCKING_FILTERS )
+def test_non_blocking_filter_and_inference_coexist(depth_sensor, inference_sensor, inference_profile, filter_type):
+    embedded_filter = get_embedded_filter_or_skip( depth_sensor, filter_type )
+    initial = embedded_filter.get_option( ENABLED )
+
+    embedded_filter.set_option( ENABLED, 1.0 )
+    try:
+        # Inference can start while the non-blocking filter is enabled...
+        require_inference_started( inference_sensor, inference_profile )
+        try:
+            # ...and the non-blocking filter can be toggled while inference streams.
+            embedded_filter.set_option( ENABLED, 0.0 )
+            embedded_filter.set_option( ENABLED, 1.0 )
+        finally:
+            inference_sensor.stop()
+            inference_sensor.close()
+    finally:
+        embedded_filter.set_option( ENABLED, initial )

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -28,6 +28,7 @@ void init_device(py::module &m) {
         .def("first_motion_sensor", [](rs2::device& self) { return self.first<rs2::motion_sensor>(); }) // No docstring in C++
         .def("first_fisheye_sensor", [](rs2::device& self) { return self.first<rs2::fisheye_sensor>(); }) // No docstring in C++
         .def("first_safety_sensor", [](rs2::device& self) { return self.first<rs2::safety_sensor>(); }) // No docstring in C++
+        .def("first_inference_sensor", [](rs2::device& self) { return self.first<rs2::inference_sensor>(); }) // No docstring in C++
         .def("supports", &rs2::device::supports, "Check if specific camera info is supported.", "info"_a)
         .def("get_info", &rs2::device::get_info, "Retrieve camera specific information, "
              "like versions of various internal components", "info"_a)


### PR DESCRIPTION
Tracked on [RSDEV-12358]

The inference stream and the decimation/temporal embedded filters cannot run at the same time. The SDK now rejects the conflicting combination in both directions with a clear wrong_api_call_sequence error:

The rule lives on the common device base, so it covers both DDS (D555) and USB (D585). object_detection_sensor now inherits inference_sensor so any inference sensor is detected uniformly. The Viewer greys out the conflicting activation controls (with tooltips) rather than letting the user hit the error.
Also adds a first_inference_sensor() Python binding and a new pytest-mutual-exclusions.py live test.