### PR TITLE
Depth fill rate multires

### DIFF
--- a/unit-tests/live/image-quality/iq_helper.py
+++ b/unit-tests/live/image-quality/iq_helper.py
@@ -13,6 +13,23 @@ import pyrealsense2 as rs
 WIDTH = 1280
 HEIGHT = 720
 
+# Standard resolution/fps sweep shared across the image-quality tests: a single
+# representative config for regular CI, extended to a broader sweep under nightly.
+# Centralized here so every IQ test uses the same set instead of each hand-maintaining
+# its own copy.
+DEFAULT_CONFIGURATIONS = [((1280, 720), 30)]
+NIGHTLY_CONFIGURATIONS = [
+    ((640, 480), 15),
+    ((640, 480), 30),
+    ((640, 480), 60),
+    ((848, 480), 15),
+    ((848, 480), 30),
+    ((848, 480), 60),
+    ((1280, 720), 5),
+    ((1280, 720), 10),
+    ((1280, 720), 15),
+]
+
 # transformation matrix from frame to aligned region of interest
 M = None
 

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -8,7 +8,8 @@ import numpy as np
 import cv2
 import logging
 import re
-from iq_helper import find_roi_location, get_roi_from_frame, is_color_close, save_failure_snapshot, WIDTH, HEIGHT
+from iq_helper import (find_roi_location, get_roi_from_frame, is_color_close, save_failure_snapshot,
+                       WIDTH, HEIGHT, DEFAULT_CONFIGURATIONS, NIGHTLY_CONFIGURATIONS)
 
 log = logging.getLogger(__name__)
 
@@ -158,20 +159,10 @@ def run_test(dev, ctx, resolution, fps):
 def test_basic_color(test_device, test_context_var):
     dev, ctx = test_device
 
-    configurations = [((1280, 720), 30)]
+    configurations = DEFAULT_CONFIGURATIONS
     # on nightly we check additional arbitrary configurations
     if "nightly" in test_context_var:
-        configurations += [
-            ((640,480), 15),
-            ((640,480), 30),
-            ((640,480), 60),
-            ((848,480), 15),
-            ((848,480), 30),
-            ((848,480), 60),
-            ((1280,720), 5),
-            ((1280,720), 10),
-            ((1280,720), 15),
-        ]
+        configurations = DEFAULT_CONFIGURATIONS + NIGHTLY_CONFIGURATIONS
 
     # D436 color stream returns near-black frames at >30 fps with Auto-Exposure ON
     # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).

--- a/unit-tests/live/image-quality/pytest-basic-depth.py
+++ b/unit-tests/live/image-quality/pytest-basic-depth.py
@@ -9,7 +9,8 @@ import time
 import logging
 from iq_helper import (find_roi_location, get_roi_from_frame, get_median_depth_from_region,
                        sample_bg_depth, make_depth_filter_chain, save_failure_snapshot,
-                       SAMPLE_REGION_SIZE, BG_SAMPLE_POINTS, CUBE_CENTER, WIDTH, HEIGHT)
+                       SAMPLE_REGION_SIZE, BG_SAMPLE_POINTS, CUBE_CENTER, WIDTH, HEIGHT,
+                       DEFAULT_CONFIGURATIONS, NIGHTLY_CONFIGURATIONS)
 
 log = logging.getLogger(__name__)
 
@@ -188,20 +189,10 @@ def run_test(dev, ctx, resolution, fps):
 def test_basic_depth(test_device, test_context_var):
     dev, ctx = test_device
 
-    configurations = [((1280, 720), 30)]
+    configurations = DEFAULT_CONFIGURATIONS
     # on nightly we check additional arbitrary configurations
     if "nightly" in test_context_var:
-        configurations += [
-            ((640, 480), 15),
-            ((640, 480), 30),
-            ((640, 480), 60),
-            ((848, 480), 15),
-            ((848, 480), 30),
-            ((848, 480), 60),
-            ((1280, 720), 5),
-            ((1280, 720), 10),
-            ((1280, 720), 15),
-        ]
+        configurations = DEFAULT_CONFIGURATIONS + NIGHTLY_CONFIGURATIONS
 
     for resolution, fps in configurations:
         run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-has-depth.py
+++ b/unit-tests/live/image-quality/pytest-has-depth.py
@@ -65,6 +65,13 @@ def is_depth_fill_rate_enough(pipeline):
 
 
 def run_test(dev, ctx, resolution, fps):
+    """Run the fill-rate check for one resolution/fps configuration.
+
+    Returns True if the configuration was supported and exercised, False if it was
+    skipped as unsupported by the device (the caller aggregates skips across the
+    sweep so unsupported configs are visible in the test's own report rather than
+    only in the debug log).
+    """
     product_name = dev.get_info(rs.camera_info.name)
 
     cfg = rs.config()
@@ -76,7 +83,7 @@ def run_test(dev, ctx, resolution, fps):
     pipeline = rs.pipeline(ctx)
     if not cfg.can_resolve(pipeline):
         log.info(f"Configuration {resolution[0]}x{resolution[1]} @ {fps}fps is not supported by the device")
-        return
+        return False
 
     pipeline.start(cfg)
     try:
@@ -108,6 +115,7 @@ def run_test(dev, ctx, resolution, fps):
     check.is_true(has_depth,
                   f"Depth fill rate too low on {product_name} at {resolution[0]}x{resolution[1]}@{fps}fps "
                   f"after {FRAMES_TO_CHECK} frames")
+    return True
 
 
 def test_depth_fill_rate(test_device_wrapped, test_context_var):
@@ -117,5 +125,9 @@ def test_depth_fill_rate(test_device_wrapped, test_context_var):
     if "nightly" in test_context_var:
         configurations = DEFAULT_CONFIGURATIONS + NIGHTLY_CONFIGURATIONS
 
-    for resolution, fps in configurations:
-        run_test(dev, ctx, resolution, fps)
+    skipped = [(resolution, fps) for resolution, fps in configurations
+               if not run_test(dev, ctx, resolution, fps)]
+
+    if skipped:
+        log.warning(f"Skipped {len(skipped)}/{len(configurations)} unsupported configuration(s): "
+                    f"{[f'{r[0]}x{r[1]}@{fps}fps' for r, fps in skipped]}")

--- a/unit-tests/live/image-quality/pytest-has-depth.py
+++ b/unit-tests/live/image-quality/pytest-has-depth.py
@@ -133,7 +133,7 @@ def run_test(dev, ctx, resolution, fps):
                   f"after {FRAMES_TO_CHECK} frames")
 
 
-def test_depth_laser_on(test_device_wrapped, test_context_var):
+def test_depth_fill_rate(test_device_wrapped, test_context_var):
     dev, ctx = test_device_wrapped
 
     all_resolutions = get_available_depth_resolutions(dev)

--- a/unit-tests/live/image-quality/pytest-has-depth.py
+++ b/unit-tests/live/image-quality/pytest-has-depth.py
@@ -12,6 +12,7 @@ from pytest_check import check
 import numpy as np
 import time
 import logging
+from iq_helper import DEFAULT_CONFIGURATIONS, NIGHTLY_CONFIGURATIONS
 log = logging.getLogger(__name__)
 
 # Defines how far in cm do pixels have to be, to be considered in a different distance
@@ -25,30 +26,6 @@ pytestmark = [
     pytest.mark.device_each("D500*"),
     pytest.mark.device_exclude("D401"),
 ]
-
-PREFERRED_FPS = 30
-
-
-def get_available_depth_resolutions(dev, preferred_fps=PREFERRED_FPS):
-    """
-    Query the device for every distinct depth (width, height) it actually advertises
-    for z16, each paired with preferred_fps if that resolution supports it, otherwise
-    its own highest available fps. Sorted by pixel count, highest first.
-    """
-    depth_sensor = dev.first_depth_sensor()
-    fps_by_resolution = {}
-    for profile in depth_sensor.get_stream_profiles():
-        if profile.stream_type() != rs.stream.depth or profile.format() != rs.format.z16:
-            continue
-        vp = profile.as_video_stream_profile()
-        fps_by_resolution.setdefault((vp.width(), vp.height()), set()).add(vp.fps())
-
-    resolutions = [
-        (res, preferred_fps if preferred_fps in fps_set else max(fps_set))
-        for res, fps_set in fps_by_resolution.items()
-    ]
-    resolutions.sort(key=lambda item: item[0][0] * item[0][1], reverse=True)
-    return resolutions
 
 
 def get_distances(depth_frame):
@@ -136,13 +113,9 @@ def run_test(dev, ctx, resolution, fps):
 def test_depth_fill_rate(test_device_wrapped, test_context_var):
     dev, ctx = test_device_wrapped
 
-    all_resolutions = get_available_depth_resolutions(dev)
-
-    # Sweeping every resolution the device advertises is expensive (each waits for up
-    # to FRAMES_TO_CHECK frames), so regular CI only runs the highest-resolution mode;
-    # the full sweep runs under nightly. If nightly still proves too slow, change
-    # "nightly" to "weekly" below to push the extended sweep out further.
-    configurations = all_resolutions if "nightly" in test_context_var else all_resolutions[:1]
+    configurations = DEFAULT_CONFIGURATIONS
+    if "nightly" in test_context_var:
+        configurations = DEFAULT_CONFIGURATIONS + NIGHTLY_CONFIGURATIONS
 
     for resolution, fps in configurations:
         run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-has-depth.py
+++ b/unit-tests/live/image-quality/pytest-has-depth.py
@@ -3,11 +3,12 @@
 
 """
 Test depth frame quality. Streams depth, checks that fill rate is above threshold
-(>50% non-zero pixels with laser ON).
+(>50% non-zero pixels with laser ON), across multiple resolutions.
 """
 
 import pytest
 import pyrealsense2 as rs
+from pytest_check import check
 import numpy as np
 import time
 import logging
@@ -24,6 +25,30 @@ pytestmark = [
     pytest.mark.device_each("D500*"),
     pytest.mark.device_exclude("D401"),
 ]
+
+PREFERRED_FPS = 30
+
+
+def get_available_depth_resolutions(dev, preferred_fps=PREFERRED_FPS):
+    """
+    Query the device for every distinct depth (width, height) it actually advertises
+    for z16, each paired with preferred_fps if that resolution supports it, otherwise
+    its own highest available fps. Sorted by pixel count, highest first.
+    """
+    depth_sensor = dev.first_depth_sensor()
+    fps_by_resolution = {}
+    for profile in depth_sensor.get_stream_profiles():
+        if profile.stream_type() != rs.stream.depth or profile.format() != rs.format.z16:
+            continue
+        vp = profile.as_video_stream_profile()
+        fps_by_resolution.setdefault((vp.width(), vp.height()), set()).add(vp.fps())
+
+    resolutions = [
+        (res, preferred_fps if preferred_fps in fps_set else max(fps_set))
+        for res, fps_set in fps_by_resolution.items()
+    ]
+    resolutions.sort(key=lambda item: item[0][0] * item[0][1], reverse=True)
+    return resolutions
 
 
 def get_distances(depth_frame):
@@ -62,17 +87,20 @@ def is_depth_fill_rate_enough(pipeline):
     return fill_rate > (1 - BLACK_PIXEL_THRESHOLD) * 100.0, num_blank_pixels
 
 
-def test_depth_laser_on(test_device_wrapped):
-    dev, ctx = test_device_wrapped
+def run_test(dev, ctx, resolution, fps):
     product_name = dev.get_info(rs.camera_info.name)
 
     cfg = rs.config()
     # On hubless multi-device rigs (e.g. Jetson with D457 + D436) the context sees every
     # connected device; without enable_device(sn) the pipeline picks the first match.
     cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
-    cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
+    cfg.enable_stream(rs.stream.depth, resolution[0], resolution[1], rs.format.z16, fps)
 
     pipeline = rs.pipeline(ctx)
+    if not cfg.can_resolve(pipeline):
+        log.info(f"Configuration {resolution[0]}x{resolution[1]} @ {fps}fps is not supported by the device")
+        return
+
     pipeline.start(cfg)
     try:
         pipeline.wait_for_frames()
@@ -90,7 +118,7 @@ def test_depth_laser_on(test_device_wrapped):
         else:
             log.info(f"Device {product_name} does not support emitter control; running with default emitter state")
 
-        log.info(f"Testing depth frame - laser ON - {product_name}")
+        log.info(f"Testing depth frame - laser ON - {resolution[0]}x{resolution[1]}@{fps}fps - {product_name}")
 
         has_depth = False
         for frame_num in range(FRAMES_TO_CHECK):
@@ -100,4 +128,21 @@ def test_depth_laser_on(test_device_wrapped):
     finally:
         pipeline.stop()
 
-    assert has_depth, f"Depth fill rate too low on {product_name} after {FRAMES_TO_CHECK} frames"
+    check.is_true(has_depth,
+                  f"Depth fill rate too low on {product_name} at {resolution[0]}x{resolution[1]}@{fps}fps "
+                  f"after {FRAMES_TO_CHECK} frames")
+
+
+def test_depth_laser_on(test_device_wrapped, test_context_var):
+    dev, ctx = test_device_wrapped
+
+    all_resolutions = get_available_depth_resolutions(dev)
+
+    # Sweeping every resolution the device advertises is expensive (each waits for up
+    # to FRAMES_TO_CHECK frames), so regular CI only runs the highest-resolution mode;
+    # the full sweep runs under nightly. If nightly still proves too slow, change
+    # "nightly" to "weekly" below to push the extended sweep out further.
+    configurations = all_resolutions if "nightly" in test_context_var else all_resolutions[:1]
+
+    for resolution, fps in configurations:
+        run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-texture-mapping.py
+++ b/unit-tests/live/image-quality/pytest-texture-mapping.py
@@ -19,7 +19,8 @@ from iq_helper import (find_roi_location, get_roi_from_frame, is_color_close,
                        get_median_depth_from_region, sample_bg_depth,
                        get_median_color_from_region, sample_bg_color,
                        make_depth_filter_chain, save_failure_snapshot,
-                       SAMPLE_REGION_SIZE, BG_SAMPLE_POINTS, CUBE_CENTER, WIDTH, HEIGHT)
+                       SAMPLE_REGION_SIZE, BG_SAMPLE_POINTS, CUBE_CENTER, WIDTH, HEIGHT,
+                       DEFAULT_CONFIGURATIONS, NIGHTLY_CONFIGURATIONS)
 
 log = logging.getLogger(__name__)
 
@@ -249,20 +250,10 @@ def run_test(dev, ctx, depth_resolution, depth_fps, color_resolution, color_fps)
 def test_texture_mapping(test_device, test_context_var):
     dev, ctx = test_device
 
-    configurations = [((1280, 720), 30)]
+    configurations = DEFAULT_CONFIGURATIONS
     # on nightly we check additional arbitrary configurations
     if "nightly" in test_context_var or "weekly" in test_context_var:
-        configurations += [
-            ((640, 480), 15),
-            ((640, 480), 30),
-            ((640, 480), 60),
-            ((848, 480), 15),
-            ((848, 480), 30),
-            ((848, 480), 60),
-            ((1280, 720), 5),
-            ((1280, 720), 10),
-            ((1280, 720), 15),
-        ]
+        configurations = DEFAULT_CONFIGURATIONS + NIGHTLY_CONFIGURATIONS
 
     # D436 color stream returns near-black frames at >30 fps with Auto-Exposure ON
     # (reproduced on FW 5.17.3.10 and 5.17.3.21, and in realsense-viewer).


### PR DESCRIPTION
## Summary

Extends the existing whole-frame depth fill-rate IQ test (`pytest-has-depth.py`) to sweep every depth resolution the connected device advertises, instead of testing only a single fixed configuration.

- **`get_available_depth_resolutions(dev)`**: queries the device's actual depth stream profiles (`z16` format) for every distinct resolution it supports, rather than a hand-maintained list. Each resolution is paired with 30fps if available, otherwise its own max fps. Sorted highest-resolution first.
- **Regular CI** runs only the highest-resolution mode (same effective coverage as before this change).
- **`nightly`** context runs the full resolution sweep. If that proves too slow, the gate is a one-line change (`"nightly"` → `"weekly"`) to push it out further.
- Added a `cfg.can_resolve(pipeline)` guard before starting the pipeline, since not every device supports every resolution/fps combination.
- Switched the pass/fail check from a hard `assert` to `pytest_check`'s `check.is_true(...)` so one failing resolution doesn't abort the rest of the sweep — matching the convention used by the other multi-resolution image-quality tests (`pytest-basic-depth.py`, `pytest-texture-mapping.py`).
- Renamed `test_depth_laser_on` → `test_depth_fill_rate` since the test no longer covers just a single laser-on configuration.

## Why

RSDSO-21729 asked for depth fill-rate coverage across multiple resolutions. Rather than adding a new test, this extends the existing whole-frame fill-rate check in place, following the same default/nightly split already used by the other image-quality tests.

## Test plan

- [ ] `pytest -v --context image-quality live/image-quality/pytest-has-depth.py::test_depth_fill_rate` passes on a connected D400/D500 device (regular-CI path, single highest resolution).
- [ ] `pytest -v --context "image-quality nightly" live/image-quality/pytest-has-depth.py::test_depth_fill_rate` passes and exercises every resolution the device advertises.
- [ ] Confirm resolutions unsupported by a given device are skipped cleanly (via `can_resolve`) rather than erroring.
