### PR TITLE
Remove Download firmware link from viewer device-info panel

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2438,11 +2438,6 @@ namespace rs2
                 ImGui::SetCursorPos({ rc.x, rc.y + line_h });
             }
 
-            rc = ImGui::GetCursorPos();
-            ImGui::SetCursorPos({ rc.x + 12, rc.y + 4 });
-            std::string download_label = rsutils::string::from() << "Download firmware...##" << id;
-            hyperlink(window, download_label.c_str(), fw_download_url());
-
             ImGui::SetCursorPos({ rc.x + 225, rc.y - 107 });
             ImGui::PopFont();
         }

--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -30,8 +30,6 @@ namespace rs2
         RS2_FWU_STATE_FAILED = 3,
     };
 
-    const char * fw_download_url() { return recommended_fw_url; }
-
     bool is_upgradeable(const std::string& curr, const std::string& available)
     {
         if (curr == "" || available == "") return false;

--- a/common/fw-update-helper.h
+++ b/common/fw-update-helper.h
@@ -11,7 +11,6 @@ namespace rs2
     class viewer_model;
 
     bool is_upgradeable(const std::string& curr, const std::string& available);
-    const char * fw_download_url();
 
     class firmware_update_manager : public process_manager
     {


### PR DESCRIPTION
**Overview:** Removes the "Download firmware..." hyperlink from the viewer's device-info panel (added in #15063).

## Why
Link no longer wanted in the device-info panel.

## Summary
- Drop the hyperlink render in `device-model.cpp`
- Remove now-dead `fw_download_url()` helper (`recommended_fw_url` still used by the FW-update notification)

## Test plan
- [ ] Build viewer, confirm device-info panel shows no "Download firmware..." link

---
🤖 Generated by AI
