### PR TITLE
d500 motion: align D555/D585 gyro path with HKR physical-unit IMU encoding

### DIFF
--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -379,6 +379,10 @@ namespace librealsense
                 register_feature( std::make_shared< close_range_filter_feature >(
                     dynamic_cast< d500_depth_sensor & >( depth_sensor ) ) );
             }
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -127,6 +127,10 @@ namespace librealsense
             // Improved Close Range Depth - USB toggle
             register_feature( std::make_shared< close_range_filter_feature >(
                     dynamic_cast< d500_depth_sensor & >( get_depth_sensor() ) ) );
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -181,6 +185,10 @@ namespace librealsense
             // Improved Close Range Depth - USB toggle
             register_feature( std::make_shared< close_range_filter_feature >(
                     dynamic_cast< d500_depth_sensor & >( get_depth_sensor() ) ) );
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -230,6 +238,10 @@ namespace librealsense
             , extended_firmware_logger_device( dev_info, d500_device::_hw_monitor, get_firmware_logs_command() )
         {
             ds_advanced_mode_base::initialize_advanced_mode( this );
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override
@@ -293,6 +305,10 @@ namespace librealsense
             // Note - requirement to gate depth options was removed to allow validation checks. Gated by FW only.
             // This should be last as we wish to protect the depth options setting when not in service safety mode
             // d500_safety::gate_depth_options();
+
+#if !defined(__APPLE__)
+            register_gyro_sensitivity();
+#endif
         }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -21,6 +21,8 @@
 #include "proc/auto-exposure-processor.h"
 #include "backend.h"
 #include <src/metadata-parser.h>
+#include <src/hid-sensor.h>
+#include <src/ds/features/gyro-sensitivity-feature.h>
 
 using namespace librealsense;
 namespace librealsense
@@ -89,6 +91,33 @@ namespace librealsense
             LOG_WARNING( device_name << " #" << serial << " - HID Motion Sensor Failure (continuing as partial device): " << e.what() );
         }
 
+    }
+
+    ds_motion_sensor & d500_motion::get_motion_sensor()
+    {
+#if defined(__APPLE__)
+        throw std::runtime_error( "Motion sensors are not supported on macOS" );
+#else
+        return dynamic_cast< ds_motion_sensor & >( get_sensor( _motion_module_device_idx.value() ) );
+#endif
+    }
+
+    std::shared_ptr< hid_sensor > d500_motion::get_raw_motion_sensor()
+    {
+#if defined(__APPLE__)
+        return nullptr;
+#else
+        auto raw_sensor = get_motion_sensor().get_raw_sensor();
+        return std::dynamic_pointer_cast< hid_sensor >( raw_sensor );
+#endif
+    }
+
+    void d500_motion::register_gyro_sensitivity()
+    {
+        // FW gate matches the D500 version that added Gyro Sensitivity support (first seen exposed via DDS/PoE on D555).
+        if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
+            register_feature(
+                std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
     }
 
     void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -114,7 +114,6 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        // FW gate matches the D500 version that added Gyro Sensitivity support (first seen exposed via DDS/PoE on D555).
         if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
             register_feature(
                 std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -16,6 +16,7 @@
 #include "ds/ds-options.h"
 #include "ds/ds-private.h"
 #include "d500-info.h"
+#include "d500-private.h"
 #include "stream.h"
 #include "proc/motion-transform.h"
 #include "proc/auto-exposure-processor.h"
@@ -27,7 +28,30 @@
 using namespace librealsense;
 namespace librealsense
 {
-    
+    namespace
+    {
+        // REVIEW BLOCKER: replace this sentinel with the first released FW that
+        // contains IO 34cf87d6 and device-manager 1be508e0.
+        const firmware_version hkr_physical_imu_min_fw( "65535.65535.65535.65535" );
+
+        bool is_hkr_physical_imu_pid( uint16_t pid )
+        {
+            switch( pid )
+            {
+            case ds::D555_PID:
+            case ds::D585_LEGACY_PID:
+            case ds::D585S_PID:
+            case ds::D585_2C_PID:
+            case ds::D585_3C_PID:
+            case ds::D585F_PID:
+            case ds::D585_2C_PROTO_PID:
+            case ds::D585_3C_PROTO_PID:
+                return true;
+            default:
+                return false;
+            }
+        }
+    }
 
     rs2_motion_device_intrinsic d500_motion::get_motion_intrinsics(rs2_stream stream) const
     {
@@ -36,10 +60,23 @@ namespace librealsense
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
+    bool d500_motion::supports_hkr_physical_imu() const
+    {
+        return is_hkr_physical_imu_pid( _pid ) && _fw_version >= hkr_physical_imu_min_fw;
+    }
+
+    bool d500_motion::is_imu_high_accuracy() const
+    {
+        return supports_hkr_physical_imu();
+    }
+
     double d500_motion::get_gyro_default_scale() const
     {
-        // D585S outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
-        return 0.003814697265625;
+        if( supports_hkr_physical_imu() )
+            return 0.0001;  // Fixed physical-unit report: 0.0001 degree/second per LSB
+
+        // Legacy D500 reports signed 16-bit raw samples at a fixed 125 dps assumption.
+        return 125. / 32768.;
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
@@ -75,6 +112,9 @@ namespace librealsense
 
                 // HID metadata attributes
                 hid_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
+
+                if( supports_hkr_physical_imu() )
+                    get_raw_motion_sensor()->set_gyro_scale_factor( 10000. );
             }
 #endif
         }
@@ -114,9 +154,14 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        if( _fw_version >= firmware_version( "7.58.40672.12546" ) && ! _has_motion_module_failed )
+        if( supports_hkr_physical_imu() && ! _has_motion_module_failed )
+        {
+            get_raw_motion_sensor()->set_gyro_sensitivity_encoding(
+                gyro_sensitivity_encoding::hkr_range_index );
             register_feature(
-                std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
+                std::make_shared< gyro_sensitivity_feature >(
+                    get_raw_motion_sensor(), get_motion_sensor(), 4.f ) );
+        }
     }
 
     void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -114,7 +114,7 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        if( _fw_version >= firmware_version( "7.58.38066.8032" ) && ! _has_motion_module_failed )
+        if( _fw_version >= firmware_version( "7.58.40672.12546" ) && ! _has_motion_module_failed )
             register_feature(
                 std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
     }

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -20,6 +20,7 @@ namespace librealsense
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
+        bool is_imu_high_accuracy() const override;
         double get_gyro_default_scale() const override;
 
     protected:
@@ -37,6 +38,7 @@ namespace librealsense
 
         ds_motion_sensor & get_motion_sensor();
         std::shared_ptr< hid_sensor > get_raw_motion_sensor();
+        bool supports_hkr_physical_imu() const;
         void register_gyro_sensitivity();
 
     private:

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -22,9 +22,6 @@ namespace librealsense
 
         double get_gyro_default_scale() const override;
 
-        ds_motion_sensor & get_motion_sensor();
-        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
-
     protected:
         friend class ds_motion_common;
         friend class ds_fisheye_sensor;
@@ -38,6 +35,8 @@ namespace librealsense
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
 
+        ds_motion_sensor & get_motion_sensor();
+        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
         void register_gyro_sensitivity();
 
     private:

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -8,6 +8,8 @@
 
 namespace librealsense
 {
+    class hid_sensor;
+
     class d500_motion : public virtual d500_device
     {
     public:
@@ -19,6 +21,9 @@ namespace librealsense
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
         double get_gyro_default_scale() const override;
+
+        ds_motion_sensor & get_motion_sensor();
+        std::shared_ptr< hid_sensor > get_raw_motion_sensor();
 
     protected:
         friend class ds_motion_common;
@@ -32,6 +37,8 @@ namespace librealsense
         // this flag because `_ds_motion_common` remains null in the partial
         // case. Mirrors the same flag in d400_motion_base.
         bool _has_motion_module_failed = false;
+
+        void register_gyro_sensitivity();
 
     private:
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);

--- a/src/ds/features/gyro-sensitivity-encoding.h
+++ b/src/ds/features/gyro-sensitivity-encoding.h
@@ -1,0 +1,48 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <stdexcept>
+
+
+namespace librealsense {
+
+
+enum class gyro_sensitivity_encoding
+{
+    d400_hid_token,
+    hkr_range_index
+};
+
+
+inline double encode_gyro_sensitivity( float value, gyro_sensitivity_encoding encoding )
+{
+    if( encoding == gyro_sensitivity_encoding::hkr_range_index )
+        return value;
+
+    switch( static_cast< int >( value ) )
+    {
+    case 0:
+        return 0.;
+    case 1:
+        return 0.1;
+    case 2:
+        return 0.2;
+    case 3:
+        return 0.3;
+    case 4:
+        return 0.4;
+    default:
+        throw std::out_of_range( "unsupported gyro sensitivity" );
+    }
+}
+
+
+inline double default_gyro_sensitivity( gyro_sensitivity_encoding encoding )
+{
+    return encoding == gyro_sensitivity_encoding::hkr_range_index ? 4. : 0.1;
+}
+
+
+}  // namespace librealsense

--- a/src/ds/features/gyro-sensitivity-feature.cpp
+++ b/src/ds/features/gyro-sensitivity-feature.cpp
@@ -13,9 +13,10 @@ namespace librealsense {
 const feature_id gyro_sensitivity_feature::ID = "Gyro Sensitivity feature";
 
 gyro_sensitivity_feature::gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor,
-                                                   ds_motion_sensor & motion )
+                                                   ds_motion_sensor & motion,
+                                                   float default_value )
 {
-    option_range enable_range = { 0.f /*min*/, 4.f /*max*/, 1.f /*step*/, 1.f /*default*/ };
+    option_range enable_range = { 0.f /*min*/, 4.f /*max*/, 1.f /*step*/, default_value };
     auto imu_sensitivity_control = std::make_shared< gyro_sensitivity_option >( motion_sensor, enable_range );
     motion.register_option( RS2_OPTION_GYRO_SENSITIVITY, imu_sensitivity_control );
 }

--- a/src/ds/features/gyro-sensitivity-feature.h
+++ b/src/ds/features/gyro-sensitivity-feature.h
@@ -19,7 +19,9 @@ class gyro_sensitivity_feature : public feature_interface
 public:
     static const feature_id ID;
 
-    gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor, ds_motion_sensor & motion );
+    gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor,
+                              ds_motion_sensor & motion,
+                              float default_value = 1.f );
 
     feature_id get_id() const override;
 

--- a/src/hid-sensor.cpp
+++ b/src/hid-sensor.cpp
@@ -24,15 +24,6 @@ static const std::map< rs2_stream, fourcc::value_type > stream_and_fourcc
         { RS2_STREAM_ACCEL, fourcc( 'A', 'C', 'C', 'L' ) },
         { RS2_STREAM_GPIO,  fourcc( 'G', 'P', 'I', 'O' ) } };
 
-/*For gyro sensitivity - FW gets 0 for 61 millidegree/s/LSB resolution
- 0.1 for 30.5 millidegree/s/LSB 
- 0.2 for 15.3 millidegree/s/LSB 
- 0.3 for 7.6 millidegree/s/LSB 
- 0.4 for 3.8 millidegree/s/LSB 
- Currently it is intended for D400 devices, when this feature will be added to D500 the convert needs to be checked*/
-static const std::map< float, double > gyro_sensitivity_convert
-    = { { 0.0f, 0 }, { 1.0f, 0.1 }, { 2.0f, 0.2 }, { 3.0f, 0.3 }, { 4.0f, 0.4 } };
-
     // in sensor.cpp
 void log_callback_end( uint32_t fps,
                        rs2_time_t callback_start_time,
@@ -364,23 +355,31 @@ void hid_sensor::set_imu_sensitivity( rs2_stream stream, float value )
     _imu_sensitivity_per_rs2_stream[stream] = value;
 }
 
+void hid_sensor::set_gyro_sensitivity_encoding( gyro_sensitivity_encoding encoding )
+{
+    _gyro_sensitivity_encoding = encoding;
+}
+
 void hid_sensor::set_gyro_scale_factor(double scale_factor) 
 {
     _hid_device->set_gyro_scale_factor( scale_factor );
 }
 
-/*For gyro sensitivity - FW expects 0/0.1/0.2/0.3/0.4 we convert the values from the enum 0/1/2/3/4
-the user chooses to the values FW expects using gyro_sensitivity_convert*/
 double hid_sensor::get_imu_sensitivity_values( rs2_stream stream )
 {
     if( _imu_sensitivity_per_rs2_stream.find( stream ) != _imu_sensitivity_per_rs2_stream.end() )
     {
-        return gyro_sensitivity_convert.at( _imu_sensitivity_per_rs2_stream[stream] );
+        const auto value = _imu_sensitivity_per_rs2_stream[stream];
+        if( stream == RS2_STREAM_GYRO )
+            return encode_gyro_sensitivity( value, _gyro_sensitivity_encoding );
+        return value;
     }
-    else
-        //FW recieve 0.1 and adjusts the gyro's sensitivity to its default setting of 1000.
-        //FW recieve 0.001 and adjusts the accel's sensitivity to its default setting of 4g.
-        return stream == RS2_STREAM_GYRO ? 0.1f : 0.001f;
+
+    if( stream == RS2_STREAM_GYRO )
+        return default_gyro_sensitivity( _gyro_sensitivity_encoding );
+
+    // FW receives 0.001 and adjusts the accelerometer sensitivity to its default setting of 4g.
+    return 0.001;
 }
 
 iio_hid_timestamp_reader::iio_hid_timestamp_reader()

--- a/src/hid-sensor.h
+++ b/src/hid-sensor.h
@@ -5,6 +5,7 @@
 
 #include "sensor.h"
 #include "platform/hid-device.h"
+#include "ds/features/gyro-sensitivity-encoding.h"
 
 
 namespace librealsense {
@@ -53,6 +54,7 @@ public:
     void stop() override;
     void set_imu_sensitivity( rs2_stream stream, float value );
     double get_imu_sensitivity_values( rs2_stream stream );
+    void set_gyro_sensitivity_encoding( gyro_sensitivity_encoding encoding );
     void set_gyro_scale_factor(double scale_factor);
     std::vector< uint8_t > get_custom_report_data( const std::string & custom_sensor_name,
                                                    const std::string & report_name,
@@ -73,6 +75,7 @@ private:
     std::unique_ptr< frame_timestamp_reader > _custom_hid_timestamp_reader;
     //Keeps set sensitivity values for gyro and accel
     std::map< rs2_stream, float > _imu_sensitivity_per_rs2_stream;
+    gyro_sensitivity_encoding _gyro_sensitivity_encoding = gyro_sensitivity_encoding::d400_hid_token;
 
     stream_profiles get_sensor_profiles( std::string sensor_name ) const;
 

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -30,8 +30,10 @@ def test_gyro_sensitivity_all_levels(test_device):
         cfg.enable_stream(rs.stream.accel)
         cfg.enable_stream(rs.stream.gyro)
 
-        profile = pipe.start(cfg)
-        sensor = profile.get_device().first_motion_sensor()
-        readback = sensor.get_option(rs.option.gyro_sensitivity)
-        assert readback == expected, f"level {value}: readback {readback}"
-        pipe.stop()
+        try:
+            profile = pipe.start(cfg)
+            sensor = profile.get_device().first_motion_sensor()
+            readback = sensor.get_option(rs.option.gyro_sensitivity)
+            assert readback == expected, f"level {value}: readback {readback}"
+        finally:
+            pipe.stop()

--- a/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
+++ b/unit-tests/live/options/pytest-gyro-sensitivity-levels.py
@@ -1,0 +1,37 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import pytest
+import platform
+import pyrealsense2 as rs
+import logging
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.device_each("D455"),
+    pytest.mark.device_each("D555"),
+    pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
+]
+
+
+def test_gyro_sensitivity_all_levels(test_device):
+    dev, ctx = test_device
+    motion_sensor = dev.first_motion_sensor()
+    if not motion_sensor.supports(rs.option.gyro_sensitivity):
+        pytest.skip("Gyro Sensitivity option not supported on this device/FW")
+
+    for value in range(5):  # RS2_GYRO_SENSITIVITY_* enum: 0..4
+        expected = float(value)
+        motion_sensor.set_option(rs.option.gyro_sensitivity, expected)
+
+        pipe = rs.pipeline(ctx)
+        pipe.set_device(dev)
+        cfg = rs.config()
+        cfg.enable_stream(rs.stream.accel)
+        cfg.enable_stream(rs.stream.gyro)
+
+        profile = pipe.start(cfg)
+        sensor = profile.get_device().first_motion_sensor()
+        readback = sensor.get_option(rs.option.gyro_sensitivity)
+        assert readback == expected, f"level {value}: readback {readback}"
+        pipe.stop()

--- a/unit-tests/live/options/pytest-pipeline-set-device.py
+++ b/unit-tests/live/options/pytest-pipeline-set-device.py
@@ -1,8 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2024 RealSense, Inc. All Rights Reserved.
 
-# LibCI doesn't have D435i so //test:device D435I// is disabled for now
-
 import pytest
 import platform
 import pyrealsense2 as rs
@@ -10,7 +8,8 @@ import logging
 log = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.device("D455"),
+    pytest.mark.device_each("D455"),
+    pytest.mark.device_each("D555"),
     pytest.mark.skipif(platform.machine() == "aarch64", reason="D455 not available on CI Jetson"),
 ]
 
@@ -20,6 +19,8 @@ gyro_sensitivity_value = 4.0
 def test_pipeline_set_device(test_device):
     dev, ctx = test_device
     motion_sensor = dev.first_motion_sensor()
+    if not motion_sensor.supports(rs.option.gyro_sensitivity):
+        pytest.skip("Gyro Sensitivity option not supported on this device/FW")
     pipe = rs.pipeline(ctx)
     pipe.set_device(dev)
 

--- a/unit-tests/options/test-gyro-sensitivity-encoding.cpp
+++ b/unit-tests/options/test-gyro-sensitivity-encoding.cpp
@@ -1,0 +1,30 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include <src/ds/features/gyro-sensitivity-encoding.h>
+
+#include "../catch.h"
+
+
+using namespace librealsense;
+
+
+TEST_CASE( "gyro sensitivity encoding is transport specific", "[options]" )
+{
+    const double d400_expected[] = { 0., 0.1, 0.2, 0.3, 0.4 };
+
+    for( int value = 0; value <= 4; ++value )
+    {
+        CHECK( encode_gyro_sensitivity(
+                   static_cast< float >( value ),
+                   gyro_sensitivity_encoding::d400_hid_token )
+               == d400_expected[value] );
+        CHECK( encode_gyro_sensitivity(
+                   static_cast< float >( value ),
+                   gyro_sensitivity_encoding::hkr_range_index )
+               == value );
+    }
+
+    CHECK( default_gyro_sensitivity( gyro_sensitivity_encoding::d400_hid_token ) == 0.1 );
+    CHECK( default_gyro_sensitivity( gyro_sensitivity_encoding::hkr_range_index ) == 4. );
+}


### PR DESCRIPTION
**Overview:** Extend D555/D585 gyro sensitivity registration to all D585 variants and align the SDK gyro path with the FW's HKR physical-unit IMU encoding.

Tracked on [RSDEV-60196]

## Why
D555 and D585 firmwares that ship the HKR physical-IMU work (IO `34cf87d6` + device-manager `1be508e0`) emit gyro samples as 32-bit fixed physical units instead of 16-bit raw registers. The SDK today interprets those samples as legacy raw 16-bit output, and the D585 constructors do not register the sensitivity option at all.

Builds on top of PR #15436 (`d555-usb-gyro-sensitivity`).

## Summary
- Introduce `gyro_sensitivity_encoding` (`d400_hid_token` / `hkr_range_index`) and route the D400 conversion table + defaults through `encode_gyro_sensitivity()` / `default_gyro_sensitivity()`.
- Add PID-based HKR detection in `d500_motion`: `supports_hkr_physical_imu()`, `is_imu_high_accuracy() override`, and switch `get_gyro_default_scale()` to `0.0001` for HKR-eligible devices.
- Set the HID gyro scale factor to `10000.` in `create_hid_device` for HKR-eligible devices and register the sensitivity option with the HKR encoding + default range index `4.f`.
- Register `RS2_OPTION_GYRO_SENSITIVITY` on the four D585 constructors (`rs5x5_device`, `rs5x5_dedicated_color_device`, `rs585_legacy_device`, `rs585s_device`); D555 registration already lands via PR #15436, macOS guard preserved.
- Add a Catch2 unit test for the encoding table.

## Behavior change (HKR-eligible D555/D585 only)
| Aspect | Before | After |
|---|---|---|
| `is_imu_high_accuracy()` | `false` (base default) | `true` |
| Frame converter | 16-bit | 32-bit (`converter_32_bit`) |
| `get_gyro_default_scale()` | `0.003814697265625` | `0.0001` |
| HID `set_gyro_scale_factor` | not called | `10000.` |
| Sensitivity encoding | n/a (D555 was `d400_hid_token`) | `hkr_range_index` |
| Option default | n/a (D555 was `1.f`) | `4.f` |
| D585 variants | option not registered | option registered on all 4 |
| D400 devices | unchanged | unchanged (encoding stays `d400_hid_token`) |

## REVIEW BLOCKER
`hkr_physical_imu_min_fw` is a sentinel `65535.65535.65535.65535`. It must be replaced with the first released FW that contains IO `34cf87d6` + device-manager `1be508e0` before this PR can merge — otherwise HKR mode activates against firmwares that still emit 16-bit samples and gyro/accel data will be misinterpreted.

## Test plan
- [ ] Unit test `test-gyro-sensitivity-encoding` passes (Windows + Linux).
- [ ] D400 regression: existing gyro sensitivity behavior unchanged on D435i / D455 (encoding stays `d400_hid_token`).
- [ ] D555 live once real FW is available: option registers, gyro frames report physical units matching FW spec, `pytest-gyro-sensitivity-levels.py` still passes.
- [ ] D585 live once real FW is available: option registers on all four variants, motion frames not garbled (32-bit converter agrees with FW output).
- [ ] macOS build: no compile errors (motion paths remain `#if !defined(__APPLE__)` guarded).

---
🤖 Generated by AI