### PR TITLE
resolute ubuntu 26 support

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -49,10 +49,11 @@ function(get_fastdds)
     # includes from many std headers. FastDDS 2.10.4 uses uint8_t (e.g. in
     # DDSFilterCompoundCondition.hpp) without explicitly including <cstdint>,
     # which fails to compile. Force-include <cstdint> in every FastDDS
-    # translation unit; harmless on older toolchains. Function-scoped, so
-    # librealsense's own compilation is unaffected.
+    # translation unit; harmless on older toolchains. add_compile_options is
+    # directory-scoped, so only targets added below (FastDDS via FetchContent)
+    # inherit it -- librealsense's own compilation is unaffected.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cstdint")
+        add_compile_options(-include cstdint)
     endif()
 
     # Get fastdds

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -42,8 +42,18 @@ function(get_fastdds)
 
     # Set special values for FastDDS sub directory
     set(BUILD_SHARED_LIBS OFF)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install) 
-    set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)  
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
+    set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
+
+    # GCC 14 / libstdc++-15 (Ubuntu 26.04 "resolute") removed transitive <cstdint>
+    # includes from many std headers. FastDDS 2.10.4 uses uint8_t (e.g. in
+    # DDSFilterCompoundCondition.hpp) without explicitly including <cstdint>,
+    # which fails to compile. Force-include <cstdint> in every FastDDS
+    # translation unit; harmless on older toolchains. Function-scoped, so
+    # librealsense's own compilation is unaffected.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cstdint")
+    endif()
 
     # Get fastdds
     FetchContent_MakeAvailable(fastdds)


### PR DESCRIPTION
CMake: force-include <cstdint> when building FastDDS on GCC/Clang

Ubuntu 26.04 "resolute" ships GCC 14 with libstdc++-15, which removed
transitive <cstdint> includes from many standard headers. FastDDS
2.10.4-realsense uses uint8_t in several headers without explicitly
including <cstdint>, which now fails to compile with errors like:

  DDSFilterCompoundCondition.hpp:42: error: 'uint8_t' was not declared
  DDSFilterCompoundCondition.hpp:42: error: use of enum 'OperationKind'
      without previous declaration

Adding -include cstdint to CMAKE_CXX_FLAGS inside the get_fastdds()
function forces every FastDDS translation unit to see <cstdint> up
front. It's function-scoped so librealsense's own compilation is
unaffected. Harmless on older toolchains (focal/jammy/noble).

Bumping FastDDS to a newer upstream release is not viable because the
2.10.x LTS is the last line that still supports Ubuntu 20.04.
