### PR TITLE
Refactor backend-v4l

### DIFF
--- a/.github/skills/cpp_coding.md
+++ b/.github/skills/cpp_coding.md
@@ -31,3 +31,10 @@ Use this protocol to ensure all C++ code modifications align with the project's 
 ### 6. Performance Checks
 *   **Hot Paths**: Check for hidden allocations in loops or streaming callbacks.
 *   **Copying**: Minimize data copying; use const references (`const T&`) for non-primitive arguments.
+
+### 7. Comments
+*   **Comments should be sparse.** Keep to 1–2 lines unless the code is large and genuinely complex.
+*   **Intention** Don't restate what the code already says, comment should convey the reason for the code.
+*   **Locallity** The comment should refer to the local code. e.g. class description should not mention inheritors or where other logic live.
+*   **Lenght** Comment lines can be as long as the surrounding code. If code lines usually trim at 120 characters comment lines don't have to be 80 characters long.
+*   **Generality** Don't reference internal session reasoning e.g. "as you instructed" 

--- a/.github/skills/cpp_coding.md
+++ b/.github/skills/cpp_coding.md
@@ -34,7 +34,7 @@ Use this protocol to ensure all C++ code modifications align with the project's 
 
 ### 7. Comments
 *   **Comments should be sparse.** Keep to 1–2 lines unless the code is large and genuinely complex.
-*   **Intention** Don't restate what the code already says, comment should convey the reason for the code.
-*   **Locallity** The comment should refer to the local code. e.g. class description should not mention inheritors or where other logic live.
-*   **Lenght** Comment lines can be as long as the surrounding code. If code lines usually trim at 120 characters comment lines don't have to be 80 characters long.
-*   **Generality** Don't reference internal session reasoning e.g. "as you instructed" 
+*   **Intention:** Don't restate what the code already says, comment should convey the reason for the code.
+*   **Locality:** The comment should refer to the local code. e.g. class description should not mention inheritors or where other logic live.
+*   **Length:** Comment lines can be as long as the surrounding code. If code lines usually trim at 120 characters comment lines don't have to be 80 characters long.
+*   **Generality:** Don't reference internal session reasoning e.g. "as you instructed" 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/backend.h"
         "${CMAKE_CURRENT_LIST_DIR}/backend-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/backend-device-group.h"
+        "${CMAKE_CURRENT_LIST_DIR}/platform/camera-identifier.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/platform-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/device-watcher.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/frame-object.h"

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -501,7 +501,7 @@ namespace librealsense
 
         if (depth_devs_info.empty() || depth_devices.empty())
         {
-            throw backend_exception("cannot access depth sensor", RS2_EXCEPTION_TYPE_BACKEND);
+            throw backend_exception("cannot access depth sensor");
         }
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -90,7 +90,7 @@ namespace librealsense
 
         if ( color_devs_info.empty() )
         {
-            throw backend_exception("cannot access color sensor", RS2_EXCEPTION_TYPE_BACKEND);
+            throw backend_exception("cannot access color sensor");
         }
 
         std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -362,7 +362,7 @@ namespace librealsense
 
         if (depth_devs_info.empty() || depth_devices.empty())
         {
-            throw backend_exception("cannot access depth sensor", RS2_EXCEPTION_TYPE_BACKEND);
+            throw backend_exception("cannot access depth sensor");
         }
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
@@ -738,7 +738,7 @@ namespace librealsense
             }
             else
             {
-                throw backend_exception( "Unsupported connection type", RS2_EXCEPTION_TYPE_BACKEND );
+                throw backend_exception( "Unsupported connection type" );
             }
         }
     }

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -463,11 +463,7 @@ namespace librealsense
 
         d500_auto_calibrated::set_depth_sensor( &depth_sensor );
 
-        using namespace platform;
-
-        std::string pid_hex_str, usb_type_str;
         d500_gvd_parsed_fields gvd_parsed_fields;
-        bool usb_modality = true;
         group_multiple_fw_calls(depth_sensor, [&]() {
             
             // D500 device can get enumerated before the whole HW in the camera is ready.
@@ -488,19 +484,9 @@ namespace librealsense
 
             _fw_version = rsutils::version(gvd_parsed_fields.fw_version);
 
-            auto _usb_mode = usb3_type;
-            usb_type_str = usb_spec_names.at(_usb_mode);
-            _usb_mode = raw_depth_sensor->get_usb_specification();
-            if (usb_spec_names.count(_usb_mode) && (usb_undefined != _usb_mode))
-                usb_type_str = usb_spec_names.at(_usb_mode);
-            else  // Backend fails to provide USB descriptor  - occurs with RS3 build. Requires further work
-                usb_modality = false;
-
             set_imu_type( gvd_buff, &gvd_parsed_fields );
 
             _is_symmetrization_enabled = check_symmetrization_enabled();
-
-            pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
 
             _is_locked = _ds_device_common->is_locked( gvd_buff.data(), d500_gvd_offsets::is_camera_locked_offset );
 
@@ -698,7 +684,8 @@ namespace librealsense
         register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, gvd_parsed_fields.fw_version);        
         register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, group.uvc_devices.front().device_path);
         register_info(RS2_CAMERA_INFO_DEBUG_OP_CODE, std::to_string(static_cast<int>(fw_cmd::GET_FW_LOGS)));
-        register_info(RS2_CAMERA_INFO_PRODUCT_ID, pid_hex_str);
+        std::string pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
+        register_info( RS2_CAMERA_INFO_PRODUCT_ID, pid_hex_str );
         register_info(RS2_CAMERA_INFO_PRODUCT_LINE, "D500");
         register_info(RS2_CAMERA_INFO_CAMERA_LOCKED, _is_locked ? "YES" : "NO");
 
@@ -706,12 +693,8 @@ namespace librealsense
         {
             register_info(RS2_CAMERA_INFO_SMCU_FW_VERSION, gvd_parsed_fields.safety_sw_suite_version);
         }
+        register_connection_info( raw_depth_sensor->get_usb_specification() );
 
-        if (usb_modality)
-        {
-            register_info(RS2_CAMERA_INFO_CONNECTION_TYPE, "USB");
-            register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
-        }
         register_info( RS2_CAMERA_INFO_IMU_TYPE, gvd_parsed_fields.imu_type );
 
         register_features();
@@ -722,6 +705,42 @@ namespace librealsense
             _coefficients_table_raw.reset();
             _new_calib_table_raw.reset();
         } );
+    }
+
+    void d500_device::register_connection_info( platform::usb_spec usb_spec )
+    {
+        using namespace platform;
+
+        if( usb_spec_names.count( usb_spec ) && ( usb_undefined != usb_spec ) )
+        {
+            std::string usb_spec_str = usb_spec_names.at( usb_spec );
+            register_info( RS2_CAMERA_INFO_CONNECTION_TYPE, "USB" );
+            register_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_spec_str );
+        }
+        else // Backend fails to provide USB descriptor
+        {
+            if( _is_mipi_device )
+            {
+                register_info( RS2_CAMERA_INFO_CONNECTION_TYPE, "GMSL" );
+                rsutils::version mipi_driver_version = platform::get_jetson_driver_version();
+                if( mipi_driver_version.is_valid() )
+                {
+                    register_info( RS2_CAMERA_INFO_MIPI_DRIVER_VERSION, mipi_driver_version.to_string() );
+
+                    // Log driver version only once across all devices
+                    static bool logged = false;
+                    if( ! logged )
+                    {
+                        LOG_INFO( "MIPI driver version detected: " << mipi_driver_version.to_string() );
+                        logged = true;
+                    }
+                }
+            }
+            else
+            {
+                throw backend_exception( "Unsupported connection type", RS2_EXCEPTION_TYPE_BACKEND );
+            }
+        }
     }
 
     void d500_device::register_features()

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -144,7 +144,8 @@ namespace librealsense
 
         void register_converters( synthetic_sensor & depth_sensor );
 
-        void init(std::shared_ptr<context> ctx, const platform::backend_device_group& group);
+        void init( std::shared_ptr< context > ctx, const platform::backend_device_group & group );
+        void register_connection_info( platform::usb_spec usb_spec );
         void register_features();
         void set_imu_type( const std::vector< uint8_t > & gvd_buf, ds::d500_gvd_parsed_fields * parsed_fields );
         friend class d500_depth_sensor;

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -127,7 +127,7 @@ namespace librealsense
             imu_devices.push_back( get_backend()->create_uvc_device( info ) );
 
         if (imu_devices.empty())
-            throw backend_exception("cannot access IMU sensor", RS2_EXCEPTION_TYPE_BACKEND);
+            throw backend_exception("cannot access IMU sensor");
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata_mipi_motion(std::move(timestamp_reader_backup)));

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -44,10 +44,9 @@ namespace librealsense
         auto res = messenger->control_transfer(0xa1 /*DFU_GETSTATUS_PACKET*/, RS2_DFU_GET_STATE, 0, 0, &state, 1, transferred, DEFAULT_TIMEOUT);
         if (res == librealsense::platform::RS2_USB_STATUS_ACCESS)
             throw backend_exception("Permission Denied!\n"
-                "This is often an indication of outdated or missing udev-rules.\n"
-                "If using Debian package, run sudo apt-get install librealsense2-dkms\n"
-                "If building from source, run ./scripts/setup_udev_rules.sh",
-                RS2_EXCEPTION_TYPE_BACKEND);
+                                    "This is often an indication of outdated or missing udev-rules.\n"
+                                    "If using Debian package, run sudo apt-get install librealsense2-dkms\n"
+                                    "If building from source, run ./scripts/setup_udev_rules.sh");
         return res == platform::RS2_USB_STATUS_SUCCESS ? (rs2_dfu_state)state : RS2_DFU_STATE_DFU_ERROR;
     }
 

--- a/src/librealsense-exception.h
+++ b/src/librealsense-exception.h
@@ -78,8 +78,8 @@ public:
 class backend_exception : public unrecoverable_exception
 {
 public:
-    backend_exception( const std::string & msg, rs2_exception_type exception_type ) noexcept
-        : unrecoverable_exception( msg, exception_type )
+    backend_exception( const std::string & msg ) noexcept
+        : unrecoverable_exception( msg, RS2_EXCEPTION_TYPE_BACKEND )
     {
     }
 };
@@ -89,7 +89,7 @@ class linux_backend_exception : public backend_exception
 {
 public:
     linux_backend_exception( const std::string & msg ) noexcept
-        : backend_exception( generate_last_error_message( msg ), RS2_EXCEPTION_TYPE_BACKEND )
+        : backend_exception( generate_last_error_message( msg ) )
     {
     }
 
@@ -106,7 +106,7 @@ class windows_backend_exception : public backend_exception
 public:
     // TODO: get last error
     windows_backend_exception( const std::string & msg ) noexcept
-        : backend_exception( msg, RS2_EXCEPTION_TYPE_BACKEND )
+        : backend_exception( msg )
     {
     }
 };

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -6,6 +6,12 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/backend-hid.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/backend-v4l2.h"
         "${CMAKE_CURRENT_LIST_DIR}/backend-hid.h"
+        "${CMAKE_CURRENT_LIST_DIR}/camera-identifier-v4l.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/camera-identifier-v4l.h"
+        "${CMAKE_CURRENT_LIST_DIR}/v4l-mipi-logic.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/v4l-mipi-logic.h"
+        "${CMAKE_CURRENT_LIST_DIR}/v4l-usb-logic.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/v4l-usb-logic.h"
 )
 
 include(libusb_config)

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -853,8 +853,8 @@ namespace librealsense
                 if (dfu_ver.find("recovery") == std::string::npos)
                     continue;
                 mipi_device_info info{};
-                info.pid = 0xbbcd;
-                info.vid = 0x8086;
+                info.pid = 0xbbcd; // D400 MIPI recovery device ID
+                info.vid = 0x8086; // D400 Intel VID
                 info.id = *it;
                 info.device_path = mipi_dfu_path;
                 info.unique_id = *it;
@@ -2919,7 +2919,7 @@ namespace librealsense
 
         std::shared_ptr<uvc_device> v4l_backend::create_uvc_device(uvc_device_info info) const
         {
-            bool mipi_device = (mipi_devices_pid.count(info.pid) > 0);
+            bool mipi_device = is_mipi_pid(info.pid);
 
             auto v4l_uvc_dev =        mipi_device ?         std::make_shared<v4l_mipi_device>(info) :
                               ((!info.has_metadata_node) ?  std::make_shared<v4l_uvc_device>(info) :

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2,6 +2,8 @@
 // Copyright(c) 2015-2024 RealSense, Inc. All Rights Reserved.
 
 #include "backend-v4l2.h"
+#include "v4l-mipi-logic.h"
+#include "v4l-usb-logic.h"
 #include <src/platform/command-transfer.h>
 #include <src/platform/hid-data.h>
 #include <src/core/time-service.h>
@@ -62,7 +64,6 @@
 
 #pragma GCC diagnostic ignored "-Woverflow"
 
-const size_t MAX_DEV_PARENT_DIR = 10;
 const double DEFAULT_KPI_FRAME_DROPS_PERCENTAGE = 0.05;
 
 //D457 Dev. TODO -shall be refactored into the kernel headers.
@@ -310,13 +311,36 @@ namespace librealsense
             return true;
         }
 
-        static int xioctl(int fh, unsigned long request, void *arg)
+        int xioctl(int fh, unsigned long request, void *arg)
         {
-            int r=0;
+            int r = 0;
             do {
                 r = ioctl(fh, request, arg);
             } while (r < 0 && errno == EINTR);
             return r;
+        }
+
+        // Retrieve device video capabilities to discriminate video capturing and metadata nodes
+        v4l2_capability v4l_uvc_device::get_dev_capabilities(const std::string dev_name)
+        {
+            // RAII to handle exceptions
+            std::unique_ptr<int, std::function<void(int*)> > fd(
+                        new int (open(dev_name.c_str(), O_RDWR | O_NONBLOCK, 0)),
+                        [](int* d){ if (d && (*d)) {::close(*d); } delete d; });
+
+            if(*fd < 0)
+                throw linux_backend_exception(rsutils::string::from() << __FUNCTION__ << ": Cannot open '" << dev_name);
+
+            v4l2_capability cap = {};
+            if(xioctl(*fd, VIDIOC_QUERYCAP, &cap) < 0)
+            {
+                if(errno == EINVAL)
+                    throw linux_backend_exception(rsutils::string::from() << __FUNCTION__ << " " << dev_name << " is no V4L2 device");
+                else
+                    throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " xioctl(VIDIOC_QUERYCAP) failed");
+            }
+
+            return cap;
         }
 
         buffer::buffer(int fd, v4l2_buf_type type, bool use_memory_map, uint32_t index)
@@ -526,58 +550,6 @@ namespace librealsense
         bool  buffers_mgr::md_node_present() const
         {
             return (buffers[e_metadata_buf]._file_desc > 0);
-        }
-
-        // retrieve the USB specification attributed to a specific USB device.
-        // This functionality is required to find the USB connection type for UVC device
-        // Note that the input parameter is passed by value
-        static usb_spec get_usb_connection_type(std::string path)
-        {
-            usb_spec res{usb_undefined};
-
-            char usb_actual_path[PATH_MAX] = {0};
-            if (realpath(path.c_str(), usb_actual_path) != nullptr)
-            {
-                path = std::string(usb_actual_path);
-                std::string camera_usb_version;
-                if(!(std::ifstream(path + "/version") >> camera_usb_version))
-                    throw linux_backend_exception("Failed to read usb version specification");
-
-                // go through the usb_name_to_spec map to find a usb type where the first element is contained in 'camera_usb_version'
-                // (contained and not strictly equal because of differences like "3.2" vs "3.20")
-                for(const auto usb_type : usb_name_to_spec ) {
-                    std::string usb_name = usb_type.first;
-                    if (std::string::npos != camera_usb_version.find(usb_name))
-                    {
-                         res = usb_type.second;
-                         return res;
-                    }
-                }
-            }
-            return res;
-        }
-
-        // Retrieve device video capabilities to discriminate video capturing and metadata nodes
-        static v4l2_capability get_dev_capabilities(const std::string dev_name)
-        {
-            // RAII to handle exceptions
-            std::unique_ptr<int, std::function<void(int*)> > fd(
-                        new int (open(dev_name.c_str(), O_RDWR | O_NONBLOCK, 0)),
-                        [](int* d){ if (d && (*d)) {::close(*d); } delete d; });
-
-            if(*fd < 0)
-                throw linux_backend_exception(rsutils::string::from() << __FUNCTION__ << ": Cannot open '" << dev_name);
-
-            v4l2_capability cap = {};
-            if(xioctl(*fd, VIDIOC_QUERYCAP, &cap) < 0)
-            {
-                if(errno == EINVAL)
-                    throw linux_backend_exception(rsutils::string::from() << __FUNCTION__ << " " << dev_name << " is no V4L2 device");
-                else
-                    throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " xioctl(VIDIOC_QUERYCAP) failed");
-            }
-
-            return cap;
         }
 
         void stream_ctl_on(int fd, v4l2_buf_type type=V4L2_BUF_TYPE_VIDEO_CAPTURE)
@@ -856,391 +828,6 @@ namespace librealsense
             return dfu_paths;
         }
 
-        bool v4l_uvc_device::is_usb_path_valid(const std::string& usb_video_path, const std::string& dev_name,
-                                               std::string& busnum, std::string& devnum, std::string& devpath)
-        {
-            struct stat st = {};
-            if(stat(dev_name.c_str(), &st) < 0)
-            {
-                throw linux_backend_exception(rsutils::string::from() << "Cannot identify '" << dev_name);
-            }
-            if(!S_ISCHR(st.st_mode))
-                throw linux_backend_exception(dev_name + " is no device");
-
-            // Search directory and up to three parent directories to find busnum/devnum
-            auto valid_path = false;
-            std::ostringstream ss;
-            ss << "/sys/dev/char/" << major(st.st_rdev) << ":" << minor(st.st_rdev) << "/device/";
-
-            auto char_dev_path = ss.str();
-
-            for(auto i=0U; i < MAX_DEV_PARENT_DIR; ++i)
-            {
-                if(std::ifstream(char_dev_path + "busnum") >> busnum)
-                {
-                    if(std::ifstream(char_dev_path + "devnum") >> devnum)
-                    {
-                        if(std::ifstream(char_dev_path + "devpath") >> devpath)
-                        {
-                            valid_path = true;
-                            break;
-                        }
-                    }
-                }
-                char_dev_path += "../";
-            }
-            return valid_path;
-        }
-
-        uvc_device_info v4l_uvc_device::get_info_from_usb_device_path(const std::string& video_path, const std::string& dev_name, const std::string& name,
-                                                                      const std::vector<std::pair <std::string, std::string>>& sys_to_dev_video_paths)
-        {
-            std::string busnum, devnum, devpath;
-
-            if (!is_usb_path_valid(video_path, dev_name, busnum, devnum, devpath))
-            {
-#ifndef RS2_USE_CUDA
-                if (rsutils::rs2_is_cuda_available())
-                {
-                    /* On the Jetson TX, the camera module is CSI & I2C and does not report as this code expects
-                    Patch suggested by JetsonHacks: https://github.com/jetsonhacks/buildLibrealsense2TX */
-                    LOG_INFO("Failed to read busnum/devnum. Device Path: " << ("/sys/class/video4linux/" + name));
-                }
-#endif
-               throw linux_backend_exception("Failed to read busnum/devnum of usb device");
-            }
-
-            LOG_INFO("Enumerating UVC " << name << " v4l_path=" << video_path << " dev_name=" << dev_name);
-            uint16_t vid{}, pid{}, mi{};
-            usb_spec usb_specification(usb_undefined);
-
-            std::string modalias;
-            if(!(std::ifstream("/sys/class/video4linux/" + name + "/device/modalias") >> modalias))
-                throw linux_backend_exception("Failed to read modalias");
-            if(modalias.size() < 14 || modalias.substr(0,5) != "usb:v" || modalias[9] != 'p')
-                throw linux_backend_exception("Not a usb format modalias");
-            if(!(std::istringstream(modalias.substr(5,4)) >> std::hex >> vid))
-                throw linux_backend_exception("Failed to read vendor ID");
-            if(!(std::istringstream(modalias.substr(10,4)) >> std::hex >> pid))
-                throw linux_backend_exception("Failed to read product ID");
-            if(!(std::ifstream("/sys/class/video4linux/" + name + "/device/bInterfaceNumber") >> std::hex >> mi))
-                throw linux_backend_exception("Failed to read interface number");
-
-            // Find the USB specification (USB2/3) type from the underlying device
-            // Use device mapping obtained in previous step to traverse node tree
-            // and extract the required descriptors
-            // Traverse from
-            // /sys/devices/pci0000:00/0000:00:xx.0/ABC/M-N/3-6:1.0/video4linux/video0
-            // to
-            // /sys/devices/pci0000:00/0000:00:xx.0/ABC/M-N/version
-            usb_specification = get_usb_connection_type(video_path + "/../../../");
-
-            uvc_device_info info{};
-            info.pid = pid;
-            info.vid = vid;
-            info.mi = mi;
-            info.id = dev_name;
-            info.device_path = video_path;
-            info.unique_id = busnum + "-" + devpath + "-" + devnum;
-            info.conn_spec = usb_specification;
-            info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
-
-            return info;
-        }
-
-        bool v4l_uvc_device::is_format_supported_on_node(const std::string& dev_name, std::string v4l_4cc_fmt)
-        {
-            int fd = open(dev_name.c_str(), O_RDWR);
-            if (fd < 0)
-                throw linux_backend_exception("Mipi device format could not be grabbed");
-
-            struct v4l2_fmtdesc fmtdesc;
-            memset(&fmtdesc,0,sizeof(fmtdesc));
-            fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-
-            uint32_t format;
-            memcpy(&format, v4l_4cc_fmt.c_str(), sizeof(format));
-
-            while (ioctl(fd,VIDIOC_ENUM_FMT,&fmtdesc) == 0)
-            {
-                if (fmtdesc.pixelformat == format)
-                {
-                    ::close(fd);
-                    return true;
-                }
-
-                fmtdesc.index++;
-            }
-
-            ::close(fd);
-
-            return false;
-        }
-
-        bool v4l_uvc_device::is_device_depth_node(const std::string& dev_name)
-        {
-            bool is_depth = false;
-
-            // first search video node links, for example, video-rs-depth-0
-            std::smatch match;
-            static std::regex video_dev_rs("video-rs-");
-            static std::regex video_dev_depth("video-rs-depth-\\d+$");
-            if(std::regex_search(dev_name, match, video_dev_rs))
-            {
-                if (std::regex_search(dev_name, match, video_dev_depth))
-                    is_depth = true;
-                else
-                    is_depth = false;
-            }
-            // then search video nodes to find the depth node
-            else if (is_format_supported_on_node(dev_name, "Z16 "))
-                is_depth = true;
-            else
-                is_depth = false;
-
-            return is_depth;
-        }
-
-        uint16_t v4l_uvc_device::get_mipi_device_pid(const std::string& dev_name)
-        {
-            // GVD product ID
-            const uint8_t GVD_PID_OFFSET    = 4;
-
-            const uint8_t GVD_PID_D457      = 0x12;
-            const uint8_t GVD_PID_D401_GMSL = 0x13;
-            const uint8_t GVD_PID_D430_GMSL = 0x0F;
-            const uint8_t GVD_PID_D415_GMSL = 0x06;
-
-            // device PID
-            uint16_t device_pid = 0;
-
-            int fd = open(dev_name.c_str(), O_RDWR);
-            if (fd < 0)
-                throw linux_backend_exception("Mipi device PID could not be found");
-
-            uint8_t gvd[276];
-            struct v4l2_ext_control ctrl;
-
-            memset(gvd,0,276);
-
-            ctrl.id = RS_CAMERA_CID_GVD;
-            ctrl.size = sizeof(gvd);
-            ctrl.p_u8 = gvd;
-
-            struct v4l2_ext_controls ext;
-
-            ext.ctrl_class = V4L2_CTRL_CLASS_CAMERA;
-            ext.controls = &ctrl;
-            ext.count = 1;
-
-            int retries = 5;
-            bool opcode_ok = false;
-            while (!opcode_ok && retries--)
-            {
-                if (xioctl(fd, VIDIOC_G_EXT_CTRLS, &ext) == 0)
-                {
-                    auto opcode = gvd[0];
-                    if (opcode != 0x10)
-                    {
-                        LOG_WARNING("Wrong opcode when pulling GVD: gvd[0] returned as: " << opcode);
-                        continue;
-                    }
-                    else {
-                        opcode_ok = true;
-                    }
-
-                    // d500 MIPI (e.g. D585 GMSL) uses a different GVD layout than d400 GMSL:
-                    // byte 8 holds the CRC32, and the RealSense VID/PID are embedded at bytes 16-19.
-                    // TODO - temp WA for D585 GMSL, until the GVD layout is fixed to match the D400 GMSL layout
-                    uint16_t embedded_vid = gvd[16] | ( gvd[17] << 8 );
-                    if( embedded_vid == 0x38e5 ) // RealSense VID identifies the d500 GMSL family
-                    {
-                        device_pid = D585_GMSL_PID;
-                        continue;
-                    }
-
-                    uint8_t product_pid = gvd[4 + GVD_PID_OFFSET];
-
-                    switch(product_pid)
-                    {
-                        case(GVD_PID_D457):
-                            device_pid = D457_PID;
-                            break;
-
-                        case(GVD_PID_D430_GMSL):
-                            device_pid = D430_GMSL_PID;
-                            break;
-
-                        case(GVD_PID_D415_GMSL):
-                            device_pid = D415_GMSL_PID;
-                            break;
-
-                        case(GVD_PID_D401_GMSL):
-                            device_pid = D401_GMSL_PID;
-                            break;
-
-                        default:
-                            LOG_WARNING("Unidentified MIPI device product id: 0x" << std::hex << (int) product_pid << "remaining retries = " << retries);
-                            device_pid = 0x0000;
-                            break;
-                    }
-                }
-                std::this_thread::sleep_for( std::chrono::milliseconds(100));
-            }
-
-            ::close(fd);
-
-            return device_pid;
-        }
-
-        void v4l_uvc_device::get_mipi_device_info(const std::string& dev_name,
-                                                  std::string& bus_info, std::string& card)
-        {
-            struct v4l2_capability vcap;
-            int fd = open(dev_name.c_str(), O_RDWR);
-            if (fd < 0)
-                throw linux_backend_exception("Mipi device capability could not be grabbed");
-            int err = ioctl(fd, VIDIOC_QUERYCAP, &vcap);
-            if (err)
-            {
-                struct media_device_info mdi;
-
-                err = ioctl(fd, MEDIA_IOC_DEVICE_INFO, &mdi);
-                if (!err)
-                {
-                    if (mdi.bus_info[0])
-                        bus_info = mdi.bus_info;
-                    else
-                        bus_info = std::string("platform:") + mdi.driver;
-
-                    if (mdi.model[0])
-                        card = mdi.model;
-                    else
-                        card = mdi.driver;
-                 }
-            }
-            else
-            {
-                bus_info = reinterpret_cast<const char *>(vcap.bus_info);
-                card = reinterpret_cast<const char *>(vcap.card);
-            }
-
-            ::close(fd);
-        }
-
-        // PID of the current MIPI camera: derived from its depth node and inherited by the
-        // camera color/IR/IMU nodes. Reset per-camera in get_mipi_rs_enum_nodes so a camera
-        // without a readable depth node cannot inherit a previous camera PID.
-        static uint16_t s_mipi_camera_pid = 0;
-
-        uvc_device_info v4l_uvc_device::get_info_from_mipi_device_path(const std::string& video_path, const std::string& name)
-        {
-            uint16_t vid{}, pid{}, mi{};
-            usb_spec usb_specification(usb_undefined);
-            std::string bus_info, card;
-
-            auto dev_name = "/dev/" + name;
-
-            get_mipi_device_info(dev_name, bus_info, card);
-
-            vid = 0x8086;
-
-            // find device PID from depth video node (see s_mipi_camera_pid)
-            try
-            {
-                if (is_device_depth_node(dev_name))
-                {
-                    s_mipi_camera_pid = get_mipi_device_pid(dev_name);
-                }
-            }
-            catch(const std::exception & e)
-            {
-                LOG_WARNING("MIPI device product id detection issue, device will be skipped: " << e.what());
-                s_mipi_camera_pid = 0;
-            }
-
-            pid = s_mipi_camera_pid;
-            if (pid == D585_GMSL_PID)
-                vid = 0x38e5; // D585 GMSL uses RealSense VID
-            
-
-//          std::cout << "video_path:" << video_path << ", name:" << dev_name << ", pid=" << std::hex << (int) pid << std::endl;
-
-            static std::regex video_dev_index("\\d+$");
-            std::smatch match;
-            uint8_t ind{};
-            if (std::regex_search(name, match, video_dev_index))
-            {
-                ind = static_cast<uint8_t>(std::stoi(match[0]));
-            }
-            else
-            {
-                LOG_WARNING("Unresolved Video4Linux device pattern: " << name << ", device is skipped");
-                throw linux_backend_exception("Unresolved Video4Linux device, device is skipped");
-            }
-
-            //  D457 exposes (assuming first_video_index = 0):
-            // - video0 for Depth and video1 for Depth's md.
-            // - video2 for RGB and video3 for RGB's md.
-            // - video4 for IR and video5 for IR's md.
-            // - video6 for IMU (accel or gyro TBD)
-            // next several lines permit to use D457 even if a usb device has already "taken" the video0,1,2 (for example)
-            // further development is needed to permit use of several mipi devices
-            static int  first_video_index = ind;
-
-            // Use camera_video_nodes as number of /dev/video[%d] for each camera sensor subset
-            const int camera_video_nodes = 7;
-            int cam_id = ind / camera_video_nodes;
-            ind = (ind - first_video_index) % camera_video_nodes; // offset from first mipi video node and assume 6 nodes per mipi camera
-            if (ind == 0 || ind == 2 || ind == 4)
-                mi = 0; // video node indicator
-            else if (ind == 1 || ind == 3 || ind == 5)
-                mi = 3; // metadata node indicator
-            else if (ind == 6)
-                mi = 4; // IMU node indicator
-            else
-            {
-                LOG_WARNING("Unresolved Video4Linux device mi, device is skipped");
-                throw linux_backend_exception("Unresolved Video4Linux device, device is skipped");
-            }
-
-            uvc_device_info info{};
-            info.pid = pid;
-            info.vid = vid;
-            info.mi = mi;
-            info.id = dev_name;
-            info.device_path = video_path;
-            // unique id for MIPI: This will assign sensor set for each camera.
-            // it cannot be generated as in usb, because the params busnum, devpath and devnum
-            // are not available via mipi
-            // assign unique id for mipi by appending camera id to bus_info (bus_info is same for each mipi port)
-            // Note - jetson can use only bus_info, as card is different for each sensor and metadata node.
-            info.unique_id = bus_info + "-" + std::to_string(cam_id); // use bus_info as per camera unique id for mipi
-            // Get DFU node for MIPI camera
-            std::vector<std::string> dfu_device_paths = get_mipi_dfu_paths();
-
-            for (const auto& dfu_device_path: dfu_device_paths) {
-                auto mipi_dfu_chardev = "/dev/" + dfu_device_path;
-                int vfd = open(mipi_dfu_chardev.c_str(), O_RDONLY | O_NONBLOCK);
-                if (vfd >= 0) {
-                    // Use legacy DFU device node used in firmware_update_manager
-                    info.dfu_device_path = mipi_dfu_chardev;
-                    ::close(vfd); // file exists, close file and continue to assign it
-                    break;
-                }
-            }
-            info.conn_spec = usb_specification;
-            info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
-
-            return info;
-        }
-
-        bool v4l_uvc_device::is_usb_device_path(const std::string& video_path)
-        {
-            static const std::regex uvc_pattern("(\\/usb\\d+\\/)\\w+"); // Locate UVC device path pattern ../usbX/...
-            return std::regex_search(video_path, uvc_pattern);
-        }
-
         void v4l_mipi_device::foreach_mipi_device(
                 std::function<void(const mipi_device_info&,
                                    const std::string&)> action)
@@ -1293,81 +880,6 @@ namespace librealsense
             }
         }
 
-        std::vector<node_info> v4l_uvc_device::get_mipi_rs_enum_nodes()
-        {
-            std::vector<node_info> mipi_rs_enum_nodes;
-
-            /* Enumerate mipi nodes by links with usage of rs-enum script */
-            std::vector<std::string> video_sensors = {"depth", "color", "ir", "imu"};
-            const int MAX_V4L2_DEVICES = 8; // assume maximum 8 mipi devices
-
-            for ( int i = 0; i < MAX_V4L2_DEVICES; i++ ) {
-                s_mipi_camera_pid = 0; // reset per camera; depth node sets it, siblings inherit
-                for (const auto &vs: video_sensors) {
-                    int vfd = -1;
-                    std::string device_path = "video-rs-" + vs + "-" + std::to_string(i);
-                    std::string device_md_path = "video-rs-" + vs + "-md-" + std::to_string(i);
-                    std::string video_path = "/dev/" + device_path;
-                    std::string video_md_path = "/dev/" + device_md_path;
-                    std::string dfu_device_path = "/dev/d4xx-dfu-" + std::to_string(i);
-                    uvc_device_info info{};
-
-                    // Get Video node
-                    // Check if file on video_path is exists
-                    vfd = open(video_path.c_str(), O_RDONLY | O_NONBLOCK);
-
-                    if (vfd < 0) // file does not exists, continue to the next one
-                        continue;
-                    else
-                        ::close(vfd); // file exists, close file and continue to assign it
-                    try
-                    {
-                        info = get_info_from_mipi_device_path(video_path, device_path);
-                    }
-                    catch(const std::exception & e)
-                    {
-                        LOG_WARNING("MIPI video device issue: " << e.what());
-                        continue;
-                    }
-
-                    // Get DFU node for MIPI camera
-                    vfd = open(dfu_device_path.c_str(), O_RDONLY | O_NONBLOCK);
-
-                    if (vfd >= 0) {
-                        ::close(vfd); // file exists, close file and continue to assign it
-                        info.dfu_device_path = dfu_device_path;
-                    }
-
-                    info.mi = vs.compare("imu") ? 0 : 4;
-                    info.unique_id += "-" + std::to_string(i);
-                    info.uvc_capabilities &= ~(V4L2_CAP_META_CAPTURE); // clean caps
-                    mipi_rs_enum_nodes.emplace_back(info, video_path);
-                    // Get metadata node
-                    // Check if file on video_md_path is exists
-                    vfd = open(video_md_path.c_str(), O_RDONLY | O_NONBLOCK);
-
-                    if (vfd < 0) // file does not exists, continue to the next one
-                        continue;
-                    else
-                        ::close(vfd); // file exists, close file and continue to assign it
-
-                    try
-                    {
-                        info = get_info_from_mipi_device_path(video_md_path, device_md_path);
-                    }
-                    catch(const std::exception & e)
-                    {
-                        LOG_WARNING("MIPI video metadata device issue: " << e.what());
-                        continue;
-                    }
-                    info.mi = 3;
-                    info.unique_id += "-" + std::to_string(i);
-                    mipi_rs_enum_nodes.emplace_back(info, video_md_path);
-                }
-            }
-            return mipi_rs_enum_nodes;
-        }
-
         std::vector<node_info> v4l_uvc_device::match_video_with_metadata_nodes(const std::vector<node_info>& uvc_nodes)
         {
             // Assume uvc_nodes is already sorted according to videoXX (video0, then video1...)
@@ -1416,24 +928,199 @@ namespace librealsense
             return uvc_devices;
         }
 
-        bool v4l_uvc_device::get_info_from_v4l_video_path(const std::string& v4l_video_path, const std::string& dev_name, uvc_device_info& info, bool is_mipi_rs_enum_nodes_empty,
-                                                      const std::vector<std::pair <std::string, std::string>>& v4l_to_dev_video_paths)
+        uvc_device_info v4l_uvc_device::get_info_from_usb_device_path( const std::string & video_path,
+                                                                       const std::string & dev_name,
+                                                                       const std::string & name )
+        {
+            std::string busnum, devnum, devpath;
+
+            if (!v4l_usb_logic::is_usb_path_valid(video_path, dev_name, busnum, devnum, devpath))
+            {
+#ifndef RS2_USE_CUDA
+                if (rsutils::rs2_is_cuda_available())
+                {
+                    /* On the Jetson TX, the camera module is CSI & I2C and does not report as this code expects
+                    Patch suggested by JetsonHacks: https://github.com/jetsonhacks/buildLibrealsense2TX */
+                    LOG_INFO("Failed to read busnum/devnum. Device Path: " << ("/sys/class/video4linux/" + name));
+                }
+#endif
+               throw linux_backend_exception("Failed to read busnum/devnum of usb device");
+            }
+
+            LOG_INFO("Enumerating UVC " << name << " v4l_path=" << video_path << " dev_name=" << dev_name);
+
+            camera_identifier_v4l_usb usb_id;
+            usb_id.resolve(name);
+
+            uvc_device_info info{};
+            info.pid = usb_id.get_pid();
+            info.vid = usb_id.get_vid();
+            info.mi = v4l_usb_logic::read_interface_number(name);
+            info.id = dev_name;
+            info.device_path = video_path;
+            info.unique_id = busnum + "-" + devpath + "-" + devnum;
+            // Find the USB specification (USB2/3) type from the underlying device, traversing from
+            // /sys/devices/.../M-N/3-6:1.0/video4linux/video0 up to /sys/devices/.../M-N/version
+            info.conn_spec = v4l_usb_logic::get_usb_connection_type(video_path + "/../../../");
+            info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
+
+            return info;
+        }
+
+        uvc_device_info v4l_uvc_device::get_info_from_mipi_device_path(const std::string& video_path, const std::string& name,
+                                                                       camera_identifier_v4l_mipi& mipi_id)
+        {
+            auto dev_name = "/dev/" + name;
+
+            std::string bus_info, card;
+            v4l_mipi_logic::get_device_info(dev_name, bus_info, card);
+
+            // Resolve PID/VID from the depth node; sibling color/IR/IMU nodes inherit it via mipi_id
+            try
+            {
+                if (v4l_mipi_logic::is_device_depth_node(dev_name))
+                    mipi_id.resolve(dev_name);
+            }
+            catch(const std::exception & e)
+            {
+                LOG_WARNING("MIPI device product id detection issue, device will be skipped: " << e.what());
+                mipi_id.reset();
+            }
+
+            uint16_t mi{};
+            int cam_id{};
+            v4l_mipi_logic::derive_mi_and_cam_id(v4l_mipi_logic::parse_video_index(name), mi, cam_id);
+
+            uvc_device_info info{};
+            info.pid = mipi_id.get_pid();
+            info.vid = mipi_id.get_vid();
+            info.mi = mi;
+            info.id = dev_name;
+            info.device_path = video_path;
+            // unique id for MIPI: This will assign sensor set for each camera. It cannot be generated as in usb,
+            // because the params busnum, devpath and devnum are not available via mipi.
+            // Assign unique id for mipi by appending camera id to bus_info (bus_info is same for each mipi port)
+            // Note - jetson can use only bus_info, as card is different for each sensor and metadata node.
+            info.unique_id = bus_info + "-" + std::to_string(cam_id);
+
+            // Get DFU node for MIPI camera
+            for (const auto& dfu_device_path : get_mipi_dfu_paths())
+            {
+                auto mipi_dfu_chardev = "/dev/" + dfu_device_path;
+                int vfd = open(mipi_dfu_chardev.c_str(), O_RDONLY | O_NONBLOCK);
+                if (vfd >= 0)
+                {
+                    // Use legacy DFU device node used in firmware_update_manager
+                    info.dfu_device_path = mipi_dfu_chardev;
+                    ::close(vfd); // file exists, close file and continue to assign it
+                    break;
+                }
+            }
+            info.conn_spec = usb_undefined;
+            info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
+
+            return info;
+        }
+
+        std::vector<node_info> v4l_uvc_device::get_mipi_rs_enum_nodes()
+        {
+            std::vector<node_info> mipi_rs_enum_nodes;
+
+            // Enumerate mipi nodes by links with usage of rs-enum script
+            std::vector<std::string> video_sensors = {"depth", "color", "ir", "imu"};
+            const int MAX_V4L2_DEVICES = 8; // assume maximum 8 mipi devices
+
+            // Carries a camera's PID/VID from its depth node to its sibling nodes
+            camera_identifier_v4l_mipi mipi_id;
+            for (int i = 0; i < MAX_V4L2_DEVICES; i++)
+            {
+                mipi_id.reset(); // reset per camera; depth node sets it, siblings inherit
+                for (const auto& vs : video_sensors)
+                {
+                    int vfd = -1;
+                    std::string device_path = v4l_mipi_logic::rs_enum_video_node_name(vs, i, false);
+                    std::string device_md_path = v4l_mipi_logic::rs_enum_video_node_name(vs, i, true);
+                    std::string video_path = "/dev/" + device_path;
+                    std::string video_md_path = "/dev/" + device_md_path;
+                    std::string dfu_device_path = v4l_mipi_logic::rs_enum_dfu_node_path(i);
+                    uvc_device_info info{};
+
+                    // Get Video node
+                    // Check if file on video_path is exists
+                    vfd = open(video_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+                    if (vfd < 0) // file does not exists, continue to the next one
+                        continue;
+                    else
+                        ::close(vfd); // file exists, close file and continue to assign it
+                    try
+                    {
+                        info = get_info_from_mipi_device_path(video_path, device_path, mipi_id);
+                    }
+                    catch(const std::exception & e)
+                    {
+                        LOG_WARNING("MIPI video device issue: " << e.what());
+                        continue;
+                    }
+
+                    // Get DFU node for MIPI camera
+                    vfd = open(dfu_device_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+                    if (vfd >= 0)
+                    {
+                        ::close(vfd); // file exists, close file and continue to assign it
+                        info.dfu_device_path = dfu_device_path;
+                    }
+
+                    info.mi = vs.compare("imu") ? 0 : 4;
+                    info.unique_id += "-" + std::to_string(i);
+                    info.uvc_capabilities &= ~(V4L2_CAP_META_CAPTURE); // clean caps
+                    mipi_rs_enum_nodes.emplace_back(info, video_path);
+
+                    // Get metadata node
+                    // Check if file on video_md_path is exists
+                    vfd = open(video_md_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+                    if (vfd < 0) // file does not exists, continue to the next one
+                        continue;
+                    else
+                        ::close(vfd); // file exists, close file and continue to assign it
+
+                    try
+                    {
+                        info = get_info_from_mipi_device_path(video_md_path, device_md_path, mipi_id);
+                    }
+                    catch(const std::exception & e)
+                    {
+                        LOG_WARNING("MIPI video metadata device issue: " << e.what());
+                        continue;
+                    }
+                    info.mi = 3;
+                    info.unique_id += "-" + std::to_string(i);
+                    mipi_rs_enum_nodes.emplace_back(info, video_md_path);
+                }
+            }
+            return mipi_rs_enum_nodes;
+        }
+
+        bool v4l_uvc_device::get_info_from_v4l_video_path( const std::string & v4l_video_path, const std::string & dev_name,
+                                                           uvc_device_info & info, bool is_mipi_rs_enum_nodes_empty, camera_identifier_v4l_mipi& mipi_id)
         {
             bool res = false;
 
             // following line grabs video0 from "/sys/devices/.../video0" paths
             auto name = v4l_video_path.substr(v4l_video_path.find_last_of('/') + 1);
 
-            if (is_usb_device_path(v4l_video_path))
+            if (v4l_usb_logic::is_usb_device_path(v4l_video_path))
             {
-                info = get_info_from_usb_device_path(v4l_video_path, dev_name, name, v4l_to_dev_video_paths);
+                info = get_info_from_usb_device_path(v4l_video_path, dev_name, name);
                 res = true;
             }
             else if(is_mipi_rs_enum_nodes_empty) //video4linux devices that are not USB devices and not previously enumerated by rs links
             {
                 // filter out all possible codecs, work only with compatible driver
                 static const std::regex rs_mipi_compatible(".vi:|ipu6");
-                info = get_info_from_mipi_device_path(v4l_video_path, name);
+                info = get_info_from_mipi_device_path(v4l_video_path, name, mipi_id);
                 if (regex_search(info.unique_id, rs_mipi_compatible)) {
                     res = true;
                 }
@@ -1446,16 +1133,13 @@ namespace librealsense
         }
 
         std::vector<node_info> v4l_uvc_device::collect_uvc_nodes(const std::vector<path_and_identifier>& v4l_videos,
-                                                                 const std::vector<node_info>& mipi_rs_enum_nodes,
                                                                  const std::vector<std::pair <std::string, std::string>>& v4l_to_dev_video_paths)
         {
-            std::vector<node_info> uvc_nodes;
-            // Append mipi nodes to uvc nodes list
-            if(mipi_rs_enum_nodes.size())
-            {
-                uvc_nodes.insert(uvc_nodes.end(), mipi_rs_enum_nodes.begin(), mipi_rs_enum_nodes.end());
-            }
+            std::vector<node_info> uvc_nodes = get_mipi_rs_enum_nodes();
+            bool is_mipi_rs_enum_nodes_empty = uvc_nodes.empty();
 
+            // Carries a fallback MIPI camera's PID/VID from its depth node to its sibling nodes across the loop
+            camera_identifier_v4l_mipi mipi_id;
             for(auto&& v4l_video : v4l_videos)
             {
                 try
@@ -1464,10 +1148,10 @@ namespace librealsense
                     if (!get_devname_from_v4l_video_path(v4l_video.path, dev_name, v4l_to_dev_video_paths))
                     {
                         continue;
-
                     }
+
                     uvc_device_info info;
-                    if (get_info_from_v4l_video_path(v4l_video.path, dev_name, info, mipi_rs_enum_nodes.empty(), v4l_to_dev_video_paths))
+                    if (get_info_from_v4l_video_path(v4l_video.path, dev_name, info, is_mipi_rs_enum_nodes_empty, mipi_id))
                     {
                         uvc_nodes.emplace_back(info, dev_name);
                     }
@@ -1477,12 +1161,11 @@ namespace librealsense
                     LOG_INFO("Not a USB video device: " << e.what());
                 }
             }
+
             return uvc_nodes;
         }
 
-        void v4l_uvc_device::foreach_uvc_device(
-                std::function<void(const uvc_device_info&,
-                                   const std::string&)> action)
+        void v4l_uvc_device::foreach_uvc_device( std::function<void(const uvc_device_info&, const std::string&)> action )
         {
             // building vector of /sys/class/video4linux/.../videoX files with path, major, minor
             std::vector<path_and_identifier> v4l_videos = collect_v4l_video_path_and_identifier();
@@ -1491,10 +1174,8 @@ namespace librealsense
             // generate map of "/sys/class/video4linux/.../videoX" to "/dev/videoY"
             auto v4l_to_dev_video_paths = generate_v4l_to_dev_video_paths(v4l_videos, dev_videos);
 
-            std::vector<node_info> mipi_rs_enum_nodes = get_mipi_rs_enum_nodes();
-
             // Collect UVC nodes info to bundle metadata and video
-            std::vector<node_info> uvc_nodes = collect_uvc_nodes(v4l_videos, mipi_rs_enum_nodes, v4l_to_dev_video_paths);
+            std::vector<node_info> uvc_nodes = collect_uvc_nodes(v4l_videos, v4l_to_dev_video_paths);
 
             // Matching video and metadata nodes
             std::vector<node_info> uvc_devices = match_video_with_metadata_nodes(uvc_nodes);

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "backend.h"
+#include "camera-identifier-v4l.h"
 #include <src/platform/uvc-device.h>
 #include <src/metadata.h>
 #include "types.h"
@@ -113,7 +114,9 @@ namespace librealsense
             int _fildes;
             std::atomic< int > _lock_counter;
         };
-        static int xioctl(int fh, unsigned long request, void *arg);
+
+        // Low-level V4L2 ioctl wrapper (retries on EINTR). Used by low level types (buffer, kernel_buf_guard)
+        int xioctl( int fh, unsigned long request, void * arg );
 
         class buffer
         {
@@ -306,31 +309,18 @@ namespace librealsense
             double _kpi_frames_drops_pct;
         };
 
-        typedef std::pair<uvc_device_info,std::string> node_info;
+        // A V4L2 enumeration node: the resolved device info plus its /dev/video* path.
+        typedef std::pair< uvc_device_info, std::string > node_info;
 
         class v4l_uvc_device : public uvc_device, public v4l_uvc_interface
         {
         public:
-            static void foreach_uvc_device(
-                    std::function<void(const uvc_device_info&,
-                                       const std::string&)> action);
+            static void foreach_uvc_device( std::function<void(const uvc_device_info&, const std::string&)> action);
 
             static std::vector<std::string> get_mipi_dfu_paths();
 
-            static bool is_usb_path_valid(const std::string& usb_video_path, const std::string &dev_name,
-                                          std::string &busnum, std::string &devnum, std::string &devpath);
-
-            static bool is_usb_device_path(const std::string& video_path);
-
-            static uvc_device_info get_info_from_usb_device_path(const std::string& video_path, const std::string& dev_name, const std::string& name, const std::vector<std::pair <std::string, std::string>>& sys_to_dev_video_paths);
-
-            static uvc_device_info get_info_from_mipi_device_path(const std::string& video_path, const std::string& name);
-
-            static bool is_format_supported_on_node(const std::string& dev_name, std::string v4l_4cc_fmt);
-            static bool is_device_depth_node(const std::string& dev_name);
-            static uint16_t get_mipi_device_pid(const std::string& dev_name);
-            static void get_mipi_device_info(const std::string& dev_name,
-                                             std::string& bus_info, std::string& card);
+            // Retrieve device video capabilities to discriminate video capturing and metadata nodes.
+            static v4l2_capability get_dev_capabilities( const std::string dev_name );
 
             v4l_uvc_device(const uvc_device_info& info, bool use_memory_map = false);
 
@@ -428,12 +418,15 @@ namespace librealsense
 
             static std::vector<std::pair <std::string, std::string>> generate_v4l_to_dev_video_paths(const std::vector<path_and_identifier>& v4l_videos,
                                                                                                      const std::vector<path_and_identifier>& dev_videos);
-            static std::vector<node_info> get_mipi_rs_enum_nodes();
-            static std::vector<node_info> collect_uvc_nodes(const std::vector<path_and_identifier>& v4l_videos, const std::vector<node_info>& mipi_rs_enum_nodes,
+            static std::vector<node_info> collect_uvc_nodes(const std::vector<path_and_identifier>& v4l_videos,
                                                             const std::vector<std::pair <std::string, std::string>>& v4l_to_dev_video_paths);
             static std::vector<node_info> match_video_with_metadata_nodes(const std::vector<node_info>& uvc_nodes);
             static bool get_info_from_v4l_video_path(const std::string& v4l_video_path, const std::string& dev_name, uvc_device_info& info, bool is_mipi_rs_enum_nodes_empty,
-                                                 const std::vector<std::pair <std::string, std::string>>& v4l_to_dev_video_paths);
+                                                 camera_identifier_v4l_mipi& mipi_id);
+            static std::vector<node_info> get_mipi_rs_enum_nodes();
+            static uvc_device_info get_info_from_mipi_device_path(const std::string& video_path, const std::string& name,
+                                                                  camera_identifier_v4l_mipi& mipi_id);
+            static uvc_device_info get_info_from_usb_device_path(const std::string& video_path, const std::string& dev_name, const std::string& name);
             static std::vector<path_and_identifier> collect_dev_video_path_and_identifier();
 
             power_state _state = D3;
@@ -505,21 +498,6 @@ namespace librealsense
             bool _are_device_capabilities_assigned;
         };
 
-
-        const uint16_t D457_PID      = 0xABCD;
-        const uint16_t D430_GMSL_PID = 0xABCE;
-        const uint16_t D415_GMSL_PID = 0xABCF;
-        const uint16_t D401_GMSL_PID = 0xABCC;
-
-        const uint16_t D585_GMSL_PID = 0xBAAA;
-
-        static const std::set<std::uint16_t> mipi_devices_pid = {
-            D457_PID,
-            D430_GMSL_PID,
-            D415_GMSL_PID,
-            D401_GMSL_PID,
-            D585_GMSL_PID
-        };
 
         // D457 Development. To be merged into underlying class
         class v4l_mipi_device : public v4l_uvc_meta_device

--- a/src/linux/camera-identifier-v4l.cpp
+++ b/src/linux/camera-identifier-v4l.cpp
@@ -19,7 +19,7 @@ namespace librealsense
         const uint16_t D415_GMSL_PID = 0xABCF;
         const uint16_t D401_GMSL_PID = 0xABCC;
 
-        const uint16_t D585_GMSL_PID = 0xBAAA;
+        const uint16_t D585_GMSL_PID = 0xBAAA;  // TODO - replace with the real D585 GMSL PID
 
         static const std::set< uint16_t > mipi_devices_pid = {
             D457_PID,

--- a/src/linux/camera-identifier-v4l.cpp
+++ b/src/linux/camera-identifier-v4l.cpp
@@ -1,0 +1,87 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include "camera-identifier-v4l.h"
+#include "v4l-mipi-logic.h"
+#include "v4l-usb-logic.h"
+
+#include <src/librealsense-exception.h>
+
+#include <sstream>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        void camera_identifier_v4l_mipi::resolve( const std::string & dev_name )
+        {
+            // GVD product ID
+            const uint8_t GVD_PID_OFFSET = 4;
+
+            const uint8_t GVD_PID_D457 = 0x12;
+            const uint8_t GVD_PID_D401_GMSL = 0x13;
+            const uint8_t GVD_PID_D430_GMSL = 0x0F;
+            const uint8_t GVD_PID_D415_GMSL = 0x06;
+
+            uint16_t device_pid = 0;
+
+            std::vector< uint8_t > gvd = v4l_mipi_logic::get_gvd( dev_name );
+
+            // d500 MIPI (e.g. D585 GMSL) uses a different GVD layout than d400 GMSL:
+            // byte 8 holds the CRC32, and the RealSense VID/PID are embedded at bytes 16-19.
+            // TODO - temp WA for D585 GMSL, until the GVD layout is fixed to match the D400 GMSL layout
+            uint16_t embedded_vid = gvd[16] | ( gvd[17] << 8 );
+            if( embedded_vid == 0x38e5 )  // RealSense VID identifies the d500 GMSL family
+            {
+                device_pid = D585_GMSL_PID;
+            }
+            else
+            {
+                uint8_t product_pid = gvd[4 + GVD_PID_OFFSET];
+
+                switch( product_pid )
+                {
+                case( GVD_PID_D457 ):
+                    device_pid = D457_PID;
+                    break;
+
+                case( GVD_PID_D430_GMSL ):
+                    device_pid = D430_GMSL_PID;
+                    break;
+
+                case( GVD_PID_D415_GMSL ):
+                    device_pid = D415_GMSL_PID;
+                    break;
+
+                case( GVD_PID_D401_GMSL ):
+                    device_pid = D401_GMSL_PID;
+                    break;
+
+                default:
+                    LOG_WARNING( "Unidentified MIPI device product id: 0x" << std::hex << (int)product_pid );
+                    device_pid = 0x0000;
+                    break;
+                }
+            }
+
+            _pid = device_pid;
+            _vid = ( _pid == D585_GMSL_PID ) ? 0x38e5 : 0x8086;  // D585 GMSL uses RealSense VID
+        }
+
+        void camera_identifier_v4l_usb::resolve( const std::string & name )
+        {
+            uint16_t vid{}, pid{};
+
+            std::string modalias = v4l_usb_logic::read_modalias( name );
+            if( modalias.size() < 14 || modalias.substr( 0, 5 ) != "usb:v" || modalias[9] != 'p' )
+                throw linux_backend_exception( "Not a usb format modalias" );
+            if( ! ( std::istringstream( modalias.substr( 5, 4 ) ) >> std::hex >> vid ) )
+                throw linux_backend_exception( "Failed to read vendor ID" );
+            if( ! ( std::istringstream( modalias.substr( 10, 4 ) ) >> std::hex >> pid ) )
+                throw linux_backend_exception( "Failed to read product ID" );
+
+            _vid = vid;
+            _pid = pid;
+        }
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/linux/camera-identifier-v4l.cpp
+++ b/src/linux/camera-identifier-v4l.cpp
@@ -8,11 +8,32 @@
 #include <src/librealsense-exception.h>
 
 #include <sstream>
+#include <set>
 
 namespace librealsense
 {
     namespace platform
     {
+        const uint16_t D457_PID      = 0xABCD;
+        const uint16_t D430_GMSL_PID = 0xABCE;
+        const uint16_t D415_GMSL_PID = 0xABCF;
+        const uint16_t D401_GMSL_PID = 0xABCC;
+
+        const uint16_t D585_GMSL_PID = 0xBAAA;
+
+        static const std::set< uint16_t > mipi_devices_pid = {
+            D457_PID,
+            D430_GMSL_PID,
+            D415_GMSL_PID,
+            D401_GMSL_PID,
+            D585_GMSL_PID
+        };
+
+        bool is_mipi_pid( uint16_t pid )
+        {
+            return mipi_devices_pid.count( pid ) > 0;
+        }
+
         void camera_identifier_v4l_mipi::resolve( const std::string & dev_name )
         {
             // GVD product ID
@@ -26,6 +47,8 @@ namespace librealsense
             uint16_t device_pid = 0;
 
             std::vector< uint8_t > gvd = v4l_mipi_logic::get_gvd( dev_name );
+            if( gvd.size() < 18 )  // need bytes up to the embedded VID at 16-17
+                throw linux_backend_exception( "GVD response too short to identify device" );
 
             // d500 MIPI (e.g. D585 GMSL) uses a different GVD layout than d400 GMSL:
             // byte 8 holds the CRC32, and the RealSense VID/PID are embedded at bytes 16-19.

--- a/src/linux/camera-identifier-v4l.h
+++ b/src/linux/camera-identifier-v4l.h
@@ -1,0 +1,64 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <src/platform/camera-identifier.h>
+
+#include <cstdint>
+#include <string>
+#include <set>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        const uint16_t D457_PID      = 0xABCD;
+        const uint16_t D430_GMSL_PID = 0xABCE;
+        const uint16_t D415_GMSL_PID = 0xABCF;
+        const uint16_t D401_GMSL_PID = 0xABCC;
+
+        const uint16_t D585_GMSL_PID = 0xBAAA;
+
+        static const std::set< std::uint16_t > mipi_devices_pid = {
+            D457_PID,
+            D430_GMSL_PID,
+            D415_GMSL_PID,
+            D401_GMSL_PID,
+            D585_GMSL_PID
+        };
+
+        // Holds the USB-style VID/PID for a V4L2 device.
+        class camera_identifier_v4l : public camera_identifier
+        {
+        public:
+            uint16_t get_vid() const override { return _vid; }
+            uint16_t get_pid() const override { return _pid; }
+
+        protected:
+            uint16_t _vid = 0;
+            uint16_t _pid = 0;
+        };
+
+        // Identifier for a MIPI/GMSL camera.
+        class camera_identifier_v4l_mipi : public camera_identifier_v4l
+        {
+        public:
+            camera_identifier_v4l_mipi() { _vid = 0x8086; }  // Legacy Intel VID by default; Current models overrides to RealSense VID
+
+            // Read the device's GVD and set PID/VID from it. dev_name must be the depth video node. Throws on failure.
+            void resolve( const std::string & dev_name );
+
+            // Clear a previously resolved PID/VID.
+            void reset() { _pid = 0; _vid = 0x8086; }
+        };
+
+        // Identifier for a USB camera.
+        class camera_identifier_v4l_usb : public camera_identifier_v4l
+        {
+        public:
+            // Read the node's modalias and set VID/PID from it. name is the video4linux node (e.g. "video0"). Throws on failure.
+            void resolve( const std::string & name );
+        };
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/linux/camera-identifier-v4l.h
+++ b/src/linux/camera-identifier-v4l.h
@@ -7,26 +7,13 @@
 
 #include <cstdint>
 #include <string>
-#include <set>
 
 namespace librealsense
 {
     namespace platform
     {
-        const uint16_t D457_PID      = 0xABCD;
-        const uint16_t D430_GMSL_PID = 0xABCE;
-        const uint16_t D415_GMSL_PID = 0xABCF;
-        const uint16_t D401_GMSL_PID = 0xABCC;
-
-        const uint16_t D585_GMSL_PID = 0xBAAA;
-
-        static const std::set< std::uint16_t > mipi_devices_pid = {
-            D457_PID,
-            D430_GMSL_PID,
-            D415_GMSL_PID,
-            D401_GMSL_PID,
-            D585_GMSL_PID
-        };
+        // True if pid is a known RealSense MIPI/GMSL product id.
+        bool is_mipi_pid( uint16_t pid );
 
         // Holds the USB-style VID/PID for a V4L2 device.
         class camera_identifier_v4l : public camera_identifier

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -1,0 +1,209 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include "v4l-mipi-logic.h"
+#include "backend-v4l2.h"  // xioctl(), linux_backend_exception
+
+#include <linux/media.h>  // media_device_info, MEDIA_IOC_DEVICE_INFO
+
+#include <cstring>
+#include <regex>
+#include <thread>
+#include <chrono>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        namespace v4l_mipi_logic
+        {
+            // MIPI GVD control id.
+            static constexpr uint32_t RS_STREAM_CONFIG_0 = 0x4000;
+            static constexpr uint32_t RS_CAMERA_CID_BASE = ( V4L2_CTRL_CLASS_CAMERA | RS_STREAM_CONFIG_0 );
+            static constexpr uint32_t RS_CAMERA_CID_GVD = ( RS_CAMERA_CID_BASE + 8 );
+
+            static constexpr size_t GVD_BUFFER_SIZE = 276;
+            static constexpr uint8_t GVD_VALID_OPCODE = 0x10;
+
+            std::vector< uint8_t > get_gvd( const std::string & dev_name )
+            {
+                int fd = open( dev_name.c_str(), O_RDWR );
+                if( fd < 0 )
+                    throw linux_backend_exception( "Mipi device GVD could not be read" );
+
+                std::vector< uint8_t > gvd( GVD_BUFFER_SIZE, 0 );
+                struct v4l2_ext_control ctrl;
+
+                ctrl.id = RS_CAMERA_CID_GVD;
+                ctrl.size = gvd.size();
+                ctrl.p_u8 = gvd.data();
+
+                struct v4l2_ext_controls ext;
+
+                ext.ctrl_class = V4L2_CTRL_CLASS_CAMERA;
+                ext.controls = &ctrl;
+                ext.count = 1;
+
+                int retries = 5;
+                bool opcode_ok = false;
+                while( ! opcode_ok && retries-- )
+                {
+                    if( xioctl( fd, VIDIOC_G_EXT_CTRLS, &ext ) == 0 )
+                    {
+                        auto opcode = gvd[0];
+                        if( opcode != GVD_VALID_OPCODE )
+                            LOG_WARNING( "Wrong opcode when pulling GVD: gvd[0] returned as: " << opcode );
+                        else
+                            opcode_ok = true;
+                    }
+                    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+                }
+
+                ::close( fd );
+
+                if( ! opcode_ok )
+                    throw linux_backend_exception( "Failed to pull a valid GVD from " + dev_name );
+
+                return gvd;
+            }
+
+            bool is_format_supported_on_node( const std::string & dev_name, std::string v4l_4cc_fmt )
+            {
+                int fd = open( dev_name.c_str(), O_RDWR );
+                if( fd < 0 )
+                    throw linux_backend_exception( "Mipi device format could not be grabbed" );
+
+                struct v4l2_fmtdesc fmtdesc;
+                memset( &fmtdesc, 0, sizeof( fmtdesc ) );
+                fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+                uint32_t format;
+                memcpy( &format, v4l_4cc_fmt.c_str(), sizeof( format ) );
+
+                while( ioctl( fd, VIDIOC_ENUM_FMT, &fmtdesc ) == 0 )
+                {
+                    if( fmtdesc.pixelformat == format )
+                    {
+                        ::close( fd );
+                        return true;
+                    }
+
+                    fmtdesc.index++;
+                }
+
+                ::close( fd );
+
+                return false;
+            }
+
+            bool is_device_depth_node( const std::string & dev_name )
+            {
+                bool is_depth = false;
+
+                // first search video node links, for example, video-rs-depth-0
+                std::smatch match;
+                static std::regex video_dev_rs( "video-rs-" );
+                static std::regex video_dev_depth( "video-rs-depth-\\d+$" );
+                if( std::regex_search( dev_name, match, video_dev_rs ) )
+                {
+                    if( std::regex_search( dev_name, match, video_dev_depth ) )
+                        is_depth = true;
+                    else
+                        is_depth = false;
+                }
+                // then search video nodes to find the depth node
+                else if( is_format_supported_on_node( dev_name, "Z16 " ) )
+                    is_depth = true;
+                else
+                    is_depth = false;
+
+                return is_depth;
+            }
+
+            void get_device_info( const std::string & dev_name, std::string & bus_info, std::string & card )
+            {
+                struct v4l2_capability vcap;
+                int fd = open( dev_name.c_str(), O_RDWR );
+                if( fd < 0 )
+                    throw linux_backend_exception( "Mipi device capability could not be grabbed" );
+                int err = ioctl( fd, VIDIOC_QUERYCAP, &vcap );
+                if( err )
+                {
+                    struct media_device_info mdi;
+
+                    err = ioctl( fd, MEDIA_IOC_DEVICE_INFO, &mdi );
+                    if( ! err )
+                    {
+                        if( mdi.bus_info[0] )
+                            bus_info = mdi.bus_info;
+                        else
+                            bus_info = std::string( "platform:" ) + mdi.driver;
+
+                        if( mdi.model[0] )
+                            card = mdi.model;
+                        else
+                            card = mdi.driver;
+                    }
+                }
+                else
+                {
+                    bus_info = reinterpret_cast< const char * >( vcap.bus_info );
+                    card = reinterpret_cast< const char * >( vcap.card );
+                }
+
+                ::close( fd );
+            }
+
+            int parse_video_index( const std::string & name )
+            {
+                static std::regex video_dev_index( "\\d+$" );
+                std::smatch match;
+                if( ! std::regex_search( name, match, video_dev_index ) )
+                {
+                    LOG_WARNING( "Unresolved Video4Linux device pattern: " << name << ", device is skipped" );
+                    throw linux_backend_exception( "Unresolved Video4Linux device, device is skipped" );
+                }
+                return std::stoi( match[0] );
+            }
+
+            void derive_mi_and_cam_id( int video_index, uint16_t & mi, int & cam_id )
+            {
+                //  D457 exposes (assuming first_video_index = 0):
+                // - video0 for Depth and video1 for Depth's md.
+                // - video2 for RGB and video3 for RGB's md.
+                // - video4 for IR and video5 for IR's md.
+                // - video6 for IMU (accel or gyro TBD)
+                // next several lines permit to use D457 even if a usb device has already "taken" the video0,1,2 (for example)
+                // further development is needed to permit use of several mipi devices
+                static int first_video_index = video_index;
+
+                // Use camera_video_nodes as number of /dev/video[%d] for each camera sensor subset
+                const int camera_video_nodes = 7;
+                cam_id = video_index / camera_video_nodes;
+                int ind = ( video_index - first_video_index )
+                    % camera_video_nodes;  // offset from first mipi video node and assume 6 nodes per mipi camera
+                if( ind == 0 || ind == 2 || ind == 4 )
+                    mi = 0;  // video node indicator
+                else if( ind == 1 || ind == 3 || ind == 5 )
+                    mi = 3;  // metadata node indicator
+                else if( ind == 6 )
+                    mi = 4;  // IMU node indicator
+                else
+                {
+                    LOG_WARNING( "Unresolved Video4Linux device mi, device is skipped" );
+                    throw linux_backend_exception( "Unresolved Video4Linux device, device is skipped" );
+                }
+            }
+
+            std::string rs_enum_video_node_name( const std::string & sensor, int cam_idx, bool metadata )
+            {
+                return "video-rs-" + sensor + ( metadata ? "-md-" : "-" ) + std::to_string( cam_idx );
+            }
+
+            std::string rs_enum_dfu_node_path( int cam_idx )
+            {
+                return "/dev/d4xx-dfu-" + std::to_string( cam_idx );
+            }
+        }  // namespace v4l_mipi_logic
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -56,7 +56,7 @@ namespace librealsense
                     {
                         auto opcode = gvd[0];
                         if( opcode != GVD_VALID_OPCODE )
-                            LOG_WARNING( "Wrong opcode when pulling GVD: gvd[0] returned as: " << opcode );
+                            LOG_WARNING( "Wrong opcode when pulling GVD: gvd[0] returned as: " << static_cast< int >( opcode ) );
                         else
                             opcode_ok = true;
                     }

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -10,6 +10,8 @@
 #include <regex>
 #include <thread>
 #include <chrono>
+#include <memory>
+#include <functional>
 
 namespace librealsense
 {
@@ -27,8 +29,10 @@ namespace librealsense
 
             std::vector< uint8_t > get_gvd( const std::string & dev_name )
             {
-                int fd = open( dev_name.c_str(), O_RDWR );
-                if( fd < 0 )
+                // RAII to close the fd on every exit path
+                std::unique_ptr< int, std::function< void( int * ) > > fd( new int( open( dev_name.c_str(), O_RDWR ) ),
+                                                                           []( int * d ) { if( d && *d >= 0 ) ::close( *d ); delete d; } );
+                if( *fd < 0 )
                     throw linux_backend_exception( "Mipi device GVD could not be read" );
 
                 std::vector< uint8_t > gvd( GVD_BUFFER_SIZE, 0 );
@@ -48,7 +52,7 @@ namespace librealsense
                 bool opcode_ok = false;
                 while( ! opcode_ok && retries-- )
                 {
-                    if( xioctl( fd, VIDIOC_G_EXT_CTRLS, &ext ) == 0 )
+                    if( xioctl( *fd, VIDIOC_G_EXT_CTRLS, &ext ) == 0 )
                     {
                         auto opcode = gvd[0];
                         if( opcode != GVD_VALID_OPCODE )
@@ -56,10 +60,9 @@ namespace librealsense
                         else
                             opcode_ok = true;
                     }
-                    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+                    if( ! opcode_ok && retries )  // wait before the next attempt, but not after the last
+                        std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
                 }
-
-                ::close( fd );
 
                 if( ! opcode_ok )
                     throw linux_backend_exception( "Failed to pull a valid GVD from " + dev_name );

--- a/src/linux/v4l-mipi-logic.h
+++ b/src/linux/v4l-mipi-logic.h
@@ -1,0 +1,37 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        // Low-level V4L2 MIPI/GMSL primitives: raw device queries and node naming conventions.
+        namespace v4l_mipi_logic
+        {
+            // Read the device's raw GVD buffer. Validates the response opcode, retrying as needed. Throws on failure.
+            std::vector< uint8_t > get_gvd( const std::string & dev_name );
+
+            bool is_device_depth_node( const std::string & dev_name );
+            bool is_format_supported_on_node( const std::string & dev_name, std::string v4l_4cc_fmt );
+
+            void get_device_info( const std::string & dev_name, std::string & bus_info, std::string & card );
+
+            // Trailing index of a video node name (e.g. "video2" -> 2). Throws if the name has no index.
+            int parse_video_index( const std::string & name );
+
+            // Map a video node index to its camera id and interface indicator (video/metadata/IMU). Throws on
+            // an index that does not fit the per-camera node layout.
+            void derive_mi_and_cam_id( int video_index, uint16_t & mi, int & cam_id );
+
+            // rs-enum link naming conventions
+            std::string rs_enum_video_node_name( const std::string & sensor, int cam_idx, bool metadata );
+            std::string rs_enum_dfu_node_path( int cam_idx );
+        }  // namespace v4l_mipi_logic
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/linux/v4l-usb-logic.cpp
+++ b/src/linux/v4l-usb-logic.cpp
@@ -1,0 +1,112 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include "v4l-usb-logic.h"
+
+#include <src/librealsense-exception.h>
+#include <rsutils/string/from.h>
+
+#include <sys/stat.h>
+#include <sys/sysmacros.h>  // major(...), minor(...)
+#include <limits.h>         // PATH_MAX
+#include <cstdlib>          // realpath
+
+#include <sstream>
+#include <fstream>
+#include <regex>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        namespace v4l_usb_logic
+        {
+            static const size_t MAX_DEV_PARENT_DIR = 10;
+
+            bool is_usb_device_path( const std::string & video_path )
+            {
+                static const std::regex uvc_pattern( "(\\/usb\\d+\\/)\\w+" );  // Locate UVC device path pattern ../usbX/...
+                return std::regex_search( video_path, uvc_pattern );
+            }
+
+            bool is_usb_path_valid( const std::string & usb_video_path, const std::string & dev_name,
+                                    std::string & busnum, std::string & devnum, std::string & devpath )
+            {
+                struct stat st = {};
+                if( stat( dev_name.c_str(), &st ) < 0 )
+                {
+                    throw linux_backend_exception( rsutils::string::from() << "Cannot identify '" << dev_name );
+                }
+                if( ! S_ISCHR( st.st_mode ) )
+                    throw linux_backend_exception( dev_name + " is no device" );
+
+                // Search directory and up to three parent directories to find busnum/devnum
+                auto valid_path = false;
+                std::ostringstream ss;
+                ss << "/sys/dev/char/" << major( st.st_rdev ) << ":" << minor( st.st_rdev ) << "/device/";
+
+                auto char_dev_path = ss.str();
+
+                for( auto i = 0U; i < MAX_DEV_PARENT_DIR; ++i )
+                {
+                    if( std::ifstream( char_dev_path + "busnum" ) >> busnum )
+                    {
+                        if( std::ifstream( char_dev_path + "devnum" ) >> devnum )
+                        {
+                            if( std::ifstream( char_dev_path + "devpath" ) >> devpath )
+                            {
+                                valid_path = true;
+                                break;
+                            }
+                        }
+                    }
+                    char_dev_path += "../";
+                }
+                return valid_path;
+            }
+
+            std::string read_modalias( const std::string & name )
+            {
+                std::string modalias;
+                if( ! ( std::ifstream( "/sys/class/video4linux/" + name + "/device/modalias" ) >> modalias ) )
+                    throw linux_backend_exception( "Failed to read modalias" );
+                return modalias;
+            }
+
+            uint16_t read_interface_number( const std::string & name )
+            {
+                uint16_t mi{};
+                if( ! ( std::ifstream( "/sys/class/video4linux/" + name + "/device/bInterfaceNumber" ) >> std::hex >> mi ) )
+                    throw linux_backend_exception( "Failed to read interface number" );
+                return mi;
+            }
+
+            usb_spec get_usb_connection_type( std::string path )
+            {
+                usb_spec res{ usb_undefined };
+
+                char usb_actual_path[PATH_MAX] = { 0 };
+                if( realpath( path.c_str(), usb_actual_path ) != nullptr )
+                {
+                    path = std::string( usb_actual_path );
+                    std::string camera_usb_version;
+                    if( ! ( std::ifstream( path + "/version" ) >> camera_usb_version ) )
+                        throw linux_backend_exception( "Failed to read usb version specification" );
+
+                    // find a usb type whose name is contained in 'camera_usb_version' (contained, not equal,
+                    // because of differences like "3.2" vs "3.20")
+                    for( const auto usb_type : usb_name_to_spec )
+                    {
+                        std::string usb_name = usb_type.first;
+                        if( std::string::npos != camera_usb_version.find( usb_name ) )
+                        {
+                            res = usb_type.second;
+                            return res;
+                        }
+                    }
+                }
+                return res;
+            }
+        }  // namespace v4l_usb_logic
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/linux/v4l-usb-logic.h
+++ b/src/linux/v4l-usb-logic.h
@@ -1,0 +1,34 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <src/usb/usb-types.h>  // usb_spec
+
+#include <cstdint>
+#include <string>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        // Low-level V4L2 USB primitives: sysfs queries and USB node path conventions.
+        namespace v4l_usb_logic
+        {
+            bool is_usb_device_path( const std::string & video_path );
+
+            // Locate the node's busnum/devnum/devpath in sysfs. Returns false if not found.
+            bool is_usb_path_valid( const std::string & usb_video_path, const std::string & dev_name,
+                                    std::string & busnum, std::string & devnum, std::string & devpath );
+
+            // Raw modalias string of a video4linux node (e.g. "video0"). Throws if unreadable.
+            std::string read_modalias( const std::string & name );
+
+            // bInterfaceNumber of a video4linux node. Throws if unreadable.
+            uint16_t read_interface_number( const std::string & name );
+
+            // Find USB connection type (USB2/3) for UVC device. Note - input parameter is passed by value.
+            usb_spec get_usb_connection_type( std::string path );
+        }  // namespace v4l_usb_logic
+    }  // namespace platform
+}  // namespace librealsense

--- a/src/platform/camera-identifier.h
+++ b/src/platform/camera-identifier.h
@@ -1,0 +1,22 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <cstdint>
+
+namespace librealsense
+{
+    namespace platform
+    {
+        // Resolves a device's USB-style VID/PID.
+        class camera_identifier
+        {
+        public:
+            virtual ~camera_identifier() = default;
+
+            virtual uint16_t get_vid() const = 0;
+            virtual uint16_t get_pid() const = 0;
+        };
+    }  // namespace platform
+}  // namespace librealsense


### PR DESCRIPTION
Tracked on [RSDEV-9251]

Refactoring as preparation for next step camera identification using GVD.

Splits the monolithic V4L2 enumeration code in backend-v4l2 into layered units with single responsibilities.

Layering (dependencies point down):

camera_identifier (src/platform/camera-identifier.h) — backend-agnostic interface supplying a device's VID/PID.
camera_identifier_v4l_{mipi,usb} (src/linux/camera-identifier-v4l.*) — identification policy: resolve() reads a device's GVD (MIPI) or modalias (USB) and derives PID/VID.
v4l_mipi_logic / v4l_usb_logic (src/linux/v4l-{mipi,usb}-logic.*) — pure low-level V4L2 primitives (raw GVD read, sysfs/modalias reads, node-naming conventions). No identifier dependency.
backend-v4l2 — orchestration only: drives enumeration and assembles uvc_device_info, calling the identifiers for VID/PID and the logic units for primitives.
