### PR TITLE
Replace pytest-retry with pytest-rerunfailures; recycle devices between rerun attempts

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -464,14 +464,21 @@ def pytest_runtest_logreport(report):
     if item is None:
         return
     name2defs = getattr(getattr(item, "_fixtureinfo", None), "name2fixturedefs", {})
-    for name, defs in name2defs.items():
-        fixturedef = defs[-1]
-        if getattr(fixturedef, "scope", "function") in ("session", "package"):
-            continue
-        try:
-            fixturedef.finish(req)
-        except Exception as e:
-            log.warning(f"recycle of fixture '{name}' between rerun attempts failed: {e!r}")
+    # This hook fires between protocol phases, where pytest's output capture is suspended —
+    # raw stdout prints from the teardown (e.g. rspy's "-D- Disabling ports...") would leak
+    # into the CI console mid-progress-line. Swallow stdout for the duration; the python
+    # logging bridge still records every line in the per-test .log file. stderr is left
+    # alone so real errors stay visible.
+    import contextlib, io
+    with contextlib.redirect_stdout(io.StringIO()):
+        for name, defs in name2defs.items():
+            fixturedef = defs[-1]
+            if getattr(fixturedef, "scope", "function") in ("session", "package"):
+                continue
+            try:
+                fixturedef.finish(req)
+            except Exception as e:
+                log.warning(f"recycle of fixture '{name}' between rerun attempts failed: {e!r}")
 
 
 def _reset_pytest_timeout_for_retry(item):

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -201,8 +201,7 @@ def pytest_addoption(parser):
         help="Pre-parsed flags (no need for --rs-help): "
              "--debug (enable -D- debug logs), "
              "-r/--regex <pattern> (filter tests by name, maps to -k), "
-             "--tag <name> (run only tests with marker, maps to -m), "
-             "--retries N (retry failed tests N times)."
+             "--tag <name> (run only tests with marker, maps to -m)."
     )
     group.addoption(
         "--test-dir",
@@ -239,11 +238,9 @@ def pytest_configure(config):
         config.option.count = repeat_val
         config.option.repeat_scope = 'module'
 
-    # Retries are handled by pytest-rerunfailures (--reruns N). It reruns the FULL protocol via
-    # _pytest.runner.runtestprotocol, so pytest_runtest_makereport fires on every attempt and
-    # setup-phase failures retry natively (regression Jenkins win #113344) — no plugin patching.
-    # Module-scoped fixtures survive reruns, so the device power-cycle between attempts is done
-    # by our pytest_runtest_logreport hook below (see "device recycle between rerun attempts").
+    # Retries: pytest-rerunfailures (--reruns N). It reruns the full protocol, so setup-phase
+    # failures retry natively; device power-cycle between attempts is done by the
+    # pytest_runtest_logreport hook below.
 
     # We override pytest-repeat's `__pytest_repeat_step_number` to module scope so
     # module-scoped fixtures (e.g. module_device_setup) can depend on it and re-instantiate
@@ -407,9 +404,8 @@ def _test_log_banner(request):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """Log test duration and any failures/errors. Also capture the item's live request for the
-    rerun-recycle hook below: item._request is invalidated (set to False) at Function.teardown,
-    and pytest_runtest_logreport(outcome="rerun") fires after teardown — too late to grab it."""
+    """Log test duration and any failures/errors, and stash the item's live request for the
+    rerun-recycle hook (item._request is cleared at teardown, before that hook fires)."""
     req = getattr(item, "_request", None)
     if req:
         _rerun_recycle_ctx[item.nodeid] = (item, req)
@@ -434,36 +430,19 @@ def pytest_runtest_makereport(item, call):
 # ============================================================================
 # Device recycle between rerun attempts
 # ============================================================================
-# pytest-rerunfailures reruns the full protocol but leaves successful module-scoped fixtures
-# cached — the rerun would reuse the same (possibly wedged) device without a power cycle. A
-# failed test often leaves the camera in a state only a power cycle can recover, so between
-# attempts we tear down every local (non-session) fixture of the item and let the rerun's
-# setup re-create them, matching pytest-retry's old "preliminary teardown" semantics.
-#
-# Seam: pytest_runtest_logreport with report.outcome == "rerun" — pytest-rerunfailures logs
-# exactly one such report per failed attempt, after that attempt's teardown and before the
-# rerun starts.
-#
-# Mechanism: FixtureDef.finish() on each local fixture in the item's closure. Finishing a
-# fixture runs the finalizers registered on it, and pytest registers a dependent's teardown as a
-# finalizer on the fixture it depends on — so finishing module_device_setup already cascades to
-# its dependents (test_device, test_context, test_device_wrapped, ...) in the correct order
-# (dependent first), with the port disable happening in module_device_setup's own teardown. The
-# blanket sweep over the closure also covers fixtures outside that chain; finish() is idempotent,
-# so a fixture already torn down by the cascade is a no-op and iteration order does not matter.
-# The rerun's setup then re-executes the chain — port enable, bring-up settle, fresh rs.context,
-# fresh device handle, module preconditions re-applied. Port off at teardown + on at setup is
-# exactly module_device_setup's designed power cycle. module_log is finished too and reopens in
-# append mode, so all attempts still land in one per-test log file.
+# pytest-rerunfailures keeps successful module-scoped fixtures cached across a rerun, so the
+# rerun would reuse the same (possibly wedged) device with no power cycle. On the "rerun" report
+# (logged once per failed attempt, before the next attempt) we finish every local fixture of the
+# item; finishing module_device_setup cascades to its dependents and its teardown powers the port
+# off, and the rerun's setup powers it back on — the power cycle. finish() is idempotent so the
+# blanket sweep is order-independent. See test_e2e_cli_options / test_e2e_rerun_console_leak.
 
 _rerun_recycle_ctx = {}  # nodeid -> (item, live request) captured in pytest_runtest_makereport
 
 
 def pytest_runtest_logreport(report):
-    # Two jobs on this hook: recycle the device between rerun attempts, and keep
-    # _rerun_recycle_ctx bounded. The ctx entry is dropped on the rerun that consumes it
-    # (makereport re-stores it for the next attempt) and on the final teardown of any test that
-    # did not rerun — so at most the in-flight items are retained, never the whole session.
+    # Recycle on rerun, and keep _rerun_recycle_ctx bounded: drop the entry on the rerun that
+    # consumes it (makereport re-stores it for the next attempt) and on any test's final teardown.
     if report.outcome != "rerun":
         if report.when == "teardown":
             _rerun_recycle_ctx.pop(report.nodeid, None)
@@ -472,11 +451,8 @@ def pytest_runtest_logreport(report):
     if item is None:
         return
     name2defs = getattr(getattr(item, "_fixtureinfo", None), "name2fixturedefs", {})
-    # This hook fires between protocol phases, where pytest's output capture is suspended —
-    # raw stdout prints from the teardown (e.g. rspy's "-D- Disabling ports...") would leak
-    # into the CI console mid-progress-line. Swallow stdout for the duration; the python
-    # logging bridge still records every line in the per-test .log file. stderr is left
-    # alone so real errors stay visible.
+    # This hook runs between phases, where pytest capture is off — swallow stdout so rspy's raw
+    # "-D-" teardown prints don't leak into the console (the logging bridge still logs them).
     import contextlib, io
     with contextlib.redirect_stdout(io.StringIO()):
         for name, defs in name2defs.items():

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -201,7 +201,8 @@ def pytest_addoption(parser):
         help="Pre-parsed flags (no need for --rs-help): "
              "--debug (enable -D- debug logs), "
              "-r/--regex <pattern> (filter tests by name, maps to -k), "
-             "--tag <name> (run only tests with marker, maps to -m)."
+             "--tag <name> (run only tests with marker, maps to -m). "
+             "Retries: --reruns N (native pytest-rerunfailures flag)."
     )
     group.addoption(
         "--test-dir",

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -239,31 +239,11 @@ def pytest_configure(config):
         config.option.count = repeat_val
         config.option.repeat_scope = 'module'
 
-    # --retries N is handled natively by the pytest-retry plugin: failed tests rerun
-    # up to N times, and the plugin tears down + re-creates module/class-scoped
-    # fixtures between attempts (pytest-retry's "preliminary teardown trick" -
-    # see pytest_retry.retry_plugin in the version pinned by requirements.txt).
-    # This gives us free device recycling and precondition re-apply.
-    #
-    # By default pytest-retry's `should_handle_retry` skips setup/teardown phase
-    # failures.  We relax that to also retry setup-phase failures (call.when ==
-    # "setup"), since those are the common case for transient hub/USB glitches
-    # at fixture time — the retry loop already does the right thing (tears down
-    # then re-runs setup + call), it just refuses to enter for setup failures.
-    # Teardown still excluded — re-running teardown after a teardown failure
-    # is brittle and matches pytest-retry's upstream stance.
-    # Regression for Jenkins win #113344 (fixture-time ERRORs must trigger retry).
-    # Version pinned by requirements.txt so upstream renames give a deterministic
-    # ImportError rather than silent behaviour drift.
-    try:
-        from pytest_retry import retry_plugin
-        def _retry_setup_too(call):
-            if call.excinfo is None or call.excinfo.typename == "Skipped":
-                return False
-            return call.when in ("setup", "call")
-        retry_plugin.should_handle_retry = _retry_setup_too
-    except ImportError:
-        pass
+    # Retries are handled by pytest-rerunfailures (--reruns N). It reruns the FULL protocol via
+    # _pytest.runner.runtestprotocol, so pytest_runtest_makereport fires on every attempt and
+    # setup-phase failures retry natively (regression Jenkins win #113344) — no plugin patching.
+    # Module-scoped fixtures survive reruns, so the device power-cycle between attempts is done
+    # by our pytest_runtest_logreport hook below (see "device recycle between rerun attempts").
 
     # We override pytest-repeat's `__pytest_repeat_step_number` to module scope so
     # module-scoped fixtures (e.g. module_device_setup) can depend on it and re-instantiate
@@ -425,22 +405,15 @@ def _test_log_banner(request):
     ensure_newline()
 
 
-# Stash a retry-setup-phase failure so pytest_runtest_call can surface the real error
-# instead of the masking KeyError (see pytest_runtest_call for the full story).
-_retry_setup_exc_key = pytest.StashKey()
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_setup(item):
-    """Record whether the setup phase failed, so pytest_runtest_call can recover the real
-    error if pytest-retry then runs the call phase on a failed retry-setup."""
-    outcome = yield
-    item.stash[_retry_setup_exc_key] = outcome.excinfo[1] if outcome.excinfo else None
-
-
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """Log test duration and any failures/errors."""
+    """Log test duration and any failures/errors. Also capture the item's live request for the
+    rerun-recycle hook below: item._request is invalidated (set to False) at Function.teardown,
+    and pytest_runtest_logreport(outcome="rerun") fires after teardown — too late to grab it."""
+    req = getattr(item, "_request", None)
+    if req:
+        _rerun_recycle_ctx[item.nodeid] = (item, req)
+
     outcome = yield
     report = outcome.get_result()
 
@@ -448,8 +421,8 @@ def pytest_runtest_makereport(item, call):
         ensure_newline()
         reason = report.longrepr[-1]
         log.info(reason)
-    # Call-phase failures are logged from pytest_runtest_call so they also appear on
-    # pytest-retry attempts (which bypass this hook); here we cover setup/teardown.
+    # Call-phase failures are logged from pytest_runtest_call (one place for every attempt);
+    # here we cover setup/teardown.
     if report.failed and call.excinfo and call.when != "call":
         ensure_newline()
         log.error(f"{call.when} {report.outcome}: {call.excinfo.typename}: {call.excinfo.value}")
@@ -458,10 +431,54 @@ def pytest_runtest_makereport(item, call):
         log.debug(f"Test execution took {report.duration:.3f}s")
 
 
+# ============================================================================
+# Device recycle between rerun attempts
+# ============================================================================
+# pytest-rerunfailures reruns the full protocol but leaves successful module-scoped fixtures
+# cached — the rerun would reuse the same (possibly wedged) device without a power cycle. A
+# failed test often leaves the camera in a state only a power cycle can recover, so between
+# attempts we tear down every local (non-session) fixture of the item and let the rerun's
+# setup re-create them, matching pytest-retry's old "preliminary teardown" semantics.
+#
+# Seam: pytest_runtest_logreport with report.outcome == "rerun" — pytest-rerunfailures logs
+# exactly one such report per failed attempt, after that attempt's teardown and before the
+# rerun starts.
+#
+# Mechanism: FixtureDef.finish() on each local fixture in the item's closure. pytest registers
+# every fixture's finish as a finalizer on its dependencies, so finishing module_device_setup
+# cascades through its dependents (test_device, test_context, test_device_wrapped, ...): their
+# finalizers run (port disable happens in module_device_setup's own teardown) and their cached
+# results clear. finish() is idempotent, so the blanket sweep is safe. The rerun's setup then
+# re-executes the chain — port enable, bring-up settle, fresh rs.context, fresh device handle,
+# module preconditions re-applied. Port off at teardown + on at setup is exactly
+# module_device_setup's designed power cycle. module_log is finished too and reopens in append
+# mode, so all attempts still land in one per-test log file.
+
+_rerun_recycle_ctx = {}  # nodeid -> (item, live request) captured in pytest_runtest_makereport
+
+
+def pytest_runtest_logreport(report):
+    if report.outcome != "rerun":
+        return
+    item, req = _rerun_recycle_ctx.get(report.nodeid, (None, None))
+    if item is None:
+        return
+    name2defs = getattr(getattr(item, "_fixtureinfo", None), "name2fixturedefs", {})
+    for name, defs in name2defs.items():
+        fixturedef = defs[-1]
+        if getattr(fixturedef, "scope", "function") in ("session", "package"):
+            continue
+        try:
+            fixturedef.finish(req)
+        except Exception as e:
+            log.warning(f"recycle of fixture '{name}' between rerun attempts failed: {e!r}")
+
+
 def _reset_pytest_timeout_for_retry(item):
-    """Re-arm pytest-timeout so each pytest-retry attempt gets a fresh --timeout budget
-    (the outer protocol yield otherwise makes retries share the first attempt's budget).
-    Also fires on first call: setup no longer counts against the call budget."""
+    """Re-arm pytest-timeout so each rerun attempt gets a fresh --timeout budget: pytest-timeout
+    arms ONE timer around the whole runtest protocol, and pytest-rerunfailures runs all attempts
+    inside that single protocol call, so without this reset attempts share the first attempt's
+    budget. Also fires on first call: setup no longer counts against the call budget."""
     try:
         from pytest_timeout import _get_item_settings
     except (ImportError, AttributeError):
@@ -476,44 +493,21 @@ def _reset_pytest_timeout_for_retry(item):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    """Reset pytest-timeout between retry attempts + surface pytest-check
+    """Reset pytest-timeout between rerun attempts + surface pytest-check
     soft-check failures in the call phase.
 
-    pytest-check defers its failures to pytest_runtest_makereport. But pytest-retry
-    reruns a test by invoking pytest_runtest_call directly and building the report
-    with TestReport.from_item_and_call, which never fires makereport. So on a retry
-    attempt the soft-check failures are invisible to the retry decision (the test
-    looks passed) and instead surface later against the teardown phase, which
-    pytest-retry refuses to retry. Net effect: a retried test is reported "passed"
-    yet still fails the run with a teardown error.
-
-    Flushing the failures here, in the call phase, makes them visible to pytest-retry
-    on every attempt (a genuinely flaky soft-check test passes on retry; a persistent
-    one stays failed) and keeps them off the teardown report. Scoped to fire only for
-    the buggy case; every other path is left to pytest-check unchanged.
-
-    Also unmasks a pytest-retry bug: pytest-retry reruns a test by calling pytest_runtest_setup
-    then pytest_runtest_call unconditionally (retry_plugin ~L237-238), ignoring whether the
-    retry-setup failed. When it did, funcargs lack the fixture and pytest_pyfunc_call raises
-    `KeyError: '<fixture>'`, hiding the real setup error and confusing the retry decision.
-    We swap that KeyError back for the recorded setup exception so the failure is
-    diagnosable and pytest-retry sees the true (retryable) error.
+    Raising the soft-check failures here (instead of leaving them to pytest-check's
+    makereport handling) attributes them to the call phase, where they are visible to
+    the rerun decision and logged per attempt into the per-test .log file. A genuinely
+    flaky soft-check test passes on rerun; a persistent one stays a plain call-phase
+    FAILURE. Every other path is left to pytest-check unchanged.
     """
     _reset_pytest_timeout_for_retry(item)
 
     outcome = yield
 
-    # Match only the fixture-missing KeyError pytest injects, not a test-body KeyError.
-    setup_exc = item.stash.get(_retry_setup_exc_key, None)
-    if (setup_exc is not None and outcome.excinfo is not None
-            and outcome.excinfo[0] is KeyError
-            and str(outcome.excinfo[1]).strip("'\"") in item.fixturenames):
-        outcome.force_exception(setup_exc)
-        item.stash[_retry_setup_exc_key] = None  # consumed
-        return
-
-    # Log every call-phase failure here so pytest-retry attempts (which bypass
-    # pytest_runtest_makereport) are also captured in the per-test .log file.
+    # Log every call-phase failure here — one place that fires on every rerun attempt —
+    # so each attempt's failure is captured in the per-test .log file.
     if outcome.excinfo is not None and not issubclass(outcome.excinfo[0], pytest.skip.Exception):
         ensure_newline()
         log.error(f"call failed: {outcome.excinfo[0].__name__}: {outcome.excinfo[1]}")

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -444,23 +444,31 @@ def pytest_runtest_makereport(item, call):
 # exactly one such report per failed attempt, after that attempt's teardown and before the
 # rerun starts.
 #
-# Mechanism: FixtureDef.finish() on each local fixture in the item's closure. pytest registers
-# every fixture's finish as a finalizer on its dependencies, so finishing module_device_setup
-# cascades through its dependents (test_device, test_context, test_device_wrapped, ...): their
-# finalizers run (port disable happens in module_device_setup's own teardown) and their cached
-# results clear. finish() is idempotent, so the blanket sweep is safe. The rerun's setup then
-# re-executes the chain — port enable, bring-up settle, fresh rs.context, fresh device handle,
-# module preconditions re-applied. Port off at teardown + on at setup is exactly
-# module_device_setup's designed power cycle. module_log is finished too and reopens in append
-# mode, so all attempts still land in one per-test log file.
+# Mechanism: FixtureDef.finish() on each local fixture in the item's closure. Finishing a
+# fixture runs the finalizers registered on it, and pytest registers a dependent's teardown as a
+# finalizer on the fixture it depends on — so finishing module_device_setup already cascades to
+# its dependents (test_device, test_context, test_device_wrapped, ...) in the correct order
+# (dependent first), with the port disable happening in module_device_setup's own teardown. The
+# blanket sweep over the closure also covers fixtures outside that chain; finish() is idempotent,
+# so a fixture already torn down by the cascade is a no-op and iteration order does not matter.
+# The rerun's setup then re-executes the chain — port enable, bring-up settle, fresh rs.context,
+# fresh device handle, module preconditions re-applied. Port off at teardown + on at setup is
+# exactly module_device_setup's designed power cycle. module_log is finished too and reopens in
+# append mode, so all attempts still land in one per-test log file.
 
 _rerun_recycle_ctx = {}  # nodeid -> (item, live request) captured in pytest_runtest_makereport
 
 
 def pytest_runtest_logreport(report):
+    # Two jobs on this hook: recycle the device between rerun attempts, and keep
+    # _rerun_recycle_ctx bounded. The ctx entry is dropped on the rerun that consumes it
+    # (makereport re-stores it for the next attempt) and on the final teardown of any test that
+    # did not rerun — so at most the in-flight items are retained, never the whole session.
     if report.outcome != "rerun":
+        if report.when == "teardown":
+            _rerun_recycle_ctx.pop(report.nodeid, None)
         return
-    item, req = _rerun_recycle_ctx.get(report.nodeid, (None, None))
+    item, req = _rerun_recycle_ctx.pop(report.nodeid, (None, None))
     if item is None:
         return
     name2defs = getattr(getattr(item, "_fixtureinfo", None), "name2fixturedefs", {})

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -201,8 +201,8 @@ def pytest_addoption(parser):
         help="Pre-parsed flags (no need for --rs-help): "
              "--debug (enable -D- debug logs), "
              "-r/--regex <pattern> (filter tests by name, maps to -k), "
-             "--tag <name> (run only tests with marker, maps to -m). "
-             "Retries: --reruns N (native pytest-rerunfailures flag)."
+             "--tag <name> (run only tests with marker, maps to -m), "
+             "--reruns N (pytest-rerunfailures retries a failed test N times)."
     )
     group.addoption(
         "--test-dir",

--- a/unit-tests/dds/pytest-control-reply.py
+++ b/unit-tests/dds/pytest-control-reply.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ) )

--- a/unit-tests/dds/pytest-dds-metadata.py
+++ b/unit-tests/dds/pytest-dds-metadata.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
     pytest.mark.skipif( platform.system() == 'Linux', reason='see file header' ),
 ]
 

--- a/unit-tests/dds/pytest-device-discovery.py
+++ b/unit-tests/dds/pytest-device-discovery.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if rspy.log.nested is not None:

--- a/unit-tests/dds/pytest-device-init.py
+++ b/unit-tests/dds/pytest-device-init.py
@@ -15,7 +15,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ), 'C  ' )

--- a/unit-tests/dds/pytest-librs-connections.py
+++ b/unit-tests/dds/pytest-librs-connections.py
@@ -15,7 +15,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if log.isEnabledFor( logging.DEBUG ):

--- a/unit-tests/dds/pytest-librs-device-properties.py
+++ b/unit-tests/dds/pytest-librs-device-properties.py
@@ -16,7 +16,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if log.isEnabledFor(logging.DEBUG):

--- a/unit-tests/dds/pytest-librs-extrinsics.py
+++ b/unit-tests/dds/pytest-librs-extrinsics.py
@@ -13,7 +13,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if log.isEnabledFor(logging.DEBUG):

--- a/unit-tests/dds/pytest-librs-formats-conversion.py
+++ b/unit-tests/dds/pytest-librs-formats-conversion.py
@@ -12,7 +12,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if log.isEnabledFor(logging.DEBUG):

--- a/unit-tests/dds/pytest-librs-intrinsics.py
+++ b/unit-tests/dds/pytest-librs-intrinsics.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if rspy.log.nested is not None:

--- a/unit-tests/dds/pytest-librs-object-detection.py
+++ b/unit-tests/dds/pytest-librs-object-detection.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if rspy.log.nested is not None:

--- a/unit-tests/dds/pytest-librs-options.py
+++ b/unit-tests/dds/pytest-librs-options.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if rspy.log.nested is not None:

--- a/unit-tests/dds/pytest-md-syncer.py
+++ b/unit-tests/dds/pytest-md-syncer.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ) )

--- a/unit-tests/dds/pytest-object-detections.py
+++ b/unit-tests/dds/pytest-object-detections.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ) )

--- a/unit-tests/dds/pytest-options.py
+++ b/unit-tests/dds/pytest-options.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 info = dds.message.device_info()

--- a/unit-tests/dds/pytest-participant.py
+++ b/unit-tests/dds/pytest-participant.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 if rspy.log.nested is not None:

--- a/unit-tests/dds/pytest-query-option.py
+++ b/unit-tests/dds/pytest-query-option.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ) )

--- a/unit-tests/dds/pytest-streaming.py
+++ b/unit-tests/dds/pytest-streaming.py
@@ -15,7 +15,7 @@ log.nested = 'C  '
 
 pytestmark = [
     pytest.mark.dds,
-    pytest.mark.flaky( retries=2 ),
+    pytest.mark.flaky( reruns=2 ),
 ]
 
 dds.debug( log.isEnabledFor( logging.DEBUG ), 'C  ' )

--- a/unit-tests/infra-tests/e2e/pytest-rerun-teardown-print.py
+++ b/unit-tests/infra-tests/e2e/pytest-rerun-teardown-print.py
@@ -1,0 +1,20 @@
+# A module fixture whose teardown writes RAW stdout (like rspy's "-D-" hub prints). The
+# between-attempts recycle runs fixture teardowns while pytest's capture is suspended, so
+# without the conftest stdout guard this marker would leak into the CI console mid-run.
+import pytest
+
+pytestmark = [pytest.mark.device("D455")]
+
+_attempt = 0
+
+
+@pytest.fixture(scope="module")
+def noisy_module_fixture():
+    yield
+    print("RAW-TEARDOWN-LEAK-MARKER")
+
+
+def test_fails_then_passes(noisy_module_fixture, module_device_setup):
+    global _attempt
+    _attempt += 1
+    assert _attempt >= 2, "intentional first-attempt failure"

--- a/unit-tests/infra-tests/e2e/pytest-retry-module-fixture.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-module-fixture.py
@@ -1,10 +1,10 @@
-# Verifies the core mechanic this PR depends on: pytest-retry tears down
-# and re-creates module-scoped fixtures between attempts (pytest-retry's
-# preliminary teardown trick, retry_plugin.py:207).
+# Verifies the core recycle mechanic: the conftest rerun-recycle hook tears
+# down module-scoped fixtures between attempts so the rerun's setup
+# re-creates them.
 #
 # Without this guarantee, module preconditions (e.g. setting D585S safety
 # service mode in test_device_wrapped) would not be re-applied after the
-# device is recycled on retry.
+# device is recycled on a rerun.
 import pytest
 
 pytestmark = [pytest.mark.device("D455")]
@@ -24,9 +24,9 @@ _test_attempt = 0
 
 def test_module_fixture_is_recreated_on_retry(counted_module_fixture):
     """Attempt 1: module-fixture setup ran once → counted_module_fixture == 1; test fails.
-    Attempt 2 (retry): pytest-retry's preliminary teardown trick tears down the
-    module fixture; setup re-runs → counted_module_fixture == 2; test asserts
-    the counter incremented (i.e. fixture was actually re-instantiated)."""
+    Attempt 2 (rerun): the conftest recycle hook tears down the module fixture;
+    setup re-runs → counted_module_fixture == 2; test asserts the counter
+    incremented (i.e. fixture was actually re-instantiated)."""
     global _test_attempt
     _test_attempt += 1
     if _test_attempt == 1:

--- a/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-module-setup-fail.py
@@ -1,7 +1,7 @@
 # A module-scoped fixture (autouse-dependency chain) that fails its first two setup
-# attempts. pytest-retry reruns setup+call unconditionally; on the failed re-setup the
-# call phase would raise KeyError('<fixture>'), masking the real error. The conftest guard
-# surfaces the real error instead, so the retry sees the true (retryable) exception.
+# attempts, then recovers. Setup-phase failures must be retried natively and the real
+# error recorded in the per-test log — never a masking KeyError('<fixture>') (which the
+# old pytest-retry engine produced by rerunning the call phase after a failed re-setup).
 import pytest
 _base = 0
 _dep = 0

--- a/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-timeout.py
@@ -1,11 +1,10 @@
-# Exercises the pytest-timeout + pytest-retry interaction. Run under
-# --retries=1 --timeout=5.
+# Exercises the pytest-timeout + rerun interaction. Run under
+# --reruns=1 --timeout=5.
 #
 # pytest-timeout arms its per-item timer in `pytest_runtest_protocol`, whose
-# yield covers setup + all call attempts + teardown. pytest-retry re-invokes
-# `pytest_runtest_call` from inside `pytest_runtest_makereport`, still under
-# that outer yield, so without a reset each retry shares the original --timeout
-# budget with the failed first attempt.
+# yield covers every attempt: pytest-rerunfailures runs all reruns inside that
+# single protocol call, so without a reset each rerun shares the original
+# --timeout budget with the failed first attempt.
 #
 # This test consumes ~3s per attempt on a 5s budget. Without the conftest
 # reset, attempt 2 has ~2s of budget left after attempt 1 and gets killed

--- a/unit-tests/infra-tests/e2e/pytest-retry-tmp-path.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry-tmp-path.py
@@ -1,0 +1,16 @@
+# Exercises the tmp_path fixture + rerun interaction. Run under --reruns 1.
+#
+# The tmp_path fixture teardown reads request.node.stash[tmppath_result_key], which is
+# populated only by pytest_runtest_makereport. A retry engine that bypasses makereport
+# (as pytest-retry did) leaves the key missing on a retried test's real teardown and the
+# finalizer raises `KeyError: <StashKey>` -- a teardown ERROR on a test that passed on
+# retry. pytest-rerunfailures reruns the whole protocol so makereport fires per attempt;
+# this scenario keeps that invariant guarded no matter which engine runs the retries.
+_attempt = 0
+
+
+def test_tmp_path_survives_retry(tmp_path):
+    global _attempt
+    _attempt += 1
+    (tmp_path / "artifact.txt").write_text("x")
+    assert _attempt >= 2, "intentional first-attempt failure"

--- a/unit-tests/infra-tests/e2e/pytest-retry.py
+++ b/unit-tests/infra-tests/e2e/pytest-retry.py
@@ -1,14 +1,13 @@
-# Verify native pytest-retry behaviour with --retries: a flaky test that
-# fails attempt 1 and passes attempt 2 should be reported as a single PASS.
-# Module-scoped fixtures are torn down + re-created between attempts, which
-# is how device recycling and precondition re-apply happen automatically.
+# Verify rerun behaviour with --reruns: a flaky test that fails attempt 1
+# and passes attempt 2 should be reported as a single PASS. The conftest
+# recycle hook tears down + re-creates local fixtures between attempts,
+# which is how device recycling and precondition re-apply happen.
 #
-# Semantics note: native pytest-retry retries the FAILING TEST only, NOT
-# the whole module. Module-level globals here (_fail_attempt,
-# _always_passes_calls) accumulate across attempts within a single subprocess
-# run because pytest-retry does not re-import the module — it only tears
-# down + re-creates fixture instances. Each run_e2e() call is a fresh
-# subprocess, so counters reset between e2e calls.
+# Semantics note: only the FAILING TEST is rerun, NOT the whole module.
+# Module-level globals here (_fail_attempt, _always_passes_calls) accumulate
+# across attempts within a single subprocess run because the module is not
+# re-imported — only fixture instances are re-created. Each run_e2e() call
+# is a fresh subprocess, so counters reset between e2e calls.
 import pytest
 
 pytestmark = [pytest.mark.device("D455")]
@@ -18,25 +17,24 @@ _always_passes_calls = 0
 
 
 def test_always_passes(module_device_setup):
-    """Runs exactly once. Native pytest-retry only retries the failing test,
-    not the whole module, so this test is not re-run when test_fails_then_passes
-    retries (contrast with the old pytest-repeat-based module-scoped retry)."""
+    """Runs exactly once. Only the failing test is rerun, not the whole
+    module, so this test is not re-run when test_fails_then_passes retries."""
     global _always_passes_calls
     _always_passes_calls += 1
 
 
 def test_fails_then_passes(module_device_setup):
-    """Fail on attempt 1, pass on attempt 2 (after pytest-retry tears down +
-    re-creates module fixtures via its preliminary teardown trick).
+    """Fail on attempt 1, pass on attempt 2 (after the recycle hook tears
+    down + re-creates module fixtures between attempts).
 
     Also asserts _always_passes_calls == 1, locking in the "only failing test
-    is retried" invariant: if pytest-retry ever re-runs the whole module on
-    retry, this assertion would catch it."""
+    is retried" invariant: if the rerun ever re-runs the whole module, this
+    assertion would catch it."""
     global _fail_attempt
     _fail_attempt += 1
     if _fail_attempt == 1:
         assert False, "intentional first-attempt failure"
     assert _always_passes_calls == 1, (
-        f"native pytest-retry should NOT re-run sibling tests on retry; "
+        f"reruns should NOT re-run sibling tests; "
         f"_always_passes_calls = {_always_passes_calls}"
     )

--- a/unit-tests/infra-tests/test_e2e_check_retry.py
+++ b/unit-tests/infra-tests/test_e2e_check_retry.py
@@ -2,16 +2,15 @@
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 """
-E2E: pytest-check soft checks under pytest-retry.
+E2E: pytest-check soft checks under reruns.
 
-pytest-check defers failures to makereport; pytest-retry reruns a test via
-pytest_runtest_call + TestReport.from_item_and_call, bypassing makereport. Without
-the conftest pytest_runtest_call bridge a failed soft check looks "passed" to the
-retry decision yet leaks onto the teardown report, so the run fails with a teardown
-error on a test reported as passed. These tests lock in the fixed behavior.
+pytest-check defers failures to makereport. The conftest pytest_runtest_call bridge raises
+them in the call phase instead, so they are attributed to the call (not teardown), visible to
+the rerun decision, and logged into the per-test .log file on every attempt. These tests lock
+in that behavior.
 """
 
-from helpers import run_e2e, assert_outcomes, parse_outcomes
+from helpers import run_e2e, parse_outcomes
 
 
 class TestCheckRetry:
@@ -20,7 +19,7 @@ class TestCheckRetry:
         """A soft check that fails every attempt ends as a plain FAILED test —
         attributed to the call phase, not a teardown ERROR, and not a false pass."""
         rc, out, *_ = run_e2e("pytest-check-retry.py",
-                               "-k", "test_persistent_soft_check", "--retries", "2")
+                               "-k", "test_persistent_soft_check", "--reruns", "2")
         assert rc != 0, out
         outcomes = parse_outcomes(out)
         assert outcomes.get("failed") == 1, out
@@ -31,10 +30,10 @@ class TestCheckRetry:
         """A soft check that fails attempt 1 and passes attempt 2 genuinely PASSES —
         no teardown error, no lingering failure."""
         rc, out, *_ = run_e2e("pytest-check-retry.py",
-                               "-k", "test_flaky_soft_check", "--retries", "2")
+                               "-k", "test_flaky_soft_check", "--reruns", "2")
         assert rc == 0, out
         outcomes = parse_outcomes(out)
         assert outcomes.get("passed") == 1, out
         assert outcomes.get("error", 0) == 0, out
         assert outcomes.get("failed", 0) == 0, out
-        assert "passed on attempt 2" in out, out
+        assert outcomes.get("rerun") == 1, f"expected exactly 1 rerun: {out}"

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -67,38 +67,38 @@ class TestCliOptionsRegistered:
         assert rc == 0
 
     def test_retries(self):
-        """--retries 1: a flaky call-phase failure is rescued by retry → single PASS.
+        """--reruns 1: a flaky call-phase failure is rescued by a rerun → single PASS.
 
-        pytest-retry tears down module-scoped fixtures (incl. module_device_setup)
-        between attempts via its preliminary-teardown trick, which is how the device
-        gets recycled and module preconditions re-applied on retry.
+        The conftest recycle hook (pytest_runtest_logreport, outcome=="rerun") tears down
+        every local fixture (incl. module_device_setup) between attempts, which is how the
+        device gets power-cycled and module preconditions re-applied on the rerun.
         """
-        rc, out, tracking = run_e2e("pytest-retry.py", "--retries", "1")
+        rc, out, tracking = run_e2e("pytest-retry.py", "--reruns", "1")
         assert_outcomes(out, passed=2)
         assert rc == 0
         calls = tracking["enable_only_calls"]
-        # Two enable_only calls: initial module-fixture creation + post-retry-teardown re-creation.
+        # Two enable_only calls: initial module-fixture creation + post-recycle re-creation.
         assert len(calls) == 2
         assert all(c['recycle'] is False for c in calls)
-        # the device recycle now comes from the teardown-disable between attempts, not recycle=True
+        # the device recycle comes from the teardown-disable between attempts, not recycle=True
         assert len(tracking["disable_calls"]) >= 1
 
     def test_retries_recreate_module_fixture(self):
         """Module-scoped fixtures must be torn down and re-instantiated between
-        retry attempts.  This is the core mechanic the conftest's
+        rerun attempts.  This is the core mechanic the conftest's
         ``test_device_wrapped`` (and any other module-scoped precondition fixture)
-        relies on for the device recycle / re-apply behaviour on retry."""
-        rc, out, _ = run_e2e("pytest-retry-module-fixture.py", "--retries", "1")
+        relies on for the device recycle / re-apply behaviour on rerun."""
+        rc, out, _ = run_e2e("pytest-retry-module-fixture.py", "--reruns", "1")
         assert_outcomes(out, passed=1)
         assert rc == 0
 
     def test_retries_on_setup_error(self):
-        """Setup-phase ERROR on attempt 1 must still trigger a retry.
+        """Setup-phase ERROR on attempt 1 must still trigger a rerun.
 
-        Regression for Jenkins win #113344.  Native pytest-retry skips setup
-        failures by default (retry_plugin.py:148-149); conftest.py patches
-        ``should_handle_retry`` to relax that gate."""
-        rc, out, _ = run_e2e("pytest-retry-setup-fail.py", "--retries", "1")
+        Regression for Jenkins win #113344.  pytest-rerunfailures reruns setup-phase
+        failures natively (it reruns the whole protocol), so no conftest patching is
+        involved — this locks the behavior in against plugin/config regressions."""
+        rc, out, _ = run_e2e("pytest-retry-setup-fail.py", "--reruns", "1")
         assert_outcomes(out, passed=1)
         assert rc == 0
 

--- a/unit-tests/infra-tests/test_e2e_log_failures.py
+++ b/unit-tests/infra-tests/test_e2e_log_failures.py
@@ -5,11 +5,10 @@
 E2E: a failing test records its exception in its per-test log file.
 
 Regression for empty failing-test logs (Jetson #17522): a test whose call phase
-raised left a .log ending on just the "Test:" header. Two effects combined --
-pytest_runtest_makereport was the only hook that logged failures, and pytest-retry
-reruns a test via pytest_runtest_call (never makereport). conftest now logs the
-call-phase failure from pytest_runtest_call (fires on every attempt), and the module
-log is opened in append mode so retries/repeats accumulate instead of overwriting.
+raised left a .log ending on just the "Test:" header. conftest logs the call-phase
+failure from pytest_runtest_call (one place that fires on every rerun attempt), and
+the module log is opened in append mode so reruns/repeats accumulate instead of
+overwriting (the between-attempts recycle finishes module_log; it reopens per attempt).
 """
 
 from helpers import run_e2e, parse_outcomes
@@ -39,10 +38,10 @@ class TestLogFailures:
         assert "Teardown:" in log, log   # common prefix across hub / hub-less / --no-reset paths
 
     def test_every_retry_attempt_recorded_in_one_file(self):
-        """Under --retries the module log is reopened in append mode per attempt and
-        makereport is bypassed; every attempt's failure AND teardown must accumulate in
-        the one file (not overwritten, not empty). --retries 2 == 3 attempts."""
-        rc, out, tracking = run_e2e("pytest-logfail.py", "--retries", "2")
+        """Under --reruns the between-attempts recycle finishes module_log and it reopens
+        in append mode per attempt; every attempt's failure AND teardown must accumulate
+        in the one file (not overwritten, not empty). --reruns 2 == 3 attempts."""
+        rc, out, tracking = run_e2e("pytest-logfail.py", "--reruns", "2")
         assert rc != 0, out
         assert parse_outcomes(out).get("failed") == 1, out
         log = _log(tracking)

--- a/unit-tests/infra-tests/test_e2e_rerun_console_leak.py
+++ b/unit-tests/infra-tests/test_e2e_rerun_console_leak.py
@@ -1,0 +1,31 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: the between-attempts recycle must not leak raw teardown stdout into the console.
+
+The rerun-recycle hook fires in pytest_runtest_logreport, between protocol phases, where
+pytest's output capture is suspended — fixture-teardown prints (e.g. rspy's "-D- Disabling
+ports..." hub lines) would otherwise splatter into the CI console mid-progress-line. The
+conftest hook swallows stdout for the duration; the python-logging bridge still records the
+lines in the per-test .log file (covered by test_e2e_log_failures).
+"""
+
+from helpers import run_e2e, parse_outcomes
+
+
+class TestRerunConsoleLeak:
+
+    def test_recycle_teardown_stdout_not_leaked(self):
+        """Attempt 1 fails → recycle runs the noisy module-fixture teardown between
+        attempts → its raw print must NOT appear in the console output, while the
+        recycle itself must still have happened (device disable tracked)."""
+        rc, out, tracking = run_e2e("pytest-rerun-teardown-print.py", "--reruns", "1")
+        assert rc == 0, out
+        outcomes = parse_outcomes(out)
+        assert outcomes.get("passed") == 1, out
+        assert outcomes.get("rerun") == 1, f"expected exactly 1 rerun: {out}"
+        assert "RAW-TEARDOWN-LEAK-MARKER" not in out, \
+            f"raw teardown stdout leaked into console:\n{out}"
+        assert len(tracking.get("disable_calls", [])) >= 1, \
+            "recycle did not run the module fixture teardown between attempts"

--- a/unit-tests/infra-tests/test_e2e_retry_setup_fail.py
+++ b/unit-tests/infra-tests/test_e2e_retry_setup_fail.py
@@ -2,15 +2,14 @@
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 """
-E2E: a module-scoped fixture that fails setup under pytest-retry must surface the REAL
-error, not a masking KeyError.
+E2E: a module-scoped fixture that fails setup must be retried, recover, and leave the REAL
+error diagnosable — never a masking KeyError.
 
-pytest-retry reruns a test by calling pytest_runtest_setup then pytest_runtest_call
-unconditionally (retry_plugin ~L237-238); it ignores whether the retry-setup failed. When it
-did, funcargs lack the fixture and pytest_pyfunc_call raises `KeyError: '<fixture>'`, hiding
-the real setup error. conftest's pytest_runtest_setup/pytest_runtest_call guard swaps that
-KeyError back for the recorded setup exception. Verified: without the guard this test sees
-`KeyError` in the output; with it, the real RuntimeError is reported and the retry recovers.
+pytest-rerunfailures reruns the whole protocol, so a failed setup is retried natively and
+pytest_runtest_makereport fires on every attempt; the conftest makereport hook logs each
+setup-phase failure into the per-test .log file. (Under the old pytest-retry engine a failed
+re-setup surfaced as `KeyError: '<fixture>'`, hiding the real error — this guard keeps that
+regression from coming back with any engine.)
 """
 
 from helpers import run_e2e, parse_outcomes
@@ -20,8 +19,14 @@ class TestRetrySetupFail:
 
     def test_module_fixture_setup_fail_surfaces_real_error(self):
         """Fixture fails setup on attempts 1 & 2 (real RuntimeError) and recovers on attempt 3.
-        The retry must never leak pytest-retry's masking KeyError."""
-        rc, out, *_ = run_e2e("pytest-retry-module-setup-fail.py", "--retries", "2")
-        assert parse_outcomes(out).get("passed") == 1, out
-        assert "KeyError" not in out, f"pytest-retry KeyError leaked:\n{out}"
-        assert "intentional module-fixture setup failure" in out, out
+        The run must recover cleanly and record the real error, never a masking KeyError."""
+        rc, out, tracking = run_e2e("pytest-retry-module-setup-fail.py", "--reruns", "2")
+        assert rc == 0, out
+        outcomes = parse_outcomes(out)
+        assert outcomes.get("passed") == 1, out
+        assert outcomes.get("rerun") == 2, f"expected 2 reruns: {out}"
+        assert "KeyError" not in out, f"masking KeyError leaked:\n{out}"
+        logs = tracking.get("logs", {})
+        module_log = logs.get("pytest-retry-module-setup-fail.log", "")
+        assert "intentional module-fixture setup failure" in module_log, \
+            f"real setup error missing from per-test log; logs: {list(logs)}"

--- a/unit-tests/infra-tests/test_e2e_retry_timeout.py
+++ b/unit-tests/infra-tests/test_e2e_retry_timeout.py
@@ -2,12 +2,11 @@
 # Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 """
-E2E: pytest-timeout resets between pytest-retry attempts.
+E2E: pytest-timeout resets between rerun attempts.
 
-pytest-timeout arms its per-item timer in `pytest_runtest_protocol`, whose
-yield covers setup + all call attempts + teardown. pytest-retry re-invokes
-`pytest_runtest_call` from `pytest_runtest_makereport`, still under that
-outer yield — so without a reset, retries share the original --timeout
+pytest-timeout arms ONE timer in `pytest_runtest_protocol`, whose yield covers
+every attempt: pytest-rerunfailures runs all its reruns inside that single
+protocol call, so without a reset the attempts share the original --timeout
 budget. A test that consumes most of the budget on attempt 1 gets killed
 mid-attempt-2 with a `+++ Timeout +++` stack dump. The conftest
 `_reset_pytest_timeout_for_retry` re-arms the timer at the start of every
@@ -25,9 +24,9 @@ class TestRetryTimeoutReset:
         With the reset, each attempt gets a fresh 5s and the test PASSES.
         2s slack per attempt tolerates slow CI scheduler jitter."""
         rc, out, *_ = run_e2e("pytest-retry-timeout.py",
-                               "--retries", "1", "--timeout", "5")
+                               "--reruns", "1", "--timeout", "5")
         assert rc == 0, out
         outcomes = parse_outcomes(out)
         assert outcomes.get("passed") == 1, out
-        assert outcomes.get("retried") == 1, f"expected exactly 1 retry: {out}"
+        assert outcomes.get("rerun") == 1, f"expected exactly 1 rerun: {out}"
         assert "+++ Timeout +++" not in out, out

--- a/unit-tests/infra-tests/test_e2e_retry_tmp_path.py
+++ b/unit-tests/infra-tests/test_e2e_retry_tmp_path.py
@@ -1,0 +1,31 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+E2E: a test that uses the tmp_path fixture must survive a rerun with no teardown error.
+
+The tmp_path fixture teardown reads request.node.stash[tmppath_result_key], populated only by
+pytest_runtest_makereport. A retry engine that bypasses makereport (as pytest-retry did) leaves
+the key missing at the retried test's real teardown and the finalizer raises
+`KeyError: <StashKey>` -- recorded as a teardown ERROR even though the test passed on retry
+(seen as Jenkins libci junit "failed on teardown with KeyError: <StashKey>").
+pytest-rerunfailures reruns the whole protocol, so makereport fires on every attempt and the
+key stays balanced. This guard keeps the whole class from coming back with any engine.
+"""
+
+from helpers import run_e2e, parse_outcomes
+
+
+class TestRetryTmpPath:
+
+    def test_tmp_path_fixture_survives_retry(self):
+        """Attempt 1 fails, attempt 2 passes. The retried test uses tmp_path, so its teardown
+        finalizer must not raise KeyError on a missing stash key -- the test genuinely PASSES
+        with no teardown error."""
+        rc, out, *_ = run_e2e("pytest-retry-tmp-path.py", "--reruns", "1")
+        assert rc == 0, out
+        outcomes = parse_outcomes(out)
+        assert outcomes.get("passed") == 1, out
+        assert outcomes.get("rerun") == 1, f"expected exactly 1 rerun: {out}"
+        assert outcomes.get("error", 0) == 0, f"tmp_path teardown KeyError leaked:\n{out}"
+        assert "KeyError" not in out, out

--- a/unit-tests/infra-tests/test_no_legacy_retry_marker.py
+++ b/unit-tests/infra-tests/test_no_legacy_retry_marker.py
@@ -1,0 +1,36 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Guard: no test uses pytest-retry's `flaky(retries=N)` kwarg.
+
+We retry via pytest-rerunfailures, whose flaky marker reads `reruns=` — a stray `retries=`
+is silently ignored (the test loses its per-test retry). Scan the whole unit-tests tree so a
+new file can't reintroduce the old syntax.
+"""
+
+import os
+import re
+
+_UNIT_TESTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# flaky(...) marker carrying a `retries=` kwarg (any spacing)
+_LEGACY = re.compile(r"mark\.flaky\([^)]*\bretries\s*=")
+
+
+def test_no_flaky_retries_kwarg():
+    offenders = []
+    for root, _dirs, files in os.walk(_UNIT_TESTS):
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(root, name)
+            if os.path.abspath(path) == os.path.abspath(__file__):
+                continue
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+            if _LEGACY.search(text):
+                offenders.append(os.path.relpath(path, _UNIT_TESTS))
+    assert not offenders, (
+        "pytest-retry `flaky(retries=N)` found; use pytest-rerunfailures `flaky(reruns=N)`:\n"
+        + "\n".join(offenders)
+    )

--- a/unit-tests/live/d400/pytest-mipi-motion.py
+++ b/unit-tests/live/d400/pytest-mipi-motion.py
@@ -12,7 +12,7 @@ import time
 pytestmark = [
     pytest.mark.device_each("D457"),
     pytest.mark.skipif(platform.machine() != "aarch64", reason="Jetson only"),
-    pytest.mark.flaky(retries=3),
+    pytest.mark.flaky(reruns=3),
 ]
 
 gyro_frame_count = 0

--- a/unit-tests/live/d500/safety/pytest-preset-get-set.py
+++ b/unit-tests/live/d500/safety/pytest-preset-get-set.py
@@ -16,7 +16,7 @@ pytestmark = [
     pytest.mark.device_each("D585S"),
     pytest.mark.priority(10),
     pytest.mark.context("weekly"),
-    pytest.mark.flaky(retries=3),
+    pytest.mark.flaky(reruns=3),
 ]
 
 

--- a/unit-tests/live/options/pytest-presets.py
+++ b/unit-tests/live/options/pytest-presets.py
@@ -12,7 +12,7 @@ pytestmark = [
     pytest.mark.device_each("D400*"),
     pytest.mark.device_each("D500*"),
     pytest.mark.context("nightly"),
-    pytest.mark.flaky(retries=2),  # See FW stability issue RSDSO-18908
+    pytest.mark.flaky(reruns=2),  # See FW stability issue RSDSO-18908
 ]
 
 

--- a/unit-tests/live/tools/pytest-realsense-viewer.py
+++ b/unit-tests/live/tools/pytest-realsense-viewer.py
@@ -21,7 +21,7 @@ pytestmark = [
     pytest.mark.context("gui"),
     # Opt out of --retries: the outer pytest-timeout clock is not reset between
     # attempts, so a retry runs on the leftover budget and gets killed mid-viewer.
-    pytest.mark.flaky(retries=0),
+    pytest.mark.flaky(reruns=0),
 ]
 
 

--- a/unit-tests/live/tools/pytest-realsense-viewer.py
+++ b/unit-tests/live/tools/pytest-realsense-viewer.py
@@ -19,8 +19,8 @@ pytestmark = [
     pytest.mark.device("D400*"),
     pytest.mark.context("nightly"),
     pytest.mark.context("gui"),
-    # Opt out of --retries: the outer pytest-timeout clock is not reset between
-    # attempts, so a retry runs on the leftover budget and gets killed mid-viewer.
+    # Opt out of retries: this launches the realsense-viewer GUI and is long-running /
+    # not reliably retryable, so a rerun just doubles CI time without adding signal.
     pytest.mark.flaky(reruns=0),
 ]
 

--- a/unit-tests/py/rspy/pytest/plugins.py
+++ b/unit-tests/py/rspy/pytest/plugins.py
@@ -18,10 +18,10 @@ import pytest
 
 REQUIRED_PYTEST_PLUGINS = {
     # module name          : pip package name (for the install hint)
-    'pytest_timeout':      'pytest-timeout',
-    'pytest_retry':        'pytest-retry',
-    'pytest_repeat':       'pytest-repeat',
-    'pytest_check':        'pytest-check',
+    'pytest_timeout':        'pytest-timeout',
+    'pytest_rerunfailures':  'pytest-rerunfailures',
+    'pytest_repeat':         'pytest-repeat',
+    'pytest_check':          'pytest-check',
 
 }
 

--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -15,7 +15,10 @@ zstandard==0.25.0 # for verifying ros2_writer's zstd-compressed .db3 frames
 # Pytest framework (cross-platform)
 pytest==8.3.5
 pytest-timeout==2.2.0
-pytest-rerunfailures==16.4
+# 16.1+ requires Python >= 3.10; Jetson JetPack 5 benches run 3.8. Retry-guard
+# infra tests verified green on both pins.
+pytest-rerunfailures==16.4; python_version >= "3.10"
+pytest-rerunfailures==16.0.1; python_version < "3.10"
 pytest-repeat==0.9.3
 pytest-check==2.8.0
 

--- a/unit-tests/requirements.txt
+++ b/unit-tests/requirements.txt
@@ -15,7 +15,7 @@ zstandard==0.25.0 # for verifying ros2_writer's zstd-compressed .db3 frames
 # Pytest framework (cross-platform)
 pytest==8.3.5
 pytest-timeout==2.2.0
-pytest-retry==1.7.0
+pytest-rerunfailures==16.4
 pytest-repeat==0.9.3
 pytest-check==2.8.0
 


### PR DESCRIPTION
**Overview:** Swap the test-retry engine from pytest-retry to pytest-rerunfailures and add a conftest hook that power-cycles the device between rerun attempts. This removes a whole class of retry-infrastructure bugs — most recently a teardown `KeyError: <StashKey>` that turned green libci runs red.

## Why
pytest-retry reruns a test by driving `pytest_runtest_setup`/`call` directly, bypassing `pytest_runtest_makereport`. Every per-item state owned by makereport desyncs on retry, which forced an accreting pile of conftest workarounds: a `should_handle_retry` patch (setup-phase retries), a setup-exception swap (masking `KeyError: '<fixture>'`), a pytest-check bridge, and — the latest instance — the `tmp_path` fixture's `tmppath_result_key` going missing at teardown, recorded as `failed on teardown with "KeyError: <StashKey>"` on tests that passed on retry (reddening libci; supersedes #15461).

pytest-rerunfailures reruns the **full protocol** via `_pytest.runner.runtestprotocol`, so makereport fires on every attempt and the whole desync class disappears. It retries setup-phase failures natively. It is also actively maintained, unlike pytest-retry (last release Jan 2025).

The one thing pytest-retry did that rerunfailures doesn't: tearing down module-scoped fixtures between attempts — which is how the device gets power-cycled and module preconditions re-applied (a failed test can leave the camera in a state only a power cycle recovers). A new conftest hook restores exactly that.

## Summary
- `conftest.py`: remove the pytest-retry `should_handle_retry` patch and the setup-exception KeyError swap (both engine-specific); add the rerun-recycle hook (`pytest_runtest_logreport`, outcome == "rerun") that `finish()`es every local (non-session) fixture of the item so the rerun's setup re-creates the chain — port disable → enable, bring-up settle, fresh context, fresh handle, preconditions re-applied, per-test log reopened in append mode. The hook swallows raw stdout for its duration (it runs between protocol phases where pytest capture is suspended, else rspy's `-D-` hub prints leak into the console); the python-logging bridge still records every line in the per-test `.log`. Keep the per-attempt pytest-timeout re-arm (still needed — pytest-timeout arms one protocol-scope timer spanning all reruns) and the pytest-check call-phase bridge.
- `requirements.txt` / `rspy/pytest/plugins.py`: pytest-retry → pytest-rerunfailures. Pinned conditionally — 16.4 on Python >= 3.10, 16.0.1 on < 3.10 (JetPack 5 Jetson benches run 3.8; 16.1+ requires 3.10).
- Infra guards: `--retries N` → `--reruns N`, outcome word `retried` → `rerun`; setup-fail guard asserts the real error via the per-test log; new `test_e2e_retry_tmp_path` (tmp_path teardown class) and `test_e2e_rerun_console_leak` (no raw stdout leak) guards.
- CLI: `--retries` is not aliased (pytest parses args before conftest can rewrite argv, and pytest-retry co-installed would claim the flag) — CI must pass `--reruns`; companion deploy PR RealSenseAI-Internal/librealsense-deploy#157 updates the groovy. Benches that still have pytest-retry installed are unaffected: it is inert without its flag.

## Test plan
- [x] Full infra suite: 150 passed, 0 failed, 9 skipped (both Python pins).
- [x] Requirement guards green: flaky rescue + device recycle between attempts, module-fixture re-creation + precondition re-apply, setup-phase retry, per-attempt timeout reset, pytest-check flaky/persistent, all attempts in one per-test log, tmp_path survives rerun, no console stdout leak.
- [x] Validated on a live bench (D400 + D500 devices): forced first-attempt failure in `pytest-ros2-compression.py` → RERUN → PASSED with the port power-cycled between attempts and zero teardown errors (same scenario produced 2 teardown `KeyError: <StashKey>` errors under pytest-retry).
- [x] Full nightly-context libci run with the companion deploy branch (build 17389): Jetson ×2, Windows, Linux ×2 all green; the only reds are two pre-existing device/test-quality failures (a D585S safety-verdict mismatch that fails identically on the old engine, and an options-watcher timing flake), neither caused by the engine and no test dropped from collection.

---
🤖 Generated by AI
