### PR TITLE
unit-tests: --rslog works for every test and --repeat pass

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -58,7 +58,7 @@ from rspy.signals import register_signal_handlers
 from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
     open_log, close_log, _compose_log_name, print_terminal_summary,
-    configure_junit_logging,
+    configure_junit_logging, install_rs_log_bridge,
 )
 from rspy.pytest.log_live_format import install as install_live_log_format
 from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
@@ -144,7 +144,7 @@ def pytest_addoption(parser):
         "--rslog",
         action="store_true",
         default=False,
-        help="Enable LibRS debug logging (rs.log_to_console)."
+        help="Enable LibRS debug logging (routed into the per-test log files)."
     )
     group.addoption(
         "--no-reset",
@@ -279,14 +279,12 @@ def pytest_configure(config):
     # Set up test log directory
     setup_test_logging(config)
 
-    # Enable LibRS debug logging if --rslog (once, globally)
-    # log_to_console writes directly to stderr from C++. Pytest's default fd-level
-    # capture swallows it, so we downgrade to sys-level capture (Python only) which
-    # lets C++ stderr through while still capturing Python stdout/stderr.
+    # Enable LibRS debug logging if --rslog (once, globally). Route the C++ logs through
+    # Python logging so they reach the per-test log files (and console under -s) for every
+    # test and every --repeat/--count pass -- see install_rs_log_bridge for why log_to_console
+    # (fd-level, swallowed by pytest's default capture) only ever showed the first enumeration.
     if rs and config.getoption("--rslog", default=False):
-        rs.log_to_console(rs.log_severity.debug)
-        if config.option.capture == 'fd':
-            config.option.capture = 'sys'
+        install_rs_log_bridge(rs)
 
     # Test discovery defaults (replaces pytest.ini which is .gitignored)
     config.addinivalue_line("python_files", "pytest-*.py")

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -26,9 +26,15 @@ def _mock_log_to_console(level):
     _tracking["rslog_calls"].append({"level": level})
     _save_tracking()
 _rs.log_to_console = _mock_log_to_console
+class _FakeLogMessage:
+    def raw(self):
+        return "fake librs log line"
 def _mock_log_to_callback(level, callback):
     _tracking["rslog_calls"].append({"level": level})
     _save_tracking()
+    # Exercise the routing path (callback fires -> Python logger receives the record),
+    # not just the registration, so the bridge itself is covered by the E2E test.
+    callback(level, _FakeLogMessage())
 _rs.log_to_callback = _mock_log_to_callback
 class _CameraInfo:
     name = "name"

--- a/unit-tests/infra-tests/e2e/e2e_conftest.py
+++ b/unit-tests/infra-tests/e2e/e2e_conftest.py
@@ -12,7 +12,7 @@ _py_dir = os.path.join(_unit_tests_dir, 'py')
 if _py_dir not in sys.path:
     sys.path.insert(0, _py_dir)
 
-# Fake pyrealsense2 — track log_to_console calls so tests can verify --rslog
+# Fake pyrealsense2 — track LibRS log-bridge calls so tests can verify --rslog
 import json as _json
 _tracking_log = os.path.join(os.path.dirname(os.path.abspath(__file__)), '_tracking.json')
 _tracking = {"rslog_calls": [], "query_kwargs": [], "enable_only_calls": [], "disable_calls": []}
@@ -26,6 +26,10 @@ def _mock_log_to_console(level):
     _tracking["rslog_calls"].append({"level": level})
     _save_tracking()
 _rs.log_to_console = _mock_log_to_console
+def _mock_log_to_callback(level, callback):
+    _tracking["rslog_calls"].append({"level": level})
+    _save_tracking()
+_rs.log_to_callback = _mock_log_to_callback
 class _CameraInfo:
     name = "name"
     product_line = "product_line"
@@ -34,6 +38,10 @@ class _CameraInfo:
 _rs.camera_info = _CameraInfo
 class _LogSeverity:
     debug = 0
+    info = 1
+    warn = 2
+    error = 3
+    fatal = 4
 _rs.log_severity = _LogSeverity
 class _FakeContext:
     @property

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -50,7 +50,7 @@ class TestCliOptionsRegistered:
         assert "timeout method: thread" in out
 
     def test_rslog(self):
-        """--rslog should call rs.log_to_console."""
+        """--rslog should install the LibRS log bridge (rs.log_to_callback)."""
         rc, out, tracking = run_e2e("pytest-passthrough.py", "--rslog")
         assert rc == 0
         assert len(tracking["rslog_calls"]) > 0

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -47,15 +47,21 @@ _rs_log_callback = None
 
 
 def install_rs_log_bridge(rs):
-    """Route LibRS (C++) logs into the 'librealsense' Python logger so they land in the
-    per-test log files (and pytest's captured-log reports) for every test -- including each
-    ``--repeat``/``--count`` pass.
+    """Route LibRS (C++) logs into a dedicated ``librealsense.rs`` Python logger so they land
+    in the per-test log files (and pytest's captured-log reports) for every test -- including
+    each ``--repeat``/``--count`` pass.
 
     Uses ``log_to_callback`` rather than ``log_to_console``: the latter writes at the fd
     level, which pytest's default ``fd`` capture swallows, so only the pre-test device
     enumeration (emitted before per-test capture starts) ever reached the console. Routing
     through Python logging is capture-method agnostic and, with ``-s``, still streams live
-    to the console via the log_cli handler."""
+    to the console via the log_cli handler.
+
+    A DEDICATED child logger (not the shared ``librealsense`` logger) is set to DEBUG so
+    --rslog surfaces LibRS debug lines regardless of --debug -- matching the legacy
+    run-unit-tests.py behavior, where --rslog and --debug were independent -- WITHOUT lowering
+    the shared logger and leaking every other test's DEBUG output. Its records still propagate
+    up to the root FileHandler (propagation is gated only by the originating logger's level)."""
     global _rs_log_callback
     if _rs_log_callback is not None:
         return
@@ -66,16 +72,18 @@ def install_rs_log_bridge(rs):
         rs.log_severity.error: logging.ERROR,
         rs.log_severity.fatal: logging.CRITICAL,
     }
+    rs_log = logging.getLogger('librealsense.rs')
 
     def _callback(severity, message):
         try:
-            log.log(level_map.get(severity, logging.DEBUG), message.raw())
+            # Older pyrealsense2 builds may hand the callback a plain str instead of a
+            # log-message object; fall back to str() so the message still gets through.
+            text = message.raw() if hasattr(message, 'raw') else str(message)
+            rs_log.log(level_map.get(severity, logging.DEBUG), text)
         except Exception:
             pass  # never let a logging callback break a test
 
-    # DEBUG so --rslog surfaces LibRS debug lines even without --debug (the FileHandler is
-    # also DEBUG; the logger level is the first gate a record must pass).
-    log.setLevel(logging.DEBUG)
+    rs_log.setLevel(logging.DEBUG)
     _rs_log_callback = _callback
     rs.log_to_callback(rs.log_severity.debug, _callback)
 

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -42,6 +42,44 @@ live_logging = False
 # --repeat/--count passes all accumulate in one file instead of overwriting each other.
 _opened_logs = set()
 
+# Keep a reference to the installed LibRS log callback so it isn't garbage-collected.
+_rs_log_callback = None
+
+
+def install_rs_log_bridge(rs):
+    """Route LibRS (C++) logs into the 'librealsense' Python logger so they land in the
+    per-test log files (and pytest's captured-log reports) for every test -- including each
+    ``--repeat``/``--count`` pass.
+
+    Uses ``log_to_callback`` rather than ``log_to_console``: the latter writes at the fd
+    level, which pytest's default ``fd`` capture swallows, so only the pre-test device
+    enumeration (emitted before per-test capture starts) ever reached the console. Routing
+    through Python logging is capture-method agnostic and, with ``-s``, still streams live
+    to the console via the log_cli handler."""
+    global _rs_log_callback
+    if _rs_log_callback is not None:
+        return
+    level_map = {
+        rs.log_severity.debug: logging.DEBUG,
+        rs.log_severity.info: logging.INFO,
+        rs.log_severity.warn: logging.WARNING,
+        rs.log_severity.error: logging.ERROR,
+        rs.log_severity.fatal: logging.CRITICAL,
+    }
+
+    def _callback(severity, message):
+        try:
+            log.log(level_map.get(severity, logging.DEBUG), message.raw())
+        except Exception:
+            pass  # never let a logging callback break a test
+
+    # DEBUG so --rslog surfaces LibRS debug lines even without --debug (the FileHandler is
+    # also DEBUG; the logger level is the first gate a record must pass).
+    log.setLevel(logging.DEBUG)
+    _rs_log_callback = _callback
+    rs.log_to_callback(rs.log_severity.debug, _callback)
+
+
 def bridge_rspy_log():
     """Wrap rspy.log.d/i/w/e to also emit via Python logging."""
     def _wrap(original_fn, py_level):


### PR DESCRIPTION
**Overview:** `--rslog` now surfaces LibRS logs for every test and every `--repeat`/`--count` pass, not just the initial device enumeration.

## Why
`--rslog` used `rs.log_to_console`, which writes at the fd level. The conftest tried to downgrade pytest capture `fd`→`sys` in `pytest_configure` to let that stderr through, but that runs too late — pytest's capture manager has already started with `fd`. So every in-test LibRS log was captured and discarded; only the one-time device enumeration (emitted before per-test capture starts) reached the console. With `--repeat`, passes 2+ showed no LibRS logs at all. The correct early hook (`pytest_load_initial_conftests`) doesn't fire from a `conftest.py`, so the capture switch can't be made to work from there.

## Summary
- Route LibRS logs into the `librealsense` Python logger via `rs.log_to_callback` instead of `log_to_console` — capture-method agnostic.
- Logs now land in the per-test `.log` files (and stream to console under `-s`) for every test and every repeat pass, at matching severity.
- `install_rs_log_bridge()` added to `logging_setup.py`; conftest calls it and drops the ineffective capture downgrade.
- E2E fake pyrealsense2 updated to mock `log_to_callback` and full severity enum.

## Test plan
- [x] `pytest pytest-rslogcheck.py --rslog --repeat 2` — LibRS marker present in the per-test log file for both `[1-2]` and `[2-2]` passes (was: 0 without `-s`).
- [x] Same with `-s` — streams live to console for both passes.
- [x] `infra-tests/test_e2e_cli_options.py` (rslog/default/repeat) — 4 passed.

Test build [14898](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/14898/)
---
🤖 Generated by AI
