### PR TITLE
python: opt-in asynchronous log_to_callback eliminating GIL/mutex deadlock on librealsense threads

### DIFF
--- a/unit-tests/log/pytest-async-callback.py
+++ b/unit-tests/log/pytest-async-callback.py
@@ -1,0 +1,51 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import time
+
+import pyrealsense2 as rs
+import log_helpers as common
+
+
+def wait_for_messages(n, timeout=5.0):
+    """Async dispatch: the callback fires on a worker thread shortly after rs.log()."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if common.n_messages >= n:
+            return
+        time.sleep(0.05)
+
+
+def test_async_callback_receives_messages(reset_logger):
+    rs.log_to_callback(rs.log_severity.warn, common.message_counter, asynchronous=True)
+    assert common.n_messages == 0
+    common.log_all()
+    wait_for_messages(2)
+    assert common.n_messages == 2  # warning, error
+
+
+def test_async_message_content(reset_logger):
+    received = []
+
+    def collect(severity, message):
+        received.append((severity, message.raw(), message.full(), message.line_number(), message.filename()))
+
+    rs.log_to_callback(rs.log_severity.error, collect, asynchronous=True)
+    rs.log(rs.log_severity.error, "async content check")
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not received:
+        time.sleep(0.05)
+    assert len(received) == 1
+    severity, raw, full, line, filename = received[0]
+    assert severity == rs.log_severity.error
+    assert raw == "async content check"
+    assert raw in full
+
+
+def test_async_and_sync_coexist(reset_logger):
+    rs.log_to_callback(rs.log_severity.error, common.message_counter, asynchronous=True)
+    rs.log_to_callback(rs.log_severity.error, common.message_counter_2)  # sync
+    common.log_all()
+    assert common.n_messages_2 == 1  # sync path: already delivered
+    wait_for_messages(1)
+    assert common.n_messages == 1

--- a/unit-tests/log/pytest-async-callback.py
+++ b/unit-tests/log/pytest-async-callback.py
@@ -7,45 +7,31 @@ import pyrealsense2 as rs
 import log_helpers as common
 
 
-def wait_for_messages(n, timeout=5.0):
-    """Async dispatch: the callback fires on a worker thread shortly after rs.log()."""
+def wait_for(predicate, timeout=5.0):
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if common.n_messages >= n:
-            return
+    while time.monotonic() < deadline and not predicate():
         time.sleep(0.05)
 
 
 def test_async_callback_receives_messages(reset_logger):
-    rs.log_to_callback(rs.log_severity.warn, common.message_counter, asynchronous=True)
-    assert common.n_messages == 0
-    common.log_all()
-    wait_for_messages(2)
-    assert common.n_messages == 2  # warning, error
-
-
-def test_async_message_content(reset_logger):
     received = []
-
-    def collect(severity, message):
-        received.append((severity, message.raw(), message.full(), message.line_number(), message.filename()))
-
-    rs.log_to_callback(rs.log_severity.error, collect, asynchronous=True)
-    rs.log(rs.log_severity.error, "async content check")
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline and not received:
-        time.sleep(0.05)
-    assert len(received) == 1
-    severity, raw, full, line, filename = received[0]
-    assert severity == rs.log_severity.error
-    assert raw == "async content check"
-    assert raw in full
+    rs.log_to_callback(rs.log_severity.warn,
+                       lambda severity, message: received.append((severity, message)),
+                       asynchronous=True)
+    common.log_all()
+    wait_for(lambda: len(received) >= 2)
+    assert len(received) == 2  # warning, error
+    assert received[0] == (rs.log_severity.warn, "warn message")
+    assert received[1] == (rs.log_severity.error, "error message")
 
 
 def test_async_and_sync_coexist(reset_logger):
-    rs.log_to_callback(rs.log_severity.error, common.message_counter, asynchronous=True)
+    received = []
+    rs.log_to_callback(rs.log_severity.error,
+                       lambda severity, message: received.append(message),
+                       asynchronous=True)
     rs.log_to_callback(rs.log_severity.error, common.message_counter_2)  # sync
     common.log_all()
-    assert common.n_messages_2 == 1  # sync path: already delivered
-    wait_for_messages(1)
-    assert common.n_messages == 1
+    assert common.n_messages_2 == 1  # sync path: delivered before log_all returns
+    wait_for(lambda: len(received) >= 1)
+    assert received == ["error message"]

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -86,12 +86,10 @@ def install_rs_log_bridge(rs):
     rs_log.setLevel(logging.DEBUG)
     _rs_log_callback = _callback
     try:
-        # Asynchronous dispatch: the emitting LibRS thread never acquires the GIL, so a
-        # LOG_DEBUG issued under an internal mutex cannot AB-BA deadlock against the main
-        # thread (seen as an unkillable pytest holding the Acroname hub after an abort)
+        # Async: the emitting LibRS thread never takes the GIL, so a LOG under an internal
+        # mutex cannot deadlock against the main thread; messages arrive as plain str
         rs.log_to_callback(rs.log_severity.debug, _callback, asynchronous=True)
-    except TypeError:
-        # Older pyrealsense2 build without the asynchronous flag
+    except TypeError:  # older pyrealsense2 build without the flag
         rs.log_to_callback(rs.log_severity.debug, _callback)
 
 

--- a/unit-tests/py/rspy/pytest/logging_setup.py
+++ b/unit-tests/py/rspy/pytest/logging_setup.py
@@ -85,7 +85,14 @@ def install_rs_log_bridge(rs):
 
     rs_log.setLevel(logging.DEBUG)
     _rs_log_callback = _callback
-    rs.log_to_callback(rs.log_severity.debug, _callback)
+    try:
+        # Asynchronous dispatch: the emitting LibRS thread never acquires the GIL, so a
+        # LOG_DEBUG issued under an internal mutex cannot AB-BA deadlock against the main
+        # thread (seen as an unkillable pytest holding the Acroname hub after an abort)
+        rs.log_to_callback(rs.log_severity.debug, _callback, asynchronous=True)
+    except TypeError:
+        # Older pyrealsense2 build without the asynchronous flag
+        rs.log_to_callback(rs.log_severity.debug, _callback)
 
 
 def bridge_rspy_log():

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -5,10 +5,6 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include <librealsense2/rs.hpp>
 #include <librealsense2/hpp/rs_export.hpp>
 #include <src/types.h>
-#include <condition_variable>
-#include <deque>
-#include <mutex>
-#include <thread>
 
 PYBIND11_MODULE(NAME, m) {
     m.doc() = R"pbdoc(
@@ -120,22 +116,17 @@ PYBIND11_MODULE(NAME, m) {
     };
     // asynchronous=True: on_log never acquires the GIL on the emitting librealsense thread
     // (which may hold internal locks -- sync dispatch can AB-BA deadlock against the main
-    // thread); messages queue and a worker thread dispatches (severity, raw_text) to Python.
+    // thread); a dispatcher thread delivers (severity, raw_text) to Python instead.
     class py_async_log_callback : public rs2_log_callback
     {
         py::function _fn;
-        std::mutex _mx;
-        std::condition_variable _cv;
-        std::deque< std::pair< rs2_log_severity, std::string > > _queue;  // bounded; excess dropped
-        bool _stop = false;
-        std::thread _worker;
-        enum : size_t { MAX_PENDING = 4096 };
+        dispatcher _dispatcher{ 4096 };  // bounded; oldest dropped on overflow
 
     public:
         explicit py_async_log_callback( py::function fn )
             : _fn( std::move( fn ) )
-            , _worker( [this] { run(); } )
         {
+            _dispatcher.start();  // constructed stopped, despite what the header says
         }
 
         void on_log( rs2_log_severity severity, rs2_log_message const & msg ) noexcept override
@@ -145,13 +136,24 @@ PYBIND11_MODULE(NAME, m) {
                 rs2_error * e = nullptr;
                 char const * raw = rs2_get_raw_log_message( &msg, &e );
                 if( e ) { rs2_free_error( e ); return; }
-                {
-                    std::lock_guard< std::mutex > lock( _mx );
-                    if( _queue.size() >= MAX_PENDING )
-                        return;
-                    _queue.emplace_back( severity, raw ? raw : "" );
-                }
-                _cv.notify_one();
+                std::string text( raw ? raw : "" );
+                _dispatcher.invoke(
+                    [this, severity, text]( dispatcher::cancellable_timer )
+                    {
+                        try
+                        {
+                            py::gil_scoped_acquire gil;
+                            _fn( severity, text );
+                        }
+                        catch( std::exception const & e )
+                        {
+                            std::cerr << "EXCEPTION in " SNAME ".log_to_callback (async): " << e.what() << std::endl;
+                        }
+                        catch( ... )
+                        {
+                            std::cerr << "UNKNOWN EXCEPTION in " SNAME ".log_to_callback (async)" << std::endl;
+                        }
+                    } );
             }
             catch( ... ) {}
         }
@@ -159,46 +161,11 @@ PYBIND11_MODULE(NAME, m) {
         // Called via Python atexit (interpreter still alive); caller must not hold the GIL
         void stop()
         {
-            {
-                std::lock_guard< std::mutex > lock( _mx );
-                _stop = true;
-            }
-            _cv.notify_one();
-            if( _worker.joinable() )
-                _worker.join();
+            _dispatcher.flush();  // deliver what's pending -- stop() discards the queue
+            _dispatcher.stop();
         }
 
         void release() override {}  // leaked at exit, same as py_log_callback above
-
-    private:
-        void run()
-        {
-            while( true )
-            {
-                std::pair< rs2_log_severity, std::string > item;
-                {
-                    std::unique_lock< std::mutex > lock( _mx );
-                    _cv.wait( lock, [this] { return _stop || ! _queue.empty(); } );
-                    if( _queue.empty() )
-                        return;  // stopping, and pending messages were flushed
-                    item = std::move( _queue.front() );
-                    _queue.pop_front();
-                }
-                try
-                {
-                    py::gil_scoped_acquire gil;
-                    _fn( item.first, item.second );
-                }
-                catch( std::exception const & e )
-                {
-                    std::cerr << "EXCEPTION in " SNAME ".log_to_callback (async): " << e.what() << std::endl;
-                }
-                catch( ... )
-                {
-                    std::cerr << "UNKNOWN EXCEPTION in " SNAME ".log_to_callback (async)" << std::endl;
-                }
-            }
-        }
     };
 
     m.def( "log_to_callback",

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -6,6 +6,12 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include <librealsense2/hpp/rs_export.hpp>
 #include <src/types.h>
 
+#if defined( BUILD_EASYLOGGINGPP ) && defined( BUILD_SHARED_LIBS )
+// A shared realsense2 doesn't export ELPP's storage, so rsutils objects linked into this
+// module (e.g. dispatcher) need our own -- see rsutils/easylogging/easyloggingpp.h
+INITIALIZE_EASYLOGGINGPP
+#endif
+
 PYBIND11_MODULE(NAME, m) {
     m.doc() = R"pbdoc(
         Librealsense Python Bindings

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -5,6 +5,10 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include <librealsense2/rs.hpp>
 #include <librealsense2/hpp/rs_export.hpp>
 #include <src/types.h>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
 
 PYBIND11_MODULE(NAME, m) {
     m.doc() = R"pbdoc(
@@ -114,14 +118,168 @@ PYBIND11_MODULE(NAME, m) {
                 super::release();
         }
     };
+    // The synchronous callback above acquires the GIL on whatever librealsense thread
+    // emitted the log line. If that thread holds an internal mutex while the Python main
+    // thread holds the GIL and blocks on that same mutex, the process deadlocks (AB-BA)
+    // and even SIGTERM cannot kill it. The asynchronous path below breaks the cycle:
+    // on_log only copies the message into a bounded queue (never touching the GIL), and a
+    // dedicated worker thread -- which never holds librealsense locks -- acquires the GIL
+    // and dispatches to Python. The cost: callbacks fire slightly after the log call, so
+    // it is opt-in (asynchronous=True) and used by test infrastructure (--rslog).
+    struct queued_log_message
+    {
+        unsigned _line;
+        std::string _filename, _raw, _full;
+    };
+    py::class_< queued_log_message >( m, "queued_log_message",
+                                      "Detached copy of a log_message, dispatched asynchronously" )
+        .def( "line_number", []( queued_log_message const & self ) { return self._line; } )
+        .def( "filename", []( queued_log_message const & self ) { return self._filename; } )
+        .def( "raw", []( queued_log_message const & self ) { return self._raw; } )
+        .def( "full", []( queued_log_message const & self ) { return self._full; } )
+        .def( "__str__", []( queued_log_message const & self ) { return self._raw; } )
+        .def( "__repr__", []( queued_log_message const & self ) { return self._full; } );
+
+    class py_async_log_callback : public rs2_log_callback
+    {
+        typedef std::function< void( rs2_log_severity, queued_log_message const & ) > log_fn;
+
+        log_fn _fn;
+        std::mutex _mx;
+        std::condition_variable _cv;
+        std::deque< std::pair< rs2_log_severity, queued_log_message > > _queue;
+        bool _stop = false;
+        std::thread _worker;
+
+        // Bound so a Python-side stall cannot grow memory without limit; excess is dropped
+        enum : size_t { MAX_PENDING = 4096 };
+
+    public:
+        explicit py_async_log_callback( log_fn && fn )
+            : _fn( std::move( fn ) )
+            , _worker( [this] { run(); } )
+        {
+        }
+
+        void on_log( rs2_log_severity severity, rs2_log_message const & msg ) noexcept override
+        {
+            // May run on any librealsense thread, possibly under internal locks: must not
+            // block and must not touch the GIL. rs2::log_message's ctor is private, so
+            // copy the fields out through the C API (ignoring per-field errors).
+            try
+            {
+                auto get_str = []( const char * s ) { return std::string( s ? s : "" ); };
+                rs2_error * e = nullptr;
+                unsigned line = rs2_get_log_message_line_number( &msg, &e );
+                if( e ) { rs2_free_error( e ); e = nullptr; line = 0; }
+                std::string filename = get_str( rs2_get_log_message_filename( &msg, &e ) );
+                if( e ) { rs2_free_error( e ); e = nullptr; }
+                std::string raw = get_str( rs2_get_raw_log_message( &msg, &e ) );
+                if( e ) { rs2_free_error( e ); e = nullptr; }
+                std::string full = get_str( rs2_get_full_log_message( &msg, &e ) );
+                if( e ) { rs2_free_error( e ); e = nullptr; }
+                queued_log_message copy{ line,
+                                         std::move( filename ),
+                                         std::move( raw ),
+                                         std::move( full ) };
+                {
+                    std::lock_guard< std::mutex > lock( _mx );
+                    if( _queue.size() >= MAX_PENDING )
+                        return;
+                    _queue.emplace_back( severity, std::move( copy ) );
+                }
+                _cv.notify_one();
+            }
+            catch( ... )
+            {
+            }
+        }
+
+        // Called from a Python atexit handler, while the interpreter is still alive, so the
+        // worker never tries to acquire the GIL after finalization. Caller must NOT hold the
+        // GIL (the worker may need it to finish its current dispatch).
+        void stop()
+        {
+            {
+                std::lock_guard< std::mutex > lock( _mx );
+                if( _stop )
+                    return;
+                _stop = true;
+            }
+            _cv.notify_one();
+            if( _worker.joinable() )
+                _worker.join();
+        }
+
+        void release() override
+        {
+            // Like py_log_callback: librealsense releases us at static destruction, when the
+            // Python thread state may already be gone -- intentionally leak instead (the
+            // worker was already stopped via atexit)
+        }
+
+    private:
+        void run()
+        {
+            while( true )
+            {
+                std::pair< rs2_log_severity, queued_log_message > item;
+                {
+                    std::unique_lock< std::mutex > lock( _mx );
+                    _cv.wait( lock, [this] { return _stop || ! _queue.empty(); } );
+                    if( _queue.empty() )
+                        return;  // only when stopping: flush whatever was queued first
+                    item = std::move( _queue.front() );
+                    _queue.pop_front();
+                }
+                try
+                {
+                    py::gil_scoped_acquire gil;
+                    _fn( item.first, item.second );
+                }
+                catch( std::exception const & e )
+                {
+                    std::cerr << "EXCEPTION in " SNAME ".log_to_callback (async): " << e.what() << std::endl;
+                }
+                catch( ... )
+                {
+                    std::cerr << "UNKNOWN EXCEPTION in " SNAME ".log_to_callback (async)" << std::endl;
+                }
+            }
+        }
+    };
+
     m.def( "log_to_callback",
-           []( rs2_log_severity min_severity, py_log_callback::log_fn callback )
+           []( rs2_log_severity min_severity, py::function callback, bool asynchronous )
            {
                rs2_error * e = nullptr;
-               py::gil_scoped_release gil;
-               rs2_log_to_callback_cpp( min_severity, new py_log_callback( std::move( callback ) ), &e );
+               if( asynchronous )
+               {
+                   auto cb = new py_async_log_callback(
+                       [callback]( rs2_log_severity severity, queued_log_message const & msg )
+                       { callback( severity, msg ); } );
+                   // Stop the worker while the interpreter is still alive; release the GIL
+                   // around the join so the worker can finish an in-flight dispatch
+                   py::module_::import( "atexit" ).attr( "register" )( py::cpp_function(
+                       [cb]()
+                       {
+                           py::gil_scoped_release gil;
+                           cb->stop();
+                       } ) );
+                   py::gil_scoped_release gil;
+                   rs2_log_to_callback_cpp( min_severity, cb, &e );
+               }
+               else
+               {
+                   py_log_callback::log_fn fn
+                       = [callback]( rs2_log_severity severity, rs2::log_message const & msg )
+                       { callback( severity, msg ); };
+                   py::gil_scoped_release gil;
+                   rs2_log_to_callback_cpp( min_severity, new py_log_callback( std::move( fn ) ), &e );
+               }
                rs2::error::handle( e );
-           } );
+           },
+           "min_severity"_a, "callback"_a, "asynchronous"_a = false );
 #endif
 
     // A call to rs.log() will cause a callback to get called! We should already own the GIL, but

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -175,14 +175,17 @@ PYBIND11_MODULE(NAME, m) {
                if( asynchronous )
                {
                    auto cb = new py_async_log_callback( std::move( callback ) );
+                   {
+                       py::gil_scoped_release gil;
+                       rs2_log_to_callback_cpp( min_severity, cb, &e );
+                   }
+                   rs2::error::handle( e );  // register atexit only for a live callback
                    py::module_::import( "atexit" ).attr( "register" )( py::cpp_function(
                        [cb]()
                        {
                            py::gil_scoped_release gil;  // let the worker finish an in-flight dispatch
                            cb->stop();
                        } ) );
-                   py::gil_scoped_release gil;
-                   rs2_log_to_callback_cpp( min_severity, cb, &e );
                }
                else
                {

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -118,44 +118,21 @@ PYBIND11_MODULE(NAME, m) {
                 super::release();
         }
     };
-    // The synchronous callback above acquires the GIL on whatever librealsense thread
-    // emitted the log line. If that thread holds an internal mutex while the Python main
-    // thread holds the GIL and blocks on that same mutex, the process deadlocks (AB-BA)
-    // and even SIGTERM cannot kill it. The asynchronous path below breaks the cycle:
-    // on_log only copies the message into a bounded queue (never touching the GIL), and a
-    // dedicated worker thread -- which never holds librealsense locks -- acquires the GIL
-    // and dispatches to Python. The cost: callbacks fire slightly after the log call, so
-    // it is opt-in (asynchronous=True) and used by test infrastructure (--rslog).
-    struct queued_log_message
-    {
-        unsigned _line;
-        std::string _filename, _raw, _full;
-    };
-    py::class_< queued_log_message >( m, "queued_log_message",
-                                      "Detached copy of a log_message, dispatched asynchronously" )
-        .def( "line_number", []( queued_log_message const & self ) { return self._line; } )
-        .def( "filename", []( queued_log_message const & self ) { return self._filename; } )
-        .def( "raw", []( queued_log_message const & self ) { return self._raw; } )
-        .def( "full", []( queued_log_message const & self ) { return self._full; } )
-        .def( "__str__", []( queued_log_message const & self ) { return self._raw; } )
-        .def( "__repr__", []( queued_log_message const & self ) { return self._full; } );
-
+    // asynchronous=True: on_log never acquires the GIL on the emitting librealsense thread
+    // (which may hold internal locks -- sync dispatch can AB-BA deadlock against the main
+    // thread); messages queue and a worker thread dispatches (severity, raw_text) to Python.
     class py_async_log_callback : public rs2_log_callback
     {
-        typedef std::function< void( rs2_log_severity, queued_log_message const & ) > log_fn;
-
-        log_fn _fn;
+        py::function _fn;
         std::mutex _mx;
         std::condition_variable _cv;
-        std::deque< std::pair< rs2_log_severity, queued_log_message > > _queue;
+        std::deque< std::pair< rs2_log_severity, std::string > > _queue;  // bounded; excess dropped
         bool _stop = false;
         std::thread _worker;
-
-        // Bound so a Python-side stall cannot grow memory without limit; excess is dropped
         enum : size_t { MAX_PENDING = 4096 };
 
     public:
-        explicit py_async_log_callback( log_fn && fn )
+        explicit py_async_log_callback( py::function fn )
             : _fn( std::move( fn ) )
             , _worker( [this] { run(); } )
         {
@@ -163,47 +140,27 @@ PYBIND11_MODULE(NAME, m) {
 
         void on_log( rs2_log_severity severity, rs2_log_message const & msg ) noexcept override
         {
-            // May run on any librealsense thread, possibly under internal locks: must not
-            // block and must not touch the GIL. rs2::log_message's ctor is private, so
-            // copy the fields out through the C API (ignoring per-field errors).
             try
             {
-                auto get_str = []( const char * s ) { return std::string( s ? s : "" ); };
                 rs2_error * e = nullptr;
-                unsigned line = rs2_get_log_message_line_number( &msg, &e );
-                if( e ) { rs2_free_error( e ); e = nullptr; line = 0; }
-                std::string filename = get_str( rs2_get_log_message_filename( &msg, &e ) );
-                if( e ) { rs2_free_error( e ); e = nullptr; }
-                std::string raw = get_str( rs2_get_raw_log_message( &msg, &e ) );
-                if( e ) { rs2_free_error( e ); e = nullptr; }
-                std::string full = get_str( rs2_get_full_log_message( &msg, &e ) );
-                if( e ) { rs2_free_error( e ); e = nullptr; }
-                queued_log_message copy{ line,
-                                         std::move( filename ),
-                                         std::move( raw ),
-                                         std::move( full ) };
+                char const * raw = rs2_get_raw_log_message( &msg, &e );
+                if( e ) { rs2_free_error( e ); return; }
                 {
                     std::lock_guard< std::mutex > lock( _mx );
                     if( _queue.size() >= MAX_PENDING )
                         return;
-                    _queue.emplace_back( severity, std::move( copy ) );
+                    _queue.emplace_back( severity, raw ? raw : "" );
                 }
                 _cv.notify_one();
             }
-            catch( ... )
-            {
-            }
+            catch( ... ) {}
         }
 
-        // Called from a Python atexit handler, while the interpreter is still alive, so the
-        // worker never tries to acquire the GIL after finalization. Caller must NOT hold the
-        // GIL (the worker may need it to finish its current dispatch).
+        // Called via Python atexit (interpreter still alive); caller must not hold the GIL
         void stop()
         {
             {
                 std::lock_guard< std::mutex > lock( _mx );
-                if( _stop )
-                    return;
                 _stop = true;
             }
             _cv.notify_one();
@@ -211,24 +168,19 @@ PYBIND11_MODULE(NAME, m) {
                 _worker.join();
         }
 
-        void release() override
-        {
-            // Like py_log_callback: librealsense releases us at static destruction, when the
-            // Python thread state may already be gone -- intentionally leak instead (the
-            // worker was already stopped via atexit)
-        }
+        void release() override {}  // leaked at exit, same as py_log_callback above
 
     private:
         void run()
         {
             while( true )
             {
-                std::pair< rs2_log_severity, queued_log_message > item;
+                std::pair< rs2_log_severity, std::string > item;
                 {
                     std::unique_lock< std::mutex > lock( _mx );
                     _cv.wait( lock, [this] { return _stop || ! _queue.empty(); } );
                     if( _queue.empty() )
-                        return;  // only when stopping: flush whatever was queued first
+                        return;  // stopping, and pending messages were flushed
                     item = std::move( _queue.front() );
                     _queue.pop_front();
                 }
@@ -255,15 +207,11 @@ PYBIND11_MODULE(NAME, m) {
                rs2_error * e = nullptr;
                if( asynchronous )
                {
-                   auto cb = new py_async_log_callback(
-                       [callback]( rs2_log_severity severity, queued_log_message const & msg )
-                       { callback( severity, msg ); } );
-                   // Stop the worker while the interpreter is still alive; release the GIL
-                   // around the join so the worker can finish an in-flight dispatch
+                   auto cb = new py_async_log_callback( std::move( callback ) );
                    py::module_::import( "atexit" ).attr( "register" )( py::cpp_function(
                        [cb]()
                        {
-                           py::gil_scoped_release gil;
+                           py::gil_scoped_release gil;  // let the worker finish an in-flight dispatch
                            cb->stop();
                        } ) );
                    py::gil_scoped_release gil;


### PR DESCRIPTION
**Overview:** `rs.log_to_callback` gains an opt-in `asynchronous` mode where log emission never acquires the Python GIL on librealsense threads, eliminating a mutex/GIL AB-BA deadlock; the pytest `--rslog` bridge uses it.

Tracked on [RSDSO-21761]

## Why
The synchronous callback acquires the GIL on whatever librealsense thread emitted the log line. If that thread holds an internal mutex while the Python main thread holds the GIL and blocks on the same mutex, the process deadlocks — observed as an unkillable pytest wedging CI agents and holding the Acroname hub (connect result=25 fleet-wide on 2026-07-14). Legacy run-unit-tests never hit this because its `--rslog` used `log_to_console` (fd-level); the pytest bridge uses `log_to_callback` so LibRS lines land in per-test logs.

## Summary
- `wrappers/python/pyrealsense2.cpp`: `log_to_callback(min_severity, callback, asynchronous=False)` — default unchanged. With `asynchronous=True`, `on_log` only copies the raw text into a bounded `rsutils` `dispatcher` (capacity 4096, no GIL); the dispatcher thread acquires the GIL and calls the Python callback with `(severity, str)`. A Python `atexit` hook flushes and stops the dispatcher while the interpreter is alive.
- Shared builds: the module now initializes its own ELPP storage (`INITIALIZE_EASYLOGGINGPP`, same pattern as rs-gl) — a shared realsense2 does not export it, and the rsutils dispatcher objects linked into the module need it.
- `rspy/pytest/logging_setup.py`: the `--rslog` bridge registers with `asynchronous=True` (its existing `str()` fallback already handles plain-text messages; TypeError fallback for older builds).
- New test `unit-tests/log/pytest-async-callback.py`: async delivery + async/sync coexistence.

## Test plan
- [x] unit-tests/log/ — 15/15 pass (13 existing sync tests unchanged + 2 new async), 3 consecutive runs, validated locally on Linux
- [x] Stress: 8 threads x 2000 messages — 16000/16000 delivered, clean interpreter exit
- [ ] LibCI run with --rslog

---
🤖 Generated by AI

