### PR TITLE
Skip D585S safety-verdict test pending RSDEV-13164

### DIFF
--- a/unit-tests/live/d500/safety/pytest-preset-active-index-safety-signal.py
+++ b/unit-tests/live/d500/safety/pytest-preset-active-index-safety-signal.py
@@ -17,6 +17,9 @@ pytestmark = [
     pytest.mark.device_each("D585S"),
     pytest.mark.context("nightly"),
     pytest.mark.skipif(sys.platform != "linux", reason="Linux only"),
+    # Disabled: preset 1 danger_collision reports 0 (obstacle not detected in the danger zone)
+    # on the D585S bench. Under investigation (lab scene vs safety algo/FW). Re-enable when fixed.
+    pytest.mark.skip(reason="RSDEV-13164: D585S preset 1 danger_collision not signalled"),
 ]
 
 #############################################################################################


### PR DESCRIPTION
**Overview:** Disable `test_active_index_changes_safety_verdict[D585S]` — it reports `danger_collision=0` for preset 1 (obstacle not detected in the danger zone) on the D585S bench. Skipped pending investigation so it stops reddening nightly libci.

Tracked on RSDEV-13164

## Why
The test writes two safety presets differing only in the danger zone's forward extent: preset 0's danger zone ends before the lab wall (`danger_collision` expected 0), preset 1's reaches past it (expected 1). The device returns `danger_collision=0` for preset 1 — the wall is not seen inside the zone. Preset 0 passes; only preset 1's danger verdict is wrong.

Pre-existing, not a regression: fails on current `development` independent of the pytest retry engine (reproduced under both pytest-retry and pytest-rerunfailures). Likely the lab scene on the D585S bench (physical wall position) or the safety vision algo/FW occlusion verdict — needs a look with the bench in hand.

## Summary
- Add `pytest.mark.skip(reason="RSDEV-13164: ...")` to the module's `pytestmark`. The file has a single test and is `device_each("D585S")`, so this disables exactly the D585S case, nothing else.

## Test plan
- [x] File parses; the test is now collected as SKIPPED.
- [ ] Re-enable under RSDEV-13164 once root-caused.

---
🤖 Generated by AI
