### PR TITLE
Add d585 dedicated color GMSL support

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -103,8 +103,21 @@ namespace rs2
             auto supported_options = s->get_supported_option_values();
             for( rs2::option_value option : supported_options )
             {
-                options_metadata[option->id]
-                    = create_option_model( option, opt_base_label, this, s, options_invalidated, error_message );
+                // Build the model first and insert only on success: options that cannot be
+                // queried (e.g. a MIPI color control with no V4L2 CID mapping) throw here, and
+                // map::operator[] would otherwise leave a default-constructed (null-endpoint)
+                // entry that crashes subdevice_model::update(). Isolate per option so one bad
+                // control does not drop the rest.
+                try
+                {
+                    auto model = create_option_model( option, opt_base_label, this, s, options_invalidated, error_message );
+                    options_metadata[option->id] = std::move( model );
+                }
+                catch( const std::exception & e )
+                {
+                    if( viewer.not_model )
+                        viewer.not_model->add_log( e.what(), RS2_LOG_SEVERITY_WARN );
+                }
             }
 
             s->on_options_changed( [this]( const options_list & list )

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -253,16 +253,14 @@ std::vector< rs2_format > device::map_supported_color_formats( rs2_format source
     // Mapping from source color format to all of the compatible target color formats.
 
     std::vector<rs2_format> target_formats = { RS2_FORMAT_RGB8, RS2_FORMAT_RGBA8, RS2_FORMAT_BGR8, RS2_FORMAT_BGRA8 };
+
     switch (source_format)
     {
     case RS2_FORMAT_M420:
-        target_formats.push_back(RS2_FORMAT_M420);
-        break;
     case RS2_FORMAT_NV12:
-        target_formats.push_back(RS2_FORMAT_NV12);
+        should_map_source_format = true;
         break;
     case RS2_FORMAT_YUYV:
-        break;
     case RS2_FORMAT_UYVY:
         break;
     default:

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -145,11 +145,28 @@ namespace librealsense
         switch( _native_format )
         {
         case RS2_FORMAT_YUYV:
-            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
-                RS2_FORMAT_YUYV,
-                map_supported_color_formats( RS2_FORMAT_YUYV ),
-                RS2_STREAM_COLOR ) );
+        {
+            auto platform_dev = get_raw_color_sensor()->get_uvc_device();
+            if( _is_mipi_device && platform_dev->is_platform_jetson() )
+            {
+                // On Jetson deserializer bytes are received swapped so YUYV is received as UYVY.
+                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< uyvy_converter >(
+                    RS2_FORMAT_YUYV,
+                    map_supported_color_formats( RS2_FORMAT_YUYV, false ),
+                    RS2_STREAM_COLOR ) );
+                color_ep.register_processing_block( { { RS2_FORMAT_YUYV } },
+                                                    { { RS2_FORMAT_YUYV, RS2_STREAM_COLOR } },
+                                                    []() { return std::make_shared< uyvy_to_yuyv >(); } );
+            }
+            else
+            {
+                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
+                    RS2_FORMAT_YUYV,
+                    map_supported_color_formats( RS2_FORMAT_YUYV ),
+                    RS2_STREAM_COLOR ) );
+            }
             break;
+            }
         case RS2_FORMAT_M420:
         case RS2_FORMAT_NV12:
             // NV12 registered before M420 so RGB targets resolve to NV12 when present, and to M420 when it is not

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -76,7 +76,17 @@ namespace librealsense
         environment::get_instance().get_extrinsics_graph().register_extrinsics(*_color_stream, *_depth_stream, _color_extrinsic);
         register_stream_to_extrinsic_group(*_color_stream, 0);
 
-        std::vector<platform::uvc_device_info> color_devs_info = filter_by_mi(group.uvc_devices, 3);
+        std::vector<platform::uvc_device_info> color_devs_info;
+        if( _is_mipi_device )
+        {
+            // On MIPI the color is a dedicated video node enumerated at mi=0 (depth/color/ir all share
+            // mi=0, ordered depth, color, ir), not a separate mi=3 node as on USB.
+            auto mi0_infos = filter_by_mi( group.uvc_devices, 0 );
+            if( mi0_infos.size() >= 2 )
+                color_devs_info = { mi0_infos[1] };
+        }
+        else
+            color_devs_info = filter_by_mi( group.uvc_devices, 3 );
 
         if ( color_devs_info.empty() )
         {

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -180,7 +180,16 @@ namespace librealsense
 
         _ds_color_common->register_color_options();
 
-        std::map< float, std::string > description_per_value = std::map<float, std::string>{ 
+        // The D585 GMSL MIPI V4L2 backend has no working control for these color PUs
+        // (querying them fails), so drop them from the shared set rather than expose dead controls.
+        if( _is_mipi_device )
+        {
+            color_ep.unregister_option( RS2_OPTION_BRIGHTNESS );
+            color_ep.unregister_option( RS2_OPTION_CONTRAST );
+            color_ep.unregister_option( RS2_OPTION_GAMMA );
+        }
+
+        std::map< float, std::string > description_per_value = std::map<float, std::string>{
             { 0.f, "Disabled"},
             { 1.f, "50Hz" },
             { 2.f, "60Hz" } };
@@ -193,7 +202,8 @@ namespace librealsense
 
         _ds_color_common->register_standard_options();
 
-        color_ep.register_pu(RS2_OPTION_HUE);
+        if( ! _is_mipi_device ) // no V4L2 MIPI CID mapping for Hue
+            color_ep.register_pu(RS2_OPTION_HUE);
 
         if( _thermal_monitor )
             _thermal_monitor->add_observer( [&]( float ) { _color_calib_table_raw.reset(); } );

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -416,6 +416,7 @@ namespace librealsense
 
         auto raw_sensor = get_raw_depth_sensor();
         _pid = group.uvc_devices.front().pid;
+        _is_mipi_device = ( ds::d500_mipi_device_pid.count( _pid ) > 0 );
 
         _color_calib_table_raw = [this]()
         {
@@ -576,44 +577,53 @@ namespace librealsense
                 depth_sensor->register_option(RS2_OPTION_DEPTH_UNITS, depth_scale);
             }
 
-            // defining the temperature options
-            auto pvt_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
-                depth_xu,
-                DS5_HKR_PVT_TEMPERATURE,
-                "PVT Temperature");
-
-            auto ohm_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
-                depth_xu,
-                DS5_HKR_OHM_TEMPERATURE,
-                "OHM Temperature");
-
-            // registering the temperature options
-            depth_sensor.register_option(RS2_OPTION_SOC_PVT_TEMPERATURE, pvt_temperature);
-            depth_sensor.register_option(RS2_OPTION_OHM_TEMPERATURE, ohm_temperature);
-
-            if (d500_projector_temperature_pids.count(_pid))
+            // Temperature depth-XU selectors (PVT 0x15, OHM 0x17, Projector 0x16) have no CID in the
+            // MIPI V4L2 backend, so skip them on D585 GMSL.
+            if (_pid != D585_GMSL_PID)
             {
-                auto proj_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                // defining the temperature options
+                auto pvt_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
                     depth_xu,
-                    DS5_HKR_PROJECTOR_TEMPERATURE,
-                    "Projector Temperature");
-                depth_sensor.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE, proj_temperature);
+                    DS5_HKR_PVT_TEMPERATURE,
+                    "PVT Temperature");
+
+                auto ohm_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                    depth_xu,
+                    DS5_HKR_OHM_TEMPERATURE,
+                    "OHM Temperature");
+
+                // registering the temperature options
+                depth_sensor.register_option(RS2_OPTION_SOC_PVT_TEMPERATURE, pvt_temperature);
+                depth_sensor.register_option(RS2_OPTION_OHM_TEMPERATURE, ohm_temperature);
+
+                if (d500_projector_temperature_pids.count(_pid))
+                {
+                    auto proj_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                        depth_xu,
+                        DS5_HKR_PROJECTOR_TEMPERATURE,
+                        "Projector Temperature");
+                    depth_sensor.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE, proj_temperature);
+                }
             }
 
-            auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,
-                                                                               depth_xu,
-                                                                               DS5_ERROR_REPORTING,
-                                                                               "Error reporting" );
+            // Error-reporting depth-XU selector (0x07) has no CID in the MIPI V4L2 backend, so skip it on D585 GMSL.
+            if (_pid != D585_GMSL_PID)
+            {
+                auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,
+                                                                                   depth_xu,
+                                                                                   DS5_ERROR_REPORTING,
+                                                                                   "Error reporting" );
 
-            _polling_error_handler = std::make_shared< polling_error_handler >(
-                1000,
-                error_control,
-                std::weak_ptr<std::atomic<bool>>( _device_alive ),
-                raw_depth_sensor->get_notifications_processor(),
-                std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
+                _polling_error_handler = std::make_shared< polling_error_handler >(
+                    1000,
+                    error_control,
+                    std::weak_ptr<std::atomic<bool>>( _device_alive ),
+                    raw_depth_sensor->get_notifications_processor(),
+                    std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
 
-            depth_sensor.register_option( RS2_OPTION_ERROR_POLLING_ENABLED,
-                                          std::make_shared< polling_errors_disable >( _polling_error_handler ) );
+                depth_sensor.register_option( RS2_OPTION_ERROR_POLLING_ENABLED,
+                                              std::make_shared< polling_errors_disable >( _polling_error_handler ) );
+            }
 
         }); //group_multiple_fw_calls
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -580,7 +580,7 @@ namespace librealsense
             // Temperature depth-XU selectors (PVT 0x15, OHM 0x17, Projector 0x16) have no CID in the
             // MIPI V4L2 backend, so skip them on D585 GMSL.
             // TODO - to be solved XU
-            if (_pid != D585_GMSL_PID)
+            if (!_is_mipi_device)
             {
                 // defining the temperature options
                 auto pvt_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
@@ -609,7 +609,7 @@ namespace librealsense
 
             // Error-reporting depth-XU selector (0x07) has no CID in the MIPI V4L2 backend, so skip it on D585 GMSL.
             // TODO - to be solved XU
-            if (_pid != D585_GMSL_PID)
+            if (!_is_mipi_device)
             {
                 auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,
                                                                                    depth_xu,

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -579,6 +579,7 @@ namespace librealsense
 
             // Temperature depth-XU selectors (PVT 0x15, OHM 0x17, Projector 0x16) have no CID in the
             // MIPI V4L2 backend, so skip them on D585 GMSL.
+            // TODO - to be solved XU
             if (_pid != D585_GMSL_PID)
             {
                 // defining the temperature options
@@ -607,6 +608,7 @@ namespace librealsense
             }
 
             // Error-reporting depth-XU selector (0x07) has no CID in the MIPI V4L2 backend, so skip it on D585 GMSL.
+            // TODO - to be solved XU
             if (_pid != D585_GMSL_PID)
             {
                 auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -378,12 +378,6 @@ namespace librealsense
         depth_ep->register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, filter_by_mi(all_device_infos, 0).front().device_path);
 
         depth_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
-
-        depth_ep->register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 1));
-        depth_ep->register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Z16, RS2_STREAM_DEPTH));
-
-        depth_ep->register_processing_block({ {RS2_FORMAT_W10} }, { {RS2_FORMAT_RAW10, RS2_STREAM_INFRARED, 1} }, []() { return std::make_shared<w10_converter>(RS2_FORMAT_RAW10); });
-        depth_ep->register_processing_block({ {RS2_FORMAT_W10} }, { {RS2_FORMAT_Y10BPACK, RS2_STREAM_INFRARED, 1} }, []() { return std::make_shared<w10_converter>(RS2_FORMAT_Y10BPACK); });
         
         return depth_ep;
     }
@@ -506,18 +500,6 @@ namespace librealsense
 
             _is_symmetrization_enabled = check_symmetrization_enabled();
 
-            depth_sensor.register_processing_block(
-                { {RS2_FORMAT_Y8I} },
-                { {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 1} , {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 2} },
-                []() { return std::make_shared<y8i_to_y8y8>(); }
-            ); // L+R
-
-            depth_sensor.register_processing_block(
-                { RS2_FORMAT_Y16I },
-                { {RS2_FORMAT_Y16, RS2_STREAM_INFRARED, 1}, {RS2_FORMAT_Y16, RS2_STREAM_INFRARED, 2} },
-                []() {return std::make_shared<y16i_10msb_to_y16y16>(); }
-            );
-                
             pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
 
             _is_locked = _ds_device_common->is_locked( gvd_buff.data(), d500_gvd_offsets::is_camera_locked_offset );
@@ -733,6 +715,7 @@ namespace librealsense
         register_info( RS2_CAMERA_INFO_IMU_TYPE, gvd_parsed_fields.imu_type );
 
         register_features();
+        register_converters( depth_sensor );
 
         d500_auto_calibrated::add_depth_write_observer( [this]()
         {
@@ -747,6 +730,32 @@ namespace librealsense
 
         register_feature( std::make_shared< auto_exposure_roi_feature >( get_depth_sensor(), _hw_monitor ) );
     }
+
+    void d500_device::register_converters( synthetic_sensor & depth_sensor )
+    {
+        depth_sensor.register_processing_block( processing_block_factory::create_id_pbf(RS2_FORMAT_Z16, RS2_STREAM_DEPTH) );
+
+        // On MIPI/GMSL only Y8I is functional, Y8 for left IR only is not supported by FW.
+        if( ! _is_mipi_device )
+            depth_sensor.register_processing_block( processing_block_factory::create_id_pbf(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 1) );
+
+        depth_sensor.register_processing_block( { {RS2_FORMAT_Y8I} },
+                                                { {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 1} , {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 2} },
+                                                []() { return std::make_shared<y8i_to_y8y8>(); } ); // L+R
+
+        depth_sensor.register_processing_block( { RS2_FORMAT_Y16I },
+                                                { {RS2_FORMAT_Y16, RS2_STREAM_INFRARED, 1}, {RS2_FORMAT_Y16, RS2_STREAM_INFRARED, 2} },
+                                                []() {return std::make_shared<y16i_10msb_to_y16y16>(); } );
+
+        
+        depth_sensor.register_processing_block( { { RS2_FORMAT_W10 } },
+                                                { { RS2_FORMAT_RAW10, RS2_STREAM_INFRARED, 1 } },
+                                                []() { return std::make_shared< w10_converter >( RS2_FORMAT_RAW10 ); } );
+        depth_sensor.register_processing_block( { { RS2_FORMAT_W10 } },
+                                                { { RS2_FORMAT_Y10BPACK, RS2_STREAM_INFRARED, 1 } },
+                                                []() { return std::make_shared< w10_converter >( RS2_FORMAT_Y10BPACK ); } );
+    }
+
 
     platform::usb_spec d500_device::get_usb_spec() const
     {

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -173,5 +173,6 @@ namespace librealsense
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _color_extrinsic;
         bool _is_locked = true;
         bool _is_symmetrization_enabled = true;
+        bool _is_mipi_device = false;
     };
 }

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -142,6 +142,8 @@ namespace librealsense
 
         command get_firmware_logs_command() const;
 
+        void register_converters( synthetic_sensor & depth_sensor );
+
         void init(std::shared_ptr<context> ctx, const platform::backend_device_group& group);
         void register_features();
         void set_imu_type( const std::vector< uint8_t > & gvd_buf, ds::d500_gvd_parsed_fields * parsed_fields );

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -155,6 +155,59 @@ namespace librealsense
     };
 
 
+    // D585 GMSL (MIPI) variant with dedicated color sensor. On MIPI the color and IMU are exposed as
+    // separate V4L2 nodes, so this uses the single-color (d500_color) and UVC-motion (d500_motion_uvc)
+    // paths rather than the USB dual-color / HID-motion paths of rs5x5_device.
+    class rs5x5_gmsl_device
+        : public d500_active
+        , public d500_color
+        , public d500_motion_uvc
+        , public ds_advanced_mode_base
+        , public extended_firmware_logger_device
+    {
+    public:
+        rs5x5_gmsl_device( std::shared_ptr< const d500_info > const & dev_info )
+            : device( dev_info )
+            , backend_device( dev_info )
+            , d500_device( dev_info )
+            , d500_active( dev_info )
+            , d500_color( dev_info, RS2_FORMAT_YUYV )
+            , d500_motion_uvc( dev_info )
+            , ds_advanced_mode_base()
+            , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
+        {
+            ds_advanced_mode_base::initialize_advanced_mode( this );
+
+            // Improved Close Range Depth - USB toggle
+            // Disabled on D585 GMSL: the MIPI V4L2 backend has no CID for the close-range depth-XU selector (0x14).
+            //register_feature( std::make_shared< close_range_filter_feature >(
+            //        dynamic_cast< d500_depth_sensor & >( get_depth_sensor() ) ) );
+        }
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
+        {
+
+            std::vector< std::shared_ptr< stream_interface > > streams = { _depth_stream, _left_ir_stream, _right_ir_stream, _color_stream,
+                                                                           _ds_motion_common->get_accel_stream(),
+                                                                           _ds_motion_common->get_gyro_stream() };
+            return create_default_matcher( streams );
+        }
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+
+            tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_100, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+
+            return tags;
+        };
+    };
+
+
     // D585 or D535 with dedicated color sensor. Can be with IR filter on lens or without.
     class rs5x5_dedicated_color_device
         : public d500_active
@@ -432,6 +485,8 @@ namespace librealsense
             case ds::D585_2C_PID:
             case ds::D585_2C_PROTO_PID:
                 return std::make_shared< rs5x5_device >( dev_info );
+            case ds::D585_GMSL_PID:
+                return std::make_shared< rs5x5_gmsl_device >( dev_info );
             case ds::D535_3C_PID:
             case ds::D535F_PID:
             case ds::D585_3C_PID:

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -187,9 +187,12 @@ namespace librealsense
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
         {
 
-            std::vector< std::shared_ptr< stream_interface > > streams = { _depth_stream, _left_ir_stream, _right_ir_stream, _color_stream,
-                                                                           _ds_motion_common->get_accel_stream(),
-                                                                           _ds_motion_common->get_gyro_stream() };
+            std::vector< std::shared_ptr< stream_interface > > streams = { _depth_stream, _left_ir_stream, _right_ir_stream, _color_stream };
+            if( ! _has_motion_module_failed && _ds_motion_common )
+            {
+                streams.push_back( _ds_motion_common->get_accel_stream() );
+                streams.push_back( _ds_motion_common->get_gyro_stream() );
+            }
             return create_default_matcher( streams );
         }
 

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -156,12 +156,12 @@ namespace librealsense
 
 
     // D585 GMSL (MIPI) variant with dedicated color sensor. On MIPI the color and IMU are exposed as
-    // separate V4L2 nodes, so this uses the single-color (d500_color) and UVC-motion (d500_motion_uvc)
-    // paths rather than the USB dual-color / HID-motion paths of rs5x5_device.
+    // separate V4L2 nodes; d500_motion selects the UVC-motion path at runtime from _is_mipi_device,
+    // so this uses the single-color (d500_color) path rather than the USB dual-color path of rs5x5_device.
     class rs5x5_gmsl_dedicated_color_device
         : public d500_active
         , public d500_color
-        , public d500_motion_uvc
+        , public d500_motion
         , public ds_advanced_mode_base
         , public extended_firmware_logger_device
     {
@@ -171,8 +171,8 @@ namespace librealsense
             , backend_device( dev_info )
             , d500_device( dev_info )
             , d500_active( dev_info )
-            , d500_color( dev_info, RS2_FORMAT_YUYV )
-            , d500_motion_uvc( dev_info )
+            , d500_color( dev_info, RS2_FORMAT_NV12 )
+            , d500_motion( dev_info )
             , ds_advanced_mode_base()
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
@@ -228,7 +228,7 @@ namespace librealsense
             , backend_device( dev_info )
             , d500_device( dev_info )
             , d500_active( dev_info )
-            , d500_color( dev_info, RS2_FORMAT_M420 )
+            , d500_color( dev_info, RS2_FORMAT_NV12 )
             , d500_motion( dev_info )
             , d500_object_detection( dev_info )
             , ds_advanced_mode_base()

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -171,7 +171,7 @@ namespace librealsense
             , backend_device( dev_info )
             , d500_device( dev_info )
             , d500_active( dev_info )
-            , d500_color( dev_info, RS2_FORMAT_NV12 )
+            , d500_color( dev_info, RS2_FORMAT_YUYV )
             , d500_motion( dev_info )
             , ds_advanced_mode_base()
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -158,7 +158,7 @@ namespace librealsense
     // D585 GMSL (MIPI) variant with dedicated color sensor. On MIPI the color and IMU are exposed as
     // separate V4L2 nodes, so this uses the single-color (d500_color) and UVC-motion (d500_motion_uvc)
     // paths rather than the USB dual-color / HID-motion paths of rs5x5_device.
-    class rs5x5_gmsl_device
+    class rs5x5_gmsl_dedicated_color_device
         : public d500_active
         , public d500_color
         , public d500_motion_uvc
@@ -166,7 +166,7 @@ namespace librealsense
         , public extended_firmware_logger_device
     {
     public:
-        rs5x5_gmsl_device( std::shared_ptr< const d500_info > const & dev_info )
+        rs5x5_gmsl_dedicated_color_device( std::shared_ptr< const d500_info > const & dev_info )
             : device( dev_info )
             , backend_device( dev_info )
             , d500_device( dev_info )
@@ -200,8 +200,10 @@ namespace librealsense
             tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            // UVC motion requires accel and gyro at equal fps (see uvc_sensor::verify_supported_requests),
+            // so both defaults must match or the viewer fails to start the motion module.
             tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_100, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
         };
@@ -486,7 +488,7 @@ namespace librealsense
             case ds::D585_2C_PROTO_PID:
                 return std::make_shared< rs5x5_device >( dev_info );
             case ds::D585_GMSL_PID:
-                return std::make_shared< rs5x5_gmsl_device >( dev_info );
+                return std::make_shared< rs5x5_gmsl_dedicated_color_device >( dev_info );
             case ds::D535_3C_PID:
             case ds::D535F_PID:
             case ds::D585_3C_PID:

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -37,44 +37,17 @@ namespace librealsense
         {fourcc('G','R','E','Y'), RS2_STREAM_ACCEL},
     };
 
-    rs2_motion_device_intrinsic d500_motion_base::get_motion_intrinsics(rs2_stream stream) const
+    rs2_motion_device_intrinsic d500_motion::get_motion_intrinsics(rs2_stream stream) const
     {
         if( _has_motion_module_failed )
             throw std::runtime_error( "Motion module is not available on this device" );
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
-    double d500_motion_base::get_gyro_default_scale() const
+    double d500_motion::get_gyro_default_scale() const
     {
         // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
         return 0.003814697265625;
-    }
-
-    d500_motion_base::d500_motion_base( std::shared_ptr< const d500_info > const & dev_info )
-        : device( dev_info )
-        , d500_device( dev_info )
-    {
-        try
-        {
-            if (get_info(RS2_CAMERA_INFO_IMU_TYPE) == "IMU_Unknown")
-            {
-                throw std::runtime_error("Motion Sensor Failure - IMU type not recognized");
-            }
-            _ds_motion_common = std::make_shared<ds_motion_common>(this, _fw_version,
-                                                                   _device_capabilities, _hw_monitor);
-        }
-        catch (const std::exception& e)
-        {
-            _has_motion_module_failed = true;
-            auto device_name = get_info( RS2_CAMERA_INFO_NAME );
-            auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
-            {
-                LOG_ERROR( device_name << " #" << serial << " - Base Motion Sensor Failure! " << e.what() );
-                throw;
-            }
-            LOG_WARNING( device_name << " #" << serial << " - Base Motion Sensor Failure (continuing as partial device): " << e.what() );
-        }
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
@@ -86,29 +59,43 @@ namespace librealsense
     d500_motion::d500_motion( std::shared_ptr< const d500_info > const & dev_info )
         : device( dev_info )
         , d500_device( dev_info )
-        , d500_motion_base( dev_info )
     {
         try
         {
-            // in case d500_motion_base failed on exception
-            if (!_ds_motion_common)
-                throw std::runtime_error("Failed upstream");
+            if (get_info(RS2_CAMERA_INFO_IMU_TYPE) == "IMU_Unknown")
+                throw std::runtime_error("Motion Sensor Failure - IMU type not recognized");
+
+            _ds_motion_common = std::make_shared<ds_motion_common>(this, _fw_version,
+                                                                   _device_capabilities, _hw_monitor);
 
             using namespace ds;
 
-            std::vector<platform::hid_device_info> hid_infos = dev_info->get_group().hid_devices;
-
-            _ds_motion_common->init_motion(hid_infos.empty(), *_depth_stream);
-
 #if !defined(__APPLE__) // Motion sensors not supported on macOS
-            // Try to add HID endpoint
-            auto hid_ep = create_hid_device( dev_info->get_context(), dev_info->get_group().hid_devices );
-            if (hid_ep)
+            std::shared_ptr<synthetic_sensor> sensor_ep;
+            if( _is_mipi_device )
             {
-                _motion_module_device_idx = static_cast<uint8_t>(add_sensor(hid_ep));
+                // IMU is a UVC-based V4L2 node at mi=4. uvc_infos holds all UVC nodes, so gate motion on it specifically.
+                // When absent, degrade to a motionless device, mirroring the HID path's nullptr-on-empty behavior.
+                std::vector<platform::uvc_device_info> uvc_infos = dev_info->get_group().uvc_devices;
+                bool no_imu = filter_by_mi(uvc_infos, 4).empty();
+                _ds_motion_common->init_motion(no_imu, *_depth_stream);
+                if (no_imu)
+                    LOG_WARNING("No IMU node (mi=4) found, IMU is disabled");
+                else
+                    sensor_ep = create_uvc_device(dev_info->get_context(), uvc_infos);
+            }
+            else
+            {
+                // IMU is a HID device.
+                std::vector<platform::hid_device_info> hid_infos = dev_info->get_group().hid_devices;
+                _ds_motion_common->init_motion(hid_infos.empty(), *_depth_stream);
+                sensor_ep = create_hid_device( dev_info->get_context(), hid_infos );
+            }
 
-                // HID metadata attributes
-                hid_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
+            if (sensor_ep)
+            {
+                _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
+                sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
             }
 #endif
         }
@@ -119,16 +106,15 @@ namespace librealsense
             auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
             if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
             {
-                LOG_ERROR( device_name << " #" << serial << " - HID Motion Sensor Failure! " << e.what() );
+                LOG_ERROR( device_name << " #" << serial << " - Motion Sensor Failure! " << e.what() );
                 throw;
             }
-            LOG_WARNING( device_name << " #" << serial << " - HID Motion Sensor Failure (continuing as partial device): " << e.what() );
+            LOG_WARNING( device_name << " #" << serial << " - Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
     }
 
-    std::shared_ptr<synthetic_sensor> d500_motion_uvc::create_uvc_device( std::shared_ptr<context> ctx,
-        const std::vector<platform::uvc_device_info>& all_uvc_infos,
-        const firmware_version& camera_fw_version )
+    std::shared_ptr<synthetic_sensor> d500_motion::create_uvc_device( std::shared_ptr<context> ctx,
+        const std::vector<platform::uvc_device_info>& all_uvc_infos )
     {
         if (all_uvc_infos.empty())
         {
@@ -184,48 +170,7 @@ namespace librealsense
         return motion_ep;
     }
 
-    d500_motion_uvc::d500_motion_uvc( std::shared_ptr< const d500_info > const & dev_info )
-        : device( dev_info )
-        , d500_device( dev_info )
-        , d500_motion_base( dev_info )
-    {
-        try
-        {
-            // in case d500_motion_base failed on exception
-            if (!_ds_motion_common)
-                throw std::runtime_error("Failed upstream");
-
-            using namespace ds;
-
-            std::vector<platform::uvc_device_info> uvc_infos = dev_info->get_group().uvc_devices;
-
-            _ds_motion_common->init_motion(uvc_infos.empty(), *_depth_stream);
-
-#if !defined(__APPLE__) // Motion sensors not supported on macOS
-            auto sensor_ep = create_uvc_device(dev_info->get_context(), uvc_infos, _fw_version);
-            if (sensor_ep)
-            {
-                _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
-
-                sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
-            }
-#endif
-        }
-        catch (const std::exception& e)
-        {
-            _has_motion_module_failed = true;
-            auto device_name = get_info( RS2_CAMERA_INFO_NAME );
-            auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
-            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
-            {
-                LOG_ERROR( device_name << " #" << serial << " - UVC Motion Sensor Failure! " << e.what() );
-                throw;
-            }
-            LOG_WARNING( device_name << " #" << serial << " - UVC Motion Sensor Failure (continuing as partial device): " << e.what() );
-        }
-    }
-
-    void d500_motion_base::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)
+    void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)
     {
         device::register_stream_to_extrinsic_group(stream, group_index);
     }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -12,6 +12,8 @@
 
 #include <src/metadata.h>
 #include <src/context.h>
+#include <src/backend.h>
+#include <src/platform/platform-utils.h>
 #include "ds/ds-timestamp.h"
 #include "ds/ds-options.h"
 #include "ds/ds-private.h"
@@ -22,22 +24,57 @@
 #include "backend.h"
 #include <src/metadata-parser.h>
 
+#include <rsutils/type/fourcc.h>
+using rsutils::type::fourcc;
+
 using namespace librealsense;
 namespace librealsense
 {
-    
+    const std::map<fourcc::value_type, rs2_format> d500_motion_fourcc_to_rs2_format = {
+        {fourcc('G','R','E','Y'), RS2_FORMAT_MOTION_XYZ32F},
+    };
+    const std::map<fourcc::value_type, rs2_stream> d500_motion_fourcc_to_rs2_stream = {
+        {fourcc('G','R','E','Y'), RS2_STREAM_ACCEL},
+    };
 
-    rs2_motion_device_intrinsic d500_motion::get_motion_intrinsics(rs2_stream stream) const
+    rs2_motion_device_intrinsic d500_motion_base::get_motion_intrinsics(rs2_stream stream) const
     {
         if( _has_motion_module_failed )
             throw std::runtime_error( "Motion module is not available on this device" );
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
-    double d500_motion::get_gyro_default_scale() const
+    double d500_motion_base::get_gyro_default_scale() const
     {
         // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
         return 0.003814697265625;
+    }
+
+    d500_motion_base::d500_motion_base( std::shared_ptr< const d500_info > const & dev_info )
+        : device( dev_info )
+        , d500_device( dev_info )
+    {
+        try
+        {
+            if (get_info(RS2_CAMERA_INFO_IMU_TYPE) == "IMU_Unknown")
+            {
+                throw std::runtime_error("Motion Sensor Failure - IMU type not recognized");
+            }
+            _ds_motion_common = std::make_shared<ds_motion_common>(this, _fw_version,
+                                                                   _device_capabilities, _hw_monitor);
+        }
+        catch (const std::exception& e)
+        {
+            _has_motion_module_failed = true;
+            auto device_name = get_info( RS2_CAMERA_INFO_NAME );
+            auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - Base Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - Base Motion Sensor Failure (continuing as partial device): " << e.what() );
+        }
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
@@ -49,19 +86,18 @@ namespace librealsense
     d500_motion::d500_motion( std::shared_ptr< const d500_info > const & dev_info )
         : device( dev_info )
         , d500_device( dev_info )
+        , d500_motion_base( dev_info )
     {
         try
         {
-            if (get_info(RS2_CAMERA_INFO_IMU_TYPE) == "IMU_Unknown")
-            {
-                throw std::runtime_error("Motion Sensor Failure - IMU type not recognized");
-            }
+            // in case d500_motion_base failed on exception
+            if (!_ds_motion_common)
+                throw std::runtime_error("Failed upstream");
+
             using namespace ds;
 
             std::vector<platform::hid_device_info> hid_infos = dev_info->get_group().hid_devices;
 
-            _ds_motion_common = std::make_shared<ds_motion_common>(this, _fw_version,
-                                                                   _device_capabilities, _hw_monitor);
             _ds_motion_common->init_motion(hid_infos.empty(), *_depth_stream);
 
 #if !defined(__APPLE__) // Motion sensors not supported on macOS
@@ -88,10 +124,108 @@ namespace librealsense
             }
             LOG_WARNING( device_name << " #" << serial << " - HID Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
-
     }
 
-    void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)
+    std::shared_ptr<synthetic_sensor> d500_motion_uvc::create_uvc_device( std::shared_ptr<context> ctx,
+        const std::vector<platform::uvc_device_info>& all_uvc_infos,
+        const firmware_version& camera_fw_version )
+    {
+        if (all_uvc_infos.empty())
+        {
+            LOG_WARNING("No UVC info provided, IMU is disabled");
+            return nullptr;
+        }
+
+        std::vector<std::shared_ptr<platform::uvc_device>> imu_devices;
+        for (auto&& info : filter_by_mi(all_uvc_infos, 4)) // Filter just mi=4, IMU
+            imu_devices.push_back( get_backend()->create_uvc_device( info ) );
+
+        if (imu_devices.empty())
+            throw backend_exception("cannot access IMU sensor", RS2_EXCEPTION_TYPE_BACKEND);
+
+        std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
+        std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata_mipi_motion(std::move(timestamp_reader_backup)));
+
+        auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
+
+        auto raw_motion_ep = std::make_shared<uvc_sensor>("Raw IMU Sensor", std::make_shared<platform::multi_pins_uvc_device>(imu_devices),
+             std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(timestamp_reader_metadata), _tf_keeper, enable_global_time_option)), this);
+
+        auto motion_ep = std::make_shared<ds_motion_sensor>("Motion Module", raw_motion_ep, this,
+                                                            d500_motion_fourcc_to_rs2_format, d500_motion_fourcc_to_rs2_stream);
+
+        motion_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+
+        // register pre-processing
+        std::shared_ptr<enable_motion_correction> mm_correct_opt = nullptr;
+
+        auto mm_calib = _ds_motion_common->get_calib_handler();
+        //  Motion intrinsic calibration presents is a prerequisite for motion correction.
+        try
+        {
+            if (mm_calib)
+            {
+                mm_correct_opt = std::make_shared<enable_motion_correction>(motion_ep.get(),
+                    option_range{ 0, 1, 1, 1 });
+                motion_ep->register_option(RS2_OPTION_ENABLE_MOTION_CORRECTION, mm_correct_opt);
+            }
+        }
+        catch (...) {}
+
+        double gyro_scale_factor = get_gyro_default_scale();
+        bool high_accuracy = is_imu_high_accuracy();
+        motion_ep->register_processing_block(
+            { {RS2_FORMAT_MOTION_XYZ32F} },
+            { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL}, {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
+            [&, mm_calib, high_accuracy, mm_correct_opt, gyro_scale_factor]()
+            { return std::make_shared< motion_to_accel_gyro >( mm_calib, mm_correct_opt, gyro_scale_factor, high_accuracy );
+        });
+
+        return motion_ep;
+    }
+
+    d500_motion_uvc::d500_motion_uvc( std::shared_ptr< const d500_info > const & dev_info )
+        : device( dev_info )
+        , d500_device( dev_info )
+        , d500_motion_base( dev_info )
+    {
+        try
+        {
+            // in case d500_motion_base failed on exception
+            if (!_ds_motion_common)
+                throw std::runtime_error("Failed upstream");
+
+            using namespace ds;
+
+            std::vector<platform::uvc_device_info> uvc_infos = dev_info->get_group().uvc_devices;
+
+            _ds_motion_common->init_motion(uvc_infos.empty(), *_depth_stream);
+
+#if !defined(__APPLE__) // Motion sensors not supported on macOS
+            auto sensor_ep = create_uvc_device(dev_info->get_context(), uvc_infos, _fw_version);
+            if (sensor_ep)
+            {
+                _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
+
+                sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
+            }
+#endif
+        }
+        catch (const std::exception& e)
+        {
+            _has_motion_module_failed = true;
+            auto device_name = get_info( RS2_CAMERA_INFO_NAME );
+            auto serial = get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
+            if( ! ds::is_partial_device_allowed( dev_info->get_context() ) )
+            {
+                LOG_ERROR( device_name << " #" << serial << " - UVC Motion Sensor Failure! " << e.what() );
+                throw;
+            }
+            LOG_WARNING( device_name << " #" << serial << " - UVC Motion Sensor Failure (continuing as partial device): " << e.what() );
+        }
+    }
+
+    void d500_motion_base::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)
     {
         device::register_stream_to_extrinsic_group(stream, group_index);
     }

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -8,13 +8,10 @@
 
 namespace librealsense
 {
-    class d500_motion : public virtual d500_device
+    class d500_motion_base : public virtual d500_device
     {
     public:
-        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
-                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
-
-        d500_motion( std::shared_ptr< const d500_info > const & );
+        d500_motion_base( std::shared_ptr< const d500_info > const & );
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
@@ -26,16 +23,37 @@ namespace librealsense
         friend class ds_motion_sensor;
 
         std::shared_ptr<ds_motion_common> _ds_motion_common;
-        // Set when HID motion-sensor construction failed and the partial device
+        // Set when motion-sensor construction failed and the partial device
         // was allowed by the `partial-device-allowed` setting. Callers that
         // access `_ds_motion_common` (e.g. derived create_matcher) must gate on
         // this flag because `_ds_motion_common` remains null in the partial
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
 
+        optional_value<uint8_t> _motion_module_device_idx;
+
     private:
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);
+    };
 
-        optional_value<uint8_t> _motion_module_device_idx;
+    // HID-based motion (USB devices).
+    class d500_motion : public d500_motion_base
+    {
+    public:
+        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
+                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
+
+        d500_motion( std::shared_ptr< const d500_info > const & );
+    };
+
+    // UVC-based motion (MIPI/GMSL devices): the IMU is a V4L2 node at mi=4, not a HID device.
+    class d500_motion_uvc : public d500_motion_base
+    {
+    public:
+        d500_motion_uvc( std::shared_ptr< const d500_info > const & );
+
+        std::shared_ptr<synthetic_sensor> create_uvc_device( std::shared_ptr<context> ctx,
+            const std::vector<platform::uvc_device_info>& all_uvc_infos,
+            const firmware_version& camera_fw_version );
     };
 }

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -8,14 +8,21 @@
 
 namespace librealsense
 {
-    class d500_motion_base : public virtual d500_device
+    // Transport chosen at runtime according to d500_device::_is_mipi_device. HID device on USB, UVC-based V4L2 on GMSL.
+    class d500_motion : public virtual d500_device
     {
     public:
-        d500_motion_base( std::shared_ptr< const d500_info > const & );
+        d500_motion( std::shared_ptr< const d500_info > const & );
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
         double get_gyro_default_scale() const override;
+
+        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
+                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
+
+        std::shared_ptr<synthetic_sensor> create_uvc_device( std::shared_ptr<context> ctx,
+                                                             const std::vector<platform::uvc_device_info>& all_uvc_infos );
 
     protected:
         friend class ds_motion_common;
@@ -30,30 +37,9 @@ namespace librealsense
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
 
-        optional_value<uint8_t> _motion_module_device_idx;
-
     private:
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);
-    };
 
-    // HID-based motion (USB devices).
-    class d500_motion : public d500_motion_base
-    {
-    public:
-        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
-                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
-
-        d500_motion( std::shared_ptr< const d500_info > const & );
-    };
-
-    // UVC-based motion (MIPI/GMSL devices): the IMU is a V4L2 node at mi=4, not a HID device.
-    class d500_motion_uvc : public d500_motion_base
-    {
-    public:
-        d500_motion_uvc( std::shared_ptr< const d500_info > const & );
-
-        std::shared_ptr<synthetic_sensor> create_uvc_device( std::shared_ptr<context> ctx,
-            const std::vector<platform::uvc_device_info>& all_uvc_infos,
-            const firmware_version& camera_fw_version );
+        optional_value<uint8_t> _motion_module_device_idx;
     };
 }

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -31,7 +31,8 @@ namespace librealsense
         const uint16_t D585F_PID              = 0x0C06; // 3C with IR only L/R cover
         const uint16_t D585_2C_PROTO_PID      = 0x0C07;
         const uint16_t D585_3C_PROTO_PID      = 0x0C08;
-        
+        const uint16_t D585_GMSL_PID          = 0xBAAA; // D585 GMSL (MIPI)
+
         // DS500 depth XU identifiers
         // Note: selector values differ from the D400-family depth_xu selectors in ds-private.h.
         const uint8_t DS5_ALIGN_DEPTH              = 0x10;  // Enable depth-to-RGB alignment for OD distance; must be sent before depth streaming starts
@@ -51,7 +52,14 @@ namespace librealsense
             D585_3C_PID,
             D585F_PID,
             D585_2C_PROTO_PID,
-            D585_3C_PROTO_PID
+            D585_3C_PROTO_PID,
+            D585_GMSL_PID
+        };
+
+        // d500 MIPI (GMSL) devices - color and IMU are exposed as separate V4L2 nodes rather than
+        // the USB layout (color on a dedicated mi=3 node, IMU over HID).
+        static const std::set<std::uint16_t> d500_mipi_device_pid = {
+            D585_GMSL_PID
         };
 
         // d500 PIDs that expose the projector temperature via HKR selector 0x16
@@ -82,7 +90,8 @@ namespace librealsense
             { D585_3C_PID,            "RealSense D585" },
             { D585F_PID,              "RealSense D585F" },
             { D585_2C_PROTO_PID,      "RealSense D585 Proto Dual RGB" },
-            { D585_3C_PROTO_PID,      "RealSense D585 Prototype" }
+            { D585_3C_PROTO_PID,      "RealSense D585 Prototype" },
+            { D585_GMSL_PID,          "RealSense D585 GMSL" }
         };
 
         //TODO

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -63,7 +63,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_fisheye_calibration_table();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_fisheye_calibration_table();
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return dev->_ds_motion_common->get_fisheye_calibration_table();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -74,7 +74,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_fisheye_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_fisheye_stream();
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return dev->_ds_motion_common->get_fisheye_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -152,7 +152,7 @@ namespace librealsense
             return dev->get_motion_intrinsics(stream);
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->get_motion_intrinsics(stream);
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return dev->get_motion_intrinsics( stream );
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -194,7 +194,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_accel_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_accel_stream();
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return dev->_ds_motion_common->get_accel_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -205,7 +205,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_gyro_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_gyro_stream();
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return dev->_ds_motion_common->get_gyro_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -306,7 +306,7 @@ namespace librealsense
             return filter_d400_device_by_capability(devices, ds::ds_caps::CAP_FISHEYE_SENSOR);
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return filter_d400_device_by_capability(devices, ds::ds_caps::CAP_FISHEYE_SENSOR);
-        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
             return std::vector< platform::uvc_device_info >();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -371,7 +371,7 @@ namespace librealsense
             dev->register_stream_to_extrinsic_group(*_gyro_stream, 0);
             dev->register_stream_to_extrinsic_group(*_accel_stream, 0);
         }
-        else if( auto dev = dynamic_cast< d500_motion_base * >( _owner ) )
+        else if( auto dev = dynamic_cast< d500_motion * >( _owner ) )
         {
             dev->register_stream_to_extrinsic_group( *_gyro_stream, 0 );
             dev->register_stream_to_extrinsic_group( *_accel_stream, 0 );

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -63,7 +63,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_fisheye_calibration_table();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_fisheye_calibration_table();
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return dev->_ds_motion_common->get_fisheye_calibration_table();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -74,7 +74,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_fisheye_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_fisheye_stream();
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return dev->_ds_motion_common->get_fisheye_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -152,7 +152,7 @@ namespace librealsense
             return dev->get_motion_intrinsics(stream);
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->get_motion_intrinsics(stream);
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return dev->get_motion_intrinsics( stream );
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -194,7 +194,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_accel_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_accel_stream();
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return dev->_ds_motion_common->get_accel_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -205,7 +205,7 @@ namespace librealsense
             return dev->_ds_motion_common->get_gyro_stream();
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return dev->_ds_motion_common->get_gyro_stream();
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return dev->_ds_motion_common->get_gyro_stream();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -306,7 +306,7 @@ namespace librealsense
             return filter_d400_device_by_capability(devices, ds::ds_caps::CAP_FISHEYE_SENSOR);
         if (auto dev = dynamic_cast<const d400_motion_uvc*>(_owner))
             return filter_d400_device_by_capability(devices, ds::ds_caps::CAP_FISHEYE_SENSOR);
-        if( auto dev = dynamic_cast< const d500_motion * >( _owner ) )
+        if( auto dev = dynamic_cast< const d500_motion_base * >( _owner ) )
             return std::vector< platform::uvc_device_info >();
         throw std::runtime_error("device not referenced in the product line");
     }
@@ -371,7 +371,7 @@ namespace librealsense
             dev->register_stream_to_extrinsic_group(*_gyro_stream, 0);
             dev->register_stream_to_extrinsic_group(*_accel_stream, 0);
         }
-        else if( auto dev = dynamic_cast< d500_motion * >( _owner ) )
+        else if( auto dev = dynamic_cast< d500_motion_base * >( _owner ) )
         {
             dev->register_stream_to_extrinsic_group( *_gyro_stream, 0 );
             dev->register_stream_to_extrinsic_group( *_accel_stream, 0 );

--- a/src/ds/ds-options.cpp
+++ b/src/ds/ds-options.cpp
@@ -378,6 +378,9 @@ namespace librealsense
     float depth_scale_option::query() const
     {
         auto table = get_depth_table(ds::GET_VAL);
+        // TODO D585 MIPI: proto FW reports depth_units=0 over GMSL; fall back to 1mm default until FW/HWM is fixed.
+        if( table.depth_units == 0 )
+            return 0.001f;
         return (float)(0.000001 * (float)table.depth_units);
     }
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1010,7 +1010,6 @@ namespace librealsense
             const uint8_t GVD_PID_D401_GMSL = 0x13;
             const uint8_t GVD_PID_D430_GMSL = 0x0F;
             const uint8_t GVD_PID_D415_GMSL = 0x06;
-            const uint8_t GVD_PID_D585      = 0x25;
 
             // device PID
             uint16_t device_pid = 0;
@@ -1050,6 +1049,16 @@ namespace librealsense
                         opcode_ok = true;
                     }
 
+                    // d500 MIPI (e.g. D585 GMSL) uses a different GVD layout than d400 GMSL:
+                    // byte 8 holds the CRC32, and the RealSense VID/PID are embedded at bytes 16-19.
+                    // TODO - temp WA for D585 GMSL, until the GVD layout is fixed to match the D400 GMSL layout
+                    uint16_t embedded_vid = gvd[16] | ( gvd[17] << 8 );
+                    if( embedded_vid == 0x38e5 ) // RealSense VID identifies the d500 GMSL family
+                    {
+                        device_pid = D585_GMSL_PID;
+                        continue;
+                    }
+
                     uint8_t product_pid = gvd[4 + GVD_PID_OFFSET];
 
                     switch(product_pid)
@@ -1068,10 +1077,6 @@ namespace librealsense
 
                         case(GVD_PID_D401_GMSL):
                             device_pid = D401_GMSL_PID;
-                            break;
-
-                        case(GVD_PID_D585):
-                            device_pid = D585_GMSL_PID;
                             break;
 
                         default:

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1128,6 +1128,11 @@ namespace librealsense
             ::close(fd);
         }
 
+        // PID of the current MIPI camera: derived from its depth node and inherited by the
+        // camera color/IR/IMU nodes. Reset per-camera in get_mipi_rs_enum_nodes so a camera
+        // without a readable depth node cannot inherit a previous camera PID.
+        static uint16_t s_mipi_camera_pid = 0;
+
         uvc_device_info v4l_uvc_device::get_info_from_mipi_device_path(const std::string& video_path, const std::string& name)
         {
             uint16_t vid{}, pid{}, mi{};
@@ -1140,22 +1145,21 @@ namespace librealsense
 
             vid = 0x8086;
 
-            // find device PID from depth video node
-            static uint16_t device_pid = 0;
+            // find device PID from depth video node (see s_mipi_camera_pid)
             try
             {
                 if (is_device_depth_node(dev_name))
                 {
-                    device_pid = get_mipi_device_pid(dev_name);
+                    s_mipi_camera_pid = get_mipi_device_pid(dev_name);
                 }
             }
             catch(const std::exception & e)
             {
                 LOG_WARNING("MIPI device product id detection issue, device will be skipped: " << e.what());
-                device_pid = 0;
+                s_mipi_camera_pid = 0;
             }
 
-            pid = device_pid;
+            pid = s_mipi_camera_pid;
             if (pid == D585_GMSL_PID)
                 vid = 0x38e5; // D585 GMSL uses RealSense VID
             
@@ -1298,6 +1302,7 @@ namespace librealsense
             const int MAX_V4L2_DEVICES = 8; // assume maximum 8 mipi devices
 
             for ( int i = 0; i < MAX_V4L2_DEVICES; i++ ) {
+                s_mipi_camera_pid = 0; // reset per camera; depth node sets it, siblings inherit
                 for (const auto &vs: video_sensors) {
                     int vfd = -1;
                     std::string device_path = "video-rs-" + vs + "-" + std::to_string(i);

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1010,6 +1010,7 @@ namespace librealsense
             const uint8_t GVD_PID_D401_GMSL = 0x13;
             const uint8_t GVD_PID_D430_GMSL = 0x0F;
             const uint8_t GVD_PID_D415_GMSL = 0x06;
+            const uint8_t GVD_PID_D585      = 0x25;
 
             // device PID
             uint16_t device_pid = 0;
@@ -1067,6 +1068,10 @@ namespace librealsense
 
                         case(GVD_PID_D401_GMSL):
                             device_pid = D401_GMSL_PID;
+                            break;
+
+                        case(GVD_PID_D585):
+                            device_pid = D585_GMSL_PID;
                             break;
 
                         default:
@@ -1128,6 +1133,8 @@ namespace librealsense
 
             get_mipi_device_info(dev_name, bus_info, card);
 
+            vid = 0x8086;
+
             // find device PID from depth video node
             static uint16_t device_pid = 0;
             try
@@ -1143,8 +1150,10 @@ namespace librealsense
                 device_pid = 0;
             }
 
-            vid = 0x8086;
             pid = device_pid;
+            if (pid == D585_GMSL_PID)
+                vid = 0x38e5; // D585 GMSL uses RealSense VID
+            
 
 //          std::cout << "video_path:" << video_path << ", name:" << dev_name << ", pid=" << std::hex << (int) pid << std::endl;
 

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -511,11 +511,14 @@ namespace librealsense
         const uint16_t D415_GMSL_PID = 0xABCF;
         const uint16_t D401_GMSL_PID = 0xABCC;
 
+        const uint16_t D585_GMSL_PID = 0xBAAA;
+
         static const std::set<std::uint16_t> mipi_devices_pid = {
             D457_PID,
             D430_GMSL_PID,
             D415_GMSL_PID,
-            D401_GMSL_PID
+            D401_GMSL_PID,
+            D585_GMSL_PID
         };
 
         // D457 Development. To be merged into underlying class

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -177,7 +177,7 @@ namespace librealsense
         else
         {
             _converter = std::make_unique< converter_16_bit_mipi >( deg2rad( gyro_scale_factor ) );
-            _accel_converter = std::make_unique< converter_32_bit_mipi >( accelerator_scale_factor );
+            _accel_converter = std::make_unique< converter_16_bit_mipi >( accelerator_scale_factor );
         }
         configure_processing_callback();
     }


### PR DESCRIPTION
**Overview**:
Initial D585-over-GMSL support — the camera is identified, a device object builds, and Depth/IR/Color stream over GMSL

Tracked on [RSDEV-9251] and [RSDEV-9250]

**Summary**
**Identify D585/GMSL**: synthetic MIPI PID D585_GMSL_PID; V4L2 backend derives it from GVD (RealSense VID 0x38e5); added to D500 SKU set/names + new d500_mipi_device_pid.
**Device build**: new rs5x5_gmsl_dedicated_color_device (uses d500_color YUYV + UVC-based motion d500_motion_uvc); d500_motion refactored into d500_motion_base + HID/UVC variants; factory routes the GMSL PID.
**MIPI adaptations**: _is_mipi_device flag; color node taken at mi=0; skip depth/color XU options that have no MIPI V4L2 CID.
Depth units work-around: fall back to 1 mm when FW reports depth_units=0 over GMSL (ds-options.cpp, TODO D585 MIPI).
**Viewer**: guard per-option model creation so an unqueryable MIPI control doesn't drop the rest.

**Test** plan
Enumerates over GMSL on Jetson → “RealSense D585 GMSL” - done
Depth + IR (1280×720) stream with valid depth distances  - done
Color streaming - done.
known intermittent camera-FW hang on when streaming depth+IR+color. Handled in another ticket (FW side).


🤖 Generated by AI
