### PR TITLE
tests: exclude D457 from auto-HDR preset test (unmapped MIPI XU 0x11)

### DIFF
--- a/unit-tests/live/hdr/pytest-hdr-preset.py
+++ b/unit-tests/live/hdr/pytest-hdr-preset.py
@@ -49,6 +49,9 @@ def test_hdr_preset_manual(test_device):
     hdr_helper.load_and_perform_test(MANUAL_HDR_CONFIG, "Auto HDR - Sanity - Manual mode")
 
 
+# D457 (GMSL/MIPI) auto-HDR routes depth-ae through XU control 0x11, which the MIPI
+# backend has no v4l2 CID mapping for; exclude until the mapping is added.
+@pytest.mark.device_exclude("D457")
 def test_hdr_preset_auto(test_device):
     hdr_helper.setup_for_device(test_device)
     hdr_helper.load_and_perform_test(AUTO_HDR_CONFIG, "Auto HDR - Sanity - Auto mode")


### PR DESCRIPTION
**Overview:** Exclude D457 from the auto variant of the HDR-preset live test, which currently fails on D457 in LibCI because the accelerated/auto-AE path is not mappable on the GMSL/MIPI backend.

Tracked on [RSDSO-21571]

## Why
`test_hdr_preset_auto` fails on D457 (Jetson/GMSL) with:

```
call failed: RuntimeError: no v4l2 mipi cid for XU depth control 17
```

The auto-HDR subpreset drives `depth-ae` through XU depth control `0x11` (`RS_DEPTH_AUTO_EXPOSURE_MODE` / `DS5_DEPTH_AUTO_EXPOSURE_MODE`). The D457 MIPI backend `v4l_mipi_device::xu_to_cid` has no `case` for `0x11`, so it throws before streaming. This surfaced with the newer FW + enhanced-AE routing (regression: earlier FW ran the auto preset fine). The manual variant (`test_hdr_preset_manual`) is unaffected and still runs on D457.

## Summary
- Add `@pytest.mark.device_exclude("D457")` to `test_hdr_preset_auto` only.
- Manual variant runs on D455 + D457; auto variant now runs on D455 only.
- Unblocks the preset test in CI while the proper fix (add the `xu_to_cid` case + matching MIPI v4l2 CID, or gate the new AE encoding off for MIPI) is decided under RSDSO-21571.

## Test plan
- [ ] LibCI Jetson JP5: `pytest-live-hdr-hdr-preset` — D457 collects `test_hdr_preset_manual` only, `test_hdr_preset_auto` skipped/excluded; D455 runs both.

---
🤖 Generated by AI
