### PR TITLE
unifi: reboot the switch on --hub-reset + bound a wedged send (TCP_USER_TIMEOUT)

### DIFF
--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -199,18 +199,14 @@ class UniFiSwitch(device_hub.device_hub):
         """
         return "enabled" if self.is_port_enabled(port) else "disabled"
 
-    def _force_close(self):
-        # Watchdog callback: closing the socket from another thread interrupts a
-        # wedged send/read on any OS (paramiko's channel timeouts don't cover the send).
-        try:
-            if self.client is not None:
-                self.client.close()
-        except Exception:
-            pass
-
     def _exec(self, command, timeout):
-        # One command, guarded by a watchdog that force-closes the transport if it wedges.
-        watchdog = threading.Timer(timeout, self._force_close)
+        # One command, guarded by a watchdog that force-closes the transport if it
+        # wedges. Closing the socket from another thread interrupts a stalled send/read
+        # on any OS (paramiko's channel timeouts don't cover the send). Close the
+        # paramiko client directly, not via a self method (device_hub wraps methods to
+        # re-register signal handlers, which fails off the main thread).
+        client = self.client
+        watchdog = threading.Timer(timeout, lambda: client.close())
         watchdog.start()
         stdin = stdout = stderr = None
         try:

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -75,12 +75,13 @@ def discover(ip=SWITCH_IP, ssh_username=SWITCH_SSH_USER, ssh_password=SWITCH_SSH
            # stops ACKing and the send hangs ~15min (tcp_retries2) instead of
            # failing fast so the reconnect/retry below can recover.
            sock = client.get_transport().sock
-           try:
-               tcp_user_timeout = getattr(socket, "TCP_USER_TIMEOUT", 18)
-               sock.setsockopt(socket.IPPROTO_TCP, tcp_user_timeout, CHANNEL_TIMEOUT * 1000)
-           except (OSError, AttributeError):
-               pass  # non-Linux / unsupported
            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+           # TCP_USER_TIMEOUT is Linux-only; on other platforms this cleanly no-ops.
+           if hasattr(socket, "TCP_USER_TIMEOUT"):
+               try:
+                   sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, CHANNEL_TIMEOUT * 1000)
+               except OSError:
+                   pass
            log.debug_indent()
            log.d("...", f"connected to {ip} via SSH")
            log.debug_unindent()

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -198,7 +198,7 @@ class UniFiSwitch(device_hub.device_hub):
         # paramiko client directly, not via a self method (device_hub wraps methods to
         # re-register signal handlers, which fails off the main thread).
         client = self.client
-        watchdog = threading.Timer(timeout, lambda: client.close())
+        watchdog = threading.Timer(timeout, lambda: client.close() if client is not None else None)
         watchdog.start()
         stdin = stdout = stderr = None
         try:
@@ -239,7 +239,10 @@ class UniFiSwitch(device_hub.device_hub):
             except (socket.timeout, socket.error, EOFError, paramiko.SSHException, OSError) as e:
                 last_exc = e
                 log.w(f"Command '{command}' failed: {e}")
-                self._reconnect()
+                try:
+                    self._reconnect()
+                except Exception as re:  # reconnect can raise; keep retrying / escalate to reboot
+                    last_exc = re
         if reboot_on_failure:
             log.w(f"Command '{command}' still failing; rebooting switch to recover...")
             try:

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -8,6 +8,7 @@ sys.path.append(parent_dir)
 from rspy import log
 import time
 import platform, re
+import threading
 from rspy import device_hub
 
 if __name__ == '__main__':
@@ -55,6 +56,8 @@ SWITCH_SSH_PASS = os.environ["UNIFI_SSH_PASSWORD"]
 # channel_timeout protects against hangs during SSH channel establishment,
 # which paramiko's exec_command(timeout=) does NOT cover.
 CHANNEL_TIMEOUT = 30
+REBOOT_WAIT = 30     # let the switch's SSH accept auth again after a reboot
+REBOOT_RETRIES = 8   # discover() attempts while the switch is booting
 
 def discover(ip=SWITCH_IP, ssh_username=SWITCH_SSH_USER, ssh_password=SWITCH_SSH_PASS, retries = 0):
     """
@@ -196,45 +199,69 @@ class UniFiSwitch(device_hub.device_hub):
         """
         return "enabled" if self.is_port_enabled(port) else "disabled"
 
-    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1):
+    def _force_close(self):
+        # Watchdog callback: closing the socket from another thread interrupts a
+        # wedged send/read on any OS (paramiko's channel timeouts don't cover the send).
+        try:
+            if self.client is not None:
+                self.client.close()
+        except Exception:
+            pass
+
+    def _exec(self, command, timeout):
+        # One command, guarded by a watchdog that force-closes the transport if it wedges.
+        watchdog = threading.Timer(timeout, self._force_close)
+        watchdog.start()
+        stdin = stdout = stderr = None
+        try:
+            stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
+            stdout.channel.settimeout(timeout)
+            stderr.channel.settimeout(timeout)
+            out = stdout.read().decode().strip()
+            err = stderr.read().decode().strip()
+        finally:
+            watchdog.cancel()
+            for s in (stdin, stdout, stderr):
+                try:
+                    if s is not None:
+                        s.close()
+                except Exception:
+                    pass
+        if err:
+            log.f(f"Error running command '{command}': {err}")
+        return out
+
+    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1, reboot_on_failure=True):
         """
-        Run a command on the switch.
-        exec_command(timeout=) + settimeout protect the read/write phase.
+        Run a command on the switch, retrying on failure and, as a last resort,
+        rebooting the switch to clear a persistently wedged CLI.
         :param command: the command to run
         :param timeout: seconds to wait for a response before retrying
-        :param retries: number of times to retry on timeout before raising TimeoutError
+        :param retries: number of reconnect+retry attempts before escalating
+        :param reboot_on_failure: reboot the switch and retry once if all attempts fail
         :return: the output of the command
         """
+        last_exc = None
         for attempt in range(retries + 1):
             if not self.is_connected():
                 log.w( f"SSH not connected, reconnecting (attempt {attempt + 1}/{retries + 1})..." )
                 self._reconnect()
-            stdin = stdout = stderr = None
             try:
-                stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
-                stdout.channel.settimeout(timeout)
-                stderr.channel.settimeout(timeout)
-                out = stdout.read().decode().strip()
-                err = stderr.read().decode().strip()
+                return self._exec(command, timeout)
             except (socket.timeout, socket.error, EOFError, paramiko.SSHException, OSError) as e:
+                last_exc = e
                 log.w(f"Command '{command}' failed: {e}")
-                try:
-                    for s in (stdin, stdout, stderr):
-                        if s is not None:
-                            s.close()
-                except Exception:
-                    pass
                 self._reconnect()
-                if attempt < retries:
-                    log.w(f"Retrying ({attempt + 1}/{retries})...")
-                    continue
-                # Raise TimeoutError only for actual timeouts; use RuntimeError for other SSH/socket failures
-                if isinstance(e, socket.timeout):
-                    raise TimeoutError(f"Command '{command}' timed out after {retries + 1} attempts") from e
-                raise RuntimeError(f"Command '{command}' failed after {retries + 1} attempts: {e}") from e
-            if err:
-                log.f(f"Error running command '{command}': {err}")
-            return out
+        if reboot_on_failure:
+            log.w(f"Command '{command}' still failing; rebooting switch to recover...")
+            try:
+                self._reboot()
+                return self._exec(command, timeout)
+            except Exception as e:
+                last_exc = e
+        if isinstance(last_exc, socket.timeout):
+            raise TimeoutError(f"Command '{command}' timed out") from last_exc
+        raise RuntimeError(f"Command '{command}' failed: {last_exc}") from last_exc
 
     def _reconnect(self):
         """
@@ -244,6 +271,21 @@ class UniFiSwitch(device_hub.device_hub):
         self.connect(retries=2)
         if self.client is None:
             raise RuntimeError("Failed to reconnect to UniFi switch")
+
+    def _reboot(self):
+        """
+        Reboot the switch and wait for its SSH to accept connections again.
+        """
+        log.w("rebooting UniFi switch to clear a wedged CLI...")
+        try:
+            self._exec("reboot", timeout=10)
+        except Exception:
+            pass  # the connection drops as the switch goes down
+        self.disconnect()
+        time.sleep(REBOOT_WAIT)
+        self.client = discover(self.ip, self.username, self.password, retries=REBOOT_RETRIES)
+        if self.client is None:
+            raise RuntimeError("UniFi switch did not come back after reboot")
 
     def enable_ports(self, ports=None, disable_other_ports=False, sleep_on_change=0):
         log.d(f"Enabling ports {ports if ports is not None else 'all'} on Unifi Switch"

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -69,6 +69,18 @@ def discover(ip=SWITCH_IP, ssh_username=SWITCH_SSH_USER, ssh_password=SWITCH_SSH
            client.connect(hostname=ip, username=ssh_username,
                                 password=ssh_password, timeout=10,
                                 channel_timeout=CHANNEL_TIMEOUT)
+           # Bound a send stalled under TCP retransmit: exec_command(timeout=) and
+           # settimeout only guard the reply read, not the send. Without this, a
+           # switch whose CLI wedges mid-command (e.g. PoE inrush on enable-all)
+           # stops ACKing and the send hangs ~15min (tcp_retries2) instead of
+           # failing fast so the reconnect/retry below can recover.
+           sock = client.get_transport().sock
+           try:
+               tcp_user_timeout = getattr(socket, "TCP_USER_TIMEOUT", 18)
+               sock.setsockopt(socket.IPPROTO_TCP, tcp_user_timeout, CHANNEL_TIMEOUT * 1000)
+           except (OSError, AttributeError):
+               pass  # non-Linux / unsupported
+           sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
            log.debug_indent()
            log.d("...", f"connected to {ip} via SSH")
            log.debug_unindent()

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -257,7 +257,7 @@ class UniFiSwitch(device_hub.device_hub):
         """
         Reboot the switch and wait for its SSH to accept connections again.
         """
-        log.w("rebooting UniFi switch to clear a wedged CLI...")
+        log.d("rebooting UniFi switch...")
         try:
             self._exec("reboot", timeout=10)
         except Exception:

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -8,7 +8,6 @@ sys.path.append(parent_dir)
 from rspy import log
 import time
 import platform, re
-import threading
 from rspy import device_hub
 
 if __name__ == '__main__':
@@ -72,12 +71,11 @@ def discover(ip=SWITCH_IP, ssh_username=SWITCH_SSH_USER, ssh_password=SWITCH_SSH
            client.connect(hostname=ip, username=ssh_username,
                                 password=ssh_password, timeout=10,
                                 channel_timeout=CHANNEL_TIMEOUT)
-           # Bound a send stalled under TCP retransmit; paramiko's timeouts guard
-           # only the reply read, not the send (else a wedged switch hangs ~15min).
-           sock = client.get_transport().sock
-           if hasattr(socket, "TCP_USER_TIMEOUT"):  # Linux-only; no-ops elsewhere
+           # Bound a send stalled under TCP retransmit (Linux); paramiko's timeouts
+           # guard the reply read, not the send, so a wedged switch would hang ~15min.
+           if hasattr(socket, "TCP_USER_TIMEOUT"):
                try:
-                   sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, CHANNEL_TIMEOUT * 1000)
+                   client.get_transport().sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, CHANNEL_TIMEOUT * 1000)
                except OSError as e:
                    log.d(f"TCP_USER_TIMEOUT setsockopt failed: {e}")
            log.debug_indent()
@@ -153,8 +151,25 @@ class UniFiSwitch(device_hub.device_hub):
     def connect(self, reset=False, retries=0):
         if self.client is None:
             self.client = discover(self.ip, self.username, self.password, retries=retries)
-        # reset is a no-op here: a wedged CLI is recovered on demand in _run_command
-        # (reboot-on-failure), not by rebooting the switch on every hub-reset.
+
+        if reset and self.client is not None:
+            # --hub-reset: reboot the switch (like the Acroname) to clear a wedged CLI
+            self._reboot()
+
+    def _reboot(self):
+        """
+        Reboot the switch and wait for its SSH to accept connections again.
+        """
+        log.d("rebooting UniFi switch...")
+        try:
+            self.client.exec_command("reboot", timeout=10)
+        except Exception:
+            pass  # the connection drops as the switch goes down
+        self.disconnect()
+        time.sleep(REBOOT_WAIT)
+        self.client = discover(self.ip, self.username, self.password, retries=REBOOT_RETRIES)
+        if self.client is None:
+            raise RuntimeError("UniFi switch did not come back after reboot")
 
     def is_connected(self):
         if self.client is None:
@@ -191,68 +206,45 @@ class UniFiSwitch(device_hub.device_hub):
         """
         return "enabled" if self.is_port_enabled(port) else "disabled"
 
-    def _exec(self, command, timeout):
-        # One command, guarded by a watchdog that force-closes the transport if it
-        # wedges. Closing the socket from another thread interrupts a stalled send/read
-        # on any OS (paramiko's channel timeouts don't cover the send). Close the
-        # paramiko client directly, not via a self method (device_hub wraps methods to
-        # re-register signal handlers, which fails off the main thread).
-        client = self.client
-        watchdog = threading.Timer(timeout, lambda: client.close() if client is not None else None)
-        watchdog.start()
-        stdin = stdout = stderr = None
-        try:
-            stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
-            stdout.channel.settimeout(timeout)
-            stderr.channel.settimeout(timeout)
-            out = stdout.read().decode().strip()
-            err = stderr.read().decode().strip()
-        finally:
-            watchdog.cancel()
-            for s in (stdin, stdout, stderr):
-                try:
-                    if s is not None:
-                        s.close()
-                except Exception:
-                    pass
-        if err:
-            log.f(f"Error running command '{command}': {err}")
-        return out
-
-    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1, reboot_on_failure=True):
+    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1):
         """
-        Run a command on the switch, retrying with a reconnect on failure and, as a
-        last resort, rebooting the switch to clear a persistently wedged CLI.
+        Run a command on the switch.
+        exec_command(timeout=) + settimeout protect the read/write phase.
         :param command: the command to run
         :param timeout: seconds to wait for a response before retrying
-        :param retries: number of reconnect+retry attempts before escalating
-        :param reboot_on_failure: reboot the switch and retry once if all attempts fail
+        :param retries: number of times to retry on timeout before raising TimeoutError
         :return: the output of the command
         """
-        last_exc = None
         for attempt in range(retries + 1):
             if not self.is_connected():
                 log.w( f"SSH not connected, reconnecting (attempt {attempt + 1}/{retries + 1})..." )
                 self._reconnect()
+            stdin = stdout = stderr = None
             try:
-                return self._exec(command, timeout)
+                stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
+                stdout.channel.settimeout(timeout)
+                stderr.channel.settimeout(timeout)
+                out = stdout.read().decode().strip()
+                err = stderr.read().decode().strip()
             except (socket.timeout, socket.error, EOFError, paramiko.SSHException, OSError) as e:
-                last_exc = e
                 log.w(f"Command '{command}' failed: {e}")
                 try:
-                    self._reconnect()
-                except Exception as re:  # reconnect can raise; keep retrying / escalate to reboot
-                    last_exc = re
-        if reboot_on_failure:
-            log.w(f"Command '{command}' still failing; rebooting switch to recover...")
-            try:
-                self._reboot()
-                return self._exec(command, timeout)
-            except Exception as e:
-                last_exc = e
-        if isinstance(last_exc, socket.timeout):
-            raise TimeoutError(f"Command '{command}' timed out after {retries + 1} attempts") from last_exc
-        raise RuntimeError(f"Command '{command}' failed after {retries + 1} attempts: {last_exc}") from last_exc
+                    for s in (stdin, stdout, stderr):
+                        if s is not None:
+                            s.close()
+                except Exception:
+                    pass
+                self._reconnect()
+                if attempt < retries:
+                    log.w(f"Retrying ({attempt + 1}/{retries})...")
+                    continue
+                # Raise TimeoutError only for actual timeouts; use RuntimeError for other SSH/socket failures
+                if isinstance(e, socket.timeout):
+                    raise TimeoutError(f"Command '{command}' timed out after {retries + 1} attempts") from e
+                raise RuntimeError(f"Command '{command}' failed after {retries + 1} attempts: {e}") from e
+            if err:
+                log.f(f"Error running command '{command}': {err}")
+            return out
 
     def _reconnect(self):
         """
@@ -262,21 +254,6 @@ class UniFiSwitch(device_hub.device_hub):
         self.connect(retries=2)
         if self.client is None:
             raise RuntimeError("Failed to reconnect to UniFi switch")
-
-    def _reboot(self):
-        """
-        Reboot the switch and wait for its SSH to accept connections again.
-        """
-        log.d("rebooting UniFi switch...")
-        try:
-            self._exec("reboot", timeout=10)
-        except Exception:
-            pass  # the connection drops as the switch goes down
-        self.disconnect()
-        time.sleep(REBOOT_WAIT)
-        self.client = discover(self.ip, self.username, self.password, retries=REBOOT_RETRIES)
-        if self.client is None:
-            raise RuntimeError("UniFi switch did not come back after reboot")
 
     def enable_ports(self, ports=None, disable_other_ports=False, sleep_on_change=0):
         log.d(f"Enabling ports {ports if ports is not None else 'all'} on Unifi Switch"

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -154,15 +154,9 @@ class UniFiSwitch(device_hub.device_hub):
         if self.client is None:
             self.client = discover(self.ip, self.username, self.password, retries=retries)
 
-        if reset:
-            # rebooting the switch takes over a minute, so the reboot code is commented out
-            # log.w("reset flag passed to unifi switch, ignoring it")
-            return
-            # self._run_command("reboot")
-            # time.sleep(5)
-            # # we need to reconnect to the device after it's rebooted, might take several tries
-            # self.disconnect()
-            # self.client = discover(retries=5)
+        if reset and self.client is not None:
+            # reboot each hub-reset (like the Acroname) to clear a wedged CLI proactively
+            self._reboot()
 
     def is_connected(self):
         if self.client is None:
@@ -227,14 +221,12 @@ class UniFiSwitch(device_hub.device_hub):
             log.f(f"Error running command '{command}': {err}")
         return out
 
-    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1, reboot_on_failure=True):
+    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1):
         """
-        Run a command on the switch, retrying on failure and, as a last resort,
-        rebooting the switch to clear a persistently wedged CLI.
+        Run a command on the switch, retrying with a reconnect on failure.
         :param command: the command to run
         :param timeout: seconds to wait for a response before retrying
-        :param retries: number of reconnect+retry attempts before escalating
-        :param reboot_on_failure: reboot the switch and retry once if all attempts fail
+        :param retries: number of reconnect+retry attempts
         :return: the output of the command
         """
         last_exc = None
@@ -248,16 +240,9 @@ class UniFiSwitch(device_hub.device_hub):
                 last_exc = e
                 log.w(f"Command '{command}' failed: {e}")
                 self._reconnect()
-        if reboot_on_failure:
-            log.w(f"Command '{command}' still failing; rebooting switch to recover...")
-            try:
-                self._reboot()
-                return self._exec(command, timeout)
-            except Exception as e:
-                last_exc = e
         if isinstance(last_exc, socket.timeout):
-            raise TimeoutError(f"Command '{command}' timed out") from last_exc
-        raise RuntimeError(f"Command '{command}' failed: {last_exc}") from last_exc
+            raise TimeoutError(f"Command '{command}' timed out after {retries + 1} attempts") from last_exc
+        raise RuntimeError(f"Command '{command}' failed after {retries + 1} attempts: {last_exc}") from last_exc
 
     def _reconnect(self):
         """

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -153,10 +153,8 @@ class UniFiSwitch(device_hub.device_hub):
     def connect(self, reset=False, retries=0):
         if self.client is None:
             self.client = discover(self.ip, self.username, self.password, retries=retries)
-
-        if reset and self.client is not None:
-            # reboot each hub-reset (like the Acroname) to clear a wedged CLI proactively
-            self._reboot()
+        # reset is a no-op here: a wedged CLI is recovered on demand in _run_command
+        # (reboot-on-failure), not by rebooting the switch on every hub-reset.
 
     def is_connected(self):
         if self.client is None:
@@ -221,12 +219,14 @@ class UniFiSwitch(device_hub.device_hub):
             log.f(f"Error running command '{command}': {err}")
         return out
 
-    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1):
+    def _run_command(self, command, timeout=CHANNEL_TIMEOUT, retries=1, reboot_on_failure=True):
         """
-        Run a command on the switch, retrying with a reconnect on failure.
+        Run a command on the switch, retrying with a reconnect on failure and, as a
+        last resort, rebooting the switch to clear a persistently wedged CLI.
         :param command: the command to run
         :param timeout: seconds to wait for a response before retrying
-        :param retries: number of reconnect+retry attempts
+        :param retries: number of reconnect+retry attempts before escalating
+        :param reboot_on_failure: reboot the switch and retry once if all attempts fail
         :return: the output of the command
         """
         last_exc = None
@@ -240,6 +240,13 @@ class UniFiSwitch(device_hub.device_hub):
                 last_exc = e
                 log.w(f"Command '{command}' failed: {e}")
                 self._reconnect()
+        if reboot_on_failure:
+            log.w(f"Command '{command}' still failing; rebooting switch to recover...")
+            try:
+                self._reboot()
+                return self._exec(command, timeout)
+            except Exception as e:
+                last_exc = e
         if isinstance(last_exc, socket.timeout):
             raise TimeoutError(f"Command '{command}' timed out after {retries + 1} attempts") from last_exc
         raise RuntimeError(f"Command '{command}' failed after {retries + 1} attempts: {last_exc}") from last_exc

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -69,19 +69,14 @@ def discover(ip=SWITCH_IP, ssh_username=SWITCH_SSH_USER, ssh_password=SWITCH_SSH
            client.connect(hostname=ip, username=ssh_username,
                                 password=ssh_password, timeout=10,
                                 channel_timeout=CHANNEL_TIMEOUT)
-           # Bound a send stalled under TCP retransmit: exec_command(timeout=) and
-           # settimeout only guard the reply read, not the send. Without this, a
-           # switch whose CLI wedges mid-command (e.g. PoE inrush on enable-all)
-           # stops ACKing and the send hangs ~15min (tcp_retries2) instead of
-           # failing fast so the reconnect/retry below can recover.
+           # Bound a send stalled under TCP retransmit; paramiko's timeouts guard
+           # only the reply read, not the send (else a wedged switch hangs ~15min).
            sock = client.get_transport().sock
-           sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-           # TCP_USER_TIMEOUT is Linux-only; on other platforms this cleanly no-ops.
-           if hasattr(socket, "TCP_USER_TIMEOUT"):
+           if hasattr(socket, "TCP_USER_TIMEOUT"):  # Linux-only; no-ops elsewhere
                try:
                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, CHANNEL_TIMEOUT * 1000)
-               except OSError:
-                   pass
+               except OSError as e:
+                   log.d(f"TCP_USER_TIMEOUT setsockopt failed: {e}")
            log.debug_indent()
            log.d("...", f"connected to {ip} via SSH")
            log.debug_unindent()


### PR DESCRIPTION
**Overview:** libci runs hung ~15 min when the UniFi PoE switch's SSH CLI wedged mid-command. This makes `--hub-reset` reboot the switch (like the Acroname) to clear it, and bounds a stalled send so a wedge can't hang the run.

## Why
A libci Linux run hung ~15 min at "Enabling ports all on Unifi Switch": the socket stalled with data unACKed after the enable-all command. paramiko's `exec_command(timeout=)` / `settimeout` guard only the reply read, not a send stalled below the app layer, so it blocked until TCP retransmit gave up (`tcp_retries2`, ~15 min). The UniFi also never rebooted on `--hub-reset` (the reboot was stubbed out), so a wedged switch stayed wedged between runs.

## Summary
- `connect(reset=True)` now reboots the switch (`_reboot()`: send reboot, wait ~30s, reconnect with retries) so `--hub-reset` clears a wedged CLI, matching the Acroname.
- `discover()` sets `TCP_USER_TIMEOUT` (Linux) on the socket so a stalled send fails in ~30s instead of ~15 min; `hasattr`-guarded, no-ops off Linux.

## Test plan
- [x] Reboot-on-reset on the exact bench that hung 3× (14900/14910/14911): `connect(reset=True)` reboots (~67s), then disable/enable succeed (1–2s); a full libci run that reboots the switch during hub-reset passed green (15 passed, no hang at "Enabling ports all on Unifi Switch").
- [x] `TCP_USER_TIMEOUT` fault-injection (blocked ACKs): command bounded to a fast failure instead of the ~15 min hang.
- [ ] Windows benches: `TCP_USER_TIMEOUT` is Linux-only (no-ops there); the reboot-on-reset path is OS-independent.

---
🤖 Generated by AI
