### PR TITLE
d400: exclude MIPI/GMSL devices from Depth Auto Exposure Mode option

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -852,12 +852,12 @@ namespace librealsense
                 gain_option = uvc_pu_gain_option;
             }
 
-            // DEPTH AUTO EXPOSURE MODE - available on global-shutter D400 SKUs.
+            // DEPTH AUTO EXPOSURE MODE - available on global-shutter D400 SKUs (USB only, not MIPI/GMSL).
             // D455: since FW 5.15.0.0; other SKUs: FW 5.17.3.20.
             const bool is_global_shutter = ( _device_capabilities & ds_caps::CAP_GLOBAL_SHUTTER ) == ds_caps::CAP_GLOBAL_SHUTTER;
             const firmware_version min_fw_for_ae_mode = (_pid == RS455_PID) ? firmware_version("5.15.0.0")
                                                                             : firmware_version("5.17.3.20");
-            if (is_global_shutter && _fw_version >= min_fw_for_ae_mode)
+            if (is_global_shutter && !_is_mipi_device && _fw_version >= min_fw_for_ae_mode)
             {
                 auto depth_auto_exposure_mode = std::make_shared<uvc_xu_option<uint8_t>>( raw_depth_sensor,
                     depth_xu,

--- a/unit-tests/live/hdr/pytest-hdr-preset.py
+++ b/unit-tests/live/hdr/pytest-hdr-preset.py
@@ -49,9 +49,6 @@ def test_hdr_preset_manual(test_device):
     hdr_helper.load_and_perform_test(MANUAL_HDR_CONFIG, "Auto HDR - Sanity - Manual mode")
 
 
-# D457 (GMSL/MIPI) auto-HDR routes depth-ae through XU control 0x11, which the MIPI
-# backend has no v4l2 CID mapping for; exclude until the mapping is added.
-@pytest.mark.device_exclude("D457")
 def test_hdr_preset_auto(test_device):
     hdr_helper.setup_for_device(test_device)
     hdr_helper.load_and_perform_test(AUTO_HDR_CONFIG, "Auto HDR - Sanity - Auto mode")


### PR DESCRIPTION
Tracked by: RSDSO-21571

**Overview:** Follow-up fix to PR #15381. The widened `RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE` registration gated only on `CAP_GLOBAL_SHUTTER` + FW version; this also enabled the option on the D400-family MIPI/GMSL variants (D457, D430-GMSL, D415-GMSL, D401-GMSL). Add `!_is_mipi_device` to the guard so no MIPI SKU registers the option, and back out the test-side workaround PR #15418 added — it is obsoleted by the root-cause fix.

## Why
D400 MIPI/GMSL devices report `CAP_GLOBAL_SHUTTER` in GVD but their MIPI backend has no `v4l2` CID mapping for XU depth control `0x11` (`DS5_DEPTH_AUTO_EXPOSURE_MODE`). Registering the option causes downstream failures such as `test_hdr_preset_auto` on D457:

```
call failed: RuntimeError: no v4l2 mipi cid for XU depth control 17
```

PR #15418 patched around this at the test layer by excluding D457 from `test_hdr_preset_auto`. With the option no longer registered on MIPI SKUs, that exclusion is no longer needed.

## Summary
- `src/ds/d400/d400-device.cpp` — add `!_is_mipi_device` to the AE-mode registration guard; comment updated to say "USB only, not MIPI/GMSL".
- `unit-tests/live/hdr/pytest-hdr-preset.py` — revert PR #15418: drop `@pytest.mark.device_exclude("D457")` from `test_hdr_preset_auto` and its rationale comment.

## Test plan
- [x] `pytest-depth-ae-mode.py` runs green on D455/D435/D405 (USB) — option registered, tests execute.
- [x] `pytest-depth-ae-mode.py` skips cleanly on D457/D430-GMSL/D415-GMSL/D401-GMSL — option not registered, fixture-level `supports()` skip fires.
- [x] `pytest-hdr-preset.py::test_hdr_preset_auto` runs (and passes) on D457 on LibCI Jetson JP5 — the XU 0x11 routing no longer happens because the option is not registered.
- [x] realsense-viewer no longer shows the "Regular / Accelerated" combobox on any MIPI/GMSL SKU (regression from PR 15381).
- [x] D455 (USB) still shows the combobox from FW 5.15.0.0 (unchanged).

---
🤖 Generated by AI