### PR TITLE
MF differentiate native from decompressed profiles

### DIFF
--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -950,6 +950,19 @@ namespace librealsense
             _power_state = D3;
         }
 
+        // A native (driver-described) uncompressed media type carries concrete layout attributes (stride/sample-size/
+        // bitrate) that MF's MJPEG-decoded duplicate lacks; require >=2 present so we prefer the native one on duplicates.
+        static bool is_driver_described_media_type( IMFMediaType * mt )
+        {
+            UINT32 v = 0;
+            if( ! mt )
+                return false;
+            int attrs = ( SUCCEEDED( mt->GetUINT32( MF_MT_DEFAULT_STRIDE, &v ) ) ? 1 : 0 )
+                      + ( SUCCEEDED( mt->GetUINT32( MF_MT_SAMPLE_SIZE, &v ) ) ? 1 : 0 )
+                      + ( SUCCEEDED( mt->GetUINT32( MF_MT_AVG_BITRATE, &v ) ) ? 1 : 0 );
+            return attrs >= 2;
+        }
+
         void wmf_uvc_device::foreach_profile(std::function<void(const mf_profile& profile, CComPtr<IMFMediaType> media_type, bool& quit)> action) const
         {
             bool quit = false;
@@ -1060,7 +1073,12 @@ namespace librealsense
         void wmf_uvc_device::play_profile(stream_profile profile, frame_callback callback)
         {
             bool profile_found = false;
-            foreach_profile([this, profile, callback, &profile_found](const mf_profile& mfp, CComPtr<IMFMediaType> media_type, bool& quit)
+            // Two passes: first commit only a driver-described (native) media type; if the requested format has no
+            // native match (e.g. only a synthesized duplicate remains) fall back to any match. This makes SET_CUR pick
+            // the real bFormatIndex when Windows exposes both a native and a decoded (e.g. MJPEG->NV12) media type.
+            auto try_commit = [&]( bool require_native )
+            {
+            foreach_profile([this, profile, callback, &profile_found, require_native](const mf_profile& mfp, CComPtr<IMFMediaType> media_type, bool& quit)
             {
                 if (mfp.profile.format != profile.format &&
                     (fourcc_map.count(mfp.profile.format) == 0 ||
@@ -1078,6 +1096,8 @@ namespace librealsense
                     {
                         if (mfp.profile.fps == int(profile.fps))
                         {
+                            if (require_native && !is_driver_described_media_type(media_type))
+                                return;  // first pass: skip a synthesized duplicate so the native media type wins
                             auto hr = _reader->SetCurrentMediaType(mfp.index, nullptr, media_type);
                             if (SUCCEEDED(hr) && media_type)
                             {
@@ -1124,6 +1144,16 @@ namespace librealsense
                     }
                 }
             });
+            };  // try_commit
+
+            try_commit( true );          // prefer the native (driver-described) media type
+            if( ! profile_found )
+            {
+                // No driver-described match - a synthesized (e.g. MJPEG-decoded) media type may be selected instead.
+                LOG_INFO( "No native media type for " << fourcc( profile.format ) << " " << profile.width << "x"
+                             << profile.height << " @" << profile.fps << "Hz; falling back to any matching media type" );
+                try_commit( false );
+            }
             if (!profile_found)
                 throw std::runtime_error("Stream profile not found!");
         }


### PR DESCRIPTION
Fix issue on some Windows machine where MF publishes both FW "native" NV12 and another NV12 profile decompressed from the MJPEG.