### PR TITLE
Fix pytest-retry teardown KeyError on tests using tmp_path

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -474,6 +474,30 @@ def _reset_pytest_timeout_for_retry(item):
     hooks.pytest_timeout_set_timer(item=item, settings=settings)
 
 
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Restore the tmp_path stash key that pytest-retry drops between attempts.
+
+    The tmp_path fixture teardown reads request.node.stash[tmppath_result_key] to apply its
+    retention policy. That key is populated ONLY by pytest_runtest_makereport (tmpdir.py). But
+    pytest-retry reruns a test via TestReport.from_item_and_call (bypassing makereport), and its
+    preliminary between-attempts teardown runs the tmp_path finalizer, which deletes the key. A
+    retried test that uses tmp_path then reaches the real protocol teardown with the key gone, and
+    the finalizer raises `KeyError: <StashKey>` -- recorded as a teardown ERROR even though the test
+    passed on retry (Jenkins libci junit: "failed on teardown with KeyError: <StashKey>").
+
+    tryfirst runs this before the fixture finalizers fire. An empty dict is safe: the retention
+    logic reads .get("call", True) (treated as passed, so the tmp dir is eligible for cleanup) then
+    deletes the key. Independent of the pytest-timeout re-arming above."""
+    try:
+        from _pytest.tmpdir import tmppath_result_key
+        if tmppath_result_key not in item.stash:
+            item.stash[tmppath_result_key] = {}
+    except ImportError:
+        pass
+    yield
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     """Reset pytest-timeout between retry attempts + surface pytest-check

--- a/unit-tests/infra-tests/e2e/pytest-retry-tmp-path.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-tmp-path.py
@@ -1,0 +1,17 @@
+# Exercises the tmp_path fixture + pytest-retry interaction. Run under --retries=1.
+#
+# The tmp_path fixture teardown reads request.node.stash[tmppath_result_key] (populated only by
+# pytest_runtest_makereport) then deletes it. pytest-retry reruns a test via
+# TestReport.from_item_and_call (bypassing makereport) and its preliminary between-attempts
+# teardown runs the tmp_path finalizer, deleting the key. A retried test that uses tmp_path then
+# reaches the real protocol teardown with the key gone, and the finalizer raises
+# `KeyError: <StashKey>` -- a teardown ERROR on a test that passed on retry. The conftest
+# pytest_runtest_teardown restores the key before finalizers fire; this test locks that in.
+_attempt = 0
+
+
+def test_tmp_path_survives_retry(tmp_path):
+    global _attempt
+    _attempt += 1
+    (tmp_path / "artifact.txt").write_text("x")
+    assert _attempt >= 2, "intentional first-attempt failure"

--- a/unit-tests/infra-tests/test_e2e_retry_tmp_path.py
+++ b/unit-tests/infra-tests/test_e2e_retry_tmp_path.py
@@ -1,0 +1,31 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: a test that uses the tmp_path fixture must survive a pytest-retry rerun.
+
+The tmp_path fixture teardown reads request.node.stash[tmppath_result_key], which is populated
+only by pytest_runtest_makereport. pytest-retry reruns via TestReport.from_item_and_call (bypassing
+makereport) and its preliminary between-attempts teardown runs the tmp_path finalizer, deleting the
+key. A retried tmp_path test then reaches the real protocol teardown with the key gone and the
+finalizer raises `KeyError: <StashKey>` -- recorded as a teardown ERROR even though the test passed
+on retry. conftest's pytest_runtest_teardown restores the key before finalizers fire. This locks in
+the fix: without it the run ends with a teardown error on a passed test.
+"""
+
+from helpers import run_e2e, parse_outcomes
+
+
+class TestRetryTmpPath:
+
+    def test_tmp_path_fixture_survives_retry(self):
+        """Attempt 1 fails, attempt 2 passes. The retried test uses tmp_path, so its teardown
+        finalizer must not raise KeyError on the dropped stash key -- the test genuinely PASSES
+        with no teardown error."""
+        rc, out, *_ = run_e2e("pytest-retry-tmp-path.py", "--retries", "1")
+        assert rc == 0, out
+        outcomes = parse_outcomes(out)
+        assert outcomes.get("passed") == 1, out
+        assert outcomes.get("retried") == 1, f"expected exactly 1 retry: {out}"
+        assert outcomes.get("error", 0) == 0, f"tmp_path teardown KeyError leaked:\n{out}"
+        assert "KeyError" not in out, out


### PR DESCRIPTION
**Overview:** A test that uses the `tmp_path` fixture and is retried by pytest-retry could fail its teardown with `KeyError: <StashKey>` even after passing on retry, turning green libci runs red.

## Why
On libci (`LRS_libci_pipeline`), a flaky live test that passed on a pytest-retry rerun still failed the build. The junit report showed `failed on teardown with "KeyError: <_pytest.stash.StashKey object>"`, and the groovy pipeline flags that teardown error as a build failure.

Root cause: the `tmp_path` fixture teardown reads `request.node.stash[tmppath_result_key]` (populated **only** by `pytest_runtest_makereport`) then deletes it. pytest-retry reruns a test via `TestReport.from_item_and_call` — bypassing `makereport` — and its preliminary between-attempts teardown runs the `tmp_path` finalizer, which deletes the key. A retried test that uses `tmp_path` then reaches the real protocol teardown with the key gone, and the finalizer raises `KeyError`. Only tests that take `tmp_path` are affected.

## Summary
- Add a `tryfirst` `pytest_runtest_teardown` hook in `conftest.py` that restores `tmppath_result_key` (empty dict) before the fixture finalizers fire, if pytest-retry dropped it. Empty dict is safe: retention reads `.get("call", True)` then deletes the key. Independent of the existing pytest-timeout retry re-arming.
- Add a device-free e2e regression (`test_e2e_retry_tmp_path.py` + `e2e/pytest-retry-tmp-path.py`) that reproduces the teardown KeyError without the fix and passes with it.

## Test plan
- [x] New guard `test_e2e_retry_tmp_path.py` fails on unpatched conftest, passes with the fix.
- [x] Existing retry guards still green: `test_e2e_retry_timeout`, `test_e2e_retry_setup_fail`, `test_e2e_check_retry`, `test_e2e_log_failures` (8/8).
- [x] Reproduced end-to-end on a real bench (D455 + D585S) with a forced first-attempt failure; fix clears the teardown error.

---
🤖 Generated by AI
