### PR TITLE
Add RS2_OPTION_ALIGN_DEPTH for D555 on-device depth-to-color alignment

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -139,6 +139,7 @@ extern "C" {
         RS2_OPTION_THRESHOLD, /**< Embedded filter: merge threshold in mm (pre-stream only) */
         RS2_OPTION_DOWNSCALE_RATIO, /**< Embedded filter: secondary-frame downscale ratio (pre-stream only) */
         RS2_OPTION_READOUT_SHAPING, /**< IR/depth sensor readout shaping [0-100%]; higher slows readout to avoid dropped frames */
+        RS2_OPTION_ALIGN_DEPTH, /**< Enable/Disable on-device depth-to-color alignment */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -580,6 +580,7 @@ std::string const & get_string_( rs2_option value )
         CASE( THRESHOLD )
         CASE( DOWNSCALE_RATIO )
         CASE( READOUT_SHAPING )
+        CASE( ALIGN_DEPTH )
 #undef CASE
         return arr;
     }();


### PR DESCRIPTION
**Overview:** Adds `RS2_OPTION_ALIGN_DEPTH` so D555 cameras can expose and control on-device depth-to-color alignment (UV map) as a standard librealsense option.

Tracked on [RSDEV-9405]

## Why
D555 firmware now performs depth-to-color alignment on-device (`Depth.option.Align_Depth` over DDS), replacing the host-side `rs2::align` processing block for this camera. Verified against a live D555 (`ros2 param list`) that this is exposed as a plain stream option, not a filter — it sits alongside `Exposure`/`Gain`/`Visual_Preset` with no `Depth.filter.*` equivalent — so no new embedded-filter or stream plumbing is needed.

## Summary
- Added `RS2_OPTION_ALIGN_DEPTH` to `rs2_option` (`include/librealsense2/h/rs_option.h`)
- Added its string-table entry in `src/to-string.cpp`
- No other code changes required: DDS options auto-register by name via the existing `options_registry` path, so the option surfaces automatically in the generic per-sensor options UI (viewer, `rs-enumerate-devices`) and in Python bindings (`BIND_ENUM` macro)

## Test plan
- [x] Built `realsense2` with and without `BUILD_WITH_DDS=ON`
- [x] Verified live against a D555 over DDS: `rs-enumerate-devices -o` and realsense-viewer both show `Align Depth` (range 0-1, default 0) under the Stereo Module options
- [ ] Automated live-hardware pytest asserting depth intrinsics match color's once enabled (pinned for follow-up)

---
🤖 Generated by AI
