### PR TITLE
docs: add Ubuntu 26.04 to supported platforms

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,7 +99,7 @@ See `.github/skills/build.md` for full build instructions. The project uses **CM
 | Platform | Notes |
 |---|---|
 | **Windows 10/11** | MSVC (Visual Studio 2019/2022) |
-| **Ubuntu 20.04 / 22.04 / 24.04** | GCC, primary Linux target |
+| **Ubuntu 20.04 / 22.04 / 24.04 / 26.04** | GCC, primary Linux target |
 | **macOS** | Clang, macOS 15+ tested in CI |
 | **NVIDIA Jetson** | ARM64, L4T |
 | **Raspberry Pi** | ARM (Raspbian) |

--- a/.github/skills/build.md
+++ b/.github/skills/build.md
@@ -15,6 +15,7 @@
 | **Windows 10/11** | Visual Studio 2019 or 2022 (MSVC) | CI uses `windows-2025` runners |
 | **Ubuntu 22.04** | GCC | Primary Linux target |
 | **Ubuntu 24.04** | GCC | Also tested in CI |
+| **Ubuntu 26.04** | GCC | Supported |
 | **macOS 15+** | Clang (Xcode) | Tested in CI on `macos-15` |
 | **NVIDIA Jetson** | GCC (ARM64, L4T) | See `doc/installation_jetson.md` |
 | **Raspberry Pi** | GCC (ARM) | See `doc/installation_raspbian.md` |

--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -1,7 +1,7 @@
 # Linux Distribution
 
 #### Using pre-build packages
-**RealSense™ SDK 2.0** provides installation packages for Intel X86/AMD64/ARM-based Debian distributions in [`dpkg`](https://en.wikipedia.org/wiki/Dpkg) format for Ubuntu 20/22/24 [LTS](https://wiki.ubuntu.com/LTS).
+**RealSense™ SDK 2.0** provides installation packages for Intel X86/AMD64/ARM-based Debian distributions in [`dpkg`](https://en.wikipedia.org/wiki/Dpkg) format for Ubuntu 20/22/24/26 [LTS](https://wiki.ubuntu.com/LTS).
 
 > Note: For EOL Ubuntu distributions please use the following versions:  
 Ubuntu 16 -> [2.51.1](https://github.com/realsenseai/librealsense/releases/tag/v2.51.1).  

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -18,7 +18,7 @@ Please ensure to work with the supported Kernel versions listed [here](https://g
 
 ## Prerequisites
 
-Supported versions are:  **Ubuntu 20/22/24 LTS** versions. 
+Supported versions are:  **Ubuntu 20/22/24/26 LTS** versions. 
 > **Note:** The scripts and commands below invoke `wget, git, add-apt-repository` which may be blocked by router settings or a firewall. \
 Infrequently, apt-get mirrors or repositories may also cause timeout. For _librealsense_ users behind an enterprise firewall, \
 configuring the system-wide Ubuntu proxy generally resolves most timeout issues.
@@ -85,7 +85,11 @@ if not the SDK will use a timer polling approach which is less sensitive for dev
    ```
    Notice: You can always remove permissions by running: `./scripts/setup_udev_rules.sh --uninstall`
 
-3. Build and apply patched kernel modules for:
+3. Build and apply patched kernel modules (**optional** — needed only for newly released cameras):
+
+    Most RealSense cameras are fully supported by the stock kernel and **do not require patching** — support for them, including per-frame metadata, is already part of the mainline _uvcvideo_ driver. \
+    Patching is only required for newly released camera models that are not yet recognized by the distribution kernel's _uvcvideo_ driver (without it, streaming works but per-frame metadata is not available).
+
     * Ubuntu 20/22/24 (focal/jammy/noble) with LTS kernel 5.15, 5.19, 6.5, 6.8, 6.11, 6.14 \
       `./scripts/patch-realsense-ubuntu-lts-hwe.sh`
     * Ubuntu 20 with LTS kernel (< 5.13) \


### PR DESCRIPTION
**Overview:** Documents Ubuntu 26.04 as a supported platform and clarifies that kernel patching is only needed for newly released cameras.

Tracked on [RSDSO-21775]

## Why
Ubuntu 26.04 LTS is out; SDK builds and runs on it, but the docs still list 24.04 as the latest supported release. The installation guide also presented kernel patching as a mandatory step, while most cameras are fully supported by the stock kernel.

## Summary
- `.github/copilot-instructions.md` — added 26.04 to the supported Ubuntu versions.
- `.github/skills/build.md` — added an Ubuntu 26.04 row to the platform table.
- `doc/installation.md` — added Ubuntu 26 to the supported LTS versions; marked kernel-module patching as optional, needed only for newly released camera models not yet recognized by the stock uvcvideo driver.
- `doc/distribution_linux.md` — added Ubuntu 26 to the dpkg package distributions line.
- The kernel-patch distro list (`Ubuntu 20/22/24 focal/jammy/noble`) is intentionally unchanged — the patch scripts don't support resolute yet; tracked on RSDSO-21775.

## Test plan
- [ ] Docs-only change; no code affected.

---
🤖 Generated by AI
