### PR TITLE
adding support for depth ae mode for gmsl devices

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -852,12 +852,13 @@ namespace librealsense
                 gain_option = uvc_pu_gain_option;
             }
 
-            // DEPTH AUTO EXPOSURE MODE - available on global-shutter D400 SKUs (USB only, not MIPI/GMSL).
+            // DEPTH AUTO EXPOSURE MODE - available on global-shutter D400 SKUs.
             // D455: since FW 5.15.0.0; other SKUs: FW 5.17.3.20.
             const bool is_global_shutter = ( _device_capabilities & ds_caps::CAP_GLOBAL_SHUTTER ) == ds_caps::CAP_GLOBAL_SHUTTER;
             const firmware_version min_fw_for_ae_mode = (_pid == RS455_PID) ? firmware_version("5.15.0.0")
                                                                             : firmware_version("5.17.3.20");
-            if (is_global_shutter && !_is_mipi_device && _fw_version >= min_fw_for_ae_mode)
+            if (is_global_shutter && _fw_version >= min_fw_for_ae_mode &&
+                    (!_is_mipi_device || mipi_driver_version >= rsutils::version("1.0.5.7")))
             {
                 auto depth_auto_exposure_mode = std::make_shared<uvc_xu_option<uint8_t>>( raw_depth_sensor,
                     depth_xu,

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -94,7 +94,7 @@ constexpr uint32_t RS_CAMERA_CID_PRESET                     = (RS_CAMERA_CID_BAS
 constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY          = (RS_CAMERA_CID_BASE+22); // [MIPI - Select projector frequency values: 0->57[KHZ], 1->91[KHZ]
 constexpr uint32_t RS_CAMERA_CID_HWMC                       = (RS_CAMERA_CID_BASE+32);
 constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING            = (RS_CAMERA_CID_BASE+34);
-constexpr uint32_t DS5_CAMERA_CID_AE_MODE                   = (RS_CAMERA_CID_BASE+35);
+constexpr uint32_t RS_CAMERA_CID_AE_MODE                    = (RS_CAMERA_CID_BASE+35);
 /* refe4rence for kernel 4.9 to be removed
 #define UVC_CID_GENERIC_XU          (V4L2_CID_PRIVATE_BASE+15)
 #define UVC_CID_LASER_POWER_MODE    (V4L2_CID_PRIVATE_BASE+16)
@@ -3202,7 +3202,7 @@ namespace librealsense
                     case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; //RS_CAMERA_CID_EXPOSURE_MODE;
                     case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
                     case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
-                    case RS_DEPTH_AUTO_EXPOSURE_MODE : return DS5_CAMERA_CID_AE_MODE;
+                    case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;
                     case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
                     case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
                     // D457 Missing functionality

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -94,7 +94,7 @@ constexpr uint32_t RS_CAMERA_CID_PRESET                     = (RS_CAMERA_CID_BAS
 constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY          = (RS_CAMERA_CID_BASE+22); // [MIPI - Select projector frequency values: 0->57[KHZ], 1->91[KHZ]
 constexpr uint32_t RS_CAMERA_CID_HWMC                       = (RS_CAMERA_CID_BASE+32);
 constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING            = (RS_CAMERA_CID_BASE+34);
-
+constexpr uint32_t DS5_CAMERA_CID_AE_MODE                   = (RS_CAMERA_CID_BASE+35);
 /* refe4rence for kernel 4.9 to be removed
 #define UVC_CID_GENERIC_XU          (V4L2_CID_PRIVATE_BASE+15)
 #define UVC_CID_LASER_POWER_MODE    (V4L2_CID_PRIVATE_BASE+16)
@@ -3202,6 +3202,7 @@ namespace librealsense
                     case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; //RS_CAMERA_CID_EXPOSURE_MODE;
                     case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
                     case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
+                    case RS_DEPTH_AUTO_EXPOSURE_MODE : return DS5_CAMERA_CID_AE_MODE;
                     case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
                     case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
                     // D457 Missing functionality


### PR DESCRIPTION
Tracked by: RSDSO-21571

Tested with D457 and D401, on Orin, JP6.2
