### PR TITLE
Enable projector temperature option for all D535/D585 family PIDs

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -591,7 +591,7 @@ namespace librealsense
             depth_sensor.register_option(RS2_OPTION_SOC_PVT_TEMPERATURE, pvt_temperature);
             depth_sensor.register_option(RS2_OPTION_OHM_TEMPERATURE, ohm_temperature);
 
-            if (_pid == D585S_PID)
+            if (d500_projector_temperature_pids.count(_pid))
             {
                 auto proj_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
                     depth_xu,

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -54,6 +54,19 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
+        // d500 PIDs that expose the projector temperature via HKR selector 0x16
+        static const std::set<std::uint16_t> d500_projector_temperature_pids = {
+            D585S_PID,
+            D535_2C_PID,
+            D535_3C_PID,
+            D535F_PID,
+            D585_2C_PID,
+            D585_3C_PID,
+            D585F_PID,
+            D585_2C_PROTO_PID,
+            D585_3C_PROTO_PID
+        };
+
         static const std::map< std::uint16_t, std::string > rs500_sku_names = {
             { D555_PID,               "RealSense D555" },
             { D555_RECOVERY_PID,      "RealSense D555 Recovery" },


### PR DESCRIPTION
Tracked by: RSDEV-12573

**Overview:** Register `RS2_OPTION_PROJECTOR_TEMPERATURE` on the full D535/D585 PID family, not only on `D585S_PID`, so RSviewer can display projector temperature on non-safety SKUs (e.g. the current D585 3C prototype `0x0C08`).

## Why
D585p projector temperature was missing from RSviewer even though the FW exposes `GTEMP` selector `0x16` on every D535/D585 SKU. `d500_device` gated `RS2_OPTION_PROJECTOR_TEMPERATURE` registration on `_pid == D585S_PID`, so all other family PIDs (including the D585 prototype PID currently in use) never had the option registered.

## Summary
- Added `d500_projector_temperature_pids` — a `std::set<uint16_t>` in `d500-private.h` listing every D500-family PID that supports the projector temperature XU selector.
- Replaced the single-PID check at `d500-device.cpp:594` with a lookup into that set, keeping D585S covered and extending support to `D535_2C/3C/F`, `D585_2C/3C/F`, and the `D585_2C/3C` prototype PIDs.

## Test plan
- [ ] Attach a D585 3C prototype (PID `0x0C08`) and confirm `Projector Temperature` appears in RSviewer's depth-sensor options list.
- [ ] Confirm value is displayed in decimal degrees Celsius and tracks `GTEMP 0` FW output.
- [ ] Regression: attach a D585S and confirm the option is still registered and readable.

---
🤖 Generated by AI