### PR TITLE
d500: hide AE-Setpoint control in viewer and reject it via advanced-mode API

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -830,9 +830,9 @@ namespace rs2
                 if (advanced.is_enabled())
                 {
                     std::string dev_name = dev.supports(RS2_CAMERA_INFO_NAME) ? dev.get_info(RS2_CAMERA_INFO_NAME) : "";
-                    bool d457_device = (dev_name.find("D457") != std::string::npos);
+                    bool ae_setpoint_unsupported = (dev_name.find("D457") != std::string::npos) || _is_d500_device;
 
-                    draw_advanced_mode_controls(advanced, amc, get_curr_advanced_controls, was_set, error_message, d457_device);
+                    draw_advanced_mode_controls(advanced, amc, get_curr_advanced_controls, was_set, error_message, ae_setpoint_unsupported);
                 }
                 else
                 {

--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -205,8 +205,8 @@ struct advanced_mode_control
     param_group<STAFactor> amp_factor;
 };
 
-inline void draw_advanced_mode_controls(rs400::advanced_mode& advanced, 
-    advanced_mode_control& amc, bool& get_curr_advanced_controls, bool& was_set, std::string& error_message, bool d457_device=false)
+inline void draw_advanced_mode_controls(rs400::advanced_mode& advanced,
+    advanced_mode_control& amc, bool& get_curr_advanced_controls, bool& was_set, std::string& error_message, bool ae_setpoint_unsupported=false)
 {
     if (get_curr_advanced_controls)
     {
@@ -566,8 +566,8 @@ inline void draw_advanced_mode_controls(rs400::advanced_mode& advanced,
         ImGui::TreePop();
     }
 
-    //AE setpoint is blocked in D457 
-    if (!d457_device && ImGui::TreeNode("AE Control"))
+    //AE setpoint is not supported on D457 and D500-family devices
+    if (!ae_setpoint_unsupported && ImGui::TreeNode("AE Control"))
     {
         ImGui::PushItemWidth(ImGui::CalcItemWidth());
 

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -576,6 +576,9 @@ namespace librealsense
 
     void ds_advanced_mode_base::set_ae_control( const STAEControl & val )
     {
+        if( _dev->get_info( rs2_camera_info::RS2_CAMERA_INFO_PRODUCT_LINE ) == "D500" )
+            throw invalid_value_exception( "set_ae_control(...) failed! AE Setpoint is not supported on D500-family devices" );
+
         set( val, advanced_mode_traits< STAEControl >::group );
         if( _preset_opt )
             _preset_opt->set( RS2_RS400_VISUAL_PRESET_CUSTOM );


### PR DESCRIPTION
**Overview:** Hides the AE-Setpoint (Mean Intensity Set Point) control for D500-family devices in the RealSense Viewer, and makes the advanced-mode API reject it explicitly instead of silently no-op'ing.

Tracked on [RSDEV-12601]

## Why
AE-Setpoint (`STAEControl::meanIntensitySetPoint`) only applies to the D400 AE V1 algorithm. D500-family devices (D555, D585, etc.) use a different enhanced/HKR Depth AE that ignores it, so changing the value from the viewer had no visible effect and read as a bug to customers (see RSDEV-11758).

## Summary
- Viewer: the "AE Control" section (setpoint slider) inside Advanced Mode's Advanced Controls is now hidden for D500-family devices, reusing the existing `_is_d500_device` check (previously only D457 was excluded).
- SDK: `ds_advanced_mode_base::set_ae_control()` now throws for D500 product-line devices, so callers going through the C/C++ advanced-mode API directly (not just the viewer) get an explicit error instead of a silent no-op.

## Test plan
- [x] Built `realsense2` and `realsense-viewer` (Release, MSVC) successfully with the change.
- [x] Manual verification on D585S: confirm the AE Control/setpoint slider no longer appears in Advanced Mode.
- [x] Manual verification on D435I: confirm the AE Control/setpoint slider still appears in Advanced Mode.
- [ ] Manual verification that `set_ae_control()` throws when called on a D500-family device via the API.

---
🤖 Generated by AI