### PR TITLE
Fix ROS buildfarm resolute binarydeb build: qsort_r undeclared in bundled zstd

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -90,6 +90,23 @@ jobs:
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
+      - name: mirror ROS buildfarm deb hardening flags
+        # The release binarydebs are built by dpkg-buildpackage, which injects
+        # Ubuntu's default hardening flags (e.g. -Werror=implicit-function-declaration
+        # on noble and later). A plain colcon build doesn't, so farm-only compile
+        # errors slip through CI. Export the same flags so this job fails like
+        # the farm would. LTO flags are dropped — they slow the build without
+        # adding diagnostic coverage.
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends dpkg-dev
+          strip_lto() { sed -E 's/-f(fat-)?lto[^ ]*//g'; }
+          cppflags="$(dpkg-buildflags --get CPPFLAGS)"
+          echo "CFLAGS=$(dpkg-buildflags --get CFLAGS | strip_lto) ${cppflags}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=$(dpkg-buildflags --get CXXFLAGS | strip_lto) ${cppflags}" >> "$GITHUB_ENV"
+          echo "LDFLAGS=$(dpkg-buildflags --get LDFLAGS | strip_lto)" >> "$GITHUB_ENV"
+
       - name: build librealsense ROS 2
         uses: ros-tooling/action-ros-ci@3a640b10f09b756dabe556dac5413aba369f71b0 #v0.4.8
         with:

--- a/.github/workflows/build-ROS2-rolling-CI.yaml
+++ b/.github/workflows/build-ROS2-rolling-CI.yaml
@@ -76,6 +76,23 @@ jobs:
           # in the stable ros2 apt index.
           use-ros2-testing: true
 
+      - name: mirror ROS buildfarm deb hardening flags
+        # The release binarydebs are built by dpkg-buildpackage, which injects
+        # Ubuntu's default hardening flags (e.g. -Werror=implicit-function-declaration
+        # on resolute). A plain colcon build doesn't, so farm-only compile errors
+        # slip through CI. Export the same flags so this job fails like the farm
+        # would. LTO flags are dropped — they slow the build without adding
+        # diagnostic coverage.
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends dpkg-dev
+          strip_lto() { sed -E 's/-f(fat-)?lto[^ ]*//g'; }
+          cppflags="$(dpkg-buildflags --get CPPFLAGS)"
+          echo "CFLAGS=$(dpkg-buildflags --get CFLAGS | strip_lto) ${cppflags}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=$(dpkg-buildflags --get CXXFLAGS | strip_lto) ${cppflags}" >> "$GITHUB_ENV"
+          echo "LDFLAGS=$(dpkg-buildflags --get LDFLAGS | strip_lto)" >> "$GITHUB_ENV"
+
       - name: build librealsense ROS 2
         uses: ros-tooling/action-ros-ci@3a640b10f09b756dabe556dac5413aba369f71b0 #v0.4.8
         with:

--- a/third-party/realsense-file/CMakeLists.txt
+++ b/third-party/realsense-file/CMakeLists.txt
@@ -55,6 +55,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       $<$<COMPILE_LANGUAGE:CXX>:-include cstdint>
       $<$<COMPILE_LANGUAGE:C>:-include stdint.h>
     )
+    # The forced include above locks glibc feature-test macros before zstd.c
+    # gets a chance to define _GNU_SOURCE itself, leaving qsort_r() undeclared.
+    # Define it on the command line so it precedes the forced include.
+    target_compile_definitions(${REALSENSE_FILE_TARGET} PRIVATE
+      $<$<COMPILE_LANGUAGE:C>:_GNU_SOURCE>
+    )
   endif()
 endif()
 


### PR DESCRIPTION
**Overview:** Fixes the librealsense2 binarydeb build failure on the ROS 2 build farm (Ubuntu resolute), and hardens our ROS 2 GitHub Actions jobs so this class of farm-only failure is caught before release.

## Why
The Rolling binarydeb build fails ([Rbin_uR64 #29](https://build.ros2.org/job/Rbin_uR64__librealsense2__ubuntu_resolute_amd64__binary/29/)):

```
third-party/realsense-file/rosbag2/zstd/zstd.c:45226:5: error: implicit declaration of function 'qsort_r' [-Wimplicit-function-declaration]
```

The bundled zstd amalgamation defines `_GNU_SOURCE` at the top of the file so glibc declares `qsort_r()`. Our `realsense-file` CMake adds `-include stdint.h` for GCC >= 13, which is processed before the file content and locks glibc's feature-test macros without `_GNU_SOURCE` — so `qsort_r` is never declared. The deb build then fails because dpkg-buildpackage injects `-Werror=implicit-function-declaration` on resolute. Our GHA colcon builds don't use the deb hardening flags, which is why CI stayed green.

Reproduced and verified locally on Linux: compiling `zstd.c` with `-include stdint.h -Werror=implicit-function-declaration` reproduces the exact farm error; adding `-D_GNU_SOURCE` on the command line fixes it.

## Summary
- `third-party/realsense-file/CMakeLists.txt`: define `_GNU_SOURCE` for C compilation alongside the forced `stdint.h` include, so it takes effect before any header. Scoped to the existing GCC >= 13 branch — no change for MSVC/clang/older GCC, no third-party source modified.
- `build-ROS2-rolling-CI.yaml` / `build-ROS2-package-CI.yaml`: new step exports `dpkg-buildflags` (minus LTO) as `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, so the GHA colcon builds compile with the same hardening flags the build farm uses and fail the same way it would.

## Test plan
- [x] Standalone repro on Linux: farm flags fail on unpatched tree, pass with `_GNU_SOURCE` defined
- [ ] GHA `build_lrs_ROS2_package_rolling` (resolute) green on this PR — with the new flag mirroring it would fail without the CMake fix
- [ ] GHA `build_lrs_ROS2_package` matrix (humble/kilted/jazzy/lyrical) green

---
🤖 Generated by AI
