### PR TITLE
d500: register Gyro Sensitivity option on USB for D500 devices

### DIFF
--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -437,10 +437,6 @@ namespace librealsense
                 register_feature( std::make_shared< close_range_filter_feature >(
                     dynamic_cast< d500_depth_sensor & >( depth_sensor ) ) );
             }
-
-#if !defined(__APPLE__)
-            register_gyro_sensitivity();
-#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -437,6 +437,10 @@ namespace librealsense
                 register_feature( std::make_shared< close_range_filter_feature >(
                     dynamic_cast< d500_depth_sensor & >( depth_sensor ) ) );
             }
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -48,8 +48,14 @@ namespace librealsense
 
     double d500_motion::get_gyro_default_scale() const
     {
-        // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
-        return 0.003814697265625;
+        if( get_pid() == ds::D585S_PID )
+        {
+            // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
+            return 0.003814697265625;
+        }
+        // Non-D585S D5X5: mirror d400_motion_base::get_gyro_default_scale() for FW >= 5.16 — FW ships values
+        // pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000) yields [deg/sec].
+        return 0.0001;
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
@@ -99,6 +105,10 @@ namespace librealsense
                 _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
                 sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
                 register_gyro_sensitivity();
+                // Non-D585S D5X5: mirror d400_motion FW >= 5.16 — mf-hid multiplies raw HID values by 10000
+                // to undo the FW's 1000-scale packing, so combined with get_gyro_default_scale() = 0.0001 the pipeline gets [deg/sec].
+                if( get_pid() != D585S_PID )
+                    get_raw_motion_sensor()->set_gyro_scale_factor( 10000.0 );
             }
 #endif
         }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -23,6 +23,8 @@
 #include "proc/auto-exposure-processor.h"
 #include "backend.h"
 #include <src/metadata-parser.h>
+#include <src/hid-sensor.h>
+#include <src/ds/features/gyro-sensitivity-feature.h>
 
 #include <rsutils/type/fourcc.h>
 using rsutils::type::fourcc;
@@ -168,6 +170,33 @@ namespace librealsense
         });
 
         return motion_ep;
+    }
+
+    ds_motion_sensor & d500_motion::get_motion_sensor()
+    {
+#if defined(__APPLE__)
+        throw std::runtime_error( "Motion sensors are not supported on macOS" );
+#else
+        return dynamic_cast< ds_motion_sensor & >( get_sensor( _motion_module_device_idx.value() ) );
+#endif
+    }
+
+    std::shared_ptr< hid_sensor > d500_motion::get_raw_motion_sensor()
+    {
+#if defined(__APPLE__)
+        return nullptr;
+#else
+        auto raw_sensor = get_motion_sensor().get_raw_sensor();
+        return std::dynamic_pointer_cast< hid_sensor >( raw_sensor );
+#endif
+    }
+
+    void d500_motion::register_gyro_sensitivity()
+    {
+        // FW gate matches the D500 version that added Gyro Sensitivity support (first seen exposed via DDS/PoE on D555).
+        if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
+            register_feature(
+                std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
     }
 
     void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -98,6 +98,7 @@ namespace librealsense
             {
                 _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
                 sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
+                register_gyro_sensitivity();
             }
 #endif
         }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -105,9 +105,11 @@ namespace librealsense
                 _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
                 sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
                 register_gyro_sensitivity();
-                // Non-D585S D5X5: mirror d400_motion FW >= 5.16 — mf-hid multiplies raw HID values by 10000
-                // to undo the FW's 1000-scale packing, so combined with get_gyro_default_scale() = 0.0001 the pipeline gets [deg/sec].
-                if( get_pid() != D585S_PID )
+                // Non-D585S D5X5 on the HID (USB) path: mirror d400_motion FW >= 5.16 — mf-hid multiplies raw HID
+                // values by 10000 to undo the FW's 1000-scale packing, so combined with get_gyro_default_scale() = 0.0001
+                // the pipeline gets [deg/sec]. Skip on MIPI/UVC (get_raw_motion_sensor() returns nullptr on that path)
+                // and on D585S (its own scale flow).
+                if( get_pid() != D585S_PID && ! _is_mipi_device )
                     get_raw_motion_sensor()->set_gyro_scale_factor( 10000.0 );
             }
 #endif
@@ -204,6 +206,11 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
+        // D585S uses a different FW versioning line (8.58.x) and a different gyro output format; skip.
+        // MIPI/UVC transport has no HID feature-report path, so the option would register with a null
+        // backing hid_sensor and fail on every set() — skip too.
+        if( get_pid() == ds::D585S_PID || _is_mipi_device )
+            return;
         if( _fw_version >= firmware_version( "7.58.40672.12546" ) && ! _has_motion_module_failed )
             register_feature(
                 std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -193,7 +193,6 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        // FW gate matches the D500 version that added Gyro Sensitivity support (first seen exposed via DDS/PoE on D555).
         if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
             register_feature(
                 std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -48,16 +48,13 @@ namespace librealsense
 
     double d500_motion::get_gyro_default_scale() const
     {
-        // MIPI/UVC transport (D585 GMSL) and D585S both output raw register values that require the physical-range
-        // scale to be applied end-to-end here — there is no mf-hid multiplication on the UVC path, and D585S has
-        // its own raw-16-bit-register format regardless of transport. Dynamic range +/-125 [deg/sec] --> 250/65536.
+        // Raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB].
+        // Used by D585S (its own flow) and MIPI/UVC (gyro sensitivity not supported there).
         if( _is_mipi_device || get_pid() == ds::D585S_PID )
         {
             return 0.003814697265625;
         }
-        // Non-D585S D5X5 on the HID (USB) path: mirror d400_motion_base::get_gyro_default_scale() for FW >= 5.16 —
-        // FW ships values pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000)
-        // yields [deg/sec].
+        // Cameras on the HID (USB) path: FW ships values pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000) yields [deg/sec].
         return 0.0001;
     }
 
@@ -108,10 +105,9 @@ namespace librealsense
                 _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
                 sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
                 register_gyro_sensitivity();
-                // Non-D585S D5X5 on the HID (USB) path: mirror d400_motion FW >= 5.16 — mf-hid multiplies raw HID
-                // values by 10000 to undo the FW's 1000-scale packing, so combined with get_gyro_default_scale() = 0.0001
-                // the pipeline gets [deg/sec]. Skip on MIPI/UVC (get_raw_motion_sensor() returns nullptr on that path)
-                // and on D585S (its own scale flow).
+                // Cameras on the HID (USB) path: mf-hid multiplies raw HID values by 10000 to undo the FW's 1000-scale packing.
+                // Combined with get_gyro_default_scale() = 0.0001 the pipeline gets [deg/sec].
+                // Skip on MIPI/UVC (get_raw_motion_sensor() returns nullptr on that path) and on D585S (its own scale flow).
                 if( get_pid() != D585S_PID && ! _is_mipi_device )
                     get_raw_motion_sensor()->set_gyro_scale_factor( 10000.0 );
             }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -193,7 +193,7 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
+        if( _fw_version >= firmware_version( "7.58.40672.12546" ) && ! _has_motion_module_failed )
             register_feature(
                 std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
     }

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -48,13 +48,16 @@ namespace librealsense
 
     double d500_motion::get_gyro_default_scale() const
     {
-        if( get_pid() == ds::D585S_PID )
+        // MIPI/UVC transport (D585 GMSL) and D585S both output raw register values that require the physical-range
+        // scale to be applied end-to-end here — there is no mf-hid multiplication on the UVC path, and D585S has
+        // its own raw-16-bit-register format regardless of transport. Dynamic range +/-125 [deg/sec] --> 250/65536.
+        if( _is_mipi_device || get_pid() == ds::D585S_PID )
         {
-            // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
             return 0.003814697265625;
         }
-        // Non-D585S D5X5: mirror d400_motion_base::get_gyro_default_scale() for FW >= 5.16 — FW ships values
-        // pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000) yields [deg/sec].
+        // Non-D585S D5X5 on the HID (USB) path: mirror d400_motion_base::get_gyro_default_scale() for FW >= 5.16 —
+        // FW ships values pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000)
+        // yields [deg/sec].
         return 0.0001;
     }
 

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -26,9 +26,6 @@ namespace librealsense
         std::shared_ptr<synthetic_sensor> create_uvc_device( std::shared_ptr<context> ctx,
                                                              const std::vector<platform::uvc_device_info>& all_uvc_infos );
 
-        ds_motion_sensor & get_motion_sensor();
-        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
-
     protected:
         friend class ds_motion_common;
         friend class ds_fisheye_sensor;
@@ -42,6 +39,8 @@ namespace librealsense
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
 
+        ds_motion_sensor & get_motion_sensor();
+        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
         void register_gyro_sensitivity();
 
     private:

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -8,6 +8,8 @@
 
 namespace librealsense
 {
+    class hid_sensor;
+
     // Transport chosen at runtime according to d500_device::_is_mipi_device. HID device on USB, UVC-based V4L2 on GMSL.
     class d500_motion : public virtual d500_device
     {
@@ -24,6 +26,9 @@ namespace librealsense
         std::shared_ptr<synthetic_sensor> create_uvc_device( std::shared_ptr<context> ctx,
                                                              const std::vector<platform::uvc_device_info>& all_uvc_infos );
 
+        ds_motion_sensor & get_motion_sensor();
+        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
+
     protected:
         friend class ds_motion_common;
         friend class ds_fisheye_sensor;
@@ -36,6 +41,8 @@ namespace librealsense
         // this flag because `_ds_motion_common` remains null in the partial
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
+
+        void register_gyro_sensitivity();
 
     private:
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -30,8 +30,10 @@ def test_gyro_sensitivity_all_levels(test_device):
         cfg.enable_stream(rs.stream.accel)
         cfg.enable_stream(rs.stream.gyro)
 
-        profile = pipe.start(cfg)
-        sensor = profile.get_device().first_motion_sensor()
-        readback = sensor.get_option(rs.option.gyro_sensitivity)
-        assert readback == expected, f"level {value}: readback {readback}"
-        pipe.stop()
+        try:
+            profile = pipe.start(cfg)
+            sensor = profile.get_device().first_motion_sensor()
+            readback = sensor.get_option(rs.option.gyro_sensitivity)
+            assert readback == expected, f"level {value}: readback {readback}"
+        finally:
+            pipe.stop()

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D455"),
-    pytest.mark.device_each("D555"),
+    pytest.mark.device_each("D500*"),
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
 

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -1,0 +1,37 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import pytest
+import platform
+import pyrealsense2 as rs
+import logging
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.device_each("D455"),
+    pytest.mark.device_each("D555"),
+    pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
+]
+
+
+def test_gyro_sensitivity_all_levels(test_device):
+    dev, ctx = test_device
+    motion_sensor = dev.first_motion_sensor()
+    if not motion_sensor.supports(rs.option.gyro_sensitivity):
+        pytest.skip("Gyro Sensitivity option not supported on this device/FW")
+
+    for value in range(5):  # RS2_GYRO_SENSITIVITY_* enum: 0..4
+        expected = float(value)
+        motion_sensor.set_option(rs.option.gyro_sensitivity, expected)
+
+        pipe = rs.pipeline(ctx)
+        pipe.set_device(dev)
+        cfg = rs.config()
+        cfg.enable_stream(rs.stream.accel)
+        cfg.enable_stream(rs.stream.gyro)
+
+        profile = pipe.start(cfg)
+        sensor = profile.get_device().first_motion_sensor()
+        readback = sensor.get_option(rs.option.gyro_sensitivity)
+        assert readback == expected, f"level {value}: readback {readback}"
+        pipe.stop()

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D455"),
     pytest.mark.device_each("D500*"),
+    pytest.mark.device_type_exclude("DDS"),  # USB-focused: DDS advertises the option through a separate transport
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
 
@@ -30,10 +31,13 @@ def test_gyro_sensitivity_all_levels(test_device):
         cfg.enable_stream(rs.stream.accel)
         cfg.enable_stream(rs.stream.gyro)
 
+        started = False
         try:
             profile = pipe.start(cfg)
+            started = True
             sensor = profile.get_device().first_motion_sensor()
             readback = sensor.get_option(rs.option.gyro_sensitivity)
             assert readback == expected, f"level {value}: readback {readback}"
         finally:
-            pipe.stop()
+            if started:
+                pipe.stop()

--- a/unit-tests/live/options/pytest-pipeline-set-device.py
+++ b/unit-tests/live/options/pytest-pipeline-set-device.py
@@ -1,8 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2024 RealSense, Inc. All Rights Reserved.
 
-# LibCI doesn't have D435i so //test:device D435I// is disabled for now
-
 import pytest
 import platform
 import pyrealsense2 as rs
@@ -10,7 +8,8 @@ import logging
 log = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.device("D455"),
+    pytest.mark.device_each("D455"),
+    pytest.mark.device_each("D555"),
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
 
@@ -20,6 +19,8 @@ gyro_sensitivity_value = 4.0
 def test_pipeline_set_device(test_device):
     dev, ctx = test_device
     motion_sensor = dev.first_motion_sensor()
+    if not motion_sensor.supports(rs.option.gyro_sensitivity):
+        pytest.skip("Gyro Sensitivity option not supported on this device/FW")
     pipe = rs.pipeline(ctx)
     pipe.set_device(dev)
 

--- a/unit-tests/live/options/pytest-pipeline-set-device.py
+++ b/unit-tests/live/options/pytest-pipeline-set-device.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D455"),
     pytest.mark.device_each("D555"),
+    pytest.mark.device_type_exclude("DDS"),  # USB-focused: DDS advertises the option through a separate transport
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
 

--- a/unit-tests/live/options/pytest-pipeline-set-device.py
+++ b/unit-tests/live/options/pytest-pipeline-set-device.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.device_each("D455"),
-    pytest.mark.device_each("D555"),
+    pytest.mark.device_each("D500*"),
     pytest.mark.device_type_exclude("DDS"),  # USB-focused: DDS advertises the option through a separate transport
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
@@ -31,9 +31,14 @@ def test_pipeline_set_device(test_device):
     cfg.enable_stream(rs.stream.accel)
     cfg.enable_stream(rs.stream.gyro)
 
-    profile = pipe.start(cfg)
-    device_from_profile = profile.get_device()
-    sensor = device_from_profile.first_motion_sensor()
-    sensor_gyro_sensitivity_value = sensor.get_option(rs.option.gyro_sensitivity)
-    assert gyro_sensitivity_value == sensor_gyro_sensitivity_value
-    pipe.stop()
+    started = False
+    try:
+        profile = pipe.start(cfg)
+        started = True
+        device_from_profile = profile.get_device()
+        sensor = device_from_profile.first_motion_sensor()
+        sensor_gyro_sensitivity_value = sensor.get_option(rs.option.gyro_sensitivity)
+        assert gyro_sensitivity_value == sensor_gyro_sensitivity_value
+    finally:
+        if started:
+            pipe.stop()


### PR DESCRIPTION
Tracked by: RSDEV-11755

**Overview:** Expose the "Gyro Sensitivity" motion-sensor option for D500 USB non-D585S SKUs, matching what the DDS/PoE path already advertises. Also aligns the D500 USB gyro scale-factor flow with the D400 FW ≥ 5.16 flow so reported deg/s values are physically consistent across the sensitivity range.

## Why
D555 FW 7.58.40672.12546 exposes the Gyro Sensitivity option over DDS/PoE, but the LRS D500 USB path never registered it — so realsense-viewer on D555 USB was missing the control. The plumbing (`gyro_sensitivity_feature`, `gyro_sensitivity_option`, HID feature-report path) is already shared; only the family-specific registration call was missing.

Additionally, `get_gyro_default_scale()` was hard-coded to D585S's raw-16-bit-ADC scale (0.003814697265625), which is D585S-specific. Non-D585S D500 USB FW ships gyro values pre-scaled by 1000 in the HID feature report; non-D585S USB now uses `0.0001` combined with `set_gyro_scale_factor(10000)`. D585S and MIPI/UVC paths keep the raw-ADC scale (no mf-hid multiplication on UVC, and D585S has its own output format).

## Summary
- `d500_motion::register_gyro_sensitivity()` — gated on FW ≥ 7.58.40672.12546, `!_has_motion_module_failed`, non-D585S, non-MIPI. Called from `d500_motion` ctor so all D5X5 USB non-D585S subclasses register the option automatically.
- `d500_motion::get_gyro_default_scale()` — returns `0.0001` on USB non-D585S, `0.003814697265625` on MIPI/UVC and D585S.
- `d500_motion` ctor calls `set_gyro_scale_factor(10000.0)` on the raw motion sensor for USB non-D585S.
- `d500_motion` exposes `get_motion_sensor()` / `get_raw_motion_sensor()` accessors (protected).
- Move the existing D455-only round-trip test from `unit-tests/live/d400/` to `unit-tests/live/options/` and broaden to D455 + D500* via stacked `device_each` marks, plus a `supports()` capability skip so D585S/MIPI safely skip.
- New `pytest-gyro-sensitivity-levels.py` iterates all five sensitivity levels (0..4) with pipeline start/stop per level on D455 + D500*, so FW acceptance is exercised — not just the LRS-side cache.

## Test plan

### LRS pytest coverage
- [x] `pytest -v --device D555 unit-tests/live/options/pytest-pipeline-set-device.py` — D555 USB round-trip.
- [x] `pytest -v --device D555 unit-tests/live/options/pytest-gyro-sensitivity-levels.py` — all five levels round-trip through pipeline start/stop on D555 USB.
- [x] `pytest -v --device D455 unit-tests/live/options/pytest-pipeline-set-device.py` — D400-line regression.

### Manual on the target device (D555 USB)
- [x] realsense-viewer over D555 USB shows the Gyro Sensitivity control.
- [x] D555 USB — verify reported gyro deg/s at each of the 5 sensitivity levels against a known-motion reference.
- [x] D555 USB — verify deg/s at the default sensitivity does not regress vs. pre-PR (LRS scale change alters magnitude if the FW wire-format assumption is off).

### Regression on carve-out devices
- [x] D585S — realsense-viewer does NOT show the Gyro Sensitivity control.
- [x] D585S — reported gyro deg/s unchanged vs. pre-PR.
- [x] D585 GMSL (MIPI) — device enumerates cleanly (no crash from the null-deref path).
- [x] D585 GMSL (MIPI) — realsense-viewer does NOT show the Gyro Sensitivity control.
- [x] D585 GMSL (MIPI) — reported gyro deg/s unchanged vs. pre-PR.

---
🤖 Generated by AI
