### PR TITLE
viewer: re-enable histogram equalization by default on D585

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -399,18 +399,6 @@ namespace rs2
             depth_colorizer->set_option(RS2_OPTION_VISUAL_PRESET, option_value);
         }
 
-        // Disable histogram equalization for D585 prototype variants (0C07, 0C08).
-        // Must be applied AFTER the VISUAL_PRESET restore block above: re-setting the Dynamic
-        // preset (default) re-enables histogram equalization via its on_set callback.
-        if (s->supports(RS2_CAMERA_INFO_PRODUCT_ID))
-        {
-            std::string device_pid = s->get_info(RS2_CAMERA_INFO_PRODUCT_ID);
-            if (device_pid == "0C07" || device_pid == "0C08")
-            {
-                depth_colorizer->set_option(RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED, 0.f);
-            }
-        }
-
         std::stringstream ss;
         ss << "##" << dev.get_info(RS2_CAMERA_INFO_NAME)
             << "/" << s->get_info(RS2_CAMERA_INFO_NAME)


### PR DESCRIPTION
**Overview:** Restores the default "Histogram Equalization Enabled" state to On for D585 in the Viewer, reverting the prototype-only restriction added in #15221.

Tracked on [RSDEV-13039]

## Why
PR #15221 forced `RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED` to 0 for D585 prototype PIDs 0C07/0C08. That was a demo-specific request. Validation reported it as a regression (RSDEV-13039), and product confirmed the option should stay On for production.

## Summary
- Remove the PID-based block in `common/subdevice-model.cpp` that disabled histogram equalization on the depth colorizer for PIDs 0C07/0C08.
- The sensor/stream rename from the same PR is not touched (already superseded by a later rename).

## Test plan
- [x] Viewer builds clean (Release, MSVC) and launches
- [ ] Manual: connect D585, verify Depth Visualization > Histogram Equalization Enabled defaults On
- [ ] Manual: verify other SKUs unaffected

---
🤖 Generated by AI
