### PR TITLE
Port L500/L515 support onto v2.58.2 (restore + adapt to backend-devic…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 string(REPLACE ${PROJECT_SOURCE_DIR}/ "" _rel_path ${CMAKE_CURRENT_LIST_DIR})
 include(${_rel_path}/core/CMakeLists.txt)
+include(${_rel_path}/algo/CMakeLists.txt)
 include(${_rel_path}/ds/CMakeLists.txt)
+include(${_rel_path}/l500/CMakeLists.txt)
 include(${_rel_path}/media/CMakeLists.txt)
 include(${_rel_path}/proc/CMakeLists.txt)
 include(${_rel_path}/res/CMakeLists.txt)

--- a/src/algo/CMakeLists.txt
+++ b/src/algo/CMakeLists.txt
@@ -1,0 +1,5 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+include(${CMAKE_CURRENT_LIST_DIR}/thermal-loop/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/max-usable-range/CMakeLists.txt)

--- a/src/algo/CMakeLists.txt
+++ b/src/algo/CMakeLists.txt
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 include(${CMAKE_CURRENT_LIST_DIR}/thermal-loop/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/max-usable-range/CMakeLists.txt)

--- a/src/algo/max-usable-range/CMakeLists.txt
+++ b/src/algo/max-usable-range/CMakeLists.txt
@@ -1,0 +1,7 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+target_sources(${LRS_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/l500/max-usable-range.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500/max-usable-range.cpp"
+)

--- a/src/algo/max-usable-range/CMakeLists.txt
+++ b/src/algo/max-usable-range/CMakeLists.txt
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 target_sources(${LRS_TARGET}
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/l500/max-usable-range.h"

--- a/src/algo/max-usable-range/l500/max-usable-range.cpp
+++ b/src/algo/max-usable-range/l500/max-usable-range.cpp
@@ -1,0 +1,24 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "max-usable-range.h"
+
+// Algo parameters
+static const float PROCESSING_GAIN = 1.75f;
+static const float THERMAL = 74.5f;
+static const float INDOOR_MAX_RANGE = 9.0f;
+
+// Based off of code in RS5-8358
+float librealsense::algo::max_usable_range::l500::max_usable_range(float noise_esimation)
+{
+    const float normalized_nest = noise_esimation / 16.0f;
+
+    auto expected_max_range = INDOOR_MAX_RANGE;
+
+    if (normalized_nest > THERMAL)
+    {
+        expected_max_range = 31000.0f * pow(normalized_nest, -2.0f) * PROCESSING_GAIN;
+    }
+
+    return expected_max_range;
+}

--- a/src/algo/max-usable-range/l500/max-usable-range.cpp
+++ b/src/algo/max-usable-range/l500/max-usable-range.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include "max-usable-range.h"
 

--- a/src/algo/max-usable-range/l500/max-usable-range.h
+++ b/src/algo/max-usable-range/l500/max-usable-range.h
@@ -1,0 +1,22 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <types.h>
+
+
+namespace librealsense {
+namespace algo {
+namespace max_usable_range {
+namespace l500 {
+
+// Calculate the maximum usable range based on current ambient light conditions
+// Input: noise estimation value
+// Output: maximum usable range [m]
+float max_usable_range( float nest );
+
+}  // namespace l500
+}  // namespace max_range
+}  // namespace algo
+}  // namespace librealsense

--- a/src/algo/max-usable-range/l500/max-usable-range.h
+++ b/src/algo/max-usable-range/l500/max-usable-range.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/algo/thermal-loop/CMakeLists.txt
+++ b/src/algo/thermal-loop/CMakeLists.txt
@@ -1,0 +1,7 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+target_sources(${LRS_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/l500-thermal-loop.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-thermal-loop.cpp"
+)

--- a/src/algo/thermal-loop/CMakeLists.txt
+++ b/src/algo/thermal-loop/CMakeLists.txt
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 target_sources(${LRS_TARGET}
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/l500-thermal-loop.h"

--- a/src/algo/thermal-loop/l500-thermal-loop.cpp
+++ b/src/algo/thermal-loop/l500-thermal-loop.cpp
@@ -1,0 +1,123 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "l500-thermal-loop.h"
+#include "../../l500/l500-private.h"
+#include <rsutils/string/from.h>
+
+namespace librealsense {
+namespace algo {
+namespace thermal_loop {
+namespace l500 {
+
+
+const int thermal_calibration_table::id = 0x317;
+
+thermal_calibration_table::thermal_calibration_table() : _resolution(0)
+{
+    _header.max_temp = 0;
+    _header.min_temp = 0;
+    _header.reference_temp = 0;
+    _header.valid = 0;
+}
+
+thermal_calibration_table::thermal_calibration_table( const std::vector< uint8_t > & data,
+                                                      int resolution )
+    : _resolution( resolution )
+{
+    auto expected_size = sizeof( thermal_table_header )
+                       + sizeof( thermal_bin ) * resolution;
+
+    _header.valid = 0;
+
+    if( data.size() != expected_size )
+        throw std::runtime_error( rsutils::string::from()
+                                  << "data size (" << data.size()
+                                  << ") does not meet expected size " << expected_size );
+
+    _header = *(thermal_table_header *)data.data();
+    
+    // The table may be invalid if the unit has not gone thru calibration
+    if( ! _header.valid )
+        throw std::runtime_error( "thermal calibration table is not valid" );
+
+    auto data_ptr = (thermal_bin *)( data.data() + sizeof( thermal_table_header ));
+    bins.assign( data_ptr, data_ptr + resolution );
+}
+
+
+bool operator==( const thermal_calibration_table & lhs, const thermal_calibration_table & rhs )
+{
+    if( lhs.bins.size() != rhs.bins.size() )
+        return false;
+
+    if( lhs._header.max_temp != rhs._header.max_temp || lhs._header.min_temp != rhs._header.min_temp
+        || lhs._header.reference_temp != rhs._header.reference_temp
+        || lhs._header.valid != rhs._header.valid )
+        return false;
+
+    for( auto i = 0; i < rhs.bins.size(); i++ )
+    {
+        if( lhs.bins[i].scale != rhs.bins[i].scale || lhs.bins[i].sheer != rhs.bins[i].sheer
+            || lhs.bins[i].tx != rhs.bins[i].tx || lhs.bins[i].ty != rhs.bins[i].ty )
+            return false;
+    }
+    return true;
+}
+
+
+double thermal_calibration_table::get_thermal_scale( double hum_temp ) const
+{
+    auto scale = bins[_resolution - 1].scale;
+
+    auto temp_range = _header.max_temp - _header.min_temp;
+    // there are 29 bins between min and max temps so 30 equal intervals
+    auto const interval = temp_range / ( _resolution + 1 );
+    // T:   |---|---|---| ... |---|
+    //    min   0   1   2 ... 28  max
+    size_t index = 0;
+    for( double temp = _header.min_temp; index < _resolution;
+            ++index, temp += interval )
+    {
+        auto interval_max = temp + interval;
+        if( hum_temp <= interval_max )
+        {
+            scale = bins[index].scale;
+            break;
+        }
+    }
+
+    // The "scale" is meant to be divided by, but we want something to multiply with!
+    if( scale == 0 )
+        throw std::runtime_error( "invalid 0 scale in thermal table" );
+    return 1. / scale;
+}
+
+
+std::vector< uint8_t > thermal_calibration_table::build_raw_data() const
+{
+    std::vector< float > data;
+
+    data.push_back( _header.min_temp );
+    data.push_back( _header.max_temp );
+    data.push_back( _header.reference_temp );
+    data.push_back( _header.valid );
+
+    for( auto i = 0; i < bins.size(); i++ )
+    {
+        data.push_back( bins[i].scale );
+        data.push_back( bins[i].sheer );
+        data.push_back( bins[i].tx );
+        data.push_back( bins[i].ty );
+    }
+
+    std::vector< uint8_t > res;
+    res.assign( (uint8_t *)( data.data() ), (uint8_t *)( data.data() + data.size() ) );
+    return res;
+}
+
+
+}
+}
+}
+}

--- a/src/algo/thermal-loop/l500-thermal-loop.cpp
+++ b/src/algo/thermal-loop/l500-thermal-loop.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include "l500-thermal-loop.h"
 #include "../../l500/l500-private.h"
@@ -68,6 +68,9 @@ bool operator==( const thermal_calibration_table & lhs, const thermal_calibratio
 
 double thermal_calibration_table::get_thermal_scale( double hum_temp ) const
 {
+    if( _resolution == 0 )
+        throw std::runtime_error( "thermal calibration table has no bins" );
+
     auto scale = bins[_resolution - 1].scale;
 
     auto temp_range = _header.max_temp - _header.min_temp;

--- a/src/algo/thermal-loop/l500-thermal-loop.h
+++ b/src/algo/thermal-loop/l500-thermal-loop.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/algo/thermal-loop/l500-thermal-loop.h
+++ b/src/algo/thermal-loop/l500-thermal-loop.h
@@ -1,0 +1,76 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+#include "../../types.h"
+#include "thermal-calibration-table-interface.h"
+
+namespace librealsense {
+namespace algo {
+namespace thermal_loop {
+namespace l500 {
+
+
+// RGB_Thermal_Info_CalibInfo table
+// -----------------------------------
+//
+// The table contains equally spaced bins between min & max temperature.
+//
+// Each bin has a set of 4 transformation parameters. The transformation maps a point in the RGB
+// image in a given temperature to its expected location in the temperature in which the RGB module
+// was calibrated.
+//
+// Reference at:
+// https://rsconf.intel.com/display/L500/0x317+RGB+Thermal+Table
+//
+#pragma pack( push, 1 )
+class thermal_calibration_table : public thermal_calibration_table_interface
+{
+public:
+    static const int id;
+    
+    // The header as it's written raw
+    struct thermal_table_header
+    {
+        float min_temp;
+        float max_temp;
+        float reference_temp;  // Reference calibration temperature (humidity sensor)
+        float valid;           // Valid table (Created in ATC && Updated in ACC)
+    };
+
+    // Each bin data, as it's written in the actual raw table
+    struct thermal_bin
+    {
+        float scale;
+        float sheer; // parameters which affect offset that are not in use
+        float tx;
+        float ty;
+    };
+
+    // Number of bins *between* min and max:
+    //     bin - size = ( max - min ) / ( resolution + 1 )
+    // In the raw calibration table, 29 is implicitly used.
+    size_t _resolution; 
+    
+    thermal_table_header _header;
+    std::vector< thermal_bin > bins;
+
+    thermal_calibration_table();
+    thermal_calibration_table( const std::vector< uint8_t > & data, int resolution = 29 );
+
+    double get_thermal_scale( double hum_temp ) const override;
+
+    std::vector< uint8_t > build_raw_data() const override;
+
+    bool is_valid() const override { return _header.valid != 0.f; }
+};
+#pragma pack( pop )
+
+bool operator==( const thermal_calibration_table & lhs, const thermal_calibration_table & rhs );
+
+}  // namespace l500
+}  // namespace thermal_loop
+}  // namespace algo
+}  // namespace librealsense

--- a/src/algo/thermal-loop/thermal-calibration-table-interface.h
+++ b/src/algo/thermal-loop/thermal-calibration-table-interface.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/algo/thermal-loop/thermal-calibration-table-interface.h
+++ b/src/algo/thermal-loop/thermal-calibration-table-interface.h
@@ -1,0 +1,27 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+
+namespace librealsense {
+namespace algo {
+namespace thermal_loop {
+
+
+struct thermal_calibration_table_interface
+{
+    virtual ~thermal_calibration_table_interface() {}
+
+    virtual bool is_valid() const = 0;
+
+    virtual double get_thermal_scale( double hum_temp ) const = 0;
+
+    virtual std::vector< uint8_t > build_raw_data() const = 0;
+};
+
+
+}  // namespace thermal_loop
+}  // namespace algo
+}  // namespace librealsense

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -10,6 +10,7 @@
 #include "backend-device.h"
 #include "ds/d400/d400-info.h"
 #include "ds/d500/d500-info.h"
+#include "l500/l500-info.h"
 #include "fw-update/fw-update-factory.h"
 #include "platform-camera.h"
 
@@ -206,6 +207,12 @@ backend_device_factory::create_devices_from_group( platform::backend_device_grou
         {
             auto d500_devices = d500_info::pick_d500_devices( ctx, devices );
             std::copy( begin( d500_devices ), end( d500_devices ), std::back_inserter( list ) );
+        }
+
+        if( mask & RS2_PRODUCT_LINE_L500 )
+        {
+            auto l500_devices = l500_info::pick_l500_devices( ctx, devices );
+            std::copy( begin( l500_devices ), end( l500_devices ), std::back_inserter( list ) );
         }
 
         // Supported recovery devices

--- a/src/fw-update/fw-update-factory.cpp
+++ b/src/fw-update/fw-update-factory.cpp
@@ -8,6 +8,8 @@
 #include "ds/d500/d500-private.h"
 #include "ds/d400/d400-fw-update-device.h"
 #include "ds/d500/d500-fw-update-device.h"
+#include "l500/l500-private.h"
+#include "l500/l500-fw-update-device.h"
 
 #include <rsutils/string/from.h>
 
@@ -27,6 +29,8 @@ namespace librealsense
             return RS2_PRODUCT_LINE_D500;
         if( ds::D585S_RECOVERY_PID == usb_info.pid )
             return RS2_PRODUCT_LINE_D500;
+        if( L500_RECOVERY_PID == usb_info.pid )
+            return RS2_PRODUCT_LINE_L500;
         return 0;
     }
 
@@ -79,6 +83,8 @@ namespace librealsense
                         case ds::D555_RECOVERY_PID:
                         case ds::D585S_RECOVERY_PID:
                             return std::make_shared< ds_d500_update_device >(shared_from_this(), usb);
+                        case L500_RECOVERY_PID:
+                            return std::make_shared< l500_update_device >(shared_from_this(), usb);
                         default:
                             // Do nothing
                             break;

--- a/src/l500/CMakeLists.txt
+++ b/src/l500/CMakeLists.txt
@@ -1,0 +1,27 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+target_sources(${LRS_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/l500-depth.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-private.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-color.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-device.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-motion.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-factory.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-fw-update-device.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-serializable.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-options.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/get-mfr-ww.cpp"
+
+        "${CMAKE_CURRENT_LIST_DIR}/l500-depth.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-private.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-color.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-device.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-motion.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-info.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-fw-update-device.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-serializable.h"
+        "${CMAKE_CURRENT_LIST_DIR}/l500-options.h"
+        "${CMAKE_CURRENT_LIST_DIR}/get-mfr-ww.h"
+)
+

--- a/src/l500/CMakeLists.txt
+++ b/src/l500/CMakeLists.txt
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 target_sources(${LRS_TARGET}
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/l500-depth.cpp"

--- a/src/l500/get-mfr-ww.cpp
+++ b/src/l500/get-mfr-ww.cpp
@@ -1,0 +1,41 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "get-mfr-ww.h"
+#include <string>
+#include <stdexcept>
+
+
+namespace utilities {
+namespace time {
+namespace l500 {
+// The Serial Number format is PYWWXXXX:
+// P – Site Name(ex.“F” for Fabrinet)
+// Y – Year(ex.“9” for 2019, "0" for 2020, , "1" for 2021  ..etc)
+// WW – Work Week
+// XXXX – Sequential number
+rsutils::time::work_week get_manufacture_work_week( const std::string & serial )
+{
+    if( serial.size() != 8 )
+        throw std::runtime_error( "Invalid serial number \"" + serial + "\" length" );
+    unsigned Y = serial[1] - '0';  // Converts char to int, '0'-> 0, '1'-> 1, ...
+    unsigned man_year = 0;
+    // using Y from serial number to get manufactoring year
+    if( Y == 9 )
+        man_year = 2019;
+    else if( Y < 9 )
+        man_year = 2020 + Y;
+    else
+        throw std::runtime_error( "Invalid serial number \"" + serial + "\" year" );
+    // using WW from serial number to get manufactoring work week
+    unsigned WW_tens = serial[2] - '0';
+    unsigned WW_singles = serial[3] - '0';
+    unsigned man_ww = ( (WW_tens)*10 ) + WW_singles;
+    if (man_ww > 53)
+        throw std::runtime_error( "Invalid serial number \"" + serial + "\" work week" );
+    return rsutils::time::work_week( man_year, man_ww );
+}
+
+}  // namespace l500
+}  // namespace time
+}  // namespace utilities

--- a/src/l500/get-mfr-ww.cpp
+++ b/src/l500/get-mfr-ww.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include "get-mfr-ww.h"
 #include <string>
@@ -10,10 +10,10 @@ namespace utilities {
 namespace time {
 namespace l500 {
 // The Serial Number format is PYWWXXXX:
-// P – Site Name(ex.“F” for Fabrinet)
-// Y – Year(ex.“9” for 2019, "0" for 2020, , "1" for 2021  ..etc)
-// WW – Work Week
-// XXXX – Sequential number
+// P - Site Name(ex."F" for Fabrinet)
+// Y - Year(ex."9" for 2019, "0" for 2020, , "1" for 2021  ..etc)
+// WW - Work Week
+// XXXX - Sequential number
 rsutils::time::work_week get_manufacture_work_week( const std::string & serial )
 {
     if( serial.size() != 8 )

--- a/src/l500/get-mfr-ww.h
+++ b/src/l500/get-mfr-ww.h
@@ -1,0 +1,18 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+#include <rsutils/time/work-week.h>
+
+
+namespace utilities {
+namespace time {
+namespace l500 {
+
+rsutils::time::work_week get_manufacture_work_week( const std::string & serial );
+
+}  // namespace l500
+}  // namespace time
+}  // namespace utilities

--- a/src/l500/get-mfr-ww.h
+++ b/src/l500/get-mfr-ww.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -1,0 +1,539 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#include "l500-color.h"
+#include "l500-info.h"
+#include <rsutils/type/fourcc.h>
+#include <src/platform/uvc-option.h>
+#include <src/image.h>
+#include <src/platform/platform-utils.h>
+
+#include "l500-private.h"
+#include "proc/color-formats-converter.h"
+#include "algo/thermal-loop/l500-thermal-loop.h"
+
+#include <rsutils/string/from.h>
+
+#include <cstddef>
+#include <mutex>
+
+
+namespace librealsense
+{
+    using rsutils::type::fourcc;
+    using namespace ivcam2;
+
+    std::map<rsutils::type::fourcc::value_type, rs2_format> l500_color_fourcc_to_rs2_format = {
+        {fourcc('Y','U','Y','2'), RS2_FORMAT_YUYV},
+        {fourcc('Y','U','Y','V'), RS2_FORMAT_YUYV},
+        {fourcc('U','Y','V','Y'), RS2_FORMAT_UYVY},
+
+        // Description of NV12 on fourcc.org:
+        //     https://www.fourcc.org/pixel-format/yuv-nv12/
+        // NV12 format on Linux kernel spac :
+        //     https://www.kernel.org/doc/html/v4.12/media/uapi/v4l/pixfmt-nv12.html
+        //
+        // WE DO NOT ENCODE WITH NV12!
+        //
+        // The encoding is actually Y411:
+        //     https://www.fourcc.org/pixel-format/yuv-y411/
+        // Unfortunately, Y411 is unsupported in the Linux kernel. Instead, we diguise it as 'NV12' but the
+        // actual encoding is still Y11.
+        //
+        // Both Y411 and NV12 are 12bpp encodings that allow high-resolution modes in the camera to still
+        // fit within the USB3 limits (YUY wasn't enough).
+        //
+        {fourcc('N','V','1','2'), RS2_FORMAT_Y411}
+    };
+
+    std::map<rsutils::type::fourcc::value_type, rs2_stream> l500_color_fourcc_to_rs2_stream = {
+        {fourcc('Y','U','Y','2'), RS2_STREAM_COLOR},
+        {fourcc('Y','U','Y','V'), RS2_STREAM_COLOR},
+        {fourcc('U','Y','V','Y'), RS2_STREAM_COLOR},
+        {fourcc('N','V','1','2'), RS2_STREAM_COLOR}
+    };
+
+    std::shared_ptr<synthetic_sensor> l500_color::create_color_device(std::shared_ptr<context> ctx, const std::vector<platform::uvc_device_info>& color_devices_info)
+    {
+        auto backend = get_backend();
+
+        std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ivcam2::l500_timestamp_reader_from_metadata());
+        auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
+        auto raw_color_ep = std::make_shared<uvc_sensor>("RGB Camera", get_backend()->create_uvc_device(color_devices_info.front()),
+            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(timestamp_reader_metadata), _tf_keeper, enable_global_time_option)),
+            this);
+        auto color_ep = std::make_shared<l500_color_sensor>(this, raw_color_ep, ctx, l500_color_fourcc_to_rs2_format, l500_color_fourcc_to_rs2_stream);
+
+        color_ep->register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, color_devices_info.front().device_path);
+
+        // processing blocks
+        color_ep->register_processing_block(
+            processing_block_factory::create_pbf_vector< yuy2_converter >(
+                RS2_FORMAT_YUYV,                                                      // from
+                map_supported_color_formats( RS2_FORMAT_YUYV ), RS2_STREAM_COLOR ) ); // to
+
+        // options
+        color_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+        color_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
+        color_ep->register_pu(RS2_OPTION_BACKLIGHT_COMPENSATION);
+        color_ep->register_pu(RS2_OPTION_BRIGHTNESS);
+        color_ep->register_pu(RS2_OPTION_CONTRAST);
+        color_ep->register_pu(RS2_OPTION_GAIN);
+        color_ep->register_pu(RS2_OPTION_HUE);
+        color_ep->register_pu(RS2_OPTION_SATURATION);
+        color_ep->register_pu(RS2_OPTION_SHARPNESS);
+        color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
+
+        color_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+
+        auto white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_WHITE_BALANCE);
+        auto auto_white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
+        color_ep->register_option(RS2_OPTION_WHITE_BALANCE, white_balance_option);
+        color_ep->register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, auto_white_balance_option);
+        color_ep->register_option(RS2_OPTION_WHITE_BALANCE,
+            std::make_shared<auto_disabling_control>(
+                white_balance_option,
+                auto_white_balance_option));
+
+        auto exposure_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_EXPOSURE);
+        auto auto_exposure_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_ENABLE_AUTO_EXPOSURE);
+        color_ep->register_option(RS2_OPTION_EXPOSURE, exposure_option);
+        color_ep->register_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, auto_exposure_option);
+        color_ep->register_option(RS2_OPTION_EXPOSURE,
+            std::make_shared<auto_disabling_control>(
+                exposure_option,
+                auto_exposure_option));
+
+        color_ep->register_option(RS2_OPTION_POWER_LINE_FREQUENCY,
+            std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_POWER_LINE_FREQUENCY,
+                std::map<float, std::string>{ { 0.f, "Disabled"},
+                { 1.f, "50Hz" },
+                { 2.f, "60Hz" },
+                { 3.f, "Auto" }, }));
+
+
+        // option to enable workaround for help weak usb hosts to support L515 devices
+        // with improved performance and stability
+        if(_fw_version >= firmware_version( "1.5.1.0" ) )
+        {
+            rs2_host_perf_mode launch_perf_mode = RS2_HOST_PERF_DEFAULT;
+
+#ifdef __ANDROID__
+            // android devices most likely low power low performance host
+            launch_perf_mode = RS2_HOST_PERF_LOW;
+#else
+            // other hosts use default settings from firmware, user still have the option to change later after launch
+            launch_perf_mode = RS2_HOST_PERF_DEFAULT;
+#endif
+
+            color_ep->register_option(RS2_OPTION_HOST_PERFORMANCE, std::make_shared<librealsense::float_option_with_description<rs2_host_perf_mode>>(option_range{ RS2_HOST_PERF_DEFAULT, RS2_HOST_PERF_COUNT - 1, 1, (float) launch_perf_mode }, "Optimize based on host performance, low power low performance host or high power high performance host"));
+        }
+
+        // metadata
+        // attributes of md_capture_timing
+        auto md_prop_offset = offsetof(metadata_raw, mode) +
+            offsetof(md_rgb_normal_mode, intel_capture_timing);
+
+        color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER, make_attribute_parser(&l500_md_capture_timing::frame_counter, md_capture_timing_attributes::frame_counter_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP, make_attribute_parser(&l500_md_capture_timing::sensor_timestamp, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS, make_attribute_parser(&l500_md_capture_timing::exposure_time, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));
+
+        // attributes of md_capture_stats
+        md_prop_offset = offsetof(metadata_raw, mode) +
+            offsetof(md_rgb_normal_mode, intel_capture_stats);
+
+        color_ep->register_metadata(RS2_FRAME_METADATA_WHITE_BALANCE, make_attribute_parser(&md_capture_stats::white_balance, md_capture_stat_attributes::white_balance_attribute, md_prop_offset));
+
+        // attributes of md_rgb_control
+        md_prop_offset = offsetof(metadata_raw, mode) +
+            offsetof(md_rgb_normal_mode, intel_rgb_control);
+
+        color_ep->register_metadata(RS2_FRAME_METADATA_GAIN_LEVEL, make_attribute_parser(&md_rgb_control::gain, md_rgb_control_attributes::gain_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE, make_attribute_parser(&md_rgb_control::manual_exp, md_rgb_control_attributes::manual_exp_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_AUTO_EXPOSURE, make_attribute_parser(&md_rgb_control::ae_mode, md_rgb_control_attributes::ae_mode_attribute, md_prop_offset,
+            [](rs2_metadata_type param) { return (param != 1); }));
+        color_ep->register_metadata(RS2_FRAME_METADATA_BRIGHTNESS, make_attribute_parser(&md_rgb_control::brightness, md_rgb_control_attributes::brightness_attribute, md_prop_offset,
+                [](const rs2_metadata_type& param) {
+                    // cast to short in order to return negative values
+                    return *(short*)&(param);
+                }));
+        color_ep->register_metadata(RS2_FRAME_METADATA_CONTRAST, make_attribute_parser(&md_rgb_control::contrast, md_rgb_control_attributes::contrast_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_SATURATION, make_attribute_parser(&md_rgb_control::saturation, md_rgb_control_attributes::saturation_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_SHARPNESS, make_attribute_parser(&md_rgb_control::sharpness, md_rgb_control_attributes::sharpness_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_AUTO_WHITE_BALANCE_TEMPERATURE, make_attribute_parser(&md_rgb_control::awb_temp, md_rgb_control_attributes::awb_temp_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_BACKLIGHT_COMPENSATION, make_attribute_parser(&md_rgb_control::backlight_comp, md_rgb_control_attributes::backlight_comp_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_GAMMA, make_attribute_parser(&md_rgb_control::gamma, md_rgb_control_attributes::gamma_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_HUE, make_attribute_parser(&md_rgb_control::hue, md_rgb_control_attributes::hue_attribute, md_prop_offset,
+            [](const rs2_metadata_type& param) {
+                // cast to short in order to return negative values
+                return *(short*)&(param);
+            }));
+        color_ep->register_metadata(RS2_FRAME_METADATA_MANUAL_WHITE_BALANCE, make_attribute_parser(&md_rgb_control::manual_wb, md_rgb_control_attributes::manual_wb_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_POWER_LINE_FREQUENCY, make_attribute_parser(&md_rgb_control::power_line_frequency, md_rgb_control_attributes::power_line_frequency_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_LOW_LIGHT_COMPENSATION, make_attribute_parser(&md_rgb_control::low_light_comp, md_rgb_control_attributes::low_light_comp_attribute, md_prop_offset));
+        color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
+
+        return color_ep;
+    }
+
+    l500_color::l500_color( std::shared_ptr< const l500_info > const & dev_info )
+        :device(dev_info),
+        backend_device(dev_info),
+        l500_device(dev_info),
+         _color_stream(new stream(RS2_STREAM_COLOR))
+    {
+        auto const & group = dev_info->get_group();
+        auto ctx = dev_info->get_context();
+
+        auto color_devs_info = filter_by_mi(group.uvc_devices, 4);
+        if (color_devs_info.size() != 1)
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "L500 with RGB models are expected to include a single color device! - "
+                                           << color_devs_info.size() << " found" );
+
+        _color_intrinsics_table = [this]() { return read_intrinsics_table(); };
+        _color_extrinsics_table_raw = [this]() { return get_raw_extrinsics_table(); };
+
+        // This lazy instance will get shared between all the extrinsics edges. If you ever need to override
+        // it, be careful not to overwrite the shared-ptr itself (register_extrinsics) or the sharing
+        // will get ruined. Instead, overwriting the rsutils::lazy<> function should do it:
+        //      *_color_extrinsic = [=]() { return extr; };
+        _color_extrinsic = std::make_shared<rsutils::lazy<rs2_extrinsics>>(
+            [this]()
+            {
+                return get_color_stream_extrinsic(*_color_extrinsics_table_raw);
+            } );
+        environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_color_stream, _color_extrinsic);
+        register_stream_to_extrinsic_group(*_color_stream, 0);
+
+        _thermal_table = [this]() {
+
+            hwmon_response_type response;
+            auto data = read_fw_table_raw( *_hw_monitor,
+                                           algo::thermal_loop::l500::thermal_calibration_table::id,
+                                           response );
+            if( response != ds::d400_hwmon_response::SUCCESS )
+            {
+                LOG_WARNING( "Failed to read FW table 0x"
+                             << std::hex
+                             << algo::thermal_loop::l500::thermal_calibration_table::id );
+                throw invalid_value_exception( rsutils::string::from()
+                                               << "Failed to read FW table 0x" << std::hex
+                                               << algo::thermal_loop::l500::thermal_calibration_table::id );
+            }
+
+            if( data.size() > sizeof( table_header ))
+                data.erase( data.begin(), data.begin() + sizeof( table_header ) );
+            return algo::thermal_loop::l500::thermal_calibration_table{ data };
+        };
+
+        _color_device_idx = add_sensor(create_color_device(ctx, color_devs_info));
+    }
+
+    l500_color_sensor * l500_color::get_color_sensor()
+    {
+        return &dynamic_cast< l500_color_sensor & >( get_sensor( _color_device_idx ));
+    }
+
+
+    rs2_intrinsics l500_color_sensor::get_raw_intrinsics( uint32_t const width,
+                                                          uint32_t const height ) const
+    {
+        using namespace ivcam2;
+
+        auto & intrinsic = *_owner->_color_intrinsics_table;
+
+        auto num_of_res = intrinsic.resolution.num_of_resolutions;
+
+        for( auto i = 0; i < num_of_res; i++ )
+        {
+            auto model = intrinsic.resolution.intrinsic_resolution[i];
+            if( model.height == height && model.width == width )
+            {
+                rs2_intrinsics intrinsics = {};
+                intrinsics.width = model.width;
+                intrinsics.height = model.height;
+                intrinsics.fx = model.ipm.focal_length.x;
+                intrinsics.fy = model.ipm.focal_length.y;
+                intrinsics.ppx = model.ipm.principal_point.x;
+                intrinsics.ppy = model.ipm.principal_point.y;
+
+                if( model.distort.radial_k1 || model.distort.radial_k2
+                    || model.distort.tangential_p1 || model.distort.tangential_p2
+                    || model.distort.radial_k3 )
+                {
+                    intrinsics.coeffs[0] = model.distort.radial_k1;
+                    intrinsics.coeffs[1] = model.distort.radial_k2;
+                    intrinsics.coeffs[2] = model.distort.tangential_p1;
+                    intrinsics.coeffs[3] = model.distort.tangential_p2;
+                    intrinsics.coeffs[4] = model.distort.radial_k3;
+
+                    intrinsics.model = l500_distortion;
+
+                }
+
+                return intrinsics;
+            }
+        }
+        throw std::runtime_error( rsutils::string::from()
+                                  << "intrinsics for resolution " << width << "," << height << " don't exist" );
+    }
+
+    rs2_intrinsics normalize( const rs2_intrinsics & intr )
+    {
+        auto res = intr;
+        res.fx = 2 * intr.fx / intr.width;
+        res.fy = 2 * intr.fy / intr.height;
+        res.ppx = 2 * intr.ppx / intr.width - 1;
+        res.ppy = 2 * intr.ppy / intr.height - 1;
+
+        return res;
+    }
+
+    rs2_intrinsics
+    denormalize( const rs2_intrinsics & intr, const uint32_t & width, const uint32_t & height )
+    {
+        auto res = intr;
+
+        res.fx = intr.fx * width / 2;
+        res.fy = intr.fy * height / 2;
+        res.ppx = ( intr.ppx + 1 ) * width / 2;
+        res.ppy = ( intr.ppy + 1 ) * height / 2;
+
+        res.width = width;
+        res.height = height;
+
+        return res;
+    }
+
+
+    rs2_intrinsics l500_color_sensor::get_intrinsics( const stream_profile & profile ) const
+    {
+        if( ! _k_thermal_intrinsics)
+        {
+            // Until we've calculated temp-based intrinsics, simply use the camera-specified
+            // intrinsics
+            return get_raw_intrinsics( profile.width, profile.height );
+        }
+
+        return denormalize( *_k_thermal_intrinsics, profile.width, profile.height );
+    }
+
+
+    rs2_intrinsics ivcam2::rgb_calibration_table::get_intrinsics() const
+    {
+        // TODO: we currently use the wrong distortion model, but all the code is
+        // written to expect the INVERSE brown. The table assumes REGULAR brown.
+        return { width, height,
+                 intr.px, intr.py,  // NOTE: this is normalized!
+                 intr.fx, intr.fy,  // NOTE: this is normalized!
+                 RS2_DISTORTION_INVERSE_BROWN_CONRADY,  // see comment above
+                 { intr.d[0], intr.d[1], intr.d[2], intr.d[3], intr.d[4] } };
+    }
+
+    void ivcam2::rgb_calibration_table::set_intrinsics( rs2_intrinsics const & i )
+    {
+        // The table in FW is resolution-agnostic; it can apply to ALL resolutions. To
+        // do this, the focal length and principal point are normalized:
+        auto norm = normalize( i );
+
+        width = i.width;
+        height = i.height;
+        intr.fx = norm.fx;
+        intr.fy = norm.fy;
+        intr.px = norm.ppx;
+        intr.py = norm.ppy;
+        intr.d[0] = i.coeffs[0];
+        intr.d[1] = i.coeffs[1];
+        intr.d[2] = i.coeffs[2];
+        intr.d[3] = i.coeffs[3];
+        intr.d[4] = i.coeffs[4];
+    }
+
+    void l500_color_sensor::set_k_thermal_intrinsics( rs2_intrinsics const & intr )
+    {
+
+        _k_thermal_intrinsics = std::make_shared< rs2_intrinsics >( normalize(intr) );
+    }
+
+    void l500_color_sensor::reset_k_thermal_intrinsics() 
+    {
+        _k_thermal_intrinsics.reset();
+    }
+
+    algo::thermal_loop::l500::thermal_calibration_table l500_color_sensor::get_thermal_table() const
+    {
+        return *_owner->_thermal_table;
+    }
+
+    void ivcam2::rgb_calibration_table::update_write_fields()
+    {
+        // We don't touch the version...
+        //version = ;
+
+        // This signifies AC results:
+        type = 0x10;
+
+        // The time-stamp is simply a sequential number that we increment
+        ++timestamp;
+    }
+
+    void l500_color_sensor::start(rs2_frame_callback_sptr callback)
+    {
+        std::lock_guard<std::mutex> lock(_state_mutex);
+
+        if (_state != sensor_state::OWNED_BY_USER)
+            throw wrong_api_call_sequence_exception("tried to start an unopened sensor");
+
+        if (supports_option(RS2_OPTION_HOST_PERFORMANCE))
+        {
+            // option to improve performance and stability on weak android hosts
+            // please refer to following bug report for details
+            // RS5-8011 [Android-L500 Hard failure] Device detach and disappear from system during stream
+
+            auto host_perf = get_option(RS2_OPTION_HOST_PERFORMANCE).query();
+
+            if (static_cast<int>(host_perf) == RS2_HOST_PERF_LOW || static_cast<int>(host_perf) == RS2_HOST_PERF_HIGH)
+            {
+                // TPROC USB Granularity and TRB threshold settings for improved performance and stability
+                // on hosts with weak cpu and system performance
+                // settings values are validated through many experiments, do not change
+
+                // on low power low performance host, usb trb set to larger granularity to reduce number of transactions
+                // and improve performance
+                int usb_trb = 7;       // 7 KB
+
+                if (static_cast<int>(host_perf) == RS2_HOST_PERF_LOW)
+                {
+                    usb_trb = 32;      // 32 KB
+                }
+
+                try {
+                    // Keep the USB power on while triggering multiple calls on it.
+                    group_multiple_fw_calls(*this, [&]() {
+                        // endpoint 5 - 32KB
+                        command cmdTprocGranEp5(ivcam2::TPROC_USB_GRAN_SET, 5, usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp5);
+
+                        command cmdTprocThresholdEp5(ivcam2::TPROC_TRB_THRSLD_SET, 5, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp5);
+                        });
+                    LOG_DEBUG("Color usb tproc granularity and TRB threshold updated.");
+                } catch (...)
+                {
+                    LOG_WARNING("Failed to update color usb tproc granularity and TRB threshold. performance and stability maybe impacted on certain platforms.");
+                }
+            }
+            else if (static_cast<int>(host_perf) == RS2_HOST_PERF_DEFAULT)
+            {
+                    LOG_DEBUG("Default host performance mode, color usb tproc granularity and TRB threshold not changed");
+            }
+        }
+
+        delayed_start(callback);
+    }
+
+    
+    void l500_color_sensor::stop()
+    {
+        std::lock_guard<std::mutex> lock(_state_mutex);
+        
+        // Protect not stopping the calibration color stream due to wrong API sequence
+        if (_state != sensor_state::OWNED_BY_USER)
+            throw wrong_api_call_sequence_exception("tried to stop sensor without starting it");
+
+        delayed_stop();
+    }
+
+
+    void l500_color_sensor::open( const stream_profiles & requests )
+    {
+        std::lock_guard< std::mutex > lock( _state_mutex );
+
+        synthetic_sensor::open( requests );
+        set_sensor_state( sensor_state::OWNED_BY_USER );
+    }
+
+    
+    void l500_color_sensor::close()
+    {
+        std::lock_guard< std::mutex > lock( _state_mutex );
+
+        if( _state != sensor_state::OWNED_BY_USER )
+            throw wrong_api_call_sequence_exception( "tried to close sensor without opening it" );
+
+        synthetic_sensor::close();
+        set_sensor_state(sensor_state::CLOSED);
+    }
+
+    std::string l500_color_sensor::state_to_string(sensor_state state)
+    {
+        switch (state)
+        {
+        case sensor_state::CLOSED:
+            return "CLOSED";
+        case sensor_state::OWNED_BY_USER:
+            return "OWNED_BY_USER";
+        default:
+            LOG_DEBUG("Invalid color sensor state: " << static_cast<int>(state));
+            return "Unknown state";
+        }
+    }
+
+    std::vector<tagged_profile> l500_color::get_profiles_tags() const
+    {
+        std::vector<tagged_profile> tags;
+
+        bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
+
+        int width = usb3mode ? 1280 : 960;
+        int height = usb3mode ? 720 : 540;
+
+        tags.push_back({ RS2_STREAM_COLOR, -1, width, height, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+
+        return tags;
+    }
+
+    ivcam2::intrinsic_rgb l500_color::read_intrinsics_table() const
+    {
+        // Get RAW data from firmware
+        LOG_DEBUG( "RGB_INTRINSIC_GET" );
+        std::vector< uint8_t > response_vec = _hw_monitor->send(command{ RGB_INTRINSIC_GET });
+
+        if (response_vec.empty())
+            throw invalid_value_exception("Calibration data invalid,buffer size is zero");
+
+        auto resolutions_rgb_table_ptr = reinterpret_cast<const ivcam2::intrinsic_rgb *>(response_vec.data());
+        auto num_of_resolutions = resolutions_rgb_table_ptr->resolution.num_of_resolutions;
+
+        // Get full maximum size of the resolution array and deduct the unused resolutions size from it
+        size_t expected_size = sizeof( ivcam2::intrinsic_rgb )
+                                - ( ( MAX_NUM_OF_RGB_RESOLUTIONS
+                                - num_of_resolutions)
+                                * sizeof( pinhole_camera_model ) );
+
+        // Validate table size
+        // FW API guarantee only as many bytes as required for the given number of resolutions, 
+        // The FW keeps the right to send more bytes.
+        if (expected_size > response_vec.size() ||
+            num_of_resolutions > MAX_NUM_OF_RGB_RESOLUTIONS)
+        {
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Calibration data invalid, number of resolutions is: "
+                                           << num_of_resolutions << ", expected size: " << expected_size
+                                           << " , actual size: " << response_vec.size() );
+        }
+
+        // Set a new memory allocated intrinsics struct (Full size 5 resolutions)
+        // Copy the relevant data from the dynamic resolution received from the FW
+        ivcam2::intrinsic_rgb  resolutions_rgb_table_output;
+        std::memcpy(&resolutions_rgb_table_output, resolutions_rgb_table_ptr, expected_size);
+
+        return resolutions_rgb_table_output;
+    }
+    std::vector<uint8_t> l500_color::get_raw_extrinsics_table() const
+    {
+        LOG_DEBUG( "RGB_EXTRINSIC_GET" );
+        return _hw_monitor->send(command{ RGB_EXTRINSIC_GET });
+    }
+}

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #include "l500-color.h"
 #include "l500-info.h"
@@ -83,8 +83,6 @@ namespace librealsense
         color_ep->register_pu(RS2_OPTION_SATURATION);
         color_ep->register_pu(RS2_OPTION_SHARPNESS);
         color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
-
-        color_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
 
         auto white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_WHITE_BALANCE);
         auto auto_white_balance_option = std::make_shared<uvc_pu_option>(raw_color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -1,0 +1,173 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <map>
+
+#include "l500-device.h"
+#include "stream.h"
+#include <src/color-sensor.h>
+#include <rsutils/type/fourcc.h>
+#include <src/core/video.h>
+#include "l500-depth.h"
+#include "algo/thermal-loop/l500-thermal-loop.h"
+
+namespace librealsense
+{
+
+    const rs2_distortion l500_distortion = RS2_DISTORTION_BROWN_CONRADY;
+
+    class l500_color
+        : public virtual l500_device
+    {
+    public:
+        std::shared_ptr<synthetic_sensor> create_color_device(std::shared_ptr<context> ctx,
+            const std::vector<platform::uvc_device_info>& color_devices_info);
+
+        l500_color( std::shared_ptr< const l500_info > const & dev_info );
+
+        l500_color_sensor * get_color_sensor() override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override;
+
+    protected:
+        std::shared_ptr<stream_interface> _color_stream;
+
+    private:
+        friend class l500_color_sensor;
+
+        uint8_t _color_device_idx = -1;
+
+        rsutils::lazy<ivcam2::intrinsic_rgb> _color_intrinsics_table;
+        rsutils::lazy<std::vector<uint8_t>> _color_extrinsics_table_raw;
+        std::shared_ptr<rsutils::lazy<rs2_extrinsics>> _color_extrinsic;
+        rsutils::lazy< algo::thermal_loop::l500::thermal_calibration_table > _thermal_table;
+
+        ivcam2::intrinsic_rgb read_intrinsics_table() const;
+        std::vector<uint8_t> get_raw_extrinsics_table() const;
+    };
+    class l500_color_sensor
+        : public synthetic_sensor
+        , public video_sensor_interface
+        , public color_sensor
+    {
+    public:
+        explicit l500_color_sensor(l500_color* owner,
+            std::shared_ptr<uvc_sensor> uvc_sensor,
+            std::shared_ptr<context> ctx,
+            std::map<rsutils::type::fourcc::value_type, rs2_format> l500_color_fourcc_to_rs2_format,
+            std::map<rsutils::type::fourcc::value_type, rs2_stream> l500_color_fourcc_to_rs2_stream)
+            : synthetic_sensor("RGB Camera", uvc_sensor, owner, l500_color_fourcc_to_rs2_format, l500_color_fourcc_to_rs2_stream),
+            _owner(owner),
+            _state(sensor_state::CLOSED)
+        {
+        }
+        rs2_intrinsics get_raw_intrinsics( uint32_t width, uint32_t height ) const;
+
+        rs2_intrinsics get_intrinsics( const stream_profile& profile ) const override;
+
+
+
+        void set_k_thermal_intrinsics( rs2_intrinsics const & intr );
+        void reset_k_thermal_intrinsics(); 
+        algo::thermal_loop::l500::thermal_calibration_table get_thermal_table() const;
+
+        stream_profiles init_stream_profiles() override
+        {
+            auto lock = environment::get_instance().get_extrinsics_graph().lock();
+
+            auto&& results = synthetic_sensor::init_stream_profiles();
+
+            for (auto&& p : results)
+            {
+                // Register stream types
+                if (p->get_stream_type() == RS2_STREAM_COLOR)
+                {
+                    assign_stream(_owner->_color_stream, p);
+                }
+
+                // Register intrinsics
+                auto&& video = dynamic_cast<video_stream_profile_interface*>(p.get());
+                const auto&& profile = to_profile(p.get());
+                std::weak_ptr<l500_color_sensor> wp =
+                    std::dynamic_pointer_cast<l500_color_sensor>(this->shared_from_this());
+                video->set_intrinsics([profile, wp]()
+                {
+                    auto sp = wp.lock();
+                    if (sp)
+                        return sp->get_intrinsics(profile);
+                    else
+                        return rs2_intrinsics{};
+                });
+            }
+
+            return results;
+        }
+
+        processing_blocks get_recommended_processing_blocks() const override
+        {
+            return get_color_recommended_proccesing_blocks();
+        }
+
+
+        // Opens the color sensor profile, if the sensor is opened by calibration process,
+        // It will close it and reopen with the requested profile.
+        void open(const stream_profiles& requests) override;
+
+        // Close the color sensor
+        void close() override;
+    
+        // Start the color sensor streaming
+        void start(rs2_frame_callback_sptr callback) override;
+        
+        // Stops the color sensor streaming
+        void stop() override;
+        
+    private:
+        l500_color* const _owner;
+        action_delayer _action_delayer;
+        std::mutex _state_mutex;
+
+        // Intrinsics from the the last successful AC( if there was one ) with k - thermal correction,
+        // We save it normalized such that it can be applied to each resolution
+        std::shared_ptr< rs2_intrinsics > _k_thermal_intrinsics;
+
+        enum class sensor_state
+        {
+            CLOSED,
+            OWNED_BY_USER
+        };
+
+        std::atomic< sensor_state > _state;
+
+        void delayed_start(rs2_frame_callback_sptr callback)
+        {
+            LOG_DEBUG("Starting color sensor...");
+            // The delay is here as a work around to a firmware bug [RS5-5453]
+            _action_delayer.do_after_delay([&]() { synthetic_sensor::start(callback); });
+            LOG_DEBUG("Color sensor started");
+        }
+
+        void delayed_stop()
+        {
+            LOG_DEBUG("Stopping color sensor...");
+            // The delay is here as a work around to a firmware bug [RS5-5453]
+            _action_delayer.do_after_delay([&]() { synthetic_sensor::stop(); });
+            LOG_DEBUG("Color sensor stopped");
+        }
+
+        std::string state_to_string(sensor_state state);
+
+        void set_sensor_state(sensor_state state)
+        {
+            LOG_DEBUG( "Sensor state changed from: " << state_to_string( _state )
+                                          << " to: " << state_to_string( state ) );
+            _state = state;
+        }
+
+    };
+
+}

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #include <vector>
 #include "device.h"
@@ -331,7 +331,7 @@ namespace librealsense
         const uint32_t baseline_address = 0xa00e0868;
         command cmd(ivcam2::fw_cmd::MRD, baseline_address, baseline_address + 4);
         auto res = _owner->_hw_monitor->send(cmd);
-        if (res.size() < 1)
+        if (res.size() < sizeof(float))
         {
             throw std::runtime_error("Invalid result size!");
         }

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -1,0 +1,593 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#include <vector>
+#include "device.h"
+#include "context.h"
+#include "stream.h"
+#include "l500-depth.h"
+#include "l500-info.h"
+#include <rsutils/type/fourcc.h>
+#include <src/platform/uvc-option.h>
+#include <src/image.h>
+#include <src/platform/uvc-option.h>
+#include <src/sync.h>
+#include <src/core/matcher-factory.h>
+#include "l500-color.h"
+#include "l500-private.h"
+#include "proc/decimation-filter.h"
+#include "proc/threshold.h" 
+#include "proc/spatial-filter.h"
+#include "proc/temporal-filter.h"
+#include "proc/hole-filling-filter.h"
+#include <cstddef>
+#include "metadata-parser.h"
+#include "l500-options.h"
+#include "algo/max-usable-range/l500/max-usable-range.h" 
+
+#include <rsutils/string/from.h>
+
+
+#define MM_TO_METER 1/1000
+#define MIN_ALGO_VERSION 115
+
+namespace librealsense
+{
+    using rsutils::type::fourcc;
+    using namespace ivcam2;
+
+    ivcam2::intrinsic_depth l500_depth::read_intrinsics_table() const
+    {
+        // Get RAW data from firmware
+        std::vector< uint8_t > response_vec = _hw_monitor->send( command{ DPT_INTRINSICS_FULL_GET } );
+
+        if (response_vec.empty())
+            throw invalid_value_exception("Calibration data invalid,buffer size is zero");
+
+        auto resolutions_depth_table_ptr = reinterpret_cast<const ivcam2::intrinsic_depth *>(response_vec.data());
+
+        auto num_of_resolutions = resolutions_depth_table_ptr->resolution.num_of_resolutions;
+        // Get full maximum size of the resolution array and deduct the unused resolutions size from it
+        size_t expected_size = sizeof( ivcam2::intrinsic_depth ) - 
+                                     ( ( MAX_NUM_OF_DEPTH_RESOLUTIONS
+                                     - num_of_resolutions)
+                                     * sizeof( intrinsic_per_resolution ) );
+
+        // Validate table size
+        // FW API guarantee only as many bytes as required for the given number of resolutions, 
+        // The FW keeps the right to send more bytes.
+        if (expected_size > response_vec.size() || 
+            num_of_resolutions > MAX_NUM_OF_DEPTH_RESOLUTIONS)
+        {
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Calibration data invalid, number of resolutions is: "
+                                           << num_of_resolutions << ", expected size: " << expected_size
+                                           << " , actual size: " << response_vec.size() );
+        }
+
+        // Set a new memory allocated intrinsics struct (Full size 5 resolutions)
+        // Copy the relevant data from the dynamic resolution received from the FW
+        ivcam2::intrinsic_depth  resolutions_depth_table_output;
+        std::memcpy(&resolutions_depth_table_output, resolutions_depth_table_ptr, expected_size);
+      
+        return resolutions_depth_table_output;
+    }
+
+    l500_depth::l500_depth( std::shared_ptr< const l500_info > const & dev_info )
+        :device(dev_info),
+        backend_device(dev_info),
+        l500_device(dev_info)
+    {
+        auto const & group = dev_info->get_group();
+        auto ctx = dev_info->get_context();
+
+        _calib_table = [this]() { return read_intrinsics_table(); };
+
+        auto& depth_sensor = get_depth_sensor();
+        auto raw_depth_sensor = get_raw_depth_sensor();
+
+        depth_sensor.register_option(
+            RS2_OPTION_LLD_TEMPERATURE,
+            std::make_shared< l500_temperature_options >( this,
+                                                          RS2_OPTION_LLD_TEMPERATURE,
+                                                          "Laser Driver temperature" ) );
+
+        depth_sensor.register_option(
+            RS2_OPTION_MC_TEMPERATURE,
+            std::make_shared< l500_temperature_options >( this,
+                                                          RS2_OPTION_MC_TEMPERATURE,
+                                                          "Mems Controller temperature" ) );
+
+        depth_sensor.register_option(
+            RS2_OPTION_MA_TEMPERATURE,
+            std::make_shared< l500_temperature_options >( this,
+                                                          RS2_OPTION_MA_TEMPERATURE,
+                                                          "DSP controller temperature" ) );
+
+        depth_sensor.register_option(
+            RS2_OPTION_APD_TEMPERATURE,
+            std::make_shared< l500_temperature_options >( this,
+                                                          RS2_OPTION_APD_TEMPERATURE,
+                                                          "Avalanche Photo Diode temperature" ) );
+
+        depth_sensor.register_option(
+            RS2_OPTION_HUMIDITY_TEMPERATURE,
+            std::make_shared< l500_temperature_options >( this,
+                                                          RS2_OPTION_HUMIDITY_TEMPERATURE,
+                                                          "Humidity temperature" ) );
+
+        depth_sensor.register_option(
+            RS2_OPTION_NOISE_ESTIMATION,
+            std::make_shared< nest_option >( this, "Noise estimation" ) );
+
+        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream, *_ir_stream);
+        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream, *_confidence_stream);
+
+        register_stream_to_extrinsic_group(*_depth_stream, 0);
+        register_stream_to_extrinsic_group(*_ir_stream, 0);
+        register_stream_to_extrinsic_group(*_confidence_stream, 0);
+
+        auto error_control = std::make_shared<uvc_xu_option<int>>(raw_depth_sensor, ivcam2::depth_xu, L500_ERROR_REPORTING, "Error reporting");
+
+        _polling_error_handler = std::make_shared<polling_error_handler>(1000,
+            error_control,
+            raw_depth_sensor->get_notifications_processor(),
+            std::make_shared<l500_notification_decoder>());
+
+        depth_sensor.register_option(RS2_OPTION_ERROR_POLLING_ENABLED, std::make_shared<polling_errors_disable>(_polling_error_handler));
+
+        // option to enable workaround for help weak usb hosts to support L515 devices
+        // with improved performance and stability
+        if(_fw_version >= firmware_version( "1.5.1.0" ) )
+        {
+            rs2_host_perf_mode launch_perf_mode = RS2_HOST_PERF_DEFAULT;
+
+#ifdef __ANDROID__
+            // android devices most likely low power low performance host
+            launch_perf_mode = RS2_HOST_PERF_LOW;
+#else
+            // other hosts use default settings from firmware, user still have the option to change later after launch
+            launch_perf_mode = RS2_HOST_PERF_DEFAULT;
+#endif
+
+            depth_sensor.register_option(RS2_OPTION_HOST_PERFORMANCE, std::make_shared<librealsense::float_option_with_description<rs2_host_perf_mode>>(option_range{ RS2_HOST_PERF_DEFAULT, RS2_HOST_PERF_COUNT - 1, 1, (float) launch_perf_mode }, "Optimize based on host performance, low power low performance host or high power high performance host"));
+
+        }
+
+        // attributes of md_capture_timing
+        auto md_prop_offset = offsetof(metadata_raw, mode) +
+            offsetof(md_l500_depth, intel_capture_timing);
+
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER, make_attribute_parser(&l500_md_capture_timing::frame_counter, md_capture_timing_attributes::frame_counter_attribute, md_prop_offset));
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP, make_attribute_parser(&l500_md_capture_timing::sensor_timestamp, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS, make_attribute_parser(&l500_md_capture_timing::exposure_time, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));
+
+        // attributes of md_depth_control
+        md_prop_offset = offsetof(metadata_raw, mode) +
+            offsetof(md_l500_depth, intel_depth_control);
+
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_FRAME_LASER_POWER, make_attribute_parser(&md_l500_depth_control::laser_power, md_l500_depth_control_attributes::laser_power, md_prop_offset));
+        depth_sensor.register_metadata(RS2_FRAME_METADATA_FRAME_LASER_POWER_MODE, make_attribute_parser(&md_l500_depth_control::laser_power_mode, md_l500_depth_control_attributes::laser_power_mode, md_prop_offset));
+    }
+
+    std::vector<tagged_profile> l500_depth::get_profiles_tags() const
+    {
+        std::vector<tagged_profile> tags;
+
+        bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
+
+        int width = usb3mode ? 640 : 320;
+        int height = usb3mode ? 480 : 240;
+
+        tags.push_back({ RS2_STREAM_DEPTH, -1, width, height, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_INFRARED, -1, width, height, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_CONFIDENCE, -1, width, height, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+        tags.push_back({ RS2_STREAM_DEPTH, -1, -1, -1, RS2_FORMAT_FG, -1, profile_tag::PROFILE_TAG_DEBUG } );
+        return tags;
+    }
+
+    std::shared_ptr<matcher> l500_depth::create_matcher(const frame_holder& frame) const
+    {
+        std::vector<std::shared_ptr<matcher>> depth_matchers =
+        {
+            std::make_shared<identity_matcher>( _depth_stream->get_unique_id(),      _depth_stream->get_stream_type() ),
+            std::make_shared<identity_matcher>( _ir_stream->get_unique_id(),         _ir_stream->get_stream_type() ),
+            std::make_shared<identity_matcher>( _confidence_stream->get_unique_id(), _confidence_stream->get_stream_type() )
+        };
+        return std::make_shared< timestamp_composite_matcher >( depth_matchers );
+    }
+
+    // If the user did not ask for IR, The open function will add it anyway. 
+    // This class filters the IR frames is this case so they will not get to the user callback function
+    // Note: This is a workaround , theoretically we did not need to add manually the IR profile to the "open" function,
+    // The processing block should take care of it, this caused a syncer bug to pop-up so we avoid this solution for now.
+    class frame_filter : public rs2_frame_callback
+    {
+    public:
+        explicit frame_filter(rs2_frame_callback_sptr user_callback, const stream_profiles &user_requests) :
+            _user_callback(user_callback),
+            _user_requests(user_requests) {}
+
+        void on_frame( rs2_frame * f ) override
+        {
+            if( is_user_requested_frame( (frame_interface *)f ) )
+            {
+                _user_callback->on_frame( f );
+            }
+            else
+            {
+                // No RAII - explicit release is required
+                ( (frame_interface *)f )->release();
+            }
+        }
+
+        void release() override {}
+
+    private:
+        bool is_user_requested_frame(frame_interface* frame)
+        {
+            return std::find_if(_user_requests.begin(), _user_requests.end(), [&](std::shared_ptr<stream_profile_interface> sp)
+            {
+                return stream_profiles_equal(frame->get_stream().get(), sp.get());
+            }) != _user_requests.end();
+        }
+
+        bool stream_profiles_equal(stream_profile_interface* l, stream_profile_interface* r)
+        {
+            auto vl = dynamic_cast<video_stream_profile_interface*>(l);
+            auto vr = dynamic_cast<video_stream_profile_interface*>(r);
+
+            if (!vl || !vr)
+                return false;
+
+            return  l->get_framerate() == r->get_framerate() &&
+                vl->get_width() == vr->get_width() &&
+                vl->get_height() == vr->get_height() &&
+                vl->get_stream_type() == vr->get_stream_type();
+        }
+
+        rs2_frame_callback_sptr _user_callback;
+        stream_profiles _user_requests;
+    };
+
+    l500_depth_sensor::l500_depth_sensor(
+        l500_device* owner,
+        std::shared_ptr<uvc_sensor> uvc_sensor,
+        std::map<rsutils::type::fourcc::value_type, rs2_format> l500_depth_fourcc_to_rs2_format_map,
+        std::map<rsutils::type::fourcc::value_type, rs2_stream> l500_depth_fourcc_to_rs2_stream_map
+    )
+        : synthetic_sensor( "L500 Depth Sensor",
+            uvc_sensor,
+            owner,
+            l500_depth_fourcc_to_rs2_format_map,
+            l500_depth_fourcc_to_rs2_stream_map )
+        , _owner( owner )
+    {
+
+        register_option( RS2_OPTION_DEPTH_UNITS, std::make_shared<const_value_option>( "Number of meters represented by a single depth unit",
+            rsutils::lazy<float>( [&]() {
+                return read_znorm(); } ) ) );
+
+        register_option( RS2_OPTION_DEPTH_OFFSET, std::make_shared<const_value_option>( "Offset from sensor to depth origin in millimetrers",
+            rsutils::lazy<float>( [&]() {
+                return get_depth_offset(); } ) ) );
+
+    }
+
+    l500_depth_sensor::~l500_depth_sensor()
+    {
+        _owner->stop_temperatures_reader();
+    }
+
+    float l500_depth_sensor::get_max_usable_depth_range() const
+    {
+        using namespace algo::max_usable_range;
+
+        if( !supports_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE) )
+            throw librealsense::wrong_api_call_sequence_exception( "max usable range option is not supported" );
+
+        if( get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE).query() != 1.0f )
+            throw librealsense::wrong_api_call_sequence_exception( "max usable range option is not on" );
+
+        if( ! is_streaming() )
+        {
+            throw librealsense::wrong_api_call_sequence_exception("depth sensor is not streaming!");
+        }
+
+       float noise_estimation = static_cast<float>(_owner->get_temperatures().nest_avg);
+
+       return l500::max_usable_range(noise_estimation);
+    }
+
+    stream_profiles l500_depth_sensor::get_debug_stream_profiles() const
+    {
+       return get_stream_profiles( PROFILE_TAG_DEBUG );
+    }
+
+    // We want to disable max-usable-range when not in a particular preset:
+    bool l500_depth_sensor::is_max_range_preset() const
+    {
+        auto res = _owner->_hw_monitor->send(command(ivcam2::IRB, 0x6C, 0x2, 0x1));
+
+        if (res.size() < sizeof(uint8_t))
+        {
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Gain trim FW command failed: size expected: " << sizeof( uint8_t )
+                                           << " , size received: " << res.size() );
+        }
+
+        int gtr = static_cast<int>(res[0]);
+        int apd = static_cast<int>(get_option(RS2_OPTION_AVALANCHE_PHOTO_DIODE).query());
+        int laser_power = static_cast<int>(get_option(RS2_OPTION_LASER_POWER).query());
+        int max_laser_power = static_cast<int>(get_option(RS2_OPTION_LASER_POWER).get_range().max);
+
+        return ((apd == 9) && (gtr == 0) && (laser_power == max_laser_power)); // indicates max_range preset
+    }
+
+
+    float l500_depth_sensor::read_baseline() const
+    {
+        const uint32_t baseline_address = 0xa00e0868;
+        command cmd(ivcam2::fw_cmd::MRD, baseline_address, baseline_address + 4);
+        auto res = _owner->_hw_monitor->send(cmd);
+        if (res.size() < 1)
+        {
+            throw std::runtime_error("Invalid result size!");
+        }
+        auto data = (float*)res.data();
+        return *data;
+    }
+
+    float l500_depth_sensor::read_znorm()
+    {
+        auto intrin = get_intrinsic();
+        if (intrin.resolution.num_of_resolutions < 1)
+        {
+            throw std::runtime_error("Invalid intrinsics!");
+        }
+        auto znorm = intrin.resolution.intrinsic_resolution[0].world.znorm;
+        return 1/znorm* MM_TO_METER;
+    }
+
+    float l500_depth_sensor::get_depth_offset() const
+    {
+        using namespace ivcam2;
+        auto & intrinsic = *_owner->_calib_table;
+        return intrinsic.orient.depth_offset;
+    }
+
+    rs2_time_t l500_timestamp_reader_from_metadata::get_frame_timestamp(const std::shared_ptr<frame_interface>& frame)
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+
+        auto f = std::dynamic_pointer_cast<librealsense::frame>(frame);
+        if (has_metadata_ts(frame))
+        {
+            auto md = (librealsense::metadata_raw*)(f->additional_data.metadata_blob.data());
+            return (double)(md->header.timestamp)*TIMESTAMP_USEC_TO_MSEC;
+        }
+        else
+        {
+            if (!one_time_note)
+            {
+                LOG_WARNING("UVC metadata payloads are not available for stream "
+                    //<< std::hex << mode.pf->fourcc << std::dec << (mode.profile.format)
+                    << ". Please refer to installation chapter for details.");
+                one_time_note = true;
+            }
+            return _backup_timestamp_reader->get_frame_timestamp(frame);
+        }
+    }
+
+    unsigned long long l500_timestamp_reader_from_metadata::get_frame_counter(const std::shared_ptr<frame_interface>& frame) const
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+
+        auto f = std::dynamic_pointer_cast<librealsense::frame>(frame);
+        if (has_metadata_fc(frame))
+        {
+            auto md = (uint8_t*)(f->additional_data.metadata_blob.data());
+            // WA until we will have the struct of metadata
+            return ((int*)md)[7];
+        }
+
+        return _backup_timestamp_reader->get_frame_counter(frame);
+    }
+
+    void l500_timestamp_reader_from_metadata::reset()
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+        one_time_note = false;
+        _backup_timestamp_reader->reset();
+        ts_wrap.reset();
+    }
+
+    rs2_timestamp_domain l500_timestamp_reader_from_metadata::get_frame_timestamp_domain(const std::shared_ptr<frame_interface>& frame) const
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mtx);
+
+        return (has_metadata_ts(frame)) ? RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK : _backup_timestamp_reader->get_frame_timestamp_domain(frame);
+    }
+
+    processing_blocks l500_depth_sensor::get_l500_recommended_proccesing_blocks()
+    {
+        processing_blocks res;
+        res.push_back(std::make_shared<temporal_filter>());
+        return res;
+    }
+
+    void l500_depth_sensor::start(rs2_frame_callback_sptr callback)
+    {
+        if (supports_option(RS2_OPTION_HOST_PERFORMANCE))
+        {
+            // option to improve performance and stability on weak android hosts
+            // please refer to following bug report for details
+            // RS5-8011 [Android-L500 Hard failure] Device detach and disappear from system during stream
+
+            auto host_perf = get_option(RS2_OPTION_HOST_PERFORMANCE).query();
+
+            if (static_cast<int>(host_perf) == RS2_HOST_PERF_LOW || static_cast<int>(host_perf) == RS2_HOST_PERF_HIGH)
+            {
+                // TPROC USB Granularity and TRB threshold settings for improved performance and stability
+                // on hosts with weak cpu and system performance
+                // settings values are validated through many experiments, do not change
+
+                // on low power low performance host, usb trb set to larger granularity to reduce number of transactions
+                // and improve performance
+                int ep2_usb_trb = 7;           // 7 KB
+                int ep3_usb_trb = 3;           // 3 KB
+                int ep4_usb_trb = 3;           // 3 KB
+
+                if (static_cast<int>(host_perf) == RS2_HOST_PERF_LOW)
+                {
+                    ep2_usb_trb = 16;          // 16 KB
+                    ep3_usb_trb = 12;          // 12 KB
+                    ep4_usb_trb = 6;           //  6 KB
+                }
+
+                try {
+                    // Keep the USB power on while triggering multiple calls on it.
+                    group_multiple_fw_calls(*this, [&]() {
+                        // endpoint 2 (depth)
+                        command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, ep2_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp2);
+
+                        command cmdTprocThresholdEp2(ivcam2::TPROC_TRB_THRSLD_SET, 2, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp2);
+
+                        // endpoint 3 (IR)
+                        command cmdTprocGranEp3(ivcam2::TPROC_USB_GRAN_SET, 3, ep3_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp3);
+
+                        command cmdTprocThresholdEp3(ivcam2::TPROC_TRB_THRSLD_SET, 3, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp3);
+
+                        // endpoint 4 (confidence)
+                        command cmdTprocGranEp4(ivcam2::TPROC_USB_GRAN_SET, 4, ep4_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp4);
+
+                        command cmdTprocThresholdEp4(ivcam2::TPROC_TRB_THRSLD_SET, 4, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp4);
+                        });
+                    LOG_DEBUG("Depth and IR usb tproc granularity and TRB threshold updated.");
+                } catch (...)
+                {
+                    LOG_WARNING("FAILED TO UPDATE depth usb tproc granularity and TRB threshold. performance and stability maybe impacted on certain platforms.");
+                }
+            }
+            else if (static_cast<int>(host_perf) == RS2_HOST_PERF_DEFAULT)
+            {
+                LOG_DEBUG("Default host performance mode, Depth/IR/Confidence usb tproc granularity and TRB threshold not changed");
+            }
+        }
+
+        // The delay is here as a work around to a firmware bug [RS5-5453]
+        _action_delayer.do_after_delay( [&]() {
+            synthetic_sensor::start( std::make_shared< frame_filter >( callback, _user_requests ) );
+
+            _owner->start_temperatures_reader();
+        } );
+    }
+
+    void l500_depth_sensor::stop()
+    {
+    // The delay is here as a work around to a firmware bug [RS5-5453]
+        _action_delayer.do_after_delay([&]() { synthetic_sensor::stop(); });
+
+        _owner->stop_temperatures_reader();
+
+    }
+
+    bool stream_profiles_correspond(stream_profile_interface* l, stream_profile_interface* r)
+    {
+        auto vl = dynamic_cast<video_stream_profile_interface*>(l);
+        auto vr = dynamic_cast<video_stream_profile_interface*>(r);
+
+        if (!vl || !vr)
+            return false;
+
+        return  l->get_framerate() == r->get_framerate() &&
+            vl->get_width() == vr->get_width() &&
+            vl->get_height() == vr->get_height();
+    }
+
+
+    void l500_depth_sensor::open(const stream_profiles& requests)
+    {
+        try
+        {
+            auto depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();
+            set_frame_metadata_modifier([&, depth_units](frame_additional_data& data) {data.depth_units = depth_units; });
+
+            _user_requests = requests;
+
+            auto is_ir_requested
+                = std::find_if( requests.begin(),
+                                requests.end(),
+                                []( std::shared_ptr< stream_profile_interface > const & sp ) {
+                                    return sp->get_stream_type() == RS2_STREAM_INFRARED;
+                                } )
+               != requests.end();
+
+            auto is_ir_needed
+                = std::find_if( requests.begin(),
+                                requests.end(),
+                                []( std::shared_ptr< stream_profile_interface > const & sp ) {
+                                    return sp->get_format() != RS2_FORMAT_FG;
+                                } )
+               != requests.end();
+
+            _validator_requests = requests;
+
+            // Enable IR stream if user didn't asked for IR
+            // IR stream improves depth frames
+            if( ! is_ir_requested && is_ir_needed )
+            {
+                auto user_request = std::find_if(requests.begin(), requests.end(), [](std::shared_ptr<stream_profile_interface> sp)
+                {return sp->get_stream_type() != RS2_STREAM_INFRARED;});
+
+                if (user_request == requests.end())
+                    throw std::runtime_error( rsutils::string::from() << "input stream_profiles is invalid" );
+
+                auto user_request_profile = dynamic_cast<video_stream_profile*>(user_request->get());
+
+                auto sp = synthetic_sensor::get_stream_profiles();
+
+                auto corresponding_ir = std::find_if(sp.begin(), sp.end(), [&](std::shared_ptr<stream_profile_interface> sp)
+                {
+                    auto vs = dynamic_cast<video_stream_profile*>(sp.get());
+                    return sp->get_stream_type() == RS2_STREAM_INFRARED && stream_profiles_correspond(sp.get(), user_request_profile);
+                });
+
+                if (corresponding_ir == sp.end())
+                    throw std::runtime_error( rsutils::string::from()
+                                              << "can't find ir stream corresponding to user request" );
+
+                _validator_requests.push_back(*corresponding_ir);
+            }
+
+
+            auto dp = std::find_if( requests.begin(),
+                                    requests.end(),
+                                    []( std::shared_ptr< stream_profile_interface > sp ) {
+                                        return sp->get_stream_type() == RS2_STREAM_DEPTH;
+                                    } );
+            if( dp != requests.end() && supports_option( RS2_OPTION_SENSOR_MODE ) )
+            {
+                auto&& sensor_mode_option = get_option(RS2_OPTION_SENSOR_MODE);
+                auto vs = dynamic_cast<video_stream_profile*>((*dp).get());
+                if( vs->get_format() == RS2_FORMAT_Z16 )
+                    sensor_mode_option.set(float(get_resolution_from_width_height(vs->get_width(), vs->get_height())));
+            }
+
+            synthetic_sensor::open(_validator_requests);
+        }
+        catch( ... )
+        {
+            LOG_ERROR( "Exception caught in l500_depth_sensor::open" );
+            throw;
+        }
+    }
+
+}  // namespace librealsense

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -1,0 +1,266 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+#include <mutex>
+#include <string>
+#include <map>
+
+#include "l500-device.h"
+#include "context.h"
+#include "backend.h"
+#include "hw-monitor.h"
+#include "image.h"
+#include "stream.h"
+#include <src/depth-sensor.h>
+#include <src/core/video.h>
+#include <rsutils/type/fourcc.h>
+#include "l500-private.h"
+#include "error-handling.h"
+#include "l500-options.h"
+#include "max-usable-range-sensor.h"
+#include "debug-stream-sensor.h"
+
+#include <rsutils/string/from.h>
+
+
+namespace librealsense
+{
+    class l500_depth : public virtual l500_device
+    {
+    public:
+
+        ivcam2::intrinsic_depth read_intrinsics_table() const;
+
+        l500_depth( std::shared_ptr< const l500_info > const & dev_info );
+
+        ~l500_depth() { stop_temperatures_reader(); }
+
+        std::vector<tagged_profile> get_profiles_tags() const override;
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+    };
+
+    class l500_depth_sensor_interface: public recordable<l500_depth_sensor_interface>
+    {
+    public:
+        virtual ivcam2::intrinsic_depth get_intrinsic() const = 0;
+        virtual float read_baseline() const = 0;
+        virtual ~l500_depth_sensor_interface() = default;
+    };
+    MAP_EXTENSION(RS2_EXTENSION_L500_DEPTH_SENSOR, librealsense::l500_depth_sensor_interface);
+
+    class l500_depth_sensor_snapshot : public l500_depth_sensor_interface, public extension_snapshot
+    {
+    public:
+        l500_depth_sensor_snapshot(ivcam2::intrinsic_depth intrinsic, float baseline):
+            _intrinsic(intrinsic), _baseline(baseline)
+        {}
+
+        ivcam2::intrinsic_depth get_intrinsic() const override
+        {
+            return _intrinsic;
+        }
+        float read_baseline() const override
+        {
+            return _baseline;
+
+        }
+        void update(std::shared_ptr<extension_snapshot> ext) override
+        {
+            if (auto api = As<l500_depth_sensor_interface>(ext))
+            {
+                _intrinsic = api->get_intrinsic();
+            }  
+        }
+
+        void create_snapshot(std::shared_ptr<l500_depth_sensor_interface>& snapshot) const override
+        {
+            snapshot = std::make_shared<l500_depth_sensor_snapshot>(get_intrinsic(), read_baseline());
+        }
+
+        void enable_recording(std::function<void(const l500_depth_sensor_interface&)> recording_function) override
+        {}
+
+        ~l500_depth_sensor_snapshot() {}
+
+    protected:
+        ivcam2::intrinsic_depth _intrinsic;
+        float _baseline;
+    };
+
+    class l500_depth_sensor
+        : public synthetic_sensor
+        , public video_sensor_interface
+        , public virtual depth_sensor
+        , public virtual l500_depth_sensor_interface
+        , public max_usable_range_sensor
+        , public debug_stream_sensor
+    {
+    public:
+        explicit l500_depth_sensor(
+            l500_device * owner,
+            std::shared_ptr< uvc_sensor > uvc_sensor,
+            std::map< uint32_t, rs2_format > l500_depth_sourcc_to_rs2_format_map,
+            std::map< uint32_t, rs2_stream > l500_depth_sourcc_to_rs2_stream_map
+        );
+        
+        ~l500_depth_sensor();
+
+        std::vector<rs2_option> get_supported_options() const override
+        {
+            std::vector<rs2_option> options;
+            for (auto opt : synthetic_sensor::get_supported_options())
+            {
+                if (std::find(_owner->_advanced_options.begin(), _owner->_advanced_options.end(), opt) != _owner->_advanced_options.end())
+                    continue;
+
+                 options.push_back(opt);
+            }
+
+            for (auto option : _owner->_advanced_options)
+                options.push_back(option);
+
+            return options;
+        }
+
+        static ivcam2::intrinsic_params get_intrinsic_params(const uint32_t width, const uint32_t height, ivcam2::intrinsic_depth intrinsic)
+        {
+            auto num_of_res = intrinsic.resolution.num_of_resolutions;
+
+            for (auto i = 0; i < num_of_res; i++)
+            {
+                auto model_world = intrinsic.resolution.intrinsic_resolution[i].world;
+                auto model_raw = intrinsic.resolution.intrinsic_resolution[i].raw;
+
+                if (model_world.pinhole_cam_model.height == height && model_world.pinhole_cam_model.width == width)
+                    return model_world;
+                else if (model_raw.pinhole_cam_model.height == height && model_raw.pinhole_cam_model.width == width)
+                    return  model_raw;
+            }
+            throw std::runtime_error( rsutils::string::from()
+                                      << "intrinsics for resolution " << width << "," << height << " doesn't exist" );
+        }
+
+        rs2_intrinsics get_intrinsics(const stream_profile& profile) const override
+        {
+            using namespace ivcam2;
+
+            auto intrinsic_params = get_intrinsic_params(profile.width, profile.height, get_intrinsic());
+
+            rs2_intrinsics intrinsics = { 0 };
+            intrinsics.width = intrinsic_params.pinhole_cam_model.width;
+            intrinsics.height = intrinsic_params.pinhole_cam_model.height;
+            intrinsics.fx = intrinsic_params.pinhole_cam_model.ipm.focal_length.x;
+            intrinsics.fy = intrinsic_params.pinhole_cam_model.ipm.focal_length.y;
+            intrinsics.ppx = intrinsic_params.pinhole_cam_model.ipm.principal_point.x;
+            intrinsics.ppy = intrinsic_params.pinhole_cam_model.ipm.principal_point.y;
+
+            intrinsics.coeffs[0] = intrinsic_params.pinhole_cam_model.distort.radial_k1;
+            intrinsics.coeffs[1] = intrinsic_params.pinhole_cam_model.distort.radial_k2;
+            intrinsics.coeffs[2] = intrinsic_params.pinhole_cam_model.distort.tangential_p1;
+            intrinsics.coeffs[3] = intrinsic_params.pinhole_cam_model.distort.tangential_p2;
+            intrinsics.coeffs[4] = intrinsic_params.pinhole_cam_model.distort.radial_k3;
+
+            intrinsics.model = RS2_DISTORTION_NONE;
+            return intrinsics;
+        }
+
+        stream_profiles init_stream_profiles() override
+        {
+            auto lock = environment::get_instance().get_extrinsics_graph().lock();
+
+            auto&& results = synthetic_sensor::init_stream_profiles();
+            for (auto&& p : results)
+            {
+                // Register stream types
+                if (p->get_stream_type() == RS2_STREAM_DEPTH)
+                {
+                    assign_stream(_owner->_depth_stream, p);
+                }
+                else if (p->get_stream_type() == RS2_STREAM_INFRARED)
+                {
+                    assign_stream(_owner->_ir_stream, p);
+                }
+                else if (p->get_stream_type() == RS2_STREAM_CONFIDENCE)
+                {
+                    assign_stream(_owner->_confidence_stream, p);
+                }
+
+                // Register intrinsics
+                auto&& video = dynamic_cast<video_stream_profile_interface*>(p.get());
+
+                const auto&& profile = to_profile(p.get());
+                std::weak_ptr<l500_depth_sensor> wp =
+                    std::dynamic_pointer_cast<l500_depth_sensor>(this->shared_from_this());
+
+                video->set_intrinsics([profile, wp]()
+                {
+                    auto sp = wp.lock();
+                    if (sp)
+                        return sp->get_intrinsics(profile);
+                    else
+                        return rs2_intrinsics{};
+                });
+            }
+
+            return results;
+        }
+        
+
+        float get_depth_scale() const override { return get_option(RS2_OPTION_DEPTH_UNITS).query(); }
+
+        ivcam2::intrinsic_depth get_intrinsic() const override
+        {
+            using namespace ivcam2;
+            return *_owner->_calib_table;
+        }
+
+        float get_max_usable_depth_range() const override;
+
+        stream_profiles get_debug_stream_profiles() const override;
+
+
+        void create_snapshot(std::shared_ptr<l500_depth_sensor_interface>& snapshot) const  override
+        {
+            snapshot = std::make_shared<l500_depth_sensor_snapshot>(get_intrinsic(), read_baseline());
+        }
+
+        void enable_recording(std::function<void(const l500_depth_sensor_interface&)> recording_function) override
+        {}
+
+        static processing_blocks get_l500_recommended_proccesing_blocks();
+
+        processing_blocks get_recommended_processing_blocks() const override
+        {
+            return get_l500_recommended_proccesing_blocks();
+        };
+
+        void set_frame_metadata_modifier(on_frame_md callback) override
+        {
+            _metadata_modifier = callback;
+            auto s = get_raw_sensor().get();
+            auto uvc = As< librealsense::uvc_sensor >(s);
+            if (uvc)
+                uvc->set_frame_metadata_modifier(callback);
+        }
+
+        float read_baseline() const override;
+        float read_znorm();
+
+        void start(rs2_frame_callback_sptr callback) override;
+        void open(const stream_profiles& requests) override;
+        void stop() override;
+        float get_depth_offset() const;
+        bool is_max_range_preset() const;
+
+    private:
+        action_delayer _action_delayer;
+        l500_device * const _owner;
+        float _depth_units;
+        stream_profiles _user_requests;
+        stream_profiles _validator_requests;
+    };
+}

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #include "l500-device.h"
 #include "l500-info.h"

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -1,0 +1,753 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#include "l500-device.h"
+#include "l500-info.h"
+
+#include "context.h"
+#include "stream.h"
+#include "image.h"
+
+#include "l500-depth.h"
+#include "l500-color.h"
+#include "l500-private.h"
+
+#include <src/proc/decimation-filter.h>
+#include <src/proc/threshold.h>
+#include <src/proc/spatial-filter.h>
+#include <src/proc/temporal-filter.h>
+#include <src/proc/hole-filling-filter.h>
+#include <src/proc/syncer-processing-block.h>
+#include <src/proc/rotation-transform.h>
+
+#include <src/firmware-version.h>
+#include <src/core/time-service.h>
+#include <src/ds/d400/d400-private.h>
+#include <rsutils/type/fourcc.h>
+#include <rsutils/time/periodic-timer.h>
+#include <rsutils/time/work-week.h>
+#include "get-mfr-ww.h"
+#include <rsutils/string/from.h>
+#include <rsutils/string/string-utilities.h>
+#include <src/platform/platform-utils.h>
+#include <src/platform/uvc-option.h>
+
+#include <vector>
+
+
+namespace librealsense
+{
+    using rsutils::type::fourcc;
+
+    std::map<fourcc::value_type, rs2_format> l500_depth_fourcc_to_rs2_format = {
+        { fourcc('G','R','E','Y'), RS2_FORMAT_Y8 },
+        { fourcc('Z','1','6',' '), RS2_FORMAT_Z16 },
+        { fourcc('C',' ',' ',' '), RS2_FORMAT_RAW8 },
+        { fourcc('C','N','F','4'), RS2_FORMAT_RAW8 },
+        { fourcc('F','G',' ',' '), RS2_FORMAT_FG },
+    };
+
+    std::map<fourcc::value_type, rs2_stream> l500_depth_fourcc_to_rs2_stream = {
+        { fourcc('G','R','E','Y'), RS2_STREAM_INFRARED },
+        { fourcc('Z','1','6',' '), RS2_STREAM_DEPTH },
+        { fourcc('C',' ',' ',' '), RS2_STREAM_CONFIDENCE },
+        { fourcc('C','N','F','4'), RS2_STREAM_CONFIDENCE },
+        { fourcc('F','G',' ',' '), RS2_STREAM_DEPTH },
+    };
+
+    using namespace ivcam2;
+
+    // Confidence: new width = old height, new height = old width * 2 (legacy image.cpp l500_confidence_resolution)
+    static void l500_confidence_resolution_fn( uint32_t & w, uint32_t & h )
+    {
+        auto ow = w;
+        w = h;
+        h = ow * 2;
+    }
+
+    l500_device::l500_device( std::shared_ptr< const l500_info > const & dev_info )
+        : backend_device(dev_info), global_time_interface(),
+        _depth_stream(new stream(RS2_STREAM_DEPTH)),
+        _ir_stream(new stream(RS2_STREAM_INFRARED)),
+        _confidence_stream(new stream(RS2_STREAM_CONFIDENCE)),
+        _temperatures()
+    {
+        auto const & group = dev_info->get_group();
+        auto ctx = dev_info->get_context();
+
+        _depth_device_idx = add_sensor(create_depth_device(ctx, group.uvc_devices));
+        _pid = group.uvc_devices.front().pid;
+        std::string device_name = (rs500_sku_names.end() != rs500_sku_names.find(_pid)) ? rs500_sku_names.at(_pid) : "RS5xx";
+
+        using namespace ivcam2;
+
+        auto& depth_sensor = get_depth_sensor();
+        auto raw_depth_sensor = get_raw_depth_sensor();
+
+#ifndef HWM_OVER_XU
+        if( group.usb_devices.size() > 0 )
+        {
+            // This use-case is mainly to support FW development & debugging on unlock units before they
+            // have any XU capabilities
+            _hw_monitor = std::make_shared<hw_monitor>(
+                std::make_shared<locked_transfer>( get_backend()->create_usb_device( group.usb_devices.front() ),
+                    raw_depth_sensor ),
+                std::make_shared<ds::d400_hwmon_response>() );
+        }
+        else
+#endif
+        {
+            _hw_monitor = std::make_shared<hw_monitor>(
+                std::make_shared<locked_transfer>( std::make_shared<command_transfer_over_xu>(
+                    *raw_depth_sensor, depth_xu, L500_HWMONITOR ),
+                    raw_depth_sensor ),
+                std::make_shared<ds::d400_hwmon_response>() );
+        }
+
+        std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
+        _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), GVD);
+        // fooling tests recordings - don't remove
+        _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), GVD);
+
+        auto optic_serial = _hw_monitor->get_module_serial_string(gvd_buff, module_serial_offset, module_serial_size);
+        auto asic_serial = _hw_monitor->get_module_serial_string(gvd_buff, module_asic_serial_offset, module_asic_serial_size);
+        auto fwv = _hw_monitor->get_firmware_version_string<uint8_t>(gvd_buff, fw_version_offset);
+        _fw_version = firmware_version(fwv);
+
+        _is_locked = _hw_monitor->get_gvd_field<uint8_t>(gvd_buff, is_camera_locked_offset) != 0;
+
+        auto pid_hex_str = rsutils::string::hexify(group.uvc_devices.front().pid);
+
+        using namespace platform;
+
+        _usb_mode = raw_depth_sensor->get_usb_specification();
+        if (usb_spec_names.count(_usb_mode) && (usb_undefined != _usb_mode))
+        {
+            auto usb_type_str = usb_spec_names.at(_usb_mode);
+            register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
+        }
+
+        register_info(RS2_CAMERA_INFO_NAME, device_name);
+        register_info(RS2_CAMERA_INFO_SERIAL_NUMBER, optic_serial);
+        register_info(RS2_CAMERA_INFO_ASIC_SERIAL_NUMBER, asic_serial);
+        register_info(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID, asic_serial);
+        register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, _fw_version);
+        register_info(RS2_CAMERA_INFO_DEBUG_OP_CODE, std::to_string(static_cast<int>(fw_cmd::GLD)));
+        register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, group.uvc_devices.front().device_path);
+        register_info(RS2_CAMERA_INFO_PRODUCT_ID, pid_hex_str);
+        register_info(RS2_CAMERA_INFO_PRODUCT_LINE, "L500");
+        register_info(RS2_CAMERA_INFO_CAMERA_LOCKED, _is_locked ? "YES" : "NO");
+
+        // If FW supportes the SET_AGE command, we update the age of the device in weeks to aid projection of aging
+        if( ( _fw_version >= firmware_version( "1.5.4.0" ) ) )
+        {
+            try
+            {
+                auto manufacture
+                    = utilities::time::l500::get_manufacture_work_week( optic_serial );
+                auto age
+                    = rsutils::time::get_work_weeks_since( manufacture );
+                command cmd( fw_cmd::UNIT_AGE_SET, (uint8_t)age );
+                _hw_monitor->send( cmd );
+            }
+            catch( ... )
+            {
+                LOG_ERROR( "Failed to set units age" );
+            }
+        }
+
+        configure_depth_options();
+    }
+
+
+    l500_depth_sensor & l500_device::get_depth_sensor()
+    {
+        return dynamic_cast<l500_depth_sensor &>(get_sensor( _depth_device_idx ));
+    }
+
+
+    std::shared_ptr<synthetic_sensor> l500_device::create_depth_device( std::shared_ptr<context> ctx,
+        const std::vector<platform::uvc_device_info>& all_device_infos )
+    {
+        auto backend = get_backend();
+
+        std::vector<std::shared_ptr<platform::uvc_device>> depth_devices;
+        for( auto&& info : filter_by_mi( all_device_infos, 0 ) ) // Filter just mi=0, DEPTH
+            depth_devices.push_back( backend->create_uvc_device( info ) );
+
+        std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata( new l500_timestamp_reader_from_metadata() );
+        auto enable_global_time_option = std::shared_ptr<global_time_option>( new global_time_option() );
+        auto raw_depth_ep = std::make_shared<uvc_sensor>( "Raw Depth Sensor", std::make_shared<platform::multi_pins_uvc_device>( depth_devices ),
+            std::unique_ptr<frame_timestamp_reader>( new global_timestamp_reader( std::move( timestamp_reader_metadata ), _tf_keeper, enable_global_time_option ) ), this );
+        raw_depth_ep->register_xu( depth_xu );
+
+        auto depth_ep = std::make_shared<l500_depth_sensor>( this, raw_depth_ep, l500_depth_fourcc_to_rs2_format, l500_depth_fourcc_to_rs2_stream );
+
+        depth_ep->register_option( RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option );
+        depth_ep->get_option( RS2_OPTION_GLOBAL_TIME_ENABLED ).set( 0 );
+
+        // NOTE: _fw_version is not yet initialized! Any additional options should get added from configure_depth_options()!
+        depth_ep->register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, filter_by_mi(all_device_infos, 0).front().device_path);
+        return depth_ep;
+    }
+
+
+    /** This processing block removes all frames that are not of the given stream types
+     *
+     * This is only a workaround!!!
+     * It seems that, when definining a processing block outputs, if any other frames exist there
+     * then an issue can be exhibited where duplicate frames are produced. This solved the issue.
+     */
+    class filtering_processing_block : public generic_processing_block {
+        std::vector< rs2_stream > _streams;
+
+    public:
+        filtering_processing_block( rs2_stream stream_to_pass )
+            : generic_processing_block( "filtering_processing_block" ), _streams( 1, stream_to_pass ) {}
+        filtering_processing_block( std::initializer_list< rs2_stream > const & streams )
+            : generic_processing_block( "filtering_processing_block" ), _streams( streams ) {}
+
+        rs2::frame process_frame( const rs2::frame_source & source,
+                                  const rs2::frame & f ) override {
+            return f;
+        }
+
+    private:
+        bool should_process( const rs2::frame & f ) override {
+            auto fs = f.as< rs2::frameset >();
+            if( fs )
+                return false;  // we'll get the individual frames back by themselves:
+            auto it = std::find( _streams.begin(), _streams.end(), f.get_profile().stream_type() );
+            return ( it != _streams.end() );  // keep the frame only if one of those we got
+        }
+        rs2::frame prepare_output( const rs2::frame_source & source, rs2::frame input,
+                                   std::vector< rs2::frame > results ) override {
+            if( results.empty() )
+                return rs2::frame{};
+            return source.allocate_composite_frame(results);
+        }
+    };
+
+
+    void l500_device::configure_depth_options()
+    {
+        synthetic_sensor & depth_sensor = get_depth_sensor();
+
+        depth_sensor.register_processing_block(
+            { {RS2_FORMAT_Z16}, {RS2_FORMAT_Y8} },
+            { {RS2_FORMAT_Z16, RS2_STREAM_DEPTH, 0, 0, 0, 0, &stream_profile::rotate_resolution} },
+            [=]() {
+                auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
+                auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // disable logging on this internal syncer
+
+                auto cpb = std::make_shared<composite_processing_block>();
+                cpb->add(z16rot);
+                cpb->add(y8rot);
+                cpb->add(sync);
+                cpb->add( std::make_shared< filtering_processing_block >( RS2_STREAM_DEPTH ) );
+                return cpb;
+            }
+        );
+
+
+        depth_sensor.register_processing_block(
+            { {RS2_FORMAT_Z16}, {RS2_FORMAT_Y8}, {RS2_FORMAT_RAW8} },
+            {
+                {RS2_FORMAT_Z16, RS2_STREAM_DEPTH, 0, 0, 0, 0, &stream_profile::rotate_resolution},
+                {RS2_FORMAT_RAW8, RS2_STREAM_CONFIDENCE, 0, 0, 0, 0, &l500_confidence_resolution_fn}
+            },
+            [=]() {
+                auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
+                auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
+                auto conf = std::make_shared<confidence_rotation_transform>();
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // disable logging on this internal syncer
+
+                auto cpb = std::make_shared<composite_processing_block>();
+                cpb->add(z16rot);
+                cpb->add(y8rot);
+                cpb->add(conf);
+                cpb->add(sync);
+                cpb->add( std::shared_ptr< filtering_processing_block >(
+                    new filtering_processing_block{RS2_STREAM_DEPTH, RS2_STREAM_CONFIDENCE} ) );
+                return cpb;
+            }
+        );
+
+        depth_sensor.register_processing_block(
+            { {RS2_FORMAT_Y8} },
+            { {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 0, 0, 0, 0, &stream_profile::rotate_resolution} },
+            []() { return std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME); }
+        );
+
+        depth_sensor.register_processing_block(
+            { {RS2_FORMAT_RAW8} },
+            { {RS2_FORMAT_RAW8, RS2_STREAM_CONFIDENCE, 0, 0, 0, 0, &l500_confidence_resolution_fn} },
+            []() { return std::make_shared<confidence_rotation_transform>(); }
+        );
+
+        depth_sensor.register_processing_block(
+            processing_block_factory::create_id_pbf( RS2_FORMAT_FG, RS2_STREAM_DEPTH ) );
+
+        std::shared_ptr< freefall_option > freefall_opt;
+        if( _fw_version >= firmware_version( "1.3.5.0" ) )
+        {
+            depth_sensor.register_option(
+                RS2_OPTION_FREEFALL_DETECTION_ENABLED,
+                freefall_opt = std::make_shared< freefall_option >( *_hw_monitor )
+            );
+        }
+        else
+        {
+            LOG_DEBUG( "Skipping Freefall control: requires FW 1.3.5" );
+        }
+        if( _fw_version >= firmware_version( "1.3.12.9" ) )
+        {
+            depth_sensor.register_option(
+                RS2_OPTION_INTER_CAM_SYNC_MODE,
+                std::make_shared< hw_sync_option >( *_hw_monitor, freefall_opt )
+            );
+        }
+        else
+        {
+            LOG_DEBUG( "Skipping HW Sync control: requires FW 1.3.12.9" );
+        }
+    }
+
+    void l500_device::force_hardware_reset() const
+    {
+        command cmd(ivcam2::fw_cmd::HW_RESET);
+        cmd.require_response = false;
+        _hw_monitor->send(cmd);
+    }
+
+    double l500_device::get_device_time_ms()
+    {
+        if (!_hw_monitor)
+            throw wrong_api_call_sequence_exception("_hw_monitor is not initialized yet");
+
+        command cmd(ivcam2::fw_cmd::MRD, ivcam2::REGISTER_CLOCK_0, ivcam2::REGISTER_CLOCK_0 + 4);
+        // TODO -Redirect HW Monitor commands to used atomic (UVC) transfers for faster transactions and transfer integrity
+        // Disabled due to limitation in FW
+        auto res = _hw_monitor->send(cmd, nullptr);
+
+        if (res.size() < sizeof(uint32_t))
+        {
+            LOG_DEBUG("size(res):" << res.size());
+            throw std::runtime_error("Not enough bytes returned from the firmware!");
+        }
+        uint32_t dt = *(uint32_t*)res.data();
+        double ts = dt * TIMESTAMP_USEC_TO_MSEC;
+        return ts;
+    }
+
+    void l500_device::enter_update_state() const
+    {
+        // Stop all data streaming/exchange pipes with HW
+        stop_activity();
+        using namespace std;
+        using namespace std::chrono;
+
+        try
+        {
+            LOG_INFO( "entering to update state, device disconnect is expected" );
+            command cmd( ivcam2::DFU );
+            cmd.param1 = 1;
+            _hw_monitor->send( cmd );
+
+            // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = DISCONNECT_PERIOD_MS / DELAY_FOR_RETRIES;
+            for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
+            {
+                // If the device was detected as removed we assume the device is entering update
+                // mode Note: if no device status callback is registered we will wait the whole time
+                // and it is OK
+                if( ! is_valid() )
+                {
+                    this_thread::sleep_for( milliseconds( DELAY_FOR_CONNECTION ) );
+                    return;
+                }
+
+                this_thread::sleep_for( milliseconds( DELAY_FOR_RETRIES ) );
+            }
+
+            if (device_changed_notifications_on())
+                LOG_WARNING("Timeout waiting for device disconnect after DFU command!");
+        }
+        catch( std::exception & e )
+        {
+            LOG_ERROR( e.what() );
+        }
+        catch( ... )
+        {
+            LOG_ERROR( "Unknown error during entering DFU state" );
+        }
+    }
+
+    std::vector<uint8_t> l500_device::backup_flash(rs2_update_progress_callback_sptr callback)
+    {
+        int flash_size = 1024 * 2048;
+        int max_bulk_size = 1016;
+        int max_iterations = int(flash_size / max_bulk_size + 1);
+
+        std::vector<uint8_t> flash;
+        flash.reserve(flash_size);
+
+        get_raw_depth_sensor()->invoke_powered([&](platform::uvc_device& dev)
+        {
+            for (int i = 0; i < max_iterations; i++)
+            {
+                int offset = max_bulk_size * i;
+                int size = max_bulk_size;
+                if (i == max_iterations - 1)
+                {
+                    size = flash_size - offset;
+                }
+
+                bool appended = false;
+
+                const int retries = 3;
+                for (int j = 0; j < retries && !appended; j++)
+                {
+                    try
+                    {
+                        command cmd(ivcam2::FRB);
+                        cmd.param1 = offset;
+                        cmd.param2 = size;
+                        auto res = _hw_monitor->send(cmd);
+
+                        flash.insert(flash.end(), res.begin(), res.end());
+                        appended = true;
+                    }
+                    catch (...)
+                    {
+                        if (i < retries - 1) std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                        else throw;
+                    }
+                }
+
+                if (callback) callback->on_update_progress((float)i / max_iterations);
+            }
+            if (callback) callback->on_update_progress(1.0);
+        });
+
+        return flash;
+    }
+
+    void l500_device::update_flash_section(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, uint32_t offset, uint32_t size, rs2_update_progress_callback_sptr callback, float continue_from, float ratio)
+    {
+        int sector_count = int( size / ivcam2::FLASH_SECTOR_SIZE );
+        int first_sector = int( offset / ivcam2::FLASH_SECTOR_SIZE );
+
+        if (sector_count * ivcam2::FLASH_SECTOR_SIZE != size)
+            sector_count++;
+
+        sector_count += first_sector;
+
+        for (int sector_index = first_sector; sector_index < sector_count; sector_index++)
+        {
+            command cmdFES(ivcam2::FES);
+            // On both FES & FWB commands We don't really need the response but we see that setting
+            // false and sending many commands cause a failure. 
+            // Looks like the FW is expecting it.
+            cmdFES.require_response = true;
+            cmdFES.param1 = int(sector_index);
+            cmdFES.param2 = 1;
+            auto res = hwm->send(cmdFES);
+
+            for (int i = 0; i < ivcam2::FLASH_SECTOR_SIZE; )
+            {
+                auto index = sector_index * ivcam2::FLASH_SECTOR_SIZE + i;
+                if (index >= offset + size)
+                    break;
+                int packet_size = std::min((int)(HW_MONITOR_COMMAND_SIZE - (i % HW_MONITOR_COMMAND_SIZE)), (int)(ivcam2::FLASH_SECTOR_SIZE - i));
+                command cmdFWB(ivcam2::FWB);
+                cmdFWB.require_response = true;
+                cmdFWB.param1 = int(index);
+                cmdFWB.param2 = packet_size;
+                cmdFWB.data.assign(image.data() + index, image.data() + index + packet_size);
+                res = hwm->send(cmdFWB);
+                i += packet_size;
+            }
+
+            if (callback)
+                callback->on_update_progress(continue_from + (float)sector_index / (float)sector_count * ratio);
+        }
+    }
+
+    void l500_device::update_section(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& merged_image, flash_section fs, uint32_t tables_size,
+        rs2_update_progress_callback_sptr callback, float continue_from, float ratio)
+    {
+        auto first_table_offset = fs.tables.front().offset;
+        float total_size = float(fs.app_size + tables_size);
+
+        float app_ratio = fs.app_size / total_size * ratio;
+        float tables_ratio = tables_size / total_size * ratio;
+
+        update_flash_section(hwm, merged_image, fs.offset, fs.app_size, callback, continue_from, app_ratio);
+        update_flash_section(hwm, merged_image, first_table_offset, tables_size, callback, app_ratio, tables_ratio);
+    }
+
+    void l500_device::update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup, rs2_update_progress_callback_sptr callback, int update_mode)
+    {
+        auto flash_image_info = ivcam2::get_flash_info(image);
+        auto flash_backup_info = ivcam2::get_flash_info(flash_backup);
+        auto merged_image = merge_images(flash_backup_info, flash_image_info, image);
+
+        // update read-write section
+        auto first_table_offset = flash_image_info.read_write_section.tables.front().offset;
+        auto tables_size = flash_image_info.header.read_write_start_address + flash_image_info.header.read_write_size - first_table_offset;
+        update_section(hwm, merged_image, flash_image_info.read_write_section, tables_size, callback, 0, update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY ? 0.5f : 1.f);
+
+        if (update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY)
+        {
+            // update read-only section
+            auto first_table_offset = flash_image_info.read_only_section.tables.front().offset;
+            auto tables_size = flash_image_info.header.read_only_start_address + flash_image_info.header.read_only_size - first_table_offset;
+            update_section(hwm, merged_image, flash_image_info.read_only_section, tables_size, callback, 0.5, 0.5);
+        }
+    }
+
+    void l500_device::update_flash(const std::vector<uint8_t>& image, rs2_update_progress_callback_sptr callback, int update_mode)
+    {
+        if (_is_locked)
+            throw std::runtime_error("this camera is locked and doesn't allow direct flash write, for firmware update use rs2_update_firmware method (DFU)");
+
+        get_raw_depth_sensor()->invoke_powered([&](platform::uvc_device& dev)
+        {
+            command cmdPFD(ivcam2::PFD);
+            cmdPFD.require_response = false;
+            auto res = _hw_monitor->send(cmdPFD);
+
+            switch (update_mode)
+            {
+            case RS2_UNSIGNED_UPDATE_MODE_FULL:
+                update_flash_section(_hw_monitor, image, 0, ivcam2::FLASH_SIZE, callback, 0, 1.0);
+                break;
+            case RS2_UNSIGNED_UPDATE_MODE_UPDATE:
+            case RS2_UNSIGNED_UPDATE_MODE_READ_ONLY:
+            {
+                auto flash_backup = backup_flash(nullptr);
+                update_flash_internal(_hw_monitor, image, flash_backup, callback, update_mode);
+                break;
+            }
+            default:
+                throw std::runtime_error("invalid update mode value");
+            }
+
+            if (callback) callback->on_update_progress(1.0);
+
+            command cmdHWRST(ivcam2::HW_RESET);
+            res = _hw_monitor->send(cmdHWRST);
+        });
+    }
+
+    command l500_device::get_firmware_logs_command() const
+    {
+        return command{ ivcam2::GLD, 0x1f4 };
+    }
+
+    command l500_device::get_flash_logs_command() const
+    {
+        return command{ ivcam2::FRB, 0x0011E000, 0x3f8 };
+    }
+
+    static void log_FW_response_first_byte(hw_monitor& hwm, const std::string& command_name, const command &cmd, size_t expected_size)
+    {
+        auto res = hwm.send(cmd);
+        if (res.size() < expected_size)
+        {
+            throw invalid_value_exception( rsutils::string::from()
+                                           << command_name + " FW command failed: size expected: " << expected_size
+                                           << " , size received: " << res.size() );
+        }
+
+        LOG_INFO(command_name << ": " << static_cast<int>(res[0]));
+    }
+
+    std::string l500_device::get_opcode_string(int opcode) const
+    {
+        return ds::d400_hwmon_response().hwmon_error2str(opcode);
+    }
+
+    std::vector< uint8_t > l500_device::send_receive_raw_data(const std::vector< uint8_t > & input)
+    {
+        std::string command_str(input.begin(), input.end());
+
+        if (command_str == "GET-NEST")
+        {
+            auto minimal_fw_ver = firmware_version("1.5.0.0");
+            if (_fw_version >= minimal_fw_ver)
+            {
+                // Handle extended temperature command
+                LOG_INFO("Nest AVG: " << get_temperatures().nest_avg);
+
+                // Handle other commands (all results log the first uint8_t)
+                log_FW_response_first_byte(*_hw_monitor, "Gain trim",
+                    command(ivcam2::IRB, 0x6C, 0x2, 0x1),
+                    sizeof(uint8_t));
+                log_FW_response_first_byte(*_hw_monitor, "IPF gain",
+                    command(ivcam2::MRD, 0xA003007C, 0xA0030080),
+                    sizeof(uint32_t));
+                log_FW_response_first_byte(*_hw_monitor, "APB VBR",
+                    command(ivcam2::AMCGET, 0x4, 0x0, 0x0),
+                    sizeof(uint32_t));
+                return std::vector< uint8_t >();
+            }
+            else
+                throw librealsense::invalid_value_exception(
+                    rsutils::string::from() << "get-nest command requires FW version >= " << minimal_fw_ver
+                                            << ", current version is: " << _fw_version );
+        }
+
+        return _hw_monitor->send(input);
+    }
+
+    std::vector<uint8_t> l500_device::build_command(uint32_t opcode,
+        uint32_t param1,
+        uint32_t param2,
+        uint32_t param3,
+        uint32_t param4,
+        uint8_t const * data,
+        size_t dataLength) const
+    {
+        return _hw_monitor->build_command(opcode, param1, param2, param3, param4, data, dataLength);
+    }
+
+    ivcam2::extended_temperatures l500_device::get_temperatures() const
+    {
+        ivcam2::extended_temperatures rv;
+        if (_have_temperatures)
+        {
+            std::lock_guard<std::mutex> lock(_temperature_mutex);
+            rv = _temperatures;
+        }
+        else
+        {
+            // Noise estimation was added at FW version 1.5.0.0
+            auto fw_version_support_nest = (_fw_version >= firmware_version("1.5.0.0")) ? true : false;
+            auto expected_size = fw_version_support_nest ? sizeof(extended_temperatures)
+                : sizeof(temperatures);
+
+
+            const auto res = _hw_monitor->send(command{ TEMPERATURES_GET });
+            // Verify read
+            if (res.size() < expected_size)
+            {
+                throw std::runtime_error( rsutils::string::from()
+                                          << "TEMPERATURES_GET - Invalid result size! expected: " << expected_size
+                                          << " bytes, "
+                                             "got: "
+                                          << res.size() << " bytes" );
+            }
+
+            if (fw_version_support_nest)
+                rv = *reinterpret_cast<extended_temperatures const *>(res.data());
+            else
+                *reinterpret_cast<temperatures *>(&rv) = *reinterpret_cast<temperatures const *>(res.data());
+        }
+        return rv;
+    }
+
+    void l500_device::start_temperatures_reader()
+    {
+        LOG_DEBUG("Starting temperature fetcher thread");
+        _keep_reading_temperature = true;
+        _temperature_reader = std::thread( [&]() {
+            try
+            {
+                auto fw_version_support_nest = _fw_version >= firmware_version( "1.5.0.0" );
+
+                auto expected_size = fw_version_support_nest ? sizeof( extended_temperatures )
+                                                             : sizeof( temperatures );
+
+                rsutils::time::periodic_timer second_has_passed(std::chrono::seconds(1));
+                second_has_passed.set_expired(); // Force condition true on start
+
+
+                while (_keep_reading_temperature)
+                {
+                    if (second_has_passed) // Update temperatures every second
+                    {
+                        const auto res = _hw_monitor->send(command{ TEMPERATURES_GET });
+                        // Verify read
+                        if (res.size() < expected_size)
+                        {
+                            throw std::runtime_error( rsutils::string::from()
+                                                      << "TEMPERATURES_GET - Invalid result size!, expected: "
+                                                      << expected_size
+                                                      << " bytes, "
+                                                         "got: "
+                                                      << res.size() << " bytes" );
+                        }
+               
+                        std::lock_guard<std::mutex> lock(_temperature_mutex);
+
+                        memset(&_temperatures, 0, sizeof(_temperatures));
+                        if (fw_version_support_nest)
+                            _temperatures = *reinterpret_cast<extended_temperatures const *>(res.data());
+                        else
+                            *reinterpret_cast<temperatures *>(&_temperatures) = *reinterpret_cast<temperatures const *>(res.data());
+                       
+                        _have_temperatures = true;
+                    }
+               
+                    // Do not hold the device alive too long if reader thread was turned off
+                    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+                }
+             }
+             catch (...)
+             {
+                 LOG_WARNING("unable to read temperatures - closing temperatures reader");
+             }
+             _have_temperatures = false;
+         });
+     }
+    
+    void l500_device::stop_temperatures_reader()
+    {
+        if (_keep_reading_temperature)
+        {
+            LOG_DEBUG("Stopping temperature fetcher thread");
+            _keep_reading_temperature = false;
+            _have_temperatures = false;
+        }
+
+        if (_temperature_reader.joinable())
+        {
+            _temperature_reader.join();
+        }
+    }
+
+    bool l500_device::check_fw_compatibility(const std::vector<uint8_t>& image) const
+    {
+        std::string fw_version = ds::extract_firmware_version_string(image);
+
+        auto min_max_fw_it = ivcam2::device_to_fw_min_max_version.find(_pid);
+        if (min_max_fw_it == ivcam2::device_to_fw_min_max_version.end())
+            throw librealsense::invalid_value_exception(
+                rsutils::string::from() << "Min and Max firmware versions have not been defined for this device: "
+                                        << std::hex << _pid );
+
+        // Limit L515 to FW versions within the 1.5.1.3-1.99.99.99 range to differenciate from the other products
+        bool result = (firmware_version(fw_version) >= firmware_version(min_max_fw_it->second.first)) &&
+            (firmware_version(fw_version) <= firmware_version(min_max_fw_it->second.second));
+        if (!result)
+            LOG_ERROR("Firmware version isn't compatible" << fw_version);
+
+        return result;
+
+    }
+
+    notification l500_notification_decoder::decode(int value)
+    {
+        // Anything listed in l500-private.h on l500_fw_error_report is an error; everything else is a warning
+        if (l500_fw_error_report.find(static_cast<uint8_t>(value)) != l500_fw_error_report.end())
+            return{ RS2_NOTIFICATION_CATEGORY_HARDWARE_ERROR, value, RS2_LOG_SEVERITY_ERROR, l500_fw_error_report.at(static_cast<uint8_t>(value)) };
+
+        return { RS2_NOTIFICATION_CATEGORY_HARDWARE_ERROR,
+                 value,
+                 RS2_LOG_SEVERITY_WARN,
+                 ( rsutils::string::from() << "L500 HW report - unresolved type " << value ) };
+    }
+}

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -1,0 +1,152 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+#include <mutex>
+#include <string>
+#include "../device.h"
+#include "../context.h"
+#include "../backend.h"
+#include <src/backend-device.h>
+#include <rsutils/lazy.h>
+#include "../hw-monitor.h"
+#include "../image.h"
+#include "../stream.h"
+#include "l500-private.h"
+#include "../error-handling.h"
+#include "../global_timestamp_reader.h"
+#include "../fw-update/fw-update-device-interface.h"
+#include <src/core/debug.h>
+
+namespace librealsense
+{
+    class l500_depth_sensor;
+    class l500_color_sensor;
+    class l500_info;
+
+    class l500_device
+        : public virtual backend_device
+        , public debug_interface
+        , public global_time_interface
+        , public updatable
+    {
+    public:
+        l500_device( std::shared_ptr< const l500_info > const & dev_info );
+
+        std::shared_ptr<synthetic_sensor> create_depth_device(std::shared_ptr<context> ctx,
+            const std::vector<platform::uvc_device_info>& all_device_infos);
+
+        virtual void configure_depth_options();
+
+        virtual l500_color_sensor * get_color_sensor() = 0;
+
+        synthetic_sensor & get_synthetic_depth_sensor() { return dynamic_cast< synthetic_sensor &>(get_sensor( _depth_device_idx )); }
+        l500_depth_sensor & get_depth_sensor();
+        std::shared_ptr<uvc_sensor> get_raw_depth_sensor()
+        {
+            synthetic_sensor& depth_sensor = get_synthetic_depth_sensor();
+            return std::dynamic_pointer_cast<uvc_sensor>(depth_sensor.get_raw_sensor());
+        }
+
+        std::vector< uint8_t > send_receive_raw_data(const std::vector< uint8_t > & input) override;
+        std::string get_opcode_string(int opcode) const override;
+        std::vector<uint8_t> build_command(uint32_t opcode,
+            uint32_t param1 = 0,
+            uint32_t param2 = 0,
+            uint32_t param3 = 0,
+            uint32_t param4 = 0,
+            uint8_t const * data = nullptr,
+            size_t dataLength = 0) const override;
+
+        void hardware_reset() override
+        {
+            force_hardware_reset();
+        }
+
+        double get_device_time_ms() override;
+
+        void enter_update_state() const override;
+        std::vector<uint8_t> backup_flash(rs2_update_progress_callback_sptr callback) override;
+        void update_flash(const std::vector<uint8_t>& image, rs2_update_progress_callback_sptr callback, int update_mode) override;
+        void update_flash_section(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, uint32_t offset, uint32_t size, 
+            rs2_update_progress_callback_sptr callback, float continue_from, float ratio);
+        void update_section(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& merged_image, flash_section fs, uint32_t tables_size,
+            rs2_update_progress_callback_sptr callback, float continue_from, float ratio);
+        void update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup,
+            rs2_update_progress_callback_sptr callback, int update_mode);
+        bool check_fw_compatibility(const std::vector<uint8_t>& image) const override;
+
+        ivcam2::extended_temperatures get_temperatures() const;
+
+
+    protected:
+        void start_temperatures_reader();
+        void stop_temperatures_reader();
+
+        friend class l500_depth_sensor;
+
+        std::shared_ptr<hw_monitor> _hw_monitor;
+        uint8_t _depth_device_idx;
+
+        std::shared_ptr<polling_error_handler> _polling_error_handler;
+
+        rsutils::lazy<ivcam2::intrinsic_depth> _calib_table;
+        firmware_version _fw_version;
+        std::shared_ptr<stream_interface> _depth_stream;
+        std::shared_ptr<stream_interface> _ir_stream;
+        std::shared_ptr<stream_interface> _confidence_stream;
+        
+        void force_hardware_reset() const;
+        bool _is_locked = true;
+
+        //TODO - add these to device class as pure virtual methods
+        command get_firmware_logs_command() const;
+        command get_flash_logs_command() const;
+
+        std::vector<rs2_option> _advanced_options;
+
+        platform::usb_spec _usb_mode;
+
+        mutable std::mutex _temperature_mutex;
+        std::atomic_bool _keep_reading_temperature{ false };  // If true temperature reading thread is working, otherwise indicate to the thread to stop
+        std::atomic_bool _have_temperatures{ false }; //  If true, then the _temperatures are valid and up-to-date.
+        std::thread _temperature_reader;
+        ivcam2::extended_temperatures _temperatures;
+    };
+
+    class l500_notification_decoder : public notification_decoder
+    {
+    public:
+        notification decode(int value) override;
+    };
+
+    class action_delayer
+    {
+    public:
+
+        void do_after_delay(std::function<void()> action, int milliseconds = 2000)
+        {
+            wait(milliseconds);
+            action();
+            _last_update = std::chrono::system_clock::now();
+        }
+
+    private:
+        void wait(int milliseconds)
+        {
+            auto now = std::chrono::system_clock::now();
+            auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_update).count();
+
+            while (diff < milliseconds)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                now = std::chrono::system_clock::now();
+                diff = std::chrono::duration_cast<std::chrono::milliseconds>(now - _last_update).count();
+            }
+        }
+
+        std::chrono::system_clock::time_point _last_update;
+    };
+}

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-factory.cpp
+++ b/src/l500/l500-factory.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2016 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2016 RealSense, Inc. All Rights Reserved.
 
 #include <mutex>
 #include <chrono>

--- a/src/l500/l500-factory.cpp
+++ b/src/l500/l500-factory.cpp
@@ -1,0 +1,177 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2016 Intel Corporation. All Rights Reserved.
+
+#include <mutex>
+#include <chrono>
+#include <vector>
+#include <iterator>
+#include <cstddef>
+
+#include "device.h"
+#include "context.h"
+#include "image.h"
+#include "metadata-parser.h"
+#include "../firmware_logger_device.h"
+#include <src/core/matcher-factory.h>
+#include "sync.h"
+#include <src/platform/platform-utils.h>
+#include <src/backend-device.h>
+
+#include "l500-info.h"
+#include "l500-depth.h"
+#include "l500-motion.h"
+#include "l500-color.h"
+#include "l500-serializable.h"
+
+namespace librealsense
+{
+    using namespace ivcam2;
+
+    class l515_device : public l500_depth,
+        public l500_options,
+        public l500_color,
+        public l500_motion,
+        public l500_serializable,
+        public firmware_logger_device
+    {
+    public:
+        l515_device( std::shared_ptr< const l500_info > const & dev_info, bool register_device_notifications )
+            : device(dev_info, register_device_notifications),
+            backend_device(dev_info, register_device_notifications),
+            l500_device(dev_info),
+            l500_depth(dev_info),
+            l500_options(dev_info),
+            l500_color(dev_info),
+            l500_motion(dev_info),
+            l500_serializable(l500_device::_hw_monitor, get_depth_sensor()),
+            firmware_logger_device(dev_info, l500_device::_hw_monitor,
+                get_firmware_logs_command(),
+                get_flash_logs_command())
+        {}
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto depth_profiles = l500_depth::get_profiles_tags();
+            auto color_profiles = l500_color::get_profiles_tags();
+            auto motion_profiles = l500_motion::get_profiles_tags();
+
+            tags.insert(tags.begin(), depth_profiles.begin(), depth_profiles.end());
+            tags.insert(tags.begin(), color_profiles.begin(), color_profiles.end());
+            tags.insert(tags.begin(), motion_profiles.begin(), motion_profiles.end());
+            return tags;
+        };
+    };
+
+    class l500_rs500_device : public l500_depth,
+        public firmware_logger_device
+    {
+    public:
+        l500_rs500_device( std::shared_ptr< const l500_info > const & dev_info, bool register_device_notifications )
+            : device(dev_info, register_device_notifications),
+            backend_device(dev_info, register_device_notifications),
+            l500_device(dev_info),
+            l500_depth(dev_info),
+            firmware_logger_device(dev_info, l500_device::_hw_monitor,
+                get_firmware_logs_command(),
+                get_flash_logs_command())
+        {}
+
+        l500_color_sensor * get_color_sensor() override { return nullptr; }
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+    };
+
+    std::shared_ptr< device_interface > l500_info::create_device()
+    {
+        if( _group.uvc_devices.empty() )
+            throw std::runtime_error("Depth Camera not found!");
+
+        auto const dev_info = std::dynamic_pointer_cast< const l500_info >( shared_from_this() );
+        bool const register_device_notifications = true;
+
+        auto pid = _group.uvc_devices.front().pid;
+        switch (pid)
+        {
+        case L500_PID:
+            return std::make_shared<l500_rs500_device>(dev_info, register_device_notifications);
+        case L515_PID_PRE_PRQ:
+        case L515_PID:
+            return std::make_shared<l515_device>(dev_info, register_device_notifications);
+       default:
+            throw std::runtime_error( rsutils::string::from() << "Unsupported L500 model! 0x" << std::hex
+                                                              << std::setw( 4 ) << std::setfill( '0' ) << (int)pid );
+        }
+    }
+
+    std::vector< std::shared_ptr< l500_info > > l500_info::pick_l500_devices(
+        std::shared_ptr<context> ctx,
+        platform::backend_device_group& group)
+    {
+        std::vector<platform::uvc_device_info> chosen;
+        std::vector<std::shared_ptr<l500_info>> results;
+
+        auto correct_pid = filter_by_product(group.uvc_devices, { L500_PID, L515_PID, L515_PID_PRE_PRQ });
+        auto group_devices = group_devices_and_hids_by_unique_id(group_devices_by_unique_id(correct_pid), group.hid_devices);
+        for (auto& g : group_devices)
+        {
+            if (!g.first.empty() && mi_present(g.first, 0))
+            {
+                auto depth = get_mi(g.first, 0);
+                platform::usb_device_info hwm;
+
+                std::vector<platform::usb_device_info> hwm_devices;
+                if (ivcam2::try_fetch_usb_device(group.usb_devices, depth, hwm))
+                    hwm_devices.push_back(hwm);
+                else
+                    LOG_DEBUG("try_fetch_usb_device(...) failed.");
+
+                if(g.first[0].pid != L500_PID)
+                    if (g.second.size() < 2)
+                    {
+                        LOG_DEBUG("L500 partial enum: " << g.second.size() << " HID devices were recognized (2+ expected)");
+#if !defined(ANDROID) && !defined(__APPLE__) // Not supported by android & macos
+                        continue;
+#endif // Not supported by android & macos
+                    }
+
+                auto info = std::make_shared< l500_info >( ctx,
+                                                           std::vector< platform::uvc_device_info >( g.first ),
+                                                           std::move( hwm_devices ),
+                                                           std::vector< platform::hid_device_info >( g.second ) );
+                chosen.push_back(depth);
+                results.push_back(info);
+            }
+            else
+            {
+                LOG_DEBUG("L500 group_devices is empty.");
+            }
+        }
+
+        trim_device_list(group.uvc_devices, chosen);
+
+        return results;
+    }
+
+    std::shared_ptr<matcher> l500_rs500_device::create_matcher(const frame_holder& frame) const
+    {
+        return l500_depth::create_matcher(frame);
+    }
+
+    std::shared_ptr<matcher> l515_device::create_matcher(const frame_holder & frame) const
+    {
+        LOG_DEBUG( "l515_device::create_matcher" );
+        std::vector<std::shared_ptr<matcher>> depth_rgb_matchers = { l500_depth::create_matcher(frame),
+            std::make_shared<identity_matcher>(_color_stream->get_unique_id(), _color_stream->get_stream_type())};
+
+        auto ts_depth_rgb = std::make_shared<timestamp_composite_matcher>(depth_rgb_matchers);
+
+        auto identity_gyro = std::make_shared<identity_matcher>(_gyro_stream->get_unique_id(), _gyro_stream->get_stream_type());
+        auto identity_accel = std::make_shared<identity_matcher>(_accel_stream->get_unique_id(), _accel_stream->get_stream_type());
+
+        std::vector<std::shared_ptr<matcher>> depth_rgb_imu_matchers = {ts_depth_rgb, identity_gyro, identity_accel};
+        return std::make_shared<composite_identity_matcher>(depth_rgb_imu_matchers);
+    }
+}

--- a/src/l500/l500-fw-update-device.cpp
+++ b/src/l500/l500-fw-update-device.cpp
@@ -1,0 +1,55 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#include "l500-fw-update-device.h"
+#include "l500-private.h"
+#include <src/ds/ds-private.h>
+
+#include <rsutils/string/from.h>
+
+
+namespace librealsense
+{
+    l500_update_device::l500_update_device( std::shared_ptr< const device_info > const & dev_info,
+                                            std::shared_ptr< platform::usb_device > const & usb_device )
+        : update_device( dev_info, usb_device, "L500" )
+    {
+        auto info = usb_device->get_info();
+        _name = ivcam2::rs500_sku_names.find(info.pid) != ivcam2::rs500_sku_names.end() ? ivcam2::rs500_sku_names.at(info.pid) : "unknown";
+        _serial_number = parse_serial_number(_serial_number_buffer);
+    }
+
+    bool l500_update_device::check_fw_compatibility(const std::vector<uint8_t>& image) const
+    {
+        std::string fw_version = ds::extract_firmware_version_string(image);
+        auto min_max_fw_it = ivcam2::device_to_fw_min_max_version.find(_usb_device->get_info().pid);
+        if (min_max_fw_it == ivcam2::device_to_fw_min_max_version.end())
+            throw librealsense::invalid_value_exception(
+                rsutils::string::from() << "Min and Max firmware versions have not been defined for this device: "
+                                        << std::hex << _pid );
+
+        // Limit L515 to FW versions within the 1.5.1.3-1.99.99.99 range to differenciate from the other products
+        bool result = (firmware_version(fw_version) >= firmware_version(min_max_fw_it->second.first)) &&
+            (firmware_version(fw_version) <= firmware_version(min_max_fw_it->second.second));
+        if (!result)
+            LOG_ERROR("Firmware version isn't compatible" << fw_version);
+
+        return result;
+    }
+
+    std::string l500_update_device::parse_serial_number(const std::vector<uint8_t>& buffer) const
+    {
+        // Note that we are using a specific serial_number_data struct then the generic one.
+        // See comment in the struct definition for more details
+        if (buffer.size() != sizeof(l500_update_device::serial_number_data))
+            throw std::runtime_error("DFU - failed to parse serial number!");
+
+        const auto serial_num_data = (l500_update_device::serial_number_data *)buffer.data();
+        std::stringstream rv;
+        for (auto i = 0; i < ivcam2::module_asic_serial_size; i++)
+            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(serial_num_data->serial[i]);
+
+        return rv.str();
+    }
+
+}

--- a/src/l500/l500-fw-update-device.cpp
+++ b/src/l500/l500-fw-update-device.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 
 #include "l500-fw-update-device.h"
 #include "l500-private.h"

--- a/src/l500/l500-fw-update-device.h
+++ b/src/l500/l500-fw-update-device.h
@@ -1,0 +1,33 @@
+﻿// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "fw-update/fw-update-device.h"
+
+namespace librealsense
+{
+    class l500_update_device : public update_device
+    {
+    public:
+        static const uint16_t DFU_VERSION_MASK = 0xFE;
+        static const uint16_t DFU_VERSION_VALUE = 0x4A; // On Units with old DFU payload can be 74/75 decimal
+
+        // The L515 device EEPROM has different bytes order then D4xx device.
+        // this struct overrides the generic serial_number_data struct at fw-update-device.h
+        struct serial_number_data
+        {
+            uint8_t spare[2];
+            uint8_t serial[6];
+        };
+
+        l500_update_device( std::shared_ptr< const device_info > const & dev_info,
+                            std::shared_ptr< platform::usb_device > const & usb_device );
+        virtual ~l500_update_device() = default;
+
+        virtual bool check_fw_compatibility(const std::vector<uint8_t>& image) const override;
+
+    protected:
+        std::string parse_serial_number(const std::vector<uint8_t>& buffer) const;
+    };
+}

--- a/src/l500/l500-fw-update-device.h
+++ b/src/l500/l500-fw-update-device.h
@@ -1,5 +1,5 @@
 ﻿// License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-info.h
+++ b/src/l500/l500-info.h
@@ -1,0 +1,27 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2016 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <src/platform/platform-device-info.h>
+
+
+namespace librealsense
+{
+    class l500_info : public platform::platform_device_info
+    {
+    public:
+        std::shared_ptr< device_interface > create_device() override;
+
+        l500_info( std::shared_ptr< context > const & ctx,
+                   std::vector< platform::uvc_device_info > && depth,
+                   std::vector< platform::usb_device_info > && hwm,
+                   std::vector< platform::hid_device_info > && hid )
+            : platform_device_info( ctx, { std::move( depth ), std::move( hwm ), std::move( hid ) } )
+        {
+        }
+
+        static std::vector< std::shared_ptr< l500_info > > pick_l500_devices(
+                std::shared_ptr< context > ctx,
+                platform::backend_device_group & group );
+    };
+}

--- a/src/l500/l500-info.h
+++ b/src/l500/l500-info.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2016 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2016 RealSense, Inc. All Rights Reserved.
 #pragma once
 
 #include <src/platform/platform-device-info.h>

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -1,0 +1,220 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#include "l500-color.h"
+#include "l500-private.h"
+#include "l500-motion.h"
+#include "l500-info.h"
+#include <rsutils/type/fourcc.h>
+#include <src/platform/uvc-option.h>
+#include <src/image.h>
+#include <src/hid-sensor.h>
+#include <src/metadata.h>
+#include <src/metadata-parser.h>
+#include "../backend.h"
+#include "proc/motion-transform.h"
+
+#include <rsutils/string/from.h>
+
+
+namespace librealsense
+{
+    using rsutils::type::fourcc;
+
+#ifdef _WIN32
+        std::vector<std::pair<std::string, stream_profile>> l500_sensor_name_and_hid_profiles =
+        {{ "HID Sensor Class Device: Gyroscope",     {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 100  }},
+         { "HID Sensor Class Device: Gyroscope",     {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 200  }},
+         { "HID Sensor Class Device: Gyroscope",     {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 400  }},
+         { "HID Sensor Class Device: Accelerometer", {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 100  }},
+         { "HID Sensor Class Device: Accelerometer", {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 200  }},
+         { "HID Sensor Class Device: Accelerometer", {  RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 400  }}};
+
+        // Translate frequency to SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL
+        std::map<rs2_stream, std::map<unsigned, unsigned>> l500_fps_and_sampling_frequency_per_rs2_stream =
+        { {RS2_STREAM_ACCEL,{{100,  1000},
+                             {200,  500},
+                             {400,  250}}},
+         {RS2_STREAM_GYRO,  {{100,  1000},
+                             {200,  500},
+                             {400,  250}}}};
+
+#else
+    std::vector<std::pair<std::string, stream_profile>> l500_sensor_name_and_hid_profiles =
+   {{ "gyro_3d",        {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 100   }},
+    { "gyro_3d",        {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 200   }},
+    { "gyro_3d",        {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO,  0, 1, 1, 400   }},
+    { "accel_3d",       {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 100   }},
+    { "accel_3d",       {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 200   }},
+    { "accel_3d",       {   RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL, 0, 1, 1, 400   }}};
+
+   // The frequency selector is vendor and model-specific
+   std::map<rs2_stream, std::map<unsigned, unsigned>> l500_fps_and_sampling_frequency_per_rs2_stream =
+   { {RS2_STREAM_ACCEL,{{100,  1},
+                        {200,  2},
+                        {400,  4}}},
+    {RS2_STREAM_GYRO,  {{100,  1},
+                        {200,  2},
+                        {400,  4}}} };
+#endif
+
+    class l500_hid_sensor : public synthetic_sensor, public motion_sensor
+    {
+    public:
+        explicit l500_hid_sensor(std::string name,
+            std::shared_ptr<raw_sensor_base> sensor,
+            device* device,
+            l500_motion* owner)
+            : synthetic_sensor(name, sensor, device), _owner(owner)
+        {
+        }
+
+        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const
+        {
+            return _owner->get_motion_intrinsics(stream);
+        }
+
+        stream_profiles init_stream_profiles() override
+        {
+            auto lock = environment::get_instance().get_extrinsics_graph().lock();
+            auto results = synthetic_sensor::init_stream_profiles();
+
+            for (auto p : results)
+            {
+                // Register stream types
+                if (p->get_stream_type() == RS2_STREAM_ACCEL)
+                    assign_stream(_owner->_accel_stream, p);
+                if (p->get_stream_type() == RS2_STREAM_GYRO)
+                    assign_stream(_owner->_gyro_stream, p);
+
+                //set motion intrinsics
+                if (p->get_stream_type() == RS2_STREAM_ACCEL || p->get_stream_type() == RS2_STREAM_GYRO)
+                {
+                    auto motion = dynamic_cast<motion_stream_profile_interface*>(p.get());
+                    assert(motion); //Expecting to succeed for motion stream (since we are under the "if")
+                    auto st = p->get_stream_type();
+                    motion->set_intrinsics([this, st]() { return get_motion_intrinsics(st); });
+                }
+            }
+
+            return results;
+        }
+
+    private:
+        const l500_motion* _owner;
+    };
+
+    std::shared_ptr<synthetic_sensor> l500_motion::create_hid_device(std::shared_ptr<context> ctx, const std::vector<platform::hid_device_info>& all_hid_infos)
+    {
+        if (all_hid_infos.empty())
+        {
+            LOG_WARNING("No HID info provided, IMU is disabled");
+            return nullptr;
+        }
+
+        std::unique_ptr<frame_timestamp_reader> iio_hid_ts_reader(new iio_hid_timestamp_reader());
+        std::unique_ptr<frame_timestamp_reader> custom_hid_ts_reader(new iio_hid_timestamp_reader());
+        auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
+        auto raw_hid_ep = std::make_shared<hid_sensor>(get_backend()->create_hid_device(all_hid_infos.front()),
+            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(iio_hid_ts_reader), _tf_keeper, enable_global_time_option)),
+            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(custom_hid_ts_reader), _tf_keeper, enable_global_time_option)),
+            l500_fps_and_sampling_frequency_per_rs2_stream,
+            l500_sensor_name_and_hid_profiles,
+            this);
+
+        auto hid_ep = std::make_shared<l500_hid_sensor>("Motion Module", raw_hid_ep, this, this);
+
+        hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+        hid_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
+        hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+
+        // register pre-processing
+        std::shared_ptr<enable_motion_correction> mm_correct_opt = nullptr;
+
+        //  Motion intrinsic calibration presents is a prerequisite for motion correction.
+        try
+        {
+            // L515 motion correction with IMU supported from FW version 01.04.01.00
+            if (_fw_version >= firmware_version("1.4.1.0") && _mm_calib)
+            {
+                mm_correct_opt = std::make_shared<enable_motion_correction>(hid_ep.get(), option_range{ 0, 1, 1, 1 });
+                hid_ep->register_option(RS2_OPTION_ENABLE_MOTION_CORRECTION, mm_correct_opt);
+            }
+        }
+        catch (...) {}
+
+        hid_ep->register_processing_block(
+            { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
+            { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
+            [&, mm_correct_opt]() { return std::make_shared<acceleration_transform>(_mm_calib, mm_correct_opt, is_imu_high_accuracy()); }
+        );
+
+        hid_ep->register_processing_block(
+            { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
+            { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
+            [&, mm_correct_opt]() { return std::make_shared<gyroscope_transform>(_mm_calib, mm_correct_opt, get_gyro_default_scale(), is_imu_high_accuracy()); }
+        );
+        return hid_ep;
+    }
+
+    l500_motion::l500_motion( std::shared_ptr< const l500_info > const & dev_info )
+        :device(dev_info), backend_device(dev_info), l500_device(dev_info),
+          _accel_stream(new stream(RS2_STREAM_ACCEL)),
+         _gyro_stream(new stream(RS2_STREAM_GYRO))
+    {
+        auto const & group = dev_info->get_group();
+        auto ctx = dev_info->get_context();
+
+        std::vector<platform::hid_device_info> hid_infos = group.hid_devices;
+
+        if (!hid_infos.empty())
+        {
+            // product id
+            _pid = static_cast<uint16_t>(strtoul(hid_infos.front().pid.data(), nullptr, 16));
+
+            // motion correction
+            _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor, _pid);
+            _accel_intrinsic = std::make_shared<rsutils::lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
+            _gyro_intrinsic = std::make_shared<rsutils::lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
+
+            // use predefined extrinsics
+            _depth_to_imu = std::make_shared<rsutils::lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
+        }
+
+        // Make sure all MM streams are positioned with the same extrinsics
+        environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
+        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_accel_stream, *_gyro_stream);
+        register_stream_to_extrinsic_group(*_gyro_stream, 0);
+        register_stream_to_extrinsic_group(*_accel_stream, 0);
+
+        auto hid_ep = create_hid_device(ctx, group.hid_devices);
+        if (hid_ep)
+        {
+            _motion_module_device_idx = add_sensor(hid_ep);
+            // HID metadata attributes
+            hid_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
+        }
+    }
+
+    std::vector<tagged_profile> l500_motion::get_profiles_tags() const
+    {
+        std::vector<tagged_profile> tags;
+
+        tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        return tags;
+    }
+
+    rs2_motion_device_intrinsic l500_motion::get_motion_intrinsics(rs2_stream stream) const
+    {
+        if (stream == RS2_STREAM_ACCEL)
+            return create_motion_intrinsics(**_accel_intrinsic);
+
+        if (stream == RS2_STREAM_GYRO)
+            return create_motion_intrinsics(**_gyro_intrinsic);
+
+        throw std::runtime_error( rsutils::string::from()
+                                  << "Motion Intrinsics unknown for stream " << rs2_stream_to_string( stream ) << "!" );
+
+    }
+}

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 
 #include "l500-color.h"
 #include "l500-private.h"

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -1,0 +1,43 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include "device.h"
+#include "stream.h"
+#include "l500/l500-device.h"
+#include "ds/d400/d400-motion.h"
+
+namespace librealsense
+{
+    class l500_motion : public virtual l500_device
+    {
+    public:
+        std::shared_ptr<synthetic_sensor> create_hid_device(std::shared_ptr<context> ctx,
+            const std::vector<platform::hid_device_info>& all_hid_infos);
+
+        l500_motion( std::shared_ptr< const l500_info > const & dev_info );
+
+        std::vector<tagged_profile> get_profiles_tags() const override;
+
+        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const;
+
+    private:
+
+        friend class l500_hid_sensor;
+
+        optional_value<uint8_t> _motion_module_device_idx;
+
+        std::shared_ptr<mm_calib_handler>        _mm_calib;
+        std::shared_ptr<rsutils::lazy<ds::imu_intrinsic>> _accel_intrinsic;
+        std::shared_ptr<rsutils::lazy<ds::imu_intrinsic>> _gyro_intrinsic;
+        std::shared_ptr<rsutils::lazy<rs2_extrinsics>>   _depth_to_imu;                  // Mechanical installation pose
+
+    protected:
+        std::shared_ptr<stream_interface> _accel_stream;
+        std::shared_ptr<stream_interface> _gyro_stream;
+    };
+
+}

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -1,0 +1,992 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "l500-options.h"
+#include "l500-private.h"
+#include "l500-depth.h"
+#include <src/firmware-version.h>
+#include <src/platform/uvc-option.h>
+
+#define L51X_RECOMMENDED_FIRMWARE_VERSION "1.5.8.1"
+
+#include <rsutils/string/from.h>
+
+
+const std::string MIN_CONTROLS_FW_VERSION("1.3.9.0");
+const std::string MIN_GET_DEFAULT_FW_VERSION( "1.5.4.0" );
+
+namespace librealsense
+{
+    using namespace ivcam2;
+
+    rs2_sensor_mode query_sensor_mode( option& resolution ) 
+    {
+        return ( rs2_sensor_mode )(int)resolution.query();
+    }
+
+    float l500_hw_options::query() const
+    {
+        return query_current( query_sensor_mode(*_resolution) );
+    }
+
+    void l500_hw_options::set(float value)
+    {
+        // Block activating alternate IR when IR reflectivity is on [RS5-8358]
+        auto &ds = _l500_dev->get_depth_sensor();
+        if( ( alternate_ir == _type ) && ( 1.0f == value ) )
+        {
+            if( ds.supports_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
+                && ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ).query() == 1.0f )
+                throw librealsense::wrong_api_call_sequence_exception(
+                    "Alternate IR cannot be enabled with IR Reflectivity" );
+        }
+
+        _hw_monitor->send( command{ AMCSET, static_cast< uint32_t >( _type ), static_cast< uint32_t >( value ) } );
+    }
+
+    option_range l500_hw_options::get_range() const
+    {
+        return _range;
+    }
+
+    float l500_hw_options::query_default( bool & success ) const
+    {
+        success = true;
+        if(_fw_version >= firmware_version( MIN_GET_DEFAULT_FW_VERSION ) )
+        {
+            return query_new_fw_default( success );
+        }
+        else
+        {
+            return query_old_fw_default();
+        }
+    }
+
+    l500_hw_options::l500_hw_options( l500_device* l500_dev,
+                                      hw_monitor * hw_monitor,
+                                      l500_control type,
+                                      option * resolution,
+                                      const std::string & description,
+                                      firmware_version fw_version,
+                                      std::shared_ptr< digital_gain_option > digital_gain )
+        : _l500_dev( l500_dev )
+        , _hw_monitor( hw_monitor )
+        , _type( type )
+        , _resolution( resolution )
+        , _description( description )
+        , _fw_version( fw_version )
+        , _digital_gain( digital_gain )
+        , _is_read_only(false)
+        , _was_set_manually( false )
+    {
+        // Keep the USB power on while triggering multiple calls on it.
+        group_multiple_fw_calls( _l500_dev->get_depth_sensor(), [&]() {
+            auto min = _hw_monitor->send( command{ AMCGET, _type, get_min } );
+            auto max = _hw_monitor->send( command{ AMCGET, _type, get_max } );
+            auto step = _hw_monitor->send( command{ AMCGET, _type, get_step } );
+
+            if( min.size() < sizeof( int32_t ) || max.size() < sizeof( int32_t )
+                || step.size() < sizeof( int32_t ) )
+            {
+                std::stringstream s;
+                s << "Size of data returned is not valid min size = " << min.size()
+                  << ", max size = " << max.size() << ", step size = " << step.size();
+                throw std::runtime_error( s.str() );
+            }
+
+            auto max_value = float( *( reinterpret_cast< int32_t * >( max.data() ) ) );
+            auto min_value = float( *( reinterpret_cast< int32_t * >( min.data() ) ) );
+
+            bool success;
+            auto res = query_default( success );
+
+            if( ! success )
+            {
+                _is_read_only = true;
+                res = -1;
+            }
+
+            _range = option_range{ min_value,
+                                   max_value,
+                                   float( *( reinterpret_cast< int32_t * >( step.data() ) ) ),
+                                   res };
+        } );
+    }
+
+    void l500_hw_options::set_default( float def )
+    {
+        _range.def = def;
+    }
+
+    void l500_hw_options::set_read_only( bool read_only )
+    {
+        _is_read_only = read_only;
+    }
+
+    void l500_hw_options::set_manually( bool set ) 
+    {
+        _was_set_manually = set;
+    }
+
+    void l500_hw_options::enable_recording(std::function<void(const option&)> recording_action)
+    {}
+
+    // this method can throw an exception if un-expected error occurred
+    // or return error by output parameter 'success' if default value not applicable
+    // on this state return value is undefined
+    float l500_hw_options::query_new_fw_default( bool & success ) const
+    {
+        success = true;
+        hwmon_response_type response;
+        auto res = _hw_monitor->send(
+            command{ AMCGET,
+                     _type,
+                     l500_command::get_default,
+                     static_cast< uint32_t >( query_sensor_mode( *_resolution ) ) },
+            &response );
+
+        // Some controls that are automatically set by the FW (e.g., APD when digital gain is AUTO) are read-only
+        // and have no defaults: the FW will return ds::d400_hwmon_response::ILLEGAL_HW_STATE for these. Some can still be modified (e.g.,
+        // laser power & min distance), and for these we expect ds::d400_hwmon_response::SUCCESS.
+        if( response == ds::d400_hwmon_response::ILLEGAL_HW_STATE )
+        {
+            success = false;
+            return -1;
+        }
+        else if( response != ds::d400_hwmon_response::SUCCESS )
+        {
+            std::stringstream s;
+            s << "hw_monitor  AMCGET of " << _type << " return error " << response;
+            throw std::runtime_error( s.str() );
+        }
+        else if (res.size() < sizeof(int32_t))
+        {
+            std::stringstream s;
+            s << "Size of data returned from query(get_default) of " << _type << " is "
+              << res.size() << " while min size = " << sizeof( int32_t );
+            throw std::runtime_error( s.str() );
+        }
+
+        auto val = *( reinterpret_cast< uint32_t * >( res.data() ) );
+        return float( val );
+    }
+
+    float l500_hw_options::query_old_fw_default( ) const
+    {
+        // For older FW without support for get_default, we have to:
+        //     1. Save the current value
+        //     2. Change to -1
+        //     3. Wait for the next frame (if streaming)
+        //     4. Read the current value
+        //     5. Restore the current value
+        auto current = query_current( query_sensor_mode( *_resolution ) );
+        _hw_monitor->send( command{ AMCSET, _type, static_cast< uint32_t >( -1 ) } );
+
+        // if the sensor is streaming the value of control will update only when the next frame
+        // arrive
+        if( _l500_dev->get_depth_sensor().is_streaming() )
+            std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+
+        auto def = query_current( query_sensor_mode( *_resolution ) );
+
+        if( current != def )
+        {
+            _hw_monitor->send( command{ AMCSET, _type, static_cast< uint32_t >( current ) } );
+        }
+
+        return def;
+    }
+
+    float l500_hw_options::query_current( rs2_sensor_mode mode ) const 
+    {
+        auto res = _hw_monitor->send( command{ AMCGET,
+                                               _type,
+                                               static_cast< uint32_t >( get_current ),
+                                               static_cast< uint32_t >( mode ) } );
+
+        if( res.size() < sizeof( int32_t ) )
+        {
+            std::stringstream s;
+            s << "Size of data returned from query(get_current) of " << _type << " is " << res.size()
+              << " while min size = " << sizeof( int32_t );
+            throw std::runtime_error( s.str() );
+        }
+        auto val = *( reinterpret_cast< uint32_t * >( res.data() ) );
+        return float( val );
+    }
+
+    l500_options::l500_options( std::shared_ptr< const l500_info > const & dev_info ) :
+        device(dev_info),
+        backend_device(dev_info),
+        l500_device(dev_info)
+    {
+        auto raw_depth_sensor = get_raw_depth_sensor();
+        auto& depth_sensor = get_depth_sensor();
+
+        // Keep the USB power on while triggering multiple HW monitor commands on it.
+        group_multiple_fw_calls( depth_sensor, [&]() {
+            if (_fw_version >= firmware_version("1.5.0.0"))
+            {
+                bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
+                if (usb3mode)
+                {
+                    auto enable_max_usable_range = std::make_shared<max_usable_range_option>(this);
+                    depth_sensor.register_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE, enable_max_usable_range);
+
+                    auto enable_ir_reflectivity = std::make_shared<ir_reflectivity_option>(this);
+                    depth_sensor.register_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY, enable_ir_reflectivity);
+                }
+            }
+
+            if( _fw_version < firmware_version( MIN_CONTROLS_FW_VERSION ) )
+            {
+                depth_sensor.register_option(
+                    RS2_OPTION_VISUAL_PRESET,
+                    std::make_shared< uvc_xu_option< int > >(
+                        raw_depth_sensor,
+                        ivcam2::depth_xu,
+                        ivcam2::L500_DIGITAL_GAIN,
+                        "Change the depth digital gain to: 1 for high gain and 2 for low gain",
+                        std::map< float, std::string >{
+                            { float( RS2_DIGITAL_GAIN_HIGH ), "High Gain" },
+                            { float( RS2_DIGITAL_GAIN_LOW ), "Low Gain" } } ) );
+            }
+            else
+            {
+                // On USB2 we have only QVGA sensor mode
+                bool usb3mode
+                    = ( _usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined );
+
+                auto default_sensor_mode
+                    = static_cast< float >( usb3mode ? RS2_SENSOR_MODE_VGA : RS2_SENSOR_MODE_QVGA );
+
+                auto resolution_option = std::make_shared< sensor_mode_option >(
+                    this, &depth_sensor,
+                    option_range{ RS2_SENSOR_MODE_VGA,
+                                  RS2_SENSOR_MODE_COUNT - 1,
+                                  1,
+                                  default_sensor_mode },
+                    "Notify the sensor about the intended streaming mode. Required for preset " );
+
+                // changing the resolution affects the defaults
+                resolution_option->add_observer( [&]( float ) {
+                    update_defaults();
+
+                    auto curr_preset = ( rs2_l500_visual_preset )(int)_preset->query();
+                    if( curr_preset != RS2_L500_VISUAL_PRESET_AUTOMATIC
+                        && curr_preset != RS2_L500_VISUAL_PRESET_CUSTOM )
+                    {
+                        change_preset( curr_preset );
+                    }
+                } );
+
+
+                depth_sensor.register_option( RS2_OPTION_SENSOR_MODE, resolution_option );
+
+                _digital_gain = std::make_shared< digital_gain_option >(
+                    raw_depth_sensor,
+                    ivcam2::depth_xu,
+                    ivcam2::L500_DIGITAL_GAIN,
+                    "Change the depth digital gain to: 1 for high gain and 2 for low gain",
+                    std::map< float, std::string >{ /*{ RS2_DIGITAL_GAIN_AUTO, "Auto Gain" },*/
+                                                { (float)(RS2_DIGITAL_GAIN_HIGH), "High Gain" },
+                                                { (float)(RS2_DIGITAL_GAIN_LOW), "Low Gain" } },
+                    _fw_version,
+                    this );
+
+                depth_sensor.register_option( RS2_OPTION_DIGITAL_GAIN, _digital_gain );
+
+                if( _fw_version >= firmware_version( "1.5.2.0" ) )
+                {
+                    _alt_ir = std::make_shared< l500_hw_options >( this,
+                                                                   _hw_monitor.get(),
+                                                                   alternate_ir,
+                                                                   resolution_option.get(),
+                                                                   "Enable/Disable alternate IR",
+                                                                   _fw_version,
+                                                                   _digital_gain );
+
+                    depth_sensor.register_option( RS2_OPTION_ALTERNATE_IR, _alt_ir );
+                }
+
+                _hw_options[RS2_OPTION_POST_PROCESSING_SHARPENING]
+                    = register_option< l500_hw_options,
+                                       l500_device *,
+                                       hw_monitor *,
+                                       l500_control,
+                                       option *,
+                                       std::string >(
+                        RS2_OPTION_POST_PROCESSING_SHARPENING,
+                        this,
+                        _hw_monitor.get(),
+                        post_processing_sharpness,
+                        resolution_option.get(),
+                        "Changes the amount of sharpening in the post-processed image",
+                        _fw_version,
+                        _digital_gain );
+
+                _hw_options[RS2_OPTION_PRE_PROCESSING_SHARPENING]
+                    = register_option< l500_hw_options,
+                                       l500_device *,
+                                       hw_monitor *,
+                                       l500_control,
+                                       option *,
+                                       std::string >(
+                        RS2_OPTION_PRE_PROCESSING_SHARPENING,
+                        this,
+                        _hw_monitor.get(),
+                        pre_processing_sharpness,
+                        resolution_option.get(),
+                        "Changes the amount of sharpening in the pre-processed image",
+                        _fw_version,
+                        _digital_gain );
+
+                _hw_options[RS2_OPTION_NOISE_FILTERING]
+                    = register_option< l500_hw_options,
+                                       l500_device *,
+                                       hw_monitor *,
+                                       l500_control,
+                                       option *,
+                                       std::string >( RS2_OPTION_NOISE_FILTERING,
+                                                      this,
+                                                      _hw_monitor.get(),
+                                                      noise_filtering,
+                                                      resolution_option.get(),
+                                                      "Control edges and background noise",
+                                                      _fw_version,
+                                                      _digital_gain );
+
+                _hw_options[RS2_OPTION_AVALANCHE_PHOTO_DIODE] = register_option< l500_hw_options,
+                                                                                 l500_device *,
+                                                                                 hw_monitor *,
+                                                                                 l500_control,
+                                                                                 option *,
+                                                                                 std::string >(
+                    RS2_OPTION_AVALANCHE_PHOTO_DIODE,
+                    this,
+                    _hw_monitor.get(),
+                    apd,
+                    resolution_option.get(),
+                    "Changes the exposure time of Avalanche Photo Diode in the receiver",
+                    _fw_version,
+                    _digital_gain );
+
+                _hw_options[RS2_OPTION_CONFIDENCE_THRESHOLD] = register_option< l500_hw_options,
+                                                                                l500_device *,
+                                                                                hw_monitor *,
+                                                                                l500_control,
+                                                                                option *,
+                                                                                std::string >(
+                    RS2_OPTION_CONFIDENCE_THRESHOLD,
+                    this,
+                    _hw_monitor.get(),
+                    confidence,
+                    resolution_option.get(),
+                    "The confidence level threshold to use to mark a "
+                    "pixel as valid by the depth algorithm",
+                    _fw_version,
+                    _digital_gain );
+
+                _hw_options[RS2_OPTION_LASER_POWER] = register_option< l500_hw_options,
+                                                                       l500_device *,
+                                                                       hw_monitor *,
+                                                                       l500_control,
+                                                                       option *,
+                                                                       std::string >(
+                    RS2_OPTION_LASER_POWER,
+                    this,
+                    _hw_monitor.get(),
+                    laser_gain,
+                    resolution_option.get(),
+                    "Power of the laser emitter, with 0 meaning projector off",
+                    _fw_version,
+                    _digital_gain );
+
+                _hw_options[RS2_OPTION_MIN_DISTANCE]
+                    = register_option< l500_hw_options,
+                                       l500_device *,
+                                       hw_monitor *,
+                                       l500_control,
+                                       option *,
+                                       std::string >( RS2_OPTION_MIN_DISTANCE,
+                                                      this,
+                                                      _hw_monitor.get(),
+                                                      min_distance,
+                                                      resolution_option.get(),
+                                                      "Minimal distance to the target (in mm)",
+                                                      _fw_version,
+                                                      _digital_gain );
+
+                _hw_options[RS2_OPTION_INVALIDATION_BYPASS]
+                    = register_option< l500_hw_options,
+                                       l500_device *,
+                                       hw_monitor *,
+                                       l500_control,
+                                       option *,
+                                       std::string >( RS2_OPTION_INVALIDATION_BYPASS,
+                                                      this,
+                                                      _hw_monitor.get(),
+                                                      invalidation_bypass,
+                                                      resolution_option.get(),
+                                                      "Enable/disable pixel invalidation",
+                                                      _fw_version,
+                                                      _digital_gain );
+
+                auto preset = calc_preset_from_controls();
+
+                _preset = std::make_shared< l500_preset_option >(
+                    option_range{ RS2_L500_VISUAL_PRESET_CUSTOM,
+                                  RS2_L500_VISUAL_PRESET_SHORT_RANGE,
+                                  1,
+                                  RS2_L500_VISUAL_PRESET_MAX_RANGE },
+                    "Preset to calibrate the camera to environment ambient, no ambient or low "
+                    "ambient.",
+                    this );
+
+                _preset->set( (float)preset );
+
+                depth_sensor.register_option( RS2_OPTION_VISUAL_PRESET, _preset );
+
+                _advanced_options = get_advanced_controls();
+
+                firmware_version recommended_fw_version(L51X_RECOMMENDED_FIRMWARE_VERSION);
+                register_info(RS2_CAMERA_INFO_RECOMMENDED_FIRMWARE_VERSION, recommended_fw_version);
+            }
+        } );
+    }
+
+    std::vector<rs2_option> l500_options::get_advanced_controls()
+    {
+        std::vector<rs2_option> res;
+
+        res.push_back(RS2_OPTION_DIGITAL_GAIN);
+        for (auto&& o : _hw_options)
+            res.push_back(o.first);
+
+        return res;
+    }
+
+    rs2_l500_visual_preset l500_options::calc_preset_from_controls() const
+    {
+        try
+        {
+            // compare default values to current values except for laser power,
+            // if we are on preset, we expect that all control's currents values will
+            // be aqual to control's default values according to current digital gain value,
+            // only laser power can have diffrant value according to preset
+            // laser power value will be check later
+            for( auto control : _hw_options )
+            {
+                if( control.first != RS2_OPTION_LASER_POWER && !control.second->is_read_only() )
+                {
+                    auto curr = control.second->query();
+                    auto def = control.second->get_range().def;
+                    if( def != curr )
+                        return RS2_L500_VISUAL_PRESET_CUSTOM;
+                }
+            }
+
+            // all the hw_options values are equal to their default values
+            // now what is left to check if the gain and laser power correspond to one of the
+            // presets
+            
+            auto laser = _hw_options.find(RS2_OPTION_LASER_POWER);
+            if (laser == _hw_options.end())
+            {
+                LOG_ERROR("RS2_OPTION_LASER_POWER didnt found on hw_options list ");
+                return RS2_L500_VISUAL_PRESET_CUSTOM;
+            }
+            auto max_laser = laser->second->get_range().max;
+            auto def_laser = laser->second->get_range().def;
+
+            std::map< std::pair< rs2_digital_gain, float >, rs2_l500_visual_preset >
+                gain_and_laser_to_preset = {
+                    { { RS2_DIGITAL_GAIN_HIGH, def_laser }, RS2_L500_VISUAL_PRESET_NO_AMBIENT },
+                    { { RS2_DIGITAL_GAIN_LOW, max_laser }, RS2_L500_VISUAL_PRESET_LOW_AMBIENT },
+                    { { RS2_DIGITAL_GAIN_HIGH, max_laser }, RS2_L500_VISUAL_PRESET_MAX_RANGE },
+                    { { RS2_DIGITAL_GAIN_LOW, def_laser }, RS2_L500_VISUAL_PRESET_SHORT_RANGE },
+                };
+
+            auto gain = ( rs2_digital_gain )(int)_digital_gain->query();
+            auto laser_val = laser->second->query();
+
+            auto it = gain_and_laser_to_preset.find( { gain, laser_val } );
+
+            if( it != gain_and_laser_to_preset.end() )
+            {
+                return it->second;
+            }
+            
+            return RS2_L500_VISUAL_PRESET_CUSTOM;
+        }
+        catch( ... )
+        {
+            LOG_ERROR( "Exception caught in calc_preset_from_controls" );
+        }
+        return RS2_L500_VISUAL_PRESET_CUSTOM;
+    }
+
+    l500_preset_option::l500_preset_option(option_range range, std::string description, l500_options * owner)
+        :float_option_with_description< rs2_l500_visual_preset >(range, description),
+        _owner( owner )
+    {}
+
+    void l500_preset_option::set( float value )
+    {
+        if( static_cast< rs2_l500_visual_preset >( int( value ) )
+            == RS2_L500_VISUAL_PRESET_DEFAULT )
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "RS2_L500_VISUAL_PRESET_DEFAULT was deprecated!" );
+
+        verify_max_usable_range_restrictions( RS2_OPTION_VISUAL_PRESET, value );
+        _owner->change_preset( static_cast< rs2_l500_visual_preset >( int( value ) ) );
+
+        float_option_with_description< rs2_l500_visual_preset >::set( value );
+    }
+
+    void l500_preset_option::set_value( float value )
+    {
+        float_option_with_description< rs2_l500_visual_preset >::set( value );
+    }
+
+    void l500_preset_option::verify_max_usable_range_restrictions( rs2_option opt, float value ) 
+    {
+        // Block changing visual preset while Max Usable Range is on [RS5-8358]
+        if( _owner->get_depth_sensor().supports_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
+            && ( _owner->get_depth_sensor().get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).query()
+                 == 1.0f ) )
+        {
+            if( ( RS2_OPTION_VISUAL_PRESET == opt )
+                && (static_cast<int>(value) == RS2_L500_VISUAL_PRESET_MAX_RANGE ) )
+                return;
+
+            throw wrong_api_call_sequence_exception(
+                rsutils::string::from() << "Visual Preset cannot be changed while Max Usable Range is enabled" );
+        }
+    }
+
+    void l500_options::on_set_option( rs2_option opt, float value )
+    {
+        auto advanced_controls = get_advanced_controls();
+        if( std::find( advanced_controls.begin(), advanced_controls.end(), opt )
+            != advanced_controls.end() )
+        {
+            // when we moved to auto preset we set all controls to -1
+            // so we have to set preset controls to defaults values now
+            /*auto curr_preset = ( rs2_l500_visual_preset )(int)_preset->query();
+            if( curr_preset == RS2_L500_VISUAL_PRESET_AUTOMATIC )
+               set_preset_controls_to_defaults();*/
+
+            move_to_custom();
+            _hw_options[opt]->set_manually( true );
+        }
+        else
+            throw wrong_api_call_sequence_exception(
+                rsutils::string::from() << "on_set_option support advanced controls only " << opt << " injected" );
+    }
+
+    void l500_options::change_gain( rs2_l500_visual_preset preset )
+    {
+        switch( preset )
+        {
+        case RS2_L500_VISUAL_PRESET_NO_AMBIENT:
+        case RS2_L500_VISUAL_PRESET_MAX_RANGE:
+            _digital_gain->set_by_preset( RS2_DIGITAL_GAIN_HIGH );
+            break;
+        case RS2_L500_VISUAL_PRESET_LOW_AMBIENT:
+        case RS2_L500_VISUAL_PRESET_SHORT_RANGE:
+            _digital_gain->set_by_preset( RS2_DIGITAL_GAIN_LOW );
+            break;
+        case RS2_L500_VISUAL_PRESET_AUTOMATIC:
+            _digital_gain->set_by_preset( RS2_DIGITAL_GAIN_AUTO );
+            break;
+        };
+    }
+
+    void l500_options::change_alt_ir( rs2_l500_visual_preset preset )
+    {
+        auto curr_preset = ( rs2_l500_visual_preset )(int)_preset->query();
+
+        if( preset == RS2_L500_VISUAL_PRESET_AUTOMATIC )
+            _alt_ir->set( 1 );
+        else if( curr_preset == RS2_L500_VISUAL_PRESET_AUTOMATIC
+                 && preset != RS2_L500_VISUAL_PRESET_CUSTOM )
+            _alt_ir->set( 0 );
+    }
+
+    void l500_options::change_laser_power( rs2_l500_visual_preset preset )
+    {
+        if( preset == RS2_L500_VISUAL_PRESET_LOW_AMBIENT
+            || preset == RS2_L500_VISUAL_PRESET_MAX_RANGE )
+            set_max_laser();
+    }
+
+    void l500_options::change_preset( rs2_l500_visual_preset preset )
+    {
+        // Keep the USB power on while triggering multiple calls on it.
+        group_multiple_fw_calls( get_depth_sensor(), [&]() {
+            // we need to reset the controls before change gain because after moving to auto gain
+            // APD is read only. This will tell the FW that the control values are defaults and
+            // therefore can be overridden automatically according to gain
+            if( preset == RS2_L500_VISUAL_PRESET_AUTOMATIC )
+            {
+                auto curr_preset = ( rs2_l500_visual_preset )(int)_preset->query();
+                if( curr_preset == RS2_L500_VISUAL_PRESET_AUTOMATIC )
+                    return;
+                reset_hw_controls();
+            }
+
+            // if the user set preset custom we should not change the controls default or current
+            // values the values should stay the same
+            if( preset == RS2_L500_VISUAL_PRESET_CUSTOM )
+            {
+                move_to_custom();
+                return;
+            }
+
+            // digital gain must be the first option that is set because it
+            // impacts the default values of some of the hw controls
+            change_gain( preset );
+            change_alt_ir( preset );
+
+            if( preset != RS2_L500_VISUAL_PRESET_AUTOMATIC )
+                set_preset_controls_to_defaults();
+
+            change_laser_power( preset );
+        } );
+    }
+
+    void l500_options::set_preset_value( rs2_l500_visual_preset preset ) 
+    {
+        _preset->set_value( (float)preset );
+    }
+
+    void l500_options::set_preset_controls_to_defaults()
+    {
+        for( auto & o : _hw_options )
+        {
+            if( ! o.second->is_read_only() )
+            {
+                auto val = o.second->get_range().def;
+                o.second->set_with_no_signal( val );
+                o.second->set_manually( false );
+            }
+        }
+    }
+
+    void l500_options::move_to_custom ()
+    {
+        _preset->set_value( RS2_L500_VISUAL_PRESET_CUSTOM );
+    }
+
+    void l500_options::reset_hw_controls()
+    {
+        // Keep the USB power on while triggering multiple calls on it.
+        group_multiple_fw_calls( get_depth_sensor(), [&]() {
+            for (auto& o : _hw_options)
+                if (!o.second->is_read_only())
+                {
+                    o.second->set_with_no_signal(-1);
+                }
+            });
+    }
+
+    void l500_options::set_max_laser()
+    {
+        auto range = _hw_options[RS2_OPTION_LASER_POWER]->get_range();
+        _hw_options[RS2_OPTION_LASER_POWER]->set_with_no_signal(range.max);
+    }
+
+    // this method not uses l500_hw_options::query_default() because
+    // we want to save the 50ms sleep on streaming and do it once to all the controlls
+    void l500_options::update_defaults()
+    {
+        // Keep the USB power on while triggering multiple calls on it.
+        group_multiple_fw_calls( get_depth_sensor(), [&]() {
+
+            auto& resolution = get_depth_sensor().get_option(RS2_OPTION_SENSOR_MODE);
+
+            std::map< rs2_option, float > defaults;
+            if (_fw_version >= firmware_version(MIN_GET_DEFAULT_FW_VERSION))
+            {
+                for (auto opt : _hw_options)
+                {
+                    bool success;
+                    defaults[opt.first] = opt.second->query_new_fw_default(success);
+
+                    if (!success)
+                    {
+                        defaults[opt.first] = -1;
+                        opt.second->set_read_only(true);
+                    }
+                    else
+                        opt.second->set_read_only(false);
+                }
+            }
+            else
+            {
+                // For older FW without support for get_default, we have to:
+                //     1. Save the current value
+                //     2. Wait for the next frame (if streaming)
+                //     3. Change to -1
+                //     4. Read the current value and store as default value
+                //     5. Restore the current value
+                std::map< rs2_option, float > currents;
+                for (auto opt : _hw_options)
+                    currents[opt.first] = opt.second->query_current(query_sensor_mode(resolution));
+
+                // if the sensor is streaming the value of control will update only when the next frame
+                // arrive
+                if (get_depth_sensor().is_streaming())
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+                for (auto opt : _hw_options)
+                {
+                    opt.second->set_with_no_signal(-1);
+                    defaults[opt.first] = opt.second->query_current(query_sensor_mode(resolution));
+                }
+
+                for (auto opt : currents)
+                {
+                    _hw_options[opt.first]->set_with_no_signal(opt.second);
+                }
+            }
+
+            for (auto opt : _hw_options)
+            {
+                opt.second->set_default(defaults[opt.first]);
+            }
+            });
+    }
+
+    void max_usable_range_option::set( float value )
+    {
+        // Restrictions for Max Usable Range option as required on [RS5-8358]
+        auto& ds = _l500_depth_dev->get_depth_sensor();
+        if (value == 1.0f)
+        {
+            auto &sensor_mode_option = ds.get_option(RS2_OPTION_SENSOR_MODE);
+            auto sensor_mode = sensor_mode_option.query();
+            bool sensor_mode_is_vga = (static_cast<int>(sensor_mode) == rs2_sensor_mode::RS2_SENSOR_MODE_VGA);
+
+            bool visual_preset_is_max_range = ds.is_max_range_preset();
+
+            if (ds.is_streaming())
+            {
+                if (!sensor_mode_is_vga || !visual_preset_is_max_range)
+                    throw wrong_api_call_sequence_exception("Please set 'VGA' resolution and 'Max Range' preset before enabling Max Usable Range");
+            }
+            else
+            {
+                if (!visual_preset_is_max_range)
+                {
+                    auto &visual_preset_option = ds.get_option(RS2_OPTION_VISUAL_PRESET);
+                    visual_preset_option.set(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE);
+                    LOG_INFO("Visual Preset was changed to: " << visual_preset_option.get_value_description(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE));
+                }
+
+                if (!sensor_mode_is_vga)
+                {
+                    sensor_mode_option.set(rs2_sensor_mode::RS2_SENSOR_MODE_VGA);
+                    LOG_INFO("Sensor Mode was changed to: " << sensor_mode_option.get_value_description(rs2_sensor_mode::RS2_SENSOR_MODE_VGA));
+                }
+            }
+        }
+        else
+        {
+            if (ds.supports_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY) && ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).query() == 1.0f)
+            {
+                ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).set(0.0f);
+                LOG_INFO("IR Reflectivity was on - turning it off");
+            }
+        }
+
+        bool_option::set(value);
+    }
+
+    void sensor_mode_option::set(float value)
+    {
+        if (is_read_only())
+            throw std::runtime_error("Cannot change sensor mode while streaming!");
+
+        if (_value == value) return;
+
+        // Restrictions for sensor mode option as required on [RS5-8358]
+        auto &ds = _l500_depth_dev->get_depth_sensor();
+
+        if( ds.supports_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
+            && ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ).query() == 1.0f
+            && (static_cast<int>(value) != rs2_sensor_mode::RS2_SENSOR_MODE_VGA ) )
+        {
+            ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ).set( 0.0f );
+            LOG_INFO( "IR Reflectivity was on - turning it off" );
+        }
+
+        if( ds.supports_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
+            && ( ds.get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).query() == 1.0f )
+            && (static_cast<int>(value) != rs2_sensor_mode::RS2_SENSOR_MODE_VGA ) )
+        {
+            ds.get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).set( 0.0f );
+            LOG_INFO( "Max Usable Range was on - turning it off" );
+        }
+
+        float_option_with_description::set(value);
+
+        // Keep the USB power on while triggering multiple calls on it.
+        group_multiple_fw_calls( ds, [&]() { notify( value ); } );
+    }
+
+    const char * max_usable_range_option::get_description() const
+    {
+
+        return "Max Usable Range calculates the maximum range of the camera given the amount of "
+               "ambient light in the scene.\n"
+               "For example, if Max Usable Range returns 5m, this means that the ambient light in "
+               "the scene is reducing the maximum range from 9m down to 5m.\n"
+               "Values are between 1.5 and 9 meters, in 1.5m increments. "
+               "Max range refers to the center 10% of the frame.";
+    }
+
+    void ir_reflectivity_option::set(float value)
+    {
+        // Restrictions for IR Reflectivity option as required on [RS5-8358]
+        auto &ds = _l500_depth_dev->get_depth_sensor();
+        if (value == 1.0f)
+        {
+            // Verify option Alternate IR is off
+            if( ds.supports_option( RS2_OPTION_ALTERNATE_IR )
+                && ds.get_option( RS2_OPTION_ALTERNATE_IR ).query() == 1.0f )
+            {
+                throw wrong_api_call_sequence_exception("Cannot enable IR Reflectivity when Alternate IR option is on");
+            }
+
+            auto &sensor_mode_option = ds.get_option(RS2_OPTION_SENSOR_MODE);
+            auto sensor_mode = sensor_mode_option.query();
+            bool sensor_mode_is_vga = (static_cast<int>(sensor_mode) == rs2_sensor_mode::RS2_SENSOR_MODE_VGA);
+
+            bool visual_preset_is_max_range = ds.is_max_range_preset();
+
+            if( ds.is_streaming() )
+            {
+                // While streaming we use active stream resolution and not sensor mode due as a
+                // patch for the DQT sensor mode wrong handling. 
+                // This should be changed for using sensor mode after DQT fix
+                auto active_streams = ds.get_active_streams();
+                auto dp = std::find_if( active_streams.begin(),
+                                        active_streams.end(),
+                                        []( std::shared_ptr< stream_profile_interface > sp ) {
+                                            return sp->get_stream_type() == RS2_STREAM_DEPTH;
+                                        } );
+
+                bool vga_sensor_mode = false;
+                if( dp != active_streams.end() )
+                {
+                    auto vs = dynamic_cast< video_stream_profile * >( ( *dp ).get() );
+                    vga_sensor_mode
+                        = ( get_resolution_from_width_height( vs->get_width(), vs->get_height() )
+                            == RS2_SENSOR_MODE_VGA );
+                }
+
+                if( ( ! vga_sensor_mode ) || ! visual_preset_is_max_range )
+                    throw wrong_api_call_sequence_exception(
+                        "Please set 'VGA' resolution, 'Max Range' preset and 20% ROI before enabling IR Reflectivity" );
+            }
+            else
+            {
+                if (!visual_preset_is_max_range)
+                {
+                    auto &visual_preset_option = ds.get_option(RS2_OPTION_VISUAL_PRESET);
+                    visual_preset_option.set(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE);
+                    LOG_INFO("Visual Preset was changed to: " << visual_preset_option.get_value_description(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE));
+                }
+
+                if (!sensor_mode_is_vga)
+                {
+                    sensor_mode_option.set(rs2_sensor_mode::RS2_SENSOR_MODE_VGA);
+                    LOG_INFO("Sensor Mode was changed to: " << sensor_mode_option.get_value_description(rs2_sensor_mode::RS2_SENSOR_MODE_VGA));
+                }
+            }
+
+            auto &max_usable_range_option = ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE);
+            if (max_usable_range_option.query() != 1.0f)
+            {
+                max_usable_range_option.set(1.0f);
+                _max_usable_range_forced_on = true;
+                LOG_INFO("Max Usable Range was off - turning it on");
+            }
+        }
+        else
+        {
+            if (_max_usable_range_forced_on)
+            {
+                _max_usable_range_forced_on = false;
+                bool_option::set( value );  // We set the value here to prevent a loop between Max Usable Range &
+                                            // Reflectivity options trying to turn off each other
+
+                ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).set(0.0f);
+                LOG_INFO("Max Usable Range was on - turning it off");
+                return;
+            }
+        }
+
+        bool_option::set(value);
+    }
+
+    const char * ir_reflectivity_option::get_description() const
+    {
+
+        return "IR Reflectivity Tool calculates the percentage of IR light reflected by the "
+               "object and returns to the camera for processing.\nFor example, a value of 60% means "
+               "that 60% of the IR light projected by the camera is reflected by the object and returns "
+               "to the camera.\n\n"
+               "Note: only active on 2D view, Visual Preset:Max Range, Resolution:VGA, ROI:20%";
+    }
+
+    void digital_gain_option::set( float value ) 
+    {
+        super::set( value );
+        _owner->update_defaults();
+
+        // when we moved to auto preset we set all controls to -1
+        // so we have to set preset controls to defaults values now
+        /*auto curr_preset = ( rs2_l500_visual_preset )(int)_preset->query();
+        if( curr_preset == RS2_L500_VISUAL_PRESET_AUTOMATIC )
+           set_preset_controls_to_defaults();*/
+
+        _owner->move_to_custom();
+    }
+
+    // set gain as result of change preset
+    void digital_gain_option::set_by_preset( float value )
+    {
+        work_around_for_old_fw();
+
+        super::set( value );
+        _owner->update_defaults();
+    }
+
+    // FW expose 'auto gain' with value 0 as one of the values of gain option in addition
+    // to 'low gain' and 'high gain'
+    // for now we don't want to expose it to user so the range starts from 1 
+    // once we want to expose it we will remove this override method
+    option_range digital_gain_option::get_range() const
+    {
+        auto range = uvc_xu_option< int >::get_range();
+        range.min = 1;
+        return range;
+    }
+
+    void digital_gain_option::work_around_for_old_fw() 
+    {
+        // On old FW versions the way to get the default values of the hw commands is to
+        // reset hw commands current values -1 and than get the current values
+        // on some of the old FW versions there is a bug that we must reset hw commands
+        // before setting the digital gain, otherwise its not updates the current with default
+        // values in digital_gain_option class we override the set_with_no_signal that called when
+        // changing preset and reset hw commands before setting the digital gain as WA to this bug
+        // we still have a limit on the scenario that user change digital gain manually (not from
+        // preset) we won't get the correct default values
+        if( _fw_version < firmware_version( MIN_GET_DEFAULT_FW_VERSION ) )
+            _owner->reset_hw_controls();  // should be before gain changing as WA for old FW versions
+    }
+}  // namespace librealsense

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include "l500-options.h"
 #include "l500-private.h"

--- a/src/l500/l500-options.h
+++ b/src/l500/l500-options.h
@@ -1,0 +1,216 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+#include "../hw-monitor.h"
+#include "l500-device.h"
+#include <src/platform/uvc-option.h>
+
+
+namespace librealsense
+{
+    enum l500_control : uint8_t
+    {
+        confidence = 0,
+        post_processing_sharpness = 1,
+        pre_processing_sharpness = 2,
+        noise_filtering = 3,
+        apd = 4,
+        laser_gain = 5,
+        min_distance = 6,
+        invalidation_bypass = 7,
+        alternate_ir = 8
+    };
+
+    enum l500_command : uint8_t
+    {
+        get_current = 0,
+        get_min = 1,
+        get_max = 2,
+        get_step = 3,
+        get_default = 4
+    };
+
+    class l500_options;
+
+    class digital_gain_option : public uvc_xu_option< int >
+    {
+        typedef uvc_xu_option< int > super;
+
+    public:
+        digital_gain_option( const std::weak_ptr< uvc_sensor > & ep,
+                             platform::extension_unit xu,
+                             uint8_t id,
+                             std::string description,
+                             const std::map< float, std::string > & description_per_value,
+                             firmware_version fw_version,
+                             l500_options * owner )
+            : super( ep, xu, id, description, description_per_value )
+            , _fw_version( fw_version )
+            , _owner( owner )
+        {
+        }
+        void set( float value ) override;
+        void set_by_preset( float value );
+        option_range get_range() const override;
+
+    private:
+        void work_around_for_old_fw();
+
+        firmware_version _fw_version;
+        l500_options * _owner;
+    };
+
+    class l500_hw_options : public option
+    {
+    public:
+        float query() const override;
+
+        void set(float value) override;
+
+        option_range get_range() const override;
+
+        bool is_enabled() const override { return true; }
+
+        const char * get_description() const override { return _description.c_str(); }
+
+        void enable_recording(std::function<void(const option&)> recording_action) override;
+
+        l500_hw_options( l500_device* l500_dev,
+                         hw_monitor* hw_monitor,
+                         l500_control type,
+                         option * resolution,
+                         const std::string & description,
+                         firmware_version fw_version,
+                         std::shared_ptr< digital_gain_option > digital_gain);
+
+        void set_default( float def );
+
+        // on new FW version query default can fail when we are on 'auto gain' mode
+        float query_new_fw_default( bool & success ) const;
+        float query_old_fw_default() const;
+
+        float query_current( rs2_sensor_mode mode ) const;
+
+        bool is_read_only() const override { return _is_read_only; }
+        void set_read_only( bool read_only );
+        void set_manually( bool set );
+
+    private:
+        float query_default( bool & success ) const;
+        
+
+        l500_control _type;
+        l500_device* _l500_dev;
+        hw_monitor* _hw_monitor;
+        option_range _range;
+        uint32_t _width;
+        uint32_t _height;
+        option* _resolution;
+        std::string _description;
+        firmware_version _fw_version;
+        std::shared_ptr< digital_gain_option > _digital_gain;
+        bool _is_read_only;
+        bool _was_set_manually;
+    };
+
+    class max_usable_range_option : public bool_option
+    {
+    public:
+        max_usable_range_option(l500_device *l500_depth_dev) : bool_option( false ), _l500_depth_dev(l500_depth_dev){};
+
+        void set(float value) override;
+
+        const char * get_description() const override;
+
+    private:
+        l500_device *_l500_depth_dev;
+    };
+
+    class sensor_mode_option
+        : public float_option_with_description< rs2_sensor_mode >
+        , public observable_option
+    {
+    public:
+        sensor_mode_option(l500_device *l500_depth_dev, sensor_base* depth_ep, option_range range, std::string description) : float_option_with_description<rs2_sensor_mode>(range, description), _l500_depth_dev(l500_depth_dev),_sensor(depth_ep) {};
+        void set(float value) override;
+        bool is_read_only() const override
+        {
+            return _sensor && _sensor->is_opened();
+        }
+
+    private:
+        l500_device *_l500_depth_dev;
+        sensor_base* _sensor;
+    };
+
+    class ir_reflectivity_option : public bool_option
+    {
+    public:
+        ir_reflectivity_option(l500_device *l500_depth_dev) : bool_option(false), _l500_depth_dev(l500_depth_dev), _max_usable_range_forced_on(false){};
+
+        void set(float value) override;
+
+        const char * get_description() const override;
+
+    private:
+        l500_device *_l500_depth_dev;
+        bool _max_usable_range_forced_on;
+    };
+
+    class l500_options;
+
+    class l500_preset_option : public float_option_with_description< rs2_l500_visual_preset >
+    {
+    public:
+        l500_preset_option( option_range range, std::string description, l500_options * owner );
+        void set( float value ) override;
+        void set_value( float value );
+
+    private:
+        void verify_max_usable_range_restrictions( rs2_option opt, float value );
+        l500_options * _owner;
+    };
+
+    class l500_options : public virtual l500_device
+    {
+    public:
+        l500_options( std::shared_ptr< const l500_info > const & dev_info );
+
+        std::vector<rs2_option> get_advanced_controls();
+        void change_preset( rs2_l500_visual_preset preset );
+        void set_preset_value( rs2_l500_visual_preset preset );
+        void reset_hw_controls();
+        rs2_l500_visual_preset calc_preset_from_controls() const;
+        void update_defaults();
+        void move_to_custom();
+    private:
+        void on_set_option(rs2_option opt, float value);
+        
+        void set_preset_controls_to_defaults();
+
+        
+        void set_max_laser();
+
+        void change_gain( rs2_l500_visual_preset preset );
+        void change_alt_ir( rs2_l500_visual_preset preset );
+        void change_laser_power( rs2_l500_visual_preset preset );
+        std::map<rs2_option, std::shared_ptr<cascade_option<l500_hw_options>>> _hw_options;
+        std::shared_ptr< digital_gain_option > _digital_gain;
+        std::shared_ptr< l500_hw_options > _alt_ir;
+        std::shared_ptr< l500_preset_option > _preset;
+
+        template<typename T, class ... Args>
+        std::shared_ptr<cascade_option<T>> register_option(rs2_option opt, Args... args)
+        {
+            auto& depth_sensor = get_synthetic_depth_sensor();
+
+            auto signaled_opt = std::make_shared <cascade_option<T>>(std::forward<Args>(args)...);
+            signaled_opt->add_observer([opt, this](float val) {on_set_option(opt, val);});
+            depth_sensor.register_option(opt, std::dynamic_pointer_cast<option>(signaled_opt));
+
+            return signaled_opt;
+        }
+    };
+
+} // namespace librealsense

--- a/src/l500/l500-options.h
+++ b/src/l500/l500-options.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 #include "../hw-monitor.h"

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #include "l500-private.h"
 #include "l500-device.h"

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -1,0 +1,218 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#include "l500-private.h"
+#include "l500-device.h"
+#include "l500-color.h"
+#include "l500-depth.h"
+#include "fw-update/fw-update-unsigned.h"
+#include "context.h"
+#include "core/video.h"
+#include "log.h"
+#include <chrono>
+
+#include <rsutils/string/from.h>
+
+
+using namespace std;
+
+namespace librealsense
+{
+    namespace ivcam2
+    {
+        
+        const uint16_t rgb_calibration_table::table_id;
+        const uint16_t rgb_calibration_table::eeprom_table_id;
+
+
+        rs2_extrinsics get_color_stream_extrinsic(const std::vector<uint8_t>& raw_data)
+        {
+            if (raw_data.size() < sizeof(pose))
+                throw invalid_value_exception("size of extrinsic invalid");
+            
+            assert( sizeof( pose ) == sizeof( rs2_extrinsics ) );
+            auto res = *(rs2_extrinsics*)raw_data.data();
+            
+            return from_raw_extrinsics(res);
+        }
+
+        bool try_fetch_usb_device(std::vector<platform::usb_device_info>& devices,
+            const platform::uvc_device_info& info, platform::usb_device_info& result)
+        {
+            for (auto it = devices.begin(); it != devices.end(); ++it)
+            {
+                if (it->unique_id == info.unique_id)
+                {
+
+                    result = *it;
+                    switch(info.pid)
+                    {
+                    case L515_PID_PRE_PRQ:
+                    case L515_PID:
+                        if(result.mi == 7)
+                        {
+                            devices.erase(it);
+                            return true;
+                        }
+                        break;
+                    case L500_PID:
+                        if(result.mi == 4 || result.mi == 6)
+                        {
+                            devices.erase(it);
+                            return true;
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+            return false;
+        }
+        float l500_temperature_options::query() const
+        {
+            if (!is_enabled())
+                throw wrong_api_call_sequence_exception("query is available during streaming only");
+            
+            auto temperature_data = _l500_depth_dev->get_temperatures();
+
+            switch (_option)
+            {
+            case RS2_OPTION_LLD_TEMPERATURE:
+                return float(temperature_data.LDD_temperature);
+            case RS2_OPTION_MC_TEMPERATURE:
+                return float(temperature_data.MC_temperature);
+            case RS2_OPTION_MA_TEMPERATURE:
+                return float(temperature_data.MA_temperature);
+            case RS2_OPTION_APD_TEMPERATURE:
+                return float(temperature_data.APD_temperature);
+            case RS2_OPTION_HUMIDITY_TEMPERATURE:
+                return float(temperature_data.HUM_temperature);
+            default:
+                throw invalid_value_exception( rsutils::string::from() << _option << " is not temperature option!" );
+            }
+        }
+
+        l500_temperature_options::l500_temperature_options(l500_device *l500_depth_dev,
+                                                            rs2_option opt,
+                                                            const std::string& description )
+            :_l500_depth_dev(l500_depth_dev)
+            , _option( opt )
+            , _description( description )
+        {
+        }
+
+        flash_structure get_rw_flash_structure(const uint32_t flash_version)
+        {
+            switch (flash_version)
+            {
+                // { number of payloads in section { ro table types }} see Flash.xml
+            case 103: return { 1, { 40, 320, 321, 326, 327, 54} };
+            default:
+                throw std::runtime_error("Unsupported flash version: " + std::to_string(flash_version));
+            }
+        }
+
+        flash_structure get_ro_flash_structure(const uint32_t flash_version)
+        {
+            switch (flash_version)
+            {
+                // { number of payloads in section { ro table types }} see Flash.xml
+            case 103: return { 4, { 256, 257, 258, 263, 264, 512, 25, 2 } };
+            default:
+                throw std::runtime_error("Unsupported flash version: " + std::to_string(flash_version));
+            }
+        }
+
+        flash_info get_flash_info(const std::vector<uint8_t>& flash_buffer)
+        {
+            flash_info rv = {};
+
+            uint32_t header_offset = FLASH_INFO_HEADER_OFFSET;
+            memcpy(&rv.header, flash_buffer.data() + header_offset, sizeof(rv.header));
+
+            uint32_t ro_toc_offset = FLASH_RO_TABLE_OF_CONTENT_OFFSET;
+            uint32_t rw_toc_offset = FLASH_RW_TABLE_OF_CONTENT_OFFSET;
+
+            auto ro_toc = parse_table_of_contents(flash_buffer, ro_toc_offset);
+            auto rw_toc = parse_table_of_contents(flash_buffer, rw_toc_offset);
+
+            auto ro_structure = get_ro_flash_structure(ro_toc.header.version);
+            auto rw_structure = get_rw_flash_structure(rw_toc.header.version);
+
+            rv.read_only_section = parse_flash_section(flash_buffer, ro_toc, ro_structure);
+            rv.read_only_section.offset = rv.header.read_only_start_address;
+            rv.read_write_section = parse_flash_section(flash_buffer, rw_toc, rw_structure);
+            rv.read_write_section.offset = rv.header.read_write_start_address;
+
+            return rv;
+        }
+
+        freefall_option::freefall_option( hw_monitor & hwm, bool enabled )
+            : _hwm( hwm )
+            , _enabled( enabled )
+        {
+            // bool_option initializes with def=true, which is what we want
+            assert( is_true() );
+        }
+
+        void freefall_option::set( float value )
+        {
+            bool_option::set( value );
+
+            command cmd{ FALL_DETECT_ENABLE, is_true() };
+            auto res = _hwm.send( cmd );
+            _record_action( *this );
+        }
+
+        void freefall_option::enable( bool e )
+        {
+            if( e != is_enabled() )
+            {
+                if( !e  &&  is_true() )
+                    set( 0 );
+                _enabled = e;
+            }
+        }
+
+        hw_sync_option::hw_sync_option( hw_monitor& hwm, std::shared_ptr< freefall_option > freefall_opt )
+            : bool_option( false )
+            , _hwm( hwm )
+            , _freefall_opt( freefall_opt )
+        {
+        }
+
+        void hw_sync_option::set( float value )
+        {
+            bool_option::set( value );
+
+            // Disable the free-fall option if we're enabled!
+            if( _freefall_opt )
+                _freefall_opt->enable( ! is_true() );
+
+            command cmd{ HW_SYNC_EX_TRIGGER, is_true() };
+            auto res = _hwm.send( cmd );
+            _record_action( *this );
+        }
+
+
+        float nest_option::query() const
+        {
+            auto temperature_data = _l500_depth_dev->get_temperatures();
+            return (float)(temperature_data.nest_avg);
+        }
+
+        rs2_sensor_mode get_resolution_from_width_height(int width, int height)
+        {
+            if ((width == 240 && height == 320) || (width == 320 && height == 240))
+                return RS2_SENSOR_MODE_QVGA;
+            else if ((width == 640 && height == 480) || (width == 480 && height == 640))
+                return RS2_SENSOR_MODE_VGA;
+            else if ((width == 1024 && height == 768) || (width == 768 && height == 1024))
+                return RS2_SENSOR_MODE_XGA;
+            else
+                throw std::runtime_error( rsutils::string::from() << "Invalid resolution " << width << "x" << height );
+        }
+
+} // librealsense::ivcam2
+} // namespace librealsense

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -1,0 +1,652 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "../backend.h"
+#include "../ds/d400/d400-private.h"
+#include <src/float3.h>
+#include <src/frame.h>
+#include <src/metadata-parser.h>
+#include <rsutils/number/crc32.h>
+#include "../types.h"
+#include "../option.h"
+#include "../core/extension.h"
+#include "../core/time-service.h"
+#include "../fw-update/fw-update-unsigned.h"
+
+#include <rsutils/string/from.h>
+#include <limits>
+#include <type_traits>
+
+
+static const int MAX_NUM_OF_RGB_RESOLUTIONS = 5;
+static const int MAX_NUM_OF_DEPTH_RESOLUTIONS = 5; 
+
+
+namespace librealsense {
+
+    static const double TIMESTAMP_USEC_TO_MSEC = 0.001;
+
+    // Provides an efficient wraparound for built-in arithmetic times, for use-cases such as a rolling timestamp
+    template <typename T, typename S>
+    class arithmetic_wraparound
+    {
+    public:
+        arithmetic_wraparound() :
+            last_input(std::numeric_limits<T>::lowest()), accumulated(0) {
+            static_assert(
+                (std::is_arithmetic<T>::value) &&
+                (std::is_arithmetic<S>::value) &&
+                (std::numeric_limits<T>::max() < std::numeric_limits<S>::max()) &&
+                (std::numeric_limits<T>::lowest() >= std::numeric_limits<S>::lowest())
+                , "Wraparound class requirements are not met");
+        }
+
+        S calc(const T input)
+        {
+            accumulated += static_cast<T>(input - last_input); // Automatically resolves wraparounds
+            last_input = input;
+            return (accumulated);
+        }
+
+        void reset() { last_input = std::numeric_limits<T>::lowest();  accumulated = 0; }
+
+    private:
+        T last_input;
+        S accumulated;
+    };
+}
+
+namespace librealsense
+{
+    const uint16_t L500_RECOVERY_PID            = 0x0b55;
+    const uint16_t L500_USB2_RECOVERY_PID_OLD   = 0x0adc; // Units with old DFU_PAYLAOD on USB2 report ds5 PID (RS_USB2_RECOVERY_PID)
+    const uint16_t L500_PID                     = 0x0b0d;
+    const uint16_t L515_PID_PRE_PRQ             = 0x0b3d;
+    const uint16_t L515_PID                     = 0x0b64;
+
+    class l500_device;
+
+    namespace ivcam2
+    {
+        // L500 depth XU identifiers
+        const uint8_t L500_HWMONITOR = 1;
+        const uint8_t L500_DIGITAL_GAIN = 2; // Renamed from L500_AMBIENT
+        const uint8_t L500_ERROR_REPORTING = 3;
+
+        const uint32_t FLASH_SIZE = 0x00200000;
+        const uint32_t FLASH_SECTOR_SIZE = 0x1000;
+
+        const uint32_t FLASH_RW_TABLE_OF_CONTENT_OFFSET = 0x0017FE00;
+        const uint32_t FLASH_RO_TABLE_OF_CONTENT_OFFSET = 0x001FFD00;
+        const uint32_t FLASH_INFO_HEADER_OFFSET = 0x001FFF00;
+
+        flash_info get_flash_info(const std::vector<uint8_t>& flash_buffer);
+
+        const platform::extension_unit depth_xu = { 0, 3, 2,
+        { 0xC9606CCB, 0x594C, 0x4D25,{ 0xaf, 0x47, 0xcc, 0xc4, 0x96, 0x43, 0x59, 0x95 } } };
+
+        const uint32_t REGISTER_CLOCK_0 = 0x9003021c;
+
+        const uint16_t L515_IMU_TABLE   = 0x0243;  // IMU calibration table on L515
+
+        enum fw_cmd : uint8_t
+        {
+            IRB                         = 0x03, //"Read from i2c ( 8x8 )"
+            MRD                         = 0x01, //"Read Tensilica memory ( 32bit ). Output : 32bit dump"
+            FRB                         = 0x09, //"Read from flash"
+            FWB                         = 0x0A, //"Write to flash"
+            FES                         = 0x0B, //"Erase flash sector"
+            FEF                         = 0x0C, //"Erase flash full"
+            GLD                         = 0x0F, //"LoggerCoreGetDataParams"
+            GVD                         = 0x10, //"Get Version and Date"
+            DFU                         = 0x1E, //"Go to DFU"
+            HW_SYNC_EX_TRIGGER          = 0x19, // Enable (not default) HW sync; will disable freefall
+            HW_RESET                    = 0x20, //"HW Reset"
+            AMCSET                      = 0x2B, // Set options (L515)
+            AMCGET                      = 0x2C, // Get options (L515)
+            DELETE_TABLE                = 0x2E,
+            TPROC_TRB_THRSLD_SET        = 0x35, // TPROC TRB threshold
+            TPROC_USB_GRAN_SET          = 0x36, // TPROC USB granularity
+            PFD                         = 0x3B, // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
+            READ_TABLE                  = 0x43, // read table from flash, for example, read imu calibration table, read_table 0x243 0
+            WRITE_TABLE                 = 0x44,
+            DPT_INTRINSICS_GET          = 0x5A,
+            TEMPERATURES_GET            = 0x6A,
+            DPT_INTRINSICS_FULL_GET     = 0x7F,
+            RGB_INTRINSIC_GET           = 0x81,
+            RGB_EXTRINSIC_GET           = 0x82,
+            FALL_DETECT_ENABLE          = 0x9D, // Enable (by default) free-fall sensor shutoff (0=disable; 1=enable)
+            GET_SPECIAL_FRAME           = 0xA0, // Request auto-calibration (0) special frames (#)
+            UNIT_AGE_SET                = 0x5B  // Sets the age of the unit in weeks
+        };
+
+#pragma pack(push, 1)
+        // Table header returned by READ_TABLE before the actual table data
+        struct table_header
+        {
+            uint8_t                 major;
+            uint8_t                 minor;
+            uint16_t                table_id;
+            uint32_t                table_size;     // full size including: TOC header + TOC + actual tables
+            uint32_t                reserved;       // 0xFFFFFFFF
+            uint32_t                crc32;          // crc of all the actual table data excluding header/CRC
+        };
+#pragma pack(pop)
+
+        static std::vector< uint8_t >
+        read_fw_table_raw( const hw_monitor & hwm, int table_id, hwmon_response_type & response )
+        {
+            std::vector< uint8_t > res;
+            command cmd( fw_cmd::READ_TABLE, table_id );
+            auto data = hwm.send( cmd, &response );
+
+            res.assign( data.data(), data.data() + data.size() );
+
+            return res;
+        }
+
+        // Read a table from firmware and, if FW says the table is empty, optionally initialize it
+        // using your own code...
+        template< typename T >
+        void read_fw_table( hw_monitor& hwm,
+                            int table_id, T * ptable,
+                            table_header * pheader = nullptr,
+                            std::function< void() > init = nullptr )
+        {
+            hwmon_response_type response;
+            std::vector< uint8_t > data = read_fw_table_raw( hwm, table_id, response );
+            size_t expected_size = sizeof( table_header ) + sizeof( T );
+            switch( response )
+            {
+            case ds::d400_hwmon_response::SUCCESS:
+                if( data.size() != expected_size )
+                    throw std::runtime_error( rsutils::string::from()
+                                              << "READ_TABLE (0x" << std::hex << table_id
+                                              << std::dec << ") data size received= " << data.size()
+                                              << " (expected " << expected_size << ")" );
+                if( pheader )
+                    *pheader = *(table_header *)data.data();
+                if( ptable )
+                    *ptable = *(T *)(data.data() + sizeof( table_header ));
+                break;
+
+            case ds::d400_hwmon_response::TABLE_IS_EMPTY:
+                if( init )
+                {
+                    // Initialize a new table
+                    init();
+                    break;
+                }
+                // fall-thru!
+                
+            default:
+                LOG_DEBUG( "Failed to read FW table 0x" << std::hex << table_id );
+                command cmd( fw_cmd::READ_TABLE, table_id );
+                throw invalid_value_exception( ds::d400_hwmon_response().hwmon_error2str( response ) );
+            }
+        }
+
+        // Write a table to firmware
+        template< typename T >
+        void write_fw_table( hw_monitor& hwm, uint16_t const table_id, T const & table, uint16_t const version = 0x0100 )
+        {
+            command cmd( fw_cmd::WRITE_TABLE, 0 );
+            cmd.data.resize( sizeof( table_header ) + sizeof( table ) );
+
+            table_header * h = (table_header *)cmd.data.data();
+            h->major = version >> 8;
+            h->minor = version & 0xFF;
+            h->table_id = table_id;
+            h->table_size = sizeof( T );
+            h->reserved = 0xFFFFFFFF;
+            h->crc32 = rsutils::number::calc_crc32( (uint8_t *)&table, sizeof( table ) );
+
+            memcpy( cmd.data.data() + sizeof( table_header ), &table, sizeof( table ) );
+            
+            hwmon_response_type response;
+            hwm.send( cmd, &response );
+            switch( response )
+            {
+            case ds::d400_hwmon_response::SUCCESS:
+                break;
+
+            default:
+                LOG_DEBUG( "Failed to write FW table 0x" << std::hex << table_id << " " << sizeof( table ) << " bytes: " );
+                throw invalid_value_exception( rsutils::string::from() << "Failed to write FW table 0x" << std::hex << table_id << ": " << ds::d400_hwmon_response().hwmon_error2str( response ));
+            }
+        }
+
+        template< typename T >
+        void read_fw_register(hw_monitor& hwm, T * preg, int const baseline_address )
+        {
+            command cmd( ivcam2::fw_cmd::MRD, baseline_address, baseline_address + sizeof( T ) );
+            auto res = hwm.send( cmd );
+            if( res.size() != sizeof( T ) )
+                throw std::runtime_error( rsutils::string::from()
+                                          << "MRD data size received= " << res.size()
+                                          << " (expected " << sizeof( T ) << ")" );
+            if( preg )
+                *preg = *(T *)res.data();
+        }
+
+#pragma pack(push, 1)
+
+        struct rgb_calibration_table
+        {
+            static const uint16_t table_id = 0x310;        // in flash
+            static const uint16_t eeprom_table_id = 0x10;  // factory calibration - read-only
+
+            uint16_t version;
+            uint16_t type;
+            uint32_t timestamp;
+            uint16_t width;
+            uint16_t height;
+            uint16_t h_offset;
+            uint16_t v_offset;
+            struct /*intrinsics*/
+            {
+                float fx;  // focal length in X, normalize by [-1 1]
+                float fy;  // focal length in Y, normalize by [-1 1]
+                float px;  // Principal point in x, normalize by [-1 1]
+                float py;  // Principal point in x, normalize by [-1 1]
+                float sheer;
+                float d[5];  // RGB forward distortion parameters (k1, k2, p1, p2, k3), brown model
+            } intr;
+            rs2_extrinsics extr;
+            uint8_t reserved[8];
+
+            void set_intrinsics( rs2_intrinsics const & );
+            rs2_intrinsics get_intrinsics() const;
+            rs2_extrinsics const & get_extrinsics() const { return extr; }
+            void update_write_fields();
+        };
+#pragma pack(pop)
+
+        // <Command Name="GVD" Opcode="0x10" Description="Get Version and Date">
+        // See CommandsIVCAM2.xml for complete up-to-date fields
+        enum gvd_fields
+        {
+            is_camera_locked_offset = 6,    // "eyeSafety": encompasses eeprom, flash, & registers
+            fw_version_offset = 12,         // "FunctionalPayloadVersion"
+            module_serial_offset = 60,      // "OpticalHeadModuleSN" -> RS2_CAMERA_INFO_SERIAL_NUMBER
+            module_asic_serial_offset = 74  // "AsicModuleSerial" -> RS2_CAMERA_INFO_ASIC_SERIAL_NUMBER & RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID
+        };
+
+        enum gvd_fields_size
+        {
+            // Keep sorted
+            module_serial_size = 4,
+            module_asic_serial_size = 6
+        };
+
+        static const std::map<std::uint16_t, std::string> rs500_sku_names = {
+            { L500_RECOVERY_PID,            "Intel RealSense L51X Recovery"},
+            { L500_USB2_RECOVERY_PID_OLD,   "Intel RealSense L51X Recovery"},
+            { L500_PID,                     "Intel RealSense L500"},
+            { L515_PID_PRE_PRQ,             "Intel RealSense L515 (pre-PRQ)"},
+            { L515_PID,                     "Intel RealSense L515"},
+        };
+
+        static std::map<uint16_t, std::pair<std::string, std::string>> device_to_fw_min_max_version = {
+            { L500_RECOVERY_PID,            { "1.5.1.3", "1.99.99.99"}},
+            { L500_USB2_RECOVERY_PID_OLD,   { "1.5.1.3", "1.99.99.99"}},
+            { L500_PID,                     { "1.5.1.3", "1.99.99.99"}},
+            { L515_PID_PRE_PRQ,             { "1.5.1.3", "1.99.99.99"}},
+            { L515_PID,                     { "1.5.1.3", "1.99.99.99"}},
+        };
+
+        // Known FW error codes, if we poll for errors (RS2_OPTION_ERROR_POLLING_ENABLED)
+        enum l500_notifications_types
+        {
+            success = 0,
+            depth_not_available,
+            overflow_infrared,
+            overflow_depth,
+            overflow_confidence,
+            depth_stream_hard_error,
+            depth_stream_soft_error,
+            temp_warning,
+            temp_critical,
+            DFU_error,
+            fall_detected = 12,
+            ld_alarm = 14,
+            hard_error = 15,
+            ld_alarm_hard_error = 16,
+            pzr_vbias_exceed_limit = 17,
+            eye_safety_general_critical_error = 18,
+            eye_safety_stuck_at_ld_error = 19,
+            eye_safety_stuck_at_mode_sign_error = 20,
+            eye_safety_stuck_at_vbst_error = 21,
+            eye_safety_stuck_at_msafe_error = 22,
+            eye_safety_stuck_at_ldd_snubber_error = 23,
+            eye_safety_stuck_at_flash_otp_error = 24
+        };
+
+        // Each of the above is mapped to a string -- but only for those we identify as errors: warnings are
+        // listed below as comments and are treated as unknown warnings...
+        // NOTE: a unit-test in func/hw-errors/ directly uses this map and tests it
+        const std::map< uint8_t, std::string > l500_fw_error_report = {
+            { success,                      "Success" },
+            { depth_not_available,          "Fatal error occur and device is unable \nto run depth stream" },
+            { overflow_infrared,            "Overflow occur on infrared stream" },
+            { overflow_depth,               "Overflow occur on depth stream" },
+            { overflow_confidence,          "Overflow occur on confidence stream" },
+            { depth_stream_hard_error,      "Receiver light saturation, stream stopped for 1 sec" },
+            { depth_stream_soft_error,      "Error that may be overcome in few sec. \nStream stoped. May be recoverable" },
+            { temp_warning,                 "Warning, temperature close to critical" },
+            { temp_critical,                "Critical temperature reached" },
+            { DFU_error,                    "DFU error" },
+            //{10 ,                         "L500 HW report - unresolved type 10"},
+            //{11 ,                         "L500 HW report - unresolved type 11"},
+            { fall_detected,                "Fall detected stream stopped"  },
+            //{13 ,                         "L500 HW report - unresolved type 13"},
+            { ld_alarm,                     "Fatal error occurred (14)" },
+            { hard_error,                   "Fatal error occurred (15)" },
+            { ld_alarm_hard_error,          "Fatal error occurred (16)" },
+            { pzr_vbias_exceed_limit,       "Fatal error occurred (17)" },
+            { eye_safety_general_critical_error,        "Fatal error occurred (18)" },
+            { eye_safety_stuck_at_ld_error,             "Fatal error occurred (19)" },
+            { eye_safety_stuck_at_mode_sign_error,      "Fatal error occurred (20)" },
+            { eye_safety_stuck_at_vbst_error,           "Fatal error occurred (21)" },
+            { eye_safety_stuck_at_msafe_error,          "Fatal error occurred (22)" },
+            { eye_safety_stuck_at_ldd_snubber_error,    "Fatal error occurred (23)" },
+            { eye_safety_stuck_at_flash_otp_error,      "Fatal error occurred (24)" }
+        };
+
+#pragma pack(push, 1)
+        struct pinhole_model
+        {
+            float2 focal_length;
+            float2 principal_point;
+        };
+
+        struct distortion
+        {
+            float radial_k1;
+            float radial_k2;
+            float tangential_p1;
+            float tangential_p2;
+            float radial_k3;
+        };
+
+        struct pinhole_camera_model
+        {
+            uint32_t width;
+            uint32_t height;
+            pinhole_model ipm;
+            distortion distort;
+        };
+
+        struct intrinsic_params
+        {
+            pinhole_camera_model pinhole_cam_model; //(Same as standard intrinsic)
+            float2 zo;
+            float znorm;
+        };
+
+        struct intrinsic_per_resolution
+        {
+            intrinsic_params raw;
+            intrinsic_params world;
+        };
+
+        struct resolutions_depth
+        {
+            uint16_t reserved16;
+            uint8_t reserved8;
+            uint8_t num_of_resolutions;
+            intrinsic_per_resolution intrinsic_resolution[MAX_NUM_OF_DEPTH_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
+        };
+
+        struct orientation
+        {
+            uint8_t hscan_direction;
+            uint8_t vscan_direction;
+            uint16_t reserved16;
+            uint32_t reserved32;
+            float depth_offset;
+        };
+
+        struct intrinsic_depth
+        {
+            orientation orient;
+            resolutions_depth resolution;
+        };
+
+        struct resolutions_rgb
+        {
+            uint16_t reserved16;
+            uint8_t reserved8;
+            uint8_t num_of_resolutions;
+            pinhole_camera_model intrinsic_resolution[MAX_NUM_OF_RGB_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
+        };
+
+        struct rgb_common
+        {
+            float sheer;
+            uint32_t reserved32;
+        };
+
+        struct intrinsic_rgb
+        {
+            rgb_common common;
+            resolutions_rgb resolution;
+        };
+
+        struct temperatures {
+            double LDD_temperature;  // Laser Diode Driver
+            double MC_temperature;
+            double MA_temperature;
+            double APD_temperature;
+            double HUM_temperature;
+            double AlgoTermalLddAvg_temperature;
+
+            temperatures()
+                : LDD_temperature(0.)
+                , MC_temperature(0.)
+                , MA_temperature(0.)
+                , APD_temperature(0.)
+                , HUM_temperature(0.)
+                , AlgoTermalLddAvg_temperature(0.) { }
+        };
+
+        //FW versions >= 1.5.0.0 added to the response vector the nest AVG value
+        struct extended_temperatures : public temperatures 
+        {
+            double nest_avg; // NEST = Noise Estimation
+
+            extended_temperatures() : temperatures(), nest_avg(.0) {}
+        };
+#pragma pack( pop )
+
+        rs2_extrinsics get_color_stream_extrinsic(const std::vector<uint8_t>& raw_data);
+        
+        bool try_fetch_usb_device(std::vector<platform::usb_device_info>& devices,
+        const platform::uvc_device_info& info, platform::usb_device_info& result);
+
+        class l500_temperature_options : public readonly_option
+        {
+        public:
+            float query() const override;
+
+            option_range get_range() const override { return option_range{ 0, 100, 0, 0 }; }
+
+            bool is_enabled() const override { return true; }
+
+            const char * get_description() const override { return _description.c_str(); }
+
+            explicit l500_temperature_options(l500_device *l500_depth_dev,
+                                               rs2_option opt,
+                                               const std::string& description );
+
+        private:
+            rs2_option _option;
+            l500_device *_l500_depth_dev;
+            std::string _description;
+        };
+
+        // Noise estimation option
+        class nest_option : public readonly_option
+        {
+        public:
+            float query() const override;
+
+            option_range get_range() const override { return option_range{ 0, 4100, 0, 0 }; }
+
+            bool is_enabled() const override { return true; }
+
+            const char * get_description() const override { return _description.c_str(); }
+
+            explicit nest_option(l500_device * l500_depth_dev, const std::string & description)
+                : _l500_depth_dev(l500_depth_dev)
+                , _description(description) {};
+
+        private:
+            l500_device *_l500_depth_dev;
+            std::string _description;
+        };
+
+        class l500_timestamp_reader : public frame_timestamp_reader
+        {
+            static const int pins = 3;
+            mutable std::vector<size_t> counter;
+
+            mutable std::recursive_mutex _mtx;
+        public:
+            l500_timestamp_reader()
+                : counter(pins)
+            {
+                reset();
+            }
+
+            void reset() override
+            {
+                std::lock_guard<std::recursive_mutex> lock(_mtx);
+                for (size_t i = 0; i < pins; ++i)
+                {
+                    counter[i] = 0;
+                }
+            }
+
+            rs2_time_t get_frame_timestamp(const std::shared_ptr<frame_interface>&) override
+            {
+                std::lock_guard<std::recursive_mutex> lock(_mtx);
+                return time_service::get_time();
+            }
+
+            unsigned long long get_frame_counter(const std::shared_ptr<frame_interface>& frame) const override
+            {
+                std::lock_guard<std::recursive_mutex> lock(_mtx);
+                size_t pin_index = 0;
+                if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
+                    pin_index = 1;
+                else if (frame->get_stream()->get_stream_type() == RS2_STREAM_CONFIDENCE)
+                    pin_index = 2;
+
+                return ++counter[pin_index];
+            }
+
+            rs2_timestamp_domain get_frame_timestamp_domain(const std::shared_ptr<frame_interface>&) const override
+            {
+                return RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME;
+            }
+        };
+
+        class l500_timestamp_reader_from_metadata : public frame_timestamp_reader
+        {
+            std::unique_ptr<l500_timestamp_reader> _backup_timestamp_reader;
+            bool one_time_note;
+            mutable std::recursive_mutex _mtx;
+            arithmetic_wraparound<uint32_t, uint64_t > ts_wrap;
+
+        protected:
+
+            bool has_metadata_ts(const std::shared_ptr<frame_interface>& frame) const
+            {
+                // Metadata support for a specific stream is immutable
+                auto f = std::dynamic_pointer_cast<librealsense::frame>(frame);
+                const bool has_md_ts = [&] { std::lock_guard<std::recursive_mutex> lock(_mtx);
+                return ((f->additional_data.metadata_size >= platform::uvc_header_size) && ((uint8_t*)f->additional_data.metadata_blob.data())[0] >= platform::uvc_header_size);
+                }();
+
+                return has_md_ts;
+            }
+
+            bool has_metadata_fc(const std::shared_ptr<frame_interface>& frame) const
+            {
+                // Metadata support for a specific stream is immutable
+                auto f = std::dynamic_pointer_cast<librealsense::frame>(frame);
+                const bool has_md_frame_counter = [&] { std::lock_guard<std::recursive_mutex> lock(_mtx);
+                return ((f->additional_data.metadata_size > platform::uvc_header_size) && ((uint8_t*)f->additional_data.metadata_blob.data())[0] > platform::uvc_header_size);
+                }();
+
+                return has_md_frame_counter;
+            }
+
+        public:
+            l500_timestamp_reader_from_metadata() :_backup_timestamp_reader(nullptr), one_time_note(false)
+            {
+                _backup_timestamp_reader = std::unique_ptr<l500_timestamp_reader>(new l500_timestamp_reader());
+                reset();
+            }
+
+            rs2_time_t get_frame_timestamp(const std::shared_ptr<frame_interface>& frame) override;
+
+            unsigned long long get_frame_counter(const std::shared_ptr<frame_interface>& frame) const override;
+
+            void reset() override;
+
+            rs2_timestamp_domain get_frame_timestamp_domain(const std::shared_ptr<frame_interface>& frame) const override;
+        };
+
+        /* For RS2_OPTION_FREEFALL_DETECTION_ENABLED */
+        class freefall_option : public bool_option
+        {
+        public:
+            freefall_option( hw_monitor& hwm, bool enabled = true );
+
+            bool is_enabled() const override { return _enabled; }
+            virtual void enable( bool = true );
+
+            virtual void set( float value ) override;
+            virtual const char * get_description() const override
+            {
+                return "When enabled (default), the sensor will turn off if a free-fall is detected";
+            }
+            virtual void enable_recording( std::function<void( const option& )> record_action ) override { _record_action = record_action; }
+
+        private:
+            std::function<void( const option& )> _record_action = []( const option& ) {};
+            hw_monitor & _hwm;
+            bool _enabled;
+        };
+
+        /*  For RS2_OPTION_INTER_CAM_SYNC_MODE
+            Not an advanced control: always off after camera startup (reset).
+            When enabled, the freefall control should turn off.
+        */
+        class hw_sync_option : public bool_option
+        {
+        public:
+            hw_sync_option( hw_monitor& hwm, std::shared_ptr< freefall_option > freefall_opt );
+
+            virtual void set( float value ) override;
+            virtual const char* get_description() const override
+            {
+                return "Enable multi-camera hardware synchronization mode (disabled on startup); not compatible with free-fall detection";
+            }
+            virtual void enable_recording( std::function<void( const option& )> record_action ) override { _record_action = record_action; }
+
+        private:
+            std::function<void( const option& )> _record_action = []( const option& ) {};
+            hw_monitor& _hwm;
+            std::shared_ptr< freefall_option > _freefall_opt;
+        };
+
+        rs2_sensor_mode get_resolution_from_width_height(int width, int height);
+
+        class ac_trigger;
+    } // librealsense::ivcam2
+} // namespace librealsense

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -1,0 +1,125 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include <set>
+#include "l500-serializable.h"
+#include "l500-options.h"
+#include <rsutils/json.h>
+#include "serialized-utilities.h"
+
+namespace librealsense
+{
+    using json = nlohmann::json;
+
+    l500_serializable::l500_serializable(std::shared_ptr<hw_monitor> hw_monitor, synthetic_sensor & depth_sensor)
+        :_hw_monitor_ptr(hw_monitor),
+         _depth_sensor(depth_sensor)
+    {
+    }
+
+    std::vector<uint8_t> l500_serializable::serialize_json() const
+    {
+        serialized_utilities::json_preset_writer writer;
+        writer.set_device_info(_depth_sensor.get_device());
+
+        return group_multiple_fw_calls( _depth_sensor, [&]() {
+
+            auto options = _depth_sensor.get_supported_options();
+
+            for( auto o : options )
+            {
+                auto && opt = _depth_sensor.get_option( o );
+                auto val = opt.query();
+                writer.write_param(get_string(o), val);
+            }
+
+            auto str = writer.to_string();
+            return std::vector< uint8_t >( str.begin(), str.end() );
+        } );
+    }
+
+    void l500_serializable::load_json( const std::string & json_content )
+    {
+        serialized_utilities::json_preset_reader reader( json_content );
+
+        // Verify if device information in preset file is compatible with the connected device.
+        reader.check_device_info(_depth_sensor.get_device());
+        
+        return group_multiple_fw_calls(_depth_sensor, [&]() {
+
+            // Set of options that should not be set in the loop
+            std::set< rs2_option > options_to_ignore{ RS2_OPTION_SENSOR_MODE,
+                                                      RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH,
+                                                      RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH };
+
+            // We have to set the sensor mode (resolution) first
+            if (_depth_sensor.supports_option(RS2_OPTION_SENSOR_MODE))
+            {
+                auto & sensor_mode = _depth_sensor.get_option(RS2_OPTION_SENSOR_MODE);
+                auto found_sensor_mode = reader.find(get_string(RS2_OPTION_SENSOR_MODE));
+                if (found_sensor_mode != reader.end())
+                {
+                    float sensor_mode_val = found_sensor_mode.value();
+                    sensor_mode.set(sensor_mode_val);
+                }
+            }
+
+            // If a non custom preset is used, we should ignore all the settings that are
+            // automatically set by the preset
+            auto found_iterator = reader.find( get_string( RS2_OPTION_VISUAL_PRESET ) );
+            if( found_iterator != reader.end() )
+            {
+                auto found_preset = rs2_l500_visual_preset( int( found_iterator.value() ) );
+                if( found_preset != RS2_L500_VISUAL_PRESET_CUSTOM
+                    && found_preset != RS2_L500_VISUAL_PRESET_DEFAULT )
+                {
+                    options_to_ignore.insert( RS2_OPTION_POST_PROCESSING_SHARPENING );
+                    options_to_ignore.insert( RS2_OPTION_PRE_PROCESSING_SHARPENING );
+                    options_to_ignore.insert( RS2_OPTION_NOISE_FILTERING );
+                    options_to_ignore.insert( RS2_OPTION_AVALANCHE_PHOTO_DIODE );
+                    options_to_ignore.insert( RS2_OPTION_CONFIDENCE_THRESHOLD );
+                    options_to_ignore.insert( RS2_OPTION_LASER_POWER );
+                    options_to_ignore.insert( RS2_OPTION_MIN_DISTANCE );
+                    options_to_ignore.insert( RS2_OPTION_INVALIDATION_BYPASS );
+                    options_to_ignore.insert( RS2_OPTION_DIGITAL_GAIN );
+                }
+            }
+
+            auto opts = _depth_sensor.get_supported_options();
+
+            auto default_preset = false;
+            for( auto o : opts )
+            {
+                auto & opt = _depth_sensor.get_option( o );
+                if( opt.is_read_only() )
+                    continue;
+                if( options_to_ignore.find( o ) != options_to_ignore.end() )
+                    continue;
+
+                auto key = get_string( o );
+                auto it = reader.find( key );
+                if( it != reader.end() )
+                {
+                    float val = it.value();
+                    if( o == RS2_OPTION_VISUAL_PRESET
+                        && (int)val == (int)RS2_L500_VISUAL_PRESET_DEFAULT )
+                    {
+                        default_preset = true;
+                        continue;
+                    }
+
+                    opt.set( val );
+                }
+            }
+            if( default_preset )
+            {
+                auto options = dynamic_cast< l500_options * >( this );
+                if( options )
+                {
+                    auto preset = options->calc_preset_from_controls();
+                    options->set_preset_value( preset );
+                }
+            }
+        } );
+    }
+    } // namespace librealsense

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include <set>
 #include "l500-serializable.h"

--- a/src/l500/l500-serializable.h
+++ b/src/l500/l500-serializable.h
@@ -1,0 +1,23 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "serializable-interface.h"
+#include "hw-monitor.h"
+#include "sensor.h"
+
+namespace librealsense
+{
+    class l500_serializable : public serializable_interface
+    {
+    public:
+        l500_serializable(std::shared_ptr<hw_monitor> hw_monitor, synthetic_sensor& depth_sensor);
+        std::vector<uint8_t> serialize_json() const override;
+        void load_json(const std::string& json_content) override;
+
+    private:
+        std::shared_ptr<hw_monitor> _hw_monitor_ptr;
+        synthetic_sensor& _depth_sensor;
+    };
+} // namespace librealsense

--- a/src/l500/l500-serializable.h
+++ b/src/l500/l500-serializable.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #pragma once
 

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -654,6 +654,10 @@ namespace librealsense
             }
         }
 
+        if (i >= _processing_blocks.size())
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "No processing block supports option " << option );
+
         update_info(RS2_CAMERA_INFO_NAME, _processing_blocks[i]->get_info(RS2_CAMERA_INFO_NAME));
 
         return *_processing_blocks[i];
@@ -683,13 +687,16 @@ namespace librealsense
         }
 
         // Set the output callback of the composite processing block as last processing block in the vector.
-        _processing_blocks.back()->set_output_callback(callback);
+        if (!_processing_blocks.empty())
+            _processing_blocks.back()->set_output_callback(callback);
     }
 
     void composite_processing_block::invoke(frame_holder frames)
     {
         // Invoke the first processing block.
         // This will trigger processing the frame in a chain by the order of the given processing blocks vector.
+        if (_processing_blocks.empty())
+            throw wrong_api_call_sequence_exception("composite_processing_block has no processing blocks");
         _processing_blocks.front()->invoke(std::move(frames));
     }
 

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -631,4 +631,66 @@ namespace librealsense
 
         set_processing_callback( make_frame_processor_callback( std::move( process_callback ) ) );
     }
+    composite_processing_block::composite_processing_block() :
+        composite_processing_block("Composite Processing Block")
+    {}
+
+    composite_processing_block::composite_processing_block(const char * name) :
+        processing_block(name)
+    {}
+
+    processing_block & composite_processing_block::get(rs2_option option)
+    {
+        // Find the first block which supports the option.
+        // It doesn't matter which one is selected, as long as it supports the option, because of the 
+        // option propogation caused by bypass_option::set(value)
+        int i = 0;
+        for (i = 0; i < _processing_blocks.size(); i++)
+        {
+            if (_processing_blocks[i]->supports_option(option))
+            {
+                auto val = _processing_blocks[i]->get_option(option).query();
+                if (val > 0.f) break;
+            }
+        }
+
+        update_info(RS2_CAMERA_INFO_NAME, _processing_blocks[i]->get_info(RS2_CAMERA_INFO_NAME));
+
+        return *_processing_blocks[i];
+    }
+
+    void composite_processing_block::add(std::shared_ptr<processing_block> block)
+    {
+        _processing_blocks.push_back(block);
+
+        const auto&& supported_options = block->get_supported_options();
+        for (auto&& opt : supported_options)
+        {
+            register_option(opt, std::make_shared<bypass_option>(this, opt));
+        }
+
+        update_info(RS2_CAMERA_INFO_NAME, block->get_info(RS2_CAMERA_INFO_NAME));
+    }
+
+    void composite_processing_block::set_output_callback(rs2_frame_callback_sptr callback)
+    {
+        // Each processing block will process the preceding processing block output frame.
+        size_t i = 0;
+        for (i = 1; i < _processing_blocks.size(); i++)
+        {
+            _processing_blocks[i - 1]->set_output_callback( make_frame_callback(
+                [i, this]( frame_interface * f ) { _processing_blocks[i]->invoke( frame_holder{ f } ); } ) );
+        }
+
+        // Set the output callback of the composite processing block as last processing block in the vector.
+        _processing_blocks.back()->set_output_callback(callback);
+    }
+
+    void composite_processing_block::invoke(frame_holder frames)
+    {
+        // Invoke the first processing block.
+        // This will trigger processing the frame in a chain by the order of the given processing blocks vector.
+        _processing_blocks.front()->invoke(std::move(frames));
+    }
+
 }

--- a/src/proc/synthetic-stream.h
+++ b/src/proc/synthetic-stream.h
@@ -209,6 +209,57 @@ namespace librealsense
         bool should_process(const rs2::frame& frame) override;
     };
 
+    // Sequential chained processing blocks
+    // The order of the processing blocks defines the execution flow.
+    class LRS_EXTENSION_API composite_processing_block : public processing_block
+    {
+    public:
+        class bypass_option : public option
+        {
+        public:
+            bypass_option(composite_processing_block* parent, rs2_option opt)
+                : _parent(parent), _opt(opt) {}
+
+            void set(float value) override {
+                // While query and other read operations
+                // will only read from the currently selected
+                // block, setting an option will propogate
+                // to all blocks in the group
+                for (size_t i = 0; i < _parent->_processing_blocks.size(); i++)
+                {
+                    if (_parent->_processing_blocks[i]->supports_option(_opt))
+                    {
+                        _parent->_processing_blocks[i]->get_option(_opt).set(value);
+                    }
+                }
+            }
+            float query() const override { return get().query(); }
+            option_range get_range() const override { return get().get_range(); }
+            bool is_enabled() const override { return get().is_enabled(); }
+            bool is_read_only() const override { return get().is_read_only(); }
+            const char* get_description() const override { return get().get_description(); }
+            const char* get_value_description(float v) const override { return get().get_value_description(v); }
+            void enable_recording(std::function<void(const option &)> record_action) override {}
+
+            option& get() { return _parent->get(_opt).get_option(_opt); }
+            const option& get() const { return _parent->get(_opt).get_option(_opt); }
+        private:
+            composite_processing_block* _parent;
+            rs2_option _opt;
+        };
+
+        composite_processing_block();
+        composite_processing_block(const char* name);
+        virtual ~composite_processing_block() { _source.flush(); };
+
+        processing_block& get(rs2_option option);
+        void add(std::shared_ptr<processing_block> block);
+        void set_output_callback(rs2_frame_callback_sptr callback) override;
+        void invoke(frame_holder frames) override;
+
+    protected:
+        std::vector<std::shared_ptr<processing_block>> _processing_blocks;
+    };
 }
 
 // API structures

--- a/third-party/rsutils/include/rsutils/time/work-week.h
+++ b/third-party/rsutils/include/rsutils/time/work-week.h
@@ -1,0 +1,44 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+
+/*
+This class is for any use that requires work weeks.
+Read more on work weeks at https://en.wikipedia.org/wiki/ISO_week_date
+Note that we use the US accounting method, in which the 1st of January is always in work week 1.
+for example, 1/1/2022 is a Saturday, so that whole week is work week 1, i.e 26-31/12/2021 are
+actualy in work week 1 of 2022
+*/
+#pragma once
+
+#include <string>
+#include <ctime>
+
+
+namespace rsutils {
+namespace time {
+
+class work_week
+{
+    unsigned _year;
+    unsigned _ww; //starts at 1
+
+public:
+    work_week(unsigned year, unsigned ww);
+    work_week( const std::time_t & time );
+    static work_week current();
+    work_week(const work_week & ) = default;
+
+    unsigned get_year() const;
+    unsigned get_work_week() const;
+    int operator-( const work_week & ww ) const;
+};
+
+// Returns the number of work weeks since given time
+unsigned get_work_weeks_since( const work_week & start );
+
+// Calulates and returns the Julian day number of the given date. 
+//read more in https://en.wikipedia.org/wiki/Julian_day
+unsigned jdn( unsigned year, unsigned month, unsigned day );
+}  // namespace time
+}  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/time/work-week.h
+++ b/third-party/rsutils/include/rsutils/time/work-week.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 
 /*

--- a/third-party/rsutils/src/work-week.cpp
+++ b/third-party/rsutils/src/work-week.cpp
@@ -1,0 +1,122 @@
+//// License: Apache 2.0. See LICENSE file in root directory.
+//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include <rsutils/time/work-week.h>
+#include <string>
+#include <stdexcept>
+#include <sstream>
+#include <time.h>
+
+
+static int work_weeks_between_years( unsigned year, unsigned other_year )
+{
+    unsigned Jan_1_JDN = rsutils::time::jdn( year, 1, 1 );
+    unsigned other_Jan_1_JDN = rsutils::time::jdn( other_year, 1, 1 );
+    // We need to compare between weeks, so we get the JDN of the Sunday of the wanted weeks
+    // (JDN + 1) % 7 gives us the day of the week for the JDN. 0 -> Sun, 1 -> Mon ...
+    int start_of_year_first_work_week = Jan_1_JDN - ( ( Jan_1_JDN + 1 ) % 7 );
+    int start_of_other_year_first_work_week = other_Jan_1_JDN - ( ( other_Jan_1_JDN + 1 ) % 7 );
+    // Subtracting the JDNs results in the number of days between 2 dates
+    return ( ( start_of_year_first_work_week - start_of_other_year_first_work_week ) / 7 );
+}
+
+static unsigned days_in_month( unsigned year, unsigned month )
+{
+    if( month == 2 )
+    {
+        if( ( year % 400 == 0 ) || ( year % 4 == 0 && year % 100 != 0 ) )
+            return 29;
+        else
+            return 28;
+    }
+    // Months with 30 days
+    else if( month == 4 || month == 6 || month == 9 || month == 11 )
+        return 30;
+    else
+        return 31;
+}
+
+namespace rsutils {
+namespace time {
+
+work_week::work_week( unsigned year, unsigned ww )
+{
+    if( ww == 0 || ww > unsigned(work_weeks_between_years(year + 1, year)))
+    {
+        std::ostringstream message;
+        message << "Invalid work week given: " << year << " doesn't have a work week " << ww;
+        throw std::runtime_error(message.str());
+    }
+    _year = year;
+    _ww = ww;
+}
+
+work_week::work_week( const std::time_t & t )
+{
+    tm buf;
+#ifdef WIN32
+    localtime_s( &buf, &t );
+    auto time = &buf;
+#else
+    auto time = localtime_r( &t, &buf );
+#endif
+
+    _year = time->tm_year + 1900;  // The tm_year field contains the number of years
+                                   // since 1900, we add 1900 to get current year
+    int Jan_1_wday = ( time->tm_wday - time->tm_yday ) % 7;
+    if( Jan_1_wday < 0 )
+        Jan_1_wday += 7;
+    _ww = ( ( time->tm_yday + Jan_1_wday ) / 7 ) + 1;
+    // As explained in the header file, the last few days of a year may belong to work week 1 of the
+    // following year. This is the case if we are at the end of December, and the next year start
+    // before the week ends
+    if( _ww == 53 && ( 31 - time->tm_mday ) < ( 6 - time->tm_wday ) )
+    {
+        _year++;
+        _ww = 1;
+    }
+}
+
+unsigned work_week::get_year() const
+{
+    return _year;
+}
+
+unsigned work_week::get_work_week() const
+{
+    return _ww;
+}
+
+int work_week::operator-( const work_week & other ) const
+{
+    return work_weeks_between_years( _year, other._year ) + ( this->_ww - other._ww );
+}
+
+work_week work_week::current()
+{
+    auto t = std::time( nullptr );
+    return work_week( t );
+}
+
+unsigned get_work_weeks_since( const work_week & start )
+{
+    auto now = work_week::current();
+    unsigned age = now - start;
+    return age;
+}
+
+// Calculation is according to formula found in the link provided in the headet file
+unsigned jdn( unsigned year, unsigned month, unsigned day )
+{
+    if (month == 0 || day == 0 || month > 12 || day > days_in_month(year, month))
+    {
+        std::ostringstream message;
+        message << "Invalid date given: " << day << "/" << month << "/" << year;
+        throw std::runtime_error(message.str());
+    }
+    return ( ( 1461 * ( year + 4800 + ( ( (int)month - 14 ) / 12 ) ) ) / 4 )
+         + ( ( 367 * ( month - 2 - ( 12 * ( ( (int)month - 14 ) / 12 ) ) ) ) / 12 )
+         - ( ( 3 * ( ( year + 4900 + ( ( (int)month - 14 ) / 12 ) ) / 100 ) ) / 4 ) + day - 32075;
+}
+}  // namespace time
+}  // namespace rsutils

--- a/third-party/rsutils/src/work-week.cpp
+++ b/third-party/rsutils/src/work-week.cpp
@@ -1,5 +1,5 @@
 //// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+//// Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
 #include <rsutils/time/work-week.h>
 #include <string>
@@ -59,6 +59,8 @@ work_week::work_week( const std::time_t & t )
     auto time = &buf;
 #else
     auto time = localtime_r( &t, &buf );
+    if( ! time )
+        throw std::runtime_error( "failed to convert time_t to local time" );
 #endif
 
     _year = time->tm_year + 1900;  // The tm_year field contains the number of years


### PR DESCRIPTION
…e-factory architecture)

- Restore src/l500, src/algo (max-usable-range, thermal-loop), work-week utils from pre-removal commit dcc73153e^
- New l500-info.h following d400-info pattern (platform_device_info, create_device(), pick_l500_devices)
- Adapt all device/sensor classes: (ctx, group) -> dev_info ctors, virtual backend_device base, shared_ptr raw sensors, 2-arg hw_monitor with d400_hwmon_response, rsutils::lazy, fourcc, rs2_*_sptr callbacks
- Restore composite_processing_block into proc/synthetic-stream
- Timestamp readers use static time_service (create_time_service removed)
- Register RS2_PRODUCT_LINE_L500 in backend-device-factory and L515 recovery PID in fw-update-factory
- Drop dead code removed upstream: zero-order includes, AC ac_depth_results, depth_sensor recording overrides
- Rename rs500_device -> l500_rs500_device (collides with new d500 class)

<!--
    Pull requests should go to the development branch:
    https://github.com/realsenseai/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/realsenseai/librealsense/blob/master/CONTRIBUTING.md
-->
