### PR TITLE
conftest: settle 4s after enabling D585-family devices (FW accel bring-up window)

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -76,6 +76,7 @@ log = logging.getLogger('librealsense')
 
 # D585 Prototype FW accel bring-up window (RSDEV-13011): seconds to wait after powering the
 # device on before letting tests stream. Threshold measured at ~3s; +1s margin.
+# TODO(RSDEV-13011): remove once the FW fix is deployed (removal tracked in RSDSO-21766).
 D585_BRINGUP_SETTLE_SEC = 4
 
 # Bridge rspy.log → Python logging early, before any test output
@@ -803,8 +804,8 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         # first ~5-7 seconds after power-on (RSDEV-13011), failing any test whose config
         # includes it. Wait out the bring-up window after enabling such a device.
         # Matches "D585 Prototype" / "D585 Proto Dual RGB" only — D585S is not affected.
-        if any('D585 Proto' in ((devices.get(sn).name if devices.get(sn) else '') or '') for sn in serials):
-            log.debug(f"D585 bring-up settle: waiting {D585_BRINGUP_SETTLE_SEC}s before tests")
+        if any('D585 Proto' in (getattr(devices.get(sn), 'name', '') or '') for sn in serials):
+            log.info(f"D585 bring-up settle: waiting {D585_BRINGUP_SETTLE_SEC}s before tests")
             time.sleep(D585_BRINGUP_SETTLE_SEC)
 
     def _teardown(serials):

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -74,7 +74,7 @@ from rspy.pytest.plugins import check_required_plugins
 
 log = logging.getLogger('librealsense')
 
-# D585-family FW accel bring-up window (RSDEV-13011): seconds to wait after powering the
+# D585 Prototype FW accel bring-up window (RSDEV-13011): seconds to wait after powering the
 # device on before letting tests stream. Threshold measured at ~3s; +1s margin.
 D585_BRINGUP_SETTLE_SEC = 4
 
@@ -799,10 +799,11 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     teardown_disable = not no_reset
 
     def _bringup_settle(serials):
-        # D585 family FW: the accelerometer produces no data if streaming starts within the
+        # D585 Prototype FW: the accelerometer produces no data if streaming starts within the
         # first ~5-7 seconds after power-on (RSDEV-13011), failing any test whose config
         # includes it. Wait out the bring-up window after enabling such a device.
-        if any('D585' in ((devices.get(sn).name if devices.get(sn) else '') or '') for sn in serials):
+        # Matches "D585 Prototype" / "D585 Proto Dual RGB" only — D585S is not affected.
+        if any('D585 Proto' in ((devices.get(sn).name if devices.get(sn) else '') or '') for sn in serials):
             log.debug(f"D585 bring-up settle: waiting {D585_BRINGUP_SETTLE_SEC}s before tests")
             time.sleep(D585_BRINGUP_SETTLE_SEC)
 

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -19,6 +19,7 @@ import pytest
 import sys
 import os
 import re
+import time
 import logging
 
 # Defense against ROS 2 launch.logging: when ROS is sourced, launch_testing's
@@ -72,6 +73,10 @@ from rspy.pytest.collection import filter_and_sort_items, assert_module_fixtures
 from rspy.pytest.plugins import check_required_plugins
 
 log = logging.getLogger('librealsense')
+
+# D585-family FW accel bring-up window (RSDEV-13011): seconds to wait after powering the
+# device on before letting tests stream. Threshold measured at ~3s; +1s margin.
+D585_BRINGUP_SETTLE_SEC = 4
 
 # Bridge rspy.log → Python logging early, before any test output
 bridge_rspy_log()
@@ -793,6 +798,14 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
     disable_other_ports = no_reset
     teardown_disable = not no_reset
 
+    def _bringup_settle(serials):
+        # D585 family FW: the accelerometer produces no data if streaming starts within the
+        # first ~5-7 seconds after power-on (RSDEV-13011), failing any test whose config
+        # includes it. Wait out the bring-up window after enabling such a device.
+        if any('D585' in ((devices.get(sn).name if devices.get(sn) else '') or '') for sn in serials):
+            log.debug(f"D585 bring-up settle: waiting {D585_BRINGUP_SETTLE_SEC}s before tests")
+            time.sleep(D585_BRINGUP_SETTLE_SEC)
+
     def _teardown(serials):
         # Log the teardown so the per-test file shows the module's cleanup -- not just
         # setup + test. Runs while this module+camera's log handler is still open.
@@ -822,6 +835,7 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         try:
             devices.enable_only(serial_number, recycle=recycle, disable_other_ports=disable_other_ports)
             log.debug(f"All {len(serial_number)} devices enabled and ready")
+            _bringup_settle(serial_number)
         except Exception as e:
             # Setup failed after possibly powering the port(s): teardown won't run (no yield),
             # so power off what we tried to enable here, lest it linger into the next module.
@@ -854,6 +868,7 @@ def module_device_setup(request, _test_device_serial, __pytest_repeat_step_numbe
         log.debug(f"{'Recycling' if recycle else 'Enabling'} device...")
         devices.enable_only([serial_number], recycle=recycle, disable_other_ports=disable_other_ports)
         log.debug(f"Device enabled and ready")
+        _bringup_settle([serial_number])
     except Exception as e:
         # Setup failed after possibly powering the port: teardown won't run (no yield), so power
         # off what we tried to enable here, lest it linger into the next module.


### PR DESCRIPTION
**Overview:** Test harness now waits 4 seconds after powering on a D585 Prototype device before tests start streaming, working around a FW window in which the accelerometer delivers no data.

Tracked on [RSDEV-13011]

## Why
D585 Prototype FW produces no accelerometer data if streaming starts within the first ~5-7 seconds after power-on (RSDEV-13011). The pipeline aggregator publishes framesets only when every resolved stream has delivered, so any test whose config includes the IMU fails with `Frame didn't arrive within 5000`. In a full nightly with the D585 Prototype enabled this failed 4 tests (`rec-play test_pipeline_interface`, `test_pipeline_start_stop`, `test_accel_streaming[100/200]`) and retry-masked a fifth (`depth-unit`).

## Summary
- `module_device_setup` (conftest): after the device-enable handshake, if an enabled device is a D585 Prototype ("D585 Proto" name match — D585S and production D585 are not affected and not delayed), sleep `D585_BRINGUP_SETTLE_SEC = 4` (measured threshold ~3s + 1s margin) before yielding to tests. Both single- and multi-device paths.
- No cost for other SKUs; ~4s per D585 Prototype module (+23s on a full nightly).
- Temporary workaround — to be reverted once the FW fix for RSDEV-13011 is deployed (removal tracked in RSDSO-21766).

## Test plan
- [x] infra-tests: 148 passed, 0 failed (rerun after the name-gate narrowing)
- [x] Full nightly (D585 Prototype included, D585S excluded), same bench as baseline: baseline = 4 failed + 5 retried; with this patch = 356 passed, 0 failed, 0 retried (all platforms green)
- [x] Settle confirmed active in per-test logs ("D585 bring-up settle: waiting 4s before tests")

---
🤖 Generated by AI
