### PR TITLE
depth-unit test: request depth stream only instead of default config

### DIFF
--- a/unit-tests/live/metadata/pytest-depth-unit.py
+++ b/unit-tests/live/metadata/pytest-depth-unit.py
@@ -23,6 +23,9 @@ def test_depth_units_metadata(test_device):
     # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
     # connected device; without enable_device(sn) the pipeline picks the first match.
     cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
+    # Depth-only: the test validates depth units, and a default config would also wait on
+    # color/IMU streams, failing the test if any unrelated stream doesn't deliver.
+    cfg.enable_stream(rs.stream.depth)
 
     try:
         pipeline_profile = pipeline.start(cfg)


### PR DESCRIPTION
**Overview:** The depth-units metadata test now streams only depth, so it no longer fails when an unrelated stream (color/IMU) doesn't deliver.

Tracked on [RSDSO-21765]

## Why
The test started the pipeline with a default config, which on most devices resolves color + IMU streams in addition to depth. The pipeline aggregator publishes framesets only after every resolved stream has delivered at least one frame, so any unrelated stream that fails to come up fails the test with `Frame didn't arrive within 5000` even though depth streams fine. Seen on D585 Prototype units where an IMU bring-up race (FW-side `Open apm failed`) leaves the accelerometer silent for a power cycle.

## Summary
- `cfg.enable_stream(rs.stream.depth)` — the test validates depth units metadata; depth is the only stream it needs.

## Test plan
- [x] 3/3 repeats pass on a bench where the original test failed 3/3 (D585 Prototype, Linux)
- [x] 3/3 repeats pass on a second Linux setup (D585S, D585 Prototype, D436)
- [ ] CI

---
🤖 Generated by AI
