### PR TITLE
Add D585 family PIDs to IMU calibration platform mapping

### DIFF
--- a/src/ds/ds-calib-parsers.cpp
+++ b/src/ds/ds-calib-parsers.cpp
@@ -175,7 +175,9 @@ namespace librealsense
             _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.0374f, 0.00719f, 0.0223f } };
             _imu_2_depth_rot = { { -1,0,0 },{ 0,1,0 },{ 0,0,-1 } };
         }
-        else if ( _pid == ds::D585_LEGACY_PID || _pid == ds::D585S_PID )
+        else if( _pid == ds::D585_LEGACY_PID || _pid == ds::D585S_PID
+              || _pid == ds::D585_2C_PID || _pid == ds::D585_3C_PID || _pid == ds::D585F_PID
+              || _pid == ds::D585_2C_PROTO_PID || _pid == ds::D585_3C_PROTO_PID )
         {
             // D585/D585S specific - Bosch BMI085
             _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.0195f, 0.0f, -0.0114f } };


### PR DESCRIPTION
**Overview:** New-VID D585 family PIDs now get the correct D585-chassis IMU extrinsics instead of default (zero-translation) values.

Tracked on [RSDEV-13008]

## Why
`ds-calib-parsers.cpp` maps IMU default intrinsic/extrinsic data by PID, but only the legacy D585 (0x0B6A) and D585S (0x0B6B) PIDs are in the D585 branch. The new-VID family PIDs (D585_2C/3C/F 0x0C04-0x0C06, D585 proto 0x0C07/0x0C08) fall into the "unmapped configurations" branch: `Undefined platform with IMU, use default intrinsic/extrinsic data, PID: 3080` — zero-translation extrinsics and a D435i-style rotation.

## Summary
- Add `D585_2C_PID`, `D585_3C_PID`, `D585F_PID`, `D585_2C_PROTO_PID`, `D585_3C_PROTO_PID` to the existing D585/D585S (Bosch BMI085) branch — same chassis, same IMU placement.
- D535 PIDs intentionally not included: different chassis, extrinsic values need mechanical data.

## Test plan
- [x] Core library builds clean (VS2022, Release)
- [x] `Undefined platform with IMU` error no longer expected for D585 Prototype (PID 0x0C08) — verified the PID constant mapping
- [ ] CI

---
🤖 Generated by AI
