### PR TITLE
Fix SIGSEGV on GMSL/MIPI D457 & D401 (enumeration + viewer option panel)

### DIFF
--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -200,6 +200,11 @@ void option_model::update_all_fields( std::string & error_message, notifications
 {
     try
     {
+        // Defensive: a valid endpoint is required. A malformed/partially constructed
+        // option_model (null endpoint) would null-deref at get_option_value below.
+        if( ! endpoint )
+            return;
+
         // After slider was dragged value updated using set_option, don't update value again here
         if( last_slider_hold_stopwatch.get_elapsed_ms() < 500 )
             return;

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -103,8 +103,23 @@ namespace rs2
             auto supported_options = s->get_supported_option_values();
             for( rs2::option_value option : supported_options )
             {
-                options_metadata[option->id]
-                    = create_option_model( option, opt_base_label, this, s, options_invalidated, error_message );
+                // Build the model first and insert only on success. Some options are
+                // advertised as supported but their metadata/range can't be read on this
+                // platform (e.g. D401 GMSL depth XU controls Inter Cam Sync Mode / Auto
+                // Exposure Mode / Readout Shaping return VIDIOC_QUERY_EXT_CTRL EINVAL).
+                // `options_metadata[id] = create_option_model(...)` would default-insert a
+                // null-endpoint option_model via operator[] and then throw, leaving a broken
+                // entry that later crashes option_model::update_all_fields (null endpoint
+                // deref) - and it aborts the whole loop, dropping every subsequent option.
+                try
+                {
+                    auto option_md = create_option_model( option, opt_base_label, this, s, options_invalidated, error_message );
+                    options_metadata[option->id] = std::move( option_md );
+                }
+                catch( const std::exception & )
+                {
+                    // supported but no readable metadata on this platform; skip it
+                }
             }
 
             s->on_options_changed( [this]( const options_list & list )

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -93,7 +93,19 @@ namespace librealsense
             auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
             platform::uvc_device_info info;
             if (_is_mipi_device)
-                info = color_devs_info[1];
+            {
+                // The color endpoint is the mi==3 UVC interface. Select it explicitly
+                // (as the non-MIPI path does) instead of blindly indexing
+                // group.uvc_devices[1]: on multi-camera / dual-bus (usb+usbv3) GMSL
+                // enumeration [1] may be a non-color node or out of range, which
+                // corrupts the copied uvc_device_info (SIGSEGV / std::bad_alloc).
+                if (!color_devs_info_mi3.empty())
+                    info = color_devs_info_mi3.front();
+                else if (color_devs_info.size() > 1)
+                    info = color_devs_info[1];
+                else
+                    throw invalid_value_exception("RS4XX MIPI: color UVC node (mi=3) not found");
+            }
             else
                 info = color_devs_info.front();
             auto uvcd = get_backend()->create_uvc_device( info );


### PR DESCRIPTION
## Summary
Fixes two SIGSEGVs in the SDK on GMSL/MIPI **D457 & D401** that make `realsense-viewer` unusable on Jetson (JetPack 7.2). Both are cases where the SDK faults on its own inputs when a GMSL/MIPI D4xx enumerates in an unexpected shape or advertises an option that can't be read on the current transport.

Jira: RSDSO-21764

### 1. Enumeration crash — `d400_color::create_color_device` (`src/ds/d400/d400-color.cpp`)
The MIPI color endpoint was chosen with an unconditional `info = color_devs_info[1];`. On multi-camera / dual-bus (usb+usbv3) GMSL enumeration the group can have `< 2` entries (or `[1]` isn't the color node), so the copied `uvc_device_info` memcpy's a dangling `std::string` → SIGSEGV in `rs2_create_device`. Now selects the color node by `mi == 3` (as the non-MIPI path already does) with a bounds guard.

### 2. D401 control-panel crash — `option_model::update_all_fields` (`common/subdevice-model.cpp`, `common/option-model.cpp`)
`options_metadata[option->id] = create_option_model(...)` lets `operator[]` default-insert a **null-endpoint** `option_model` *before* `create_option_model` runs. On the D401 GMSL the depth XU controls **Inter Cam Sync Mode / Auto Exposure Mode / Readout Shaping** are advertised as supported but fail `VIDIOC_QUERY_EXT_CTRL` (EINVAL / "no v4l2 mipi cid"), so `create_option_model` throws at `get_option_range`, leaving the broken entry in the map (and aborting the loop, silently dropping later options). `update_all_fields` then null-derefs `endpoint->get_option_value()` when the panel is drawn. Now builds the model in a local and inserts only on success (skipping unreadable options), plus a defensive `if (!endpoint) return;` guard in `update_all_fields`.

## Test
Validated on Jetson AGX Orin (JetPack 7.2, L4T R39.2, kernel 6.8.12-tegra, d4xx 1.0.4.6) with GMSL **D457 + D401**:
- `rs-enumerate-devices` lists all cameras (previously core-dumped).
- `realsense-viewer` opens/streams the D401 without crashing; unreadable D401 XU options are skipped instead of crashing.
- No regression on the USB D435IF / D436 or the D457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
