### PR TITLE
tests: exclude device setup from non-realtime deadlock timeout

### DIFF
--- a/unit-tests/live/rec-play/pytest-non-realtime.py
+++ b/unit-tests/live/rec-play/pytest-non-realtime.py
@@ -13,7 +13,9 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.timeout(20),
+    # func_only: keep the tight deadlock guard on the test body only -- device setup (e.g. D555
+    # PoE power-on + DDS discovery takes ~17s) must not eat the budget; it has its own bounded waits
+    pytest.mark.timeout(20, func_only=True),
     pytest.mark.context("weekly"),
 ]
 


### PR DESCRIPTION
**Overview:** The non-realtime playback test's 20s deadlock timeout no longer counts device setup, so slow device power-on can't kill the whole test session.

Tracked on [RSDSO-21768]

## Why
`pytest.mark.timeout(20)` in `pytest-non-realtime.py` uses pytest-timeout's default `func_only=False`, so the 20s budget includes fixture setup. For DDS devices (D555), setup alone — PoE power-on + DDS discovery — takes ~17s, so the timer can fire mid-setup. With `timeout_method="thread"` (our conftest default) pytest-timeout then calls `os._exit(1)`: the entire pytest session dies mid-run — no retry, remaining tests never run, and no junit results are written.

## Summary
- Add `func_only=True` to the timeout mark: the 20s guard now covers only the test body (the DSO-15157 pipeline-stop deadlock it was written to catch).
- Device setup is already self-bounded (port-disable and enumeration waits raise a normal, retryable failure), so it needs no budget of its own.

## Test plan
- [x] Verified marker parses to `Settings(timeout=20, func_only=True)` and the test collects cleanly
- [ ] Nightly CI run passes `test_non_realtime_stop[D555]` with device recycle in setup

---
🤖 Generated by AI

