### PR TITLE
unit-tests: exclude D500 from AE-setpoint test, enable advanced-mode suite in default CI

### DIFF
--- a/unit-tests/live/options/pytest-advanced-mode.py
+++ b/unit-tests/live/options/pytest-advanced-mode.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
-    pytest.mark.context("nightly"),
 ]
 
 
@@ -245,6 +244,7 @@ def test_set_color_correction(test_device_wrapped):
     assert new_cc.colorCorrection12 == pytest.approx(1.3, abs=0.01)
 
 
+@pytest.mark.device_exclude("D500*")  # AE Setpoint is not supported on D500-family devices
 def test_set_ae_control(test_device_wrapped):
     if not _module_state.get('preset_ok'):
         pytest.skip("prerequisite test_visual_preset_support failed")


### PR DESCRIPTION
**Overview:** Excludes D500-family devices from `test_set_ae_control` and removes the `nightly`-only gate from the advanced-mode test suite so it runs in the default CI context.

Tracked on [RSDEV-12601]

## Why
`test_set_ae_control` set and round-tripped the AE-Setpoint value on any D400/D500 device. After #15421, `set_ae_control()` now throws for D500-family devices (AE-Setpoint isn't supported there), so this test started failing on D500.

## Summary
- Added `@pytest.mark.device_exclude("D500*")` to `test_set_ae_control` only — the rest of the advanced-mode suite still runs on D500.
- Removed `pytest.mark.context("nightly")` from the module-level `pytestmark` so the suite runs in the default CI context instead of only nightly.

## Test plan
- [x] `pytest --collect-only` on `pytest-advanced-mode.py` collects cleanly with the new markers, no warnings.
- [ ] CI run confirms `test_set_ae_control` skips on D500 devices and passes on D400 devices.

---
🤖 Generated by AI