### PR TITLE
unit-tests: warn when a UniFi switch port links below 1 Gbps

### DIFF
--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -164,7 +164,7 @@ class UniFiSwitch(device_hub.device_hub):
             up = link.split('/')[-1].upper() == 'U'
             m = re.match(r'(\d+)([FH])', rate)
             if m is None:
-                log.d(f"UniFi port {port}: unrecognised rate field {rate!r}, skipping")
+                log.w(f"UniFi port {port}: unrecognised rate field {rate!r}, skipping")
                 continue
             speed = int(m.group(1))
             duplex = {'F': 'full', 'H': 'half'}.get(m.group(2), '')
@@ -180,7 +180,7 @@ class UniFiSwitch(device_hub.device_hub):
         try:
             info = self._get_port_link_info()
         except Exception as e:
-            log.d(f"could not read UniFi port link speeds: {e}")
+            log.w(f"could not read UniFi port link speeds: {e}")
             return
         for port, i in sorted(info.items()):
             if not i['up']:

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -116,7 +116,7 @@ class UniFiSwitch(device_hub.device_hub):
 
         self.mac_port_dict = None
 
-        self.log_port_link_speeds()
+        self._log_port_link_speeds()
 
     def _init_mac_port_dict(self):
         """
@@ -163,12 +163,15 @@ class UniFiSwitch(device_hub.device_hub):
             rate = parts[2]  # e.g. "1000F", "100F", "0H"
             up = link.split('/')[-1].upper() == 'U'
             m = re.match(r'(\d+)([FH])', rate)
-            speed = int(m.group(1)) if m else 0
-            duplex = {'F': 'full', 'H': 'half'}.get(m.group(2), '') if m else ''
+            if m is None:
+                log.d(f"UniFi port {port}: unrecognised rate field {rate!r}, skipping")
+                continue
+            speed = int(m.group(1))
+            duplex = {'F': 'full', 'H': 'half'}.get(m.group(2), '')
             info[port] = {'up': up, 'speed_mbps': speed, 'duplex': duplex}
         return info
 
-    def log_port_link_speeds(self):
+    def _log_port_link_speeds(self):
         """
         Log the negotiated link speed of every linked port, and warn on any port
         that came up below 1 Gbps (a common symptom of a bad cable, crimp, or port

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -116,6 +116,8 @@ class UniFiSwitch(device_hub.device_hub):
 
         self.mac_port_dict = None
 
+        self.log_port_link_speeds()
+
     def _init_mac_port_dict(self):
         """
         Initialize mac_port_dict which maps MAC addresses to port numbers
@@ -141,6 +143,50 @@ class UniFiSwitch(device_hub.device_hub):
             port_stats[port_num] = is_port_up
 
         return port_stats
+
+    # Rate column in 'swctrl port show' looks like "1000F" (1000 Mbps full duplex) or "0H" when down
+    GIGABIT_MBPS = 1000
+
+    def _get_port_link_info(self):
+        """
+        Parse 'swctrl port show' into per-port link state and negotiated speed.
+        :return: {port_num: {'up': bool, 'speed_mbps': int, 'duplex': str}}
+        """
+        cmd_out = self._run_command("swctrl port show")
+        info = {}
+        for line in cmd_out.splitlines():
+            parts = line.split()
+            if len(parts) < 3 or not parts[0].isdigit():
+                continue  # skip headers/separators
+            port = int(parts[0])
+            link = parts[1]  # admin/phys, e.g. "U/U" (up/up) or "U/D" (up/down)
+            rate = parts[2]  # e.g. "1000F", "100F", "0H"
+            up = link.split('/')[-1].upper() == 'U'
+            m = re.match(r'(\d+)([FH])', rate)
+            speed = int(m.group(1)) if m else 0
+            duplex = {'F': 'full', 'H': 'half'}.get(m.group(2), '') if m else ''
+            info[port] = {'up': up, 'speed_mbps': speed, 'duplex': duplex}
+        return info
+
+    def log_port_link_speeds(self):
+        """
+        Log the negotiated link speed of every linked port, and warn on any port
+        that came up below 1 Gbps (a common symptom of a bad cable, crimp, or port
+        that silently starves the D555 video path of jumbo frames).
+        """
+        try:
+            info = self._get_port_link_info()
+        except Exception as e:
+            log.d(f"could not read UniFi port link speeds: {e}")
+            return
+        for port, i in sorted(info.items()):
+            if not i['up']:
+                continue
+            msg = f"UniFi port {port} link: {i['speed_mbps']} Mbps {i['duplex']}".rstrip()
+            if i['speed_mbps'] < self.GIGABIT_MBPS:
+                log.w(f"{msg} -- below 1 Gbps! suspect cable/port/crimp on this link")
+            else:
+                log.d(msg)
 
     def get_name(self):
         """


### PR DESCRIPTION
**Overview:** Surface degraded links on the UniFi PoE switch (which powers the D555) by logging each port's negotiated speed on connect and warning when any linked port comes up below 1 Gbps.

## Why
A recent Windows nightly (rsdsk254) went red with a cascade of D555 failures — `Frame didn't arrive within 5000`, `Frame did not arrive in time`, then `Failed to reconnect to UniFi switch`. Investigation found the bench camera NIC had auto-negotiated down to **100 Mbps** (identical setup on rsdsk255 / vtglnx163 / vtglnx164 all link at 1 Gbps). At 100 Mbps the control path (small packets) works — device enumerates, options/HWMC/eth-config pass — but jumbo frames get dropped, so the D555 video path silently starves and every streaming test fails. Root cause was a physical link fault (cable/port), and nothing in the logs pointed at it.

This adds a loud, early signal so the next occurrence is diagnosed in seconds instead of a full investigation.

## What
- `_get_port_link_info()` parses `swctrl port show` into `{port: {up, speed_mbps, duplex}}` (Rate column, e.g. `1000F`, `100F`, `0H`). Unrecognised rate fields are logged at debug and skipped.
- `_log_port_link_speeds()` logs each linked port's speed, and emits a `log.w` warning for any up-port below 1 Gbps.
- Called once from `UniFiSwitch.__init__` (hub is created once per process, so no per-test spam). Read failures are swallowed at debug level and never block hub init.

## Testing
Parser validated against real `swctrl port show` output from the bench switch plus a synthetic 100 Mbps port:
```
port 1: DOWN (skipped)
WARN: UniFi port 3 link: 100 Mbps full -- below 1 Gbps!
d:    UniFi port 8 link: 1000 Mbps full
```

<img width="327" height="55" alt="image" src="https://github.com/user-attachments/assets/2c5fbd8e-8d85-4441-9cf3-f841939c31fb" />


🤖 Generated by AI
