### PR TITLE
Ashraf/resol ubu26

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -61,10 +61,15 @@ function(get_fastdds)
     # source dir instead of hardcoding a list, so a future FastDDS bump that
     # adds new libraries won't silently regress resolute.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        # BFS over FastDDS's directory tree. list(GET)+list(REMOVE_AT) is used
+        # instead of list(POP_FRONT) so the block stays compatible with the
+        # librealsense-wide cmake_minimum_required(3.10) even if this file's
+        # own 3.16.3 requirement is ever relaxed.
         set(_fastdds_all_targets)
         set(_fastdds_pending "${fastdds_SOURCE_DIR}")
         while(_fastdds_pending)
-            list(POP_FRONT _fastdds_pending _dir)
+            list(GET _fastdds_pending 0 _dir)
+            list(REMOVE_AT _fastdds_pending 0)
             get_property(_here_targets DIRECTORY "${_dir}" PROPERTY BUILDSYSTEM_TARGETS)
             list(APPEND _fastdds_all_targets ${_here_targets})
             get_property(_here_subdirs DIRECTORY "${_dir}" PROPERTY SUBDIRECTORIES)

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -45,20 +45,44 @@ function(get_fastdds)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
     set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
 
+    # Get fastdds
+    FetchContent_MakeAvailable(fastdds)
+
     # GCC 14 / libstdc++-15 (Ubuntu 26.04 "resolute") removed transitive <cstdint>
     # includes from many std headers. FastDDS 2.10.4 uses uint8_t (e.g. in
     # DDSFilterCompoundCondition.hpp) without explicitly including <cstdint>,
-    # which fails to compile. Force-include <cstdint> in every FastDDS
-    # translation unit; harmless on older toolchains. add_compile_options is
-    # directory-scoped, so only targets added below (FastDDS via FetchContent)
-    # inherit it -- librealsense's own compilation is unaffected.
+    # which fails to compile. Force-include <cstdint> ONLY for FastDDS's own
+    # targets, and only for their CXX translation units -- <cstdint> is a C++
+    # header, so applying the flag directory-wide (via add_compile_options)
+    # breaks C compilation elsewhere in the tree (e.g. third-party/glad/glad.c
+    # linked into realsense2-gl fatal-errors with "cstdint: No such file").
+    #
+    # We discover FastDDS's targets by walking BUILDSYSTEM_TARGETS under its
+    # source dir instead of hardcoding a list, so a future FastDDS bump that
+    # adds new libraries won't silently regress resolute.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        add_compile_options(-include cstdint)
+        set(_fastdds_all_targets)
+        set(_fastdds_pending "${fastdds_SOURCE_DIR}")
+        while(_fastdds_pending)
+            list(POP_FRONT _fastdds_pending _dir)
+            get_property(_here_targets DIRECTORY "${_dir}" PROPERTY BUILDSYSTEM_TARGETS)
+            list(APPEND _fastdds_all_targets ${_here_targets})
+            get_property(_here_subdirs DIRECTORY "${_dir}" PROPERTY SUBDIRECTORIES)
+            list(APPEND _fastdds_pending ${_here_subdirs})
+        endwhile()
+
+        foreach(_fastdds_tgt ${_fastdds_all_targets})
+            # Only compilable targets support target_compile_options PRIVATE;
+            # INTERFACE / UTILITY targets have no sources of their own and
+            # would fatal on the call.
+            get_target_property(_fastdds_tgt_type ${_fastdds_tgt} TYPE)
+            if(_fastdds_tgt_type MATCHES "^(STATIC|SHARED|MODULE|OBJECT)_LIBRARY$|^EXECUTABLE$")
+                target_compile_options(${_fastdds_tgt} PRIVATE
+                                       $<$<COMPILE_LANGUAGE:CXX>:-include cstdint>)
+            endif()
+        endforeach()
     endif()
 
-    # Get fastdds
-    FetchContent_MakeAvailable(fastdds)
-    
     # Mark new options from FetchContent as advanced options
     mark_as_advanced(FETCHCONTENT_SOURCE_DIR_FASTDDS)
     mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FASTDDS)


### PR DESCRIPTION
## Fix scope of FastDDS `-include cstdint` workaround (fixes Focal LibCI)

### Problem

Nightly LibCI on Focal ([build #15094](https://rsjenkins.realsenseai.com/job/LRS_linux_compile_lib_ci/15094/consoleFull)) started failing after the resolute-ubuntu-26 PR (#15437) merged:

```
[70%] Building C object src/gl/CMakeFiles/realsense2-gl.dir/__/__/third-party/glad/glad.c.o
<command-line>: fatal error: cstdint: No such file or directory
compilation terminated.
```

`glad.c` is C. `<cstdint>` is a C++ header. A C compiler cannot include it — the flag was leaking to the wrong translation units.

### Root cause

The FastDDS workaround in `CMake/external_fastdds.cmake` used:

```cmake
if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
    add_compile_options(-include cstdint)
endif()
```

`add_compile_options` is **directory-scoped**. Because `external_fastdds.cmake` is `include()`-d from the top-level `CMakeLists.txt`, "current directory" is the whole project — so the flag got applied to every target, including `realsense2-gl` (which builds `glad.c` as C).

Focal has `<cstdint>` fine and doesn't need the workaround at all, but the flag was still being added unconditionally on any GCC/Clang. Result: nightly breaks on Focal, resolute keeps working.

### Fix

Attach `-include cstdint` to FastDDS's own targets only, and only for their C++ translation units, via `target_compile_options` with a `$<COMPILE_LANGUAGE:CXX>` generator expression. `FetchContent_MakeAvailable` runs first so the targets exist. `PRIVATE` scope means no propagation to consumers. `INTERFACE_LIBRARY` targets (e.g. `eProsima_atomic`) are skipped — they have no compile step and `PRIVATE` isn't legal on them.

### Verification

Ran `cmake … -DBUILD_WITH_DDS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` inside the `lrs_resolute:01` image against this branch and inspected `compile_commands.json`:

| Category | Files | With `-include cstdint` |
|---|---:|---:|
| librealsense C files (`.c`) | 31 | **0** ✅ |
| FastDDS C++ files | 219 | **219** ✅ |

Focal `glad.c` no longer picks up the flag → Focal nightly compiles. FastDDS on resolute still gets the flag on every C++ TU → resolute build stays fixed.

### Related
- Fixes regression from #15437 (Ubuntu 26.04 "resolute" support)
