### PR TITLE
Fix segfault from racing log level changes with concurrent logging

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -10,7 +10,6 @@
 #include <rsutils/os/ensure-console.h>
 
 #include <stdexcept>
-#include <mutex>
 #include <fstream>
 
 
@@ -59,12 +58,23 @@ namespace librealsense
         rs2_log_severity minimum_file_severity = RS2_LOG_SEVERITY_NONE;
         rs2_log_severity minimum_callback_severity = RS2_LOG_SEVERITY_NONE;
 
-        std::mutex log_mutex;
         std::ofstream log_file;
         std::vector< std::string > callback_dispatchers;
 
         std::string filename;
         const std::string log_id = NAME;
+
+        // el::Loggers::reconfigureLogger() ends up in Logger::configure(), which mutates state before taking
+        // its own lock (a bug present in every released version of this now-archived, unmaintained library --
+        // see RSDSO-21284). We can't patch third-party code, so we serialize externally instead, using the
+        // same (recursive) el::Logger lock that LIBRS_LOG_/LIBRS_LOG_STR_ already hold while reading.
+        template< typename Fn >
+        void reconfigure_locked( Fn && fn ) const
+        {
+            auto * logger = el::Loggers::getLogger( log_id );
+            el::base::threading::ScopedLock lock( logger->lock() );
+            fn();
+        }
 
     public:
         static el::Level severity_to_level(rs2_log_severity severity)
@@ -136,7 +146,7 @@ namespace librealsense
                                  severity >= minimum_file_severity ? "true" : "false" );
             }
 
-            el::Loggers::reconfigureLogger(log_id, defaultConf);
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, defaultConf ); } );
         }
 
         void open_def() const
@@ -149,7 +159,7 @@ namespace librealsense
             defaultConf.setGlobally( el::ConfigurationType::ToFile, "false" );
             defaultConf.setGlobally( el::ConfigurationType::ToStandardOutput, "false" );
 
-            el::Loggers::reconfigureLogger(log_id, defaultConf);
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, defaultConf ); } );
         }
 
 
@@ -270,10 +280,10 @@ namespace librealsense
         // Stop logging and reset logger to initial configurations
         void reset_logger()
         {
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::Enabled, "false" );
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToFile, "false" );
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToStandardOutput, "false" );
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, "0" );
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::Enabled, "false" ); } );
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToFile, "false" ); } );
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToStandardOutput, "false" ); } );
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, "0" ); } );
             remove_callbacks();
 
             minimum_console_severity = RS2_LOG_SEVERITY_NONE;
@@ -316,7 +326,7 @@ namespace librealsense
             // Or, with the flag el::LoggingFlags::StrictLogFileSizeCheck, at each log output...
             //el::Loggers::addFlag( el::LoggingFlag::StrictLogFileSizeCheck );
 
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, size.c_str() );
+            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, size.c_str() ); } );
             el::Helpers::installPreRollOutCallback( rolloutHandler );
         }
     };

--- a/src/log.h
+++ b/src/log.h
@@ -72,6 +72,8 @@ namespace librealsense
         void reconfigure_locked( Fn && fn ) const
         {
             auto * logger = el::Loggers::getLogger( log_id );
+            if( ! logger )
+                return;
             el::base::threading::ScopedLock lock( logger->lock() );
             fn();
         }
@@ -280,10 +282,14 @@ namespace librealsense
         // Stop logging and reset logger to initial configurations
         void reset_logger()
         {
-            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::Enabled, "false" ); } );
-            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToFile, "false" ); } );
-            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToStandardOutput, "false" ); } );
-            reconfigure_locked( [&] { el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, "0" ); } );
+            // One lock for all four, so a concurrent reader can't observe a partially-reset logger
+            // (e.g. Enabled=false but ToFile still true).
+            reconfigure_locked( [&] {
+                el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::Enabled, "false" );
+                el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToFile, "false" );
+                el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::ToStandardOutput, "false" );
+                el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, "0" );
+            } );
             remove_callbacks();
 
             minimum_console_severity = RS2_LOG_SEVERITY_NONE;

--- a/third-party/easyloggingpp/src/easylogging++.cc
+++ b/third-party/easyloggingpp/src/easylogging++.cc
@@ -645,7 +645,6 @@ Logger& Logger::operator=(const Logger& logger) {
 }
 
 void Logger::configure(const Configurations& configurations) {
-  base::threading::ScopedLock scopedLock(lock());
   m_isConfigured = false;  // we set it to false in case if we fail
   initUnflushedCount();
   if (m_typedConfigurations != nullptr) {
@@ -654,6 +653,7 @@ void Logger::configure(const Configurations& configurations) {
       flush();
     }
   }
+  base::threading::ScopedLock scopedLock(lock());
   if (m_configurations != configurations) {
     m_configurations.setFromBase(const_cast<Configurations*>(&configurations));
   }

--- a/third-party/easyloggingpp/src/easylogging++.cc
+++ b/third-party/easyloggingpp/src/easylogging++.cc
@@ -645,6 +645,7 @@ Logger& Logger::operator=(const Logger& logger) {
 }
 
 void Logger::configure(const Configurations& configurations) {
+  base::threading::ScopedLock scopedLock(lock());
   m_isConfigured = false;  // we set it to false in case if we fail
   initUnflushedCount();
   if (m_typedConfigurations != nullptr) {
@@ -653,7 +654,6 @@ void Logger::configure(const Configurations& configurations) {
       flush();
     }
   }
-  base::threading::ScopedLock scopedLock(lock());
   if (m_configurations != configurations) {
     m_configurations.setFromBase(const_cast<Configurations*>(&configurations));
   }

--- a/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
+++ b/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
@@ -55,22 +55,20 @@
 // The logger's lock must be held while checking enabled() and while the message is being built: rs2::log_to_console()
 // et al. reconfigure the logger (replacing its TypedConfigurations) under that same lock, from any thread, at any
 // time -- an unlocked enabled() check can dereference a TypedConfigurations being deleted concurrently and segfault.
+// The lock is scoped (RAII), not manually released, so it can't leak if building/streaming the message throws; ELPP's
+// own Writer acquires the same (recursive) lock again internally, safely nesting within ours.
 #define LIBRS_LOG_STR_( LEVEL, STR )                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
         if( logger__ )                                                                                                 \
         {                                                                                                              \
-            logger__->acquireLock();                                                                                   \
+            el::base::threading::ScopedLock lock__( logger__->lock() );                                                \
             if( logger__->enabled( el::Level::LEVEL ) )                                                                \
             {                                                                                                          \
                 el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
-                        .construct( logger__, false )                                                                  \
+                        .construct( logger__ )                                                                         \
                     << STR;                                                                                            \
-            }                                                                                                          \
-            else                                                                                                       \
-            {                                                                                                          \
-                logger__->releaseLock();                                                                               \
             }                                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \
@@ -83,18 +81,14 @@
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
         if( logger__ )                                                                                                 \
         {                                                                                                              \
-            logger__->acquireLock();                                                                                   \
+            el::base::threading::ScopedLock lock__( logger__->lock() );                                                \
             if( logger__->typedConfigurations() && logger__->enabled( el::Level::LEVEL ) )                             \
             {                                                                                                          \
                 std::ostringstream os__;                                                                               \
                 os__ << __VA_ARGS__;                                                                                   \
                 el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
-                        .construct( logger__, false )                                                                  \
+                        .construct( logger__ )                                                                         \
                     << os__.str();                                                                                     \
-            }                                                                                                          \
-            else                                                                                                       \
-            {                                                                                                          \
-                logger__->releaseLock();                                                                               \
             }                                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \

--- a/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
+++ b/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
@@ -49,17 +49,29 @@
 #else //__ANDROID__  
 
 // Direct log to ELPP, without conversion to string first; use this as an optimization, if you have simple string output
-// 
+//
 // We've seen cases where this fails in U22, causing weird effects with custom overloads/types (e.g., json)
+//
+// The logger's lock must be held while checking enabled() and while the message is being built: rs2::log_to_console()
+// et al. reconfigure the logger (replacing its TypedConfigurations) under that same lock, from any thread, at any
+// time -- an unlocked enabled() check can dereference a TypedConfigurations being deleted concurrently and segfault.
 #define LIBRS_LOG_STR_( LEVEL, STR )                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
-        if( logger__ && logger__->enabled( el::Level::LEVEL ) )                                                        \
+        if( logger__ )                                                                                                 \
         {                                                                                                              \
-            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
-                    .construct( logger__ )                                                                             \
-                << STR;                                                                                                \
+            logger__->acquireLock();                                                                                   \
+            if( logger__->enabled( el::Level::LEVEL ) )                                                                \
+            {                                                                                                          \
+                el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
+                        .construct( logger__, false )                                                                  \
+                    << STR;                                                                                            \
+            }                                                                                                          \
+            else                                                                                                       \
+            {                                                                                                          \
+                logger__->releaseLock();                                                                               \
+            }                                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \
     while( false )
@@ -69,13 +81,21 @@
     do                                                                                                                 \
     {                                                                                                                  \
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
-        if( logger__ && logger__->typedConfigurations() &&  logger__->enabled( el::Level::LEVEL ) )                    \
+        if( logger__ )                                                                                                 \
         {                                                                                                              \
-            std::ostringstream os__;                                                                                   \
-            os__ << __VA_ARGS__;                                                                                       \
-            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
-                    .construct( logger__ )                                                                             \
-                << os__.str();                                                                                         \
+            logger__->acquireLock();                                                                                   \
+            if( logger__->typedConfigurations() && logger__->enabled( el::Level::LEVEL ) )                             \
+            {                                                                                                          \
+                std::ostringstream os__;                                                                               \
+                os__ << __VA_ARGS__;                                                                                   \
+                el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
+                        .construct( logger__, false )                                                                  \
+                    << os__.str();                                                                                     \
+            }                                                                                                          \
+            else                                                                                                       \
+            {                                                                                                          \
+                logger__->releaseLock();                                                                               \
+            }                                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \
     while( false )

--- a/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
+++ b/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
@@ -52,24 +52,27 @@
 //
 // We've seen cases where this fails in U22, causing weird effects with custom overloads/types (e.g., json)
 //
-// The logger's lock must be held while checking enabled() and while the message is being built: rs2::log_to_console()
-// et al. reconfigure the logger (replacing its TypedConfigurations) under that same lock, from any thread, at any
-// time -- an unlocked enabled() check can dereference a TypedConfigurations being deleted concurrently and segfault.
-// The lock is scoped (RAII), not manually released, so it can't leak if building/streaming the message throws; ELPP's
-// own Writer acquires the same (recursive) lock again internally, safely nesting within ours.
+namespace rsutils {
+// log_to_console() et al. reconfigure the logger (replacing TypedConfigurations) under its lock, from any thread, at
+// any time; check enabled() under that same lock too, or risk dereferencing a TypedConfigurations mid-delete.
+inline bool elpp_enabled( el::Logger * logger__, el::Level level )
+{
+    if( ! logger__ )
+        return false;
+    el::base::threading::ScopedLock lock__( logger__->lock() );
+    return logger__->typedConfigurations() && logger__->enabled( level );
+}
+}  // namespace rsutils
+
 #define LIBRS_LOG_STR_( LEVEL, STR )                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
-        if( logger__ )                                                                                                 \
+        if( rsutils::elpp_enabled( logger__, el::Level::LEVEL ) )                                                      \
         {                                                                                                              \
-            el::base::threading::ScopedLock lock__( logger__->lock() );                                                \
-            if( logger__->enabled( el::Level::LEVEL ) )                                                                \
-            {                                                                                                          \
-                el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
-                        .construct( logger__ )                                                                         \
-                    << STR;                                                                                            \
-            }                                                                                                          \
+            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
+                    .construct( logger__ )                                                                             \
+                << STR;                                                                                                \
         }                                                                                                              \
     }                                                                                                                  \
     while( false )
@@ -79,17 +82,13 @@
     do                                                                                                                 \
     {                                                                                                                  \
         auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
-        if( logger__ )                                                                                                 \
+        if( rsutils::elpp_enabled( logger__, el::Level::LEVEL ) )                                                      \
         {                                                                                                              \
-            el::base::threading::ScopedLock lock__( logger__->lock() );                                                \
-            if( logger__->typedConfigurations() && logger__->enabled( el::Level::LEVEL ) )                             \
-            {                                                                                                          \
-                std::ostringstream os__;                                                                               \
-                os__ << __VA_ARGS__;                                                                                   \
-                el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )\
-                        .construct( logger__ )                                                                         \
-                    << os__.str();                                                                                     \
-            }                                                                                                          \
+            std::ostringstream os__;                                                                                   \
+            os__ << __VA_ARGS__;                                                                                       \
+            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
+                    .construct( logger__ )                                                                             \
+                << os__.str();                                                                                         \
         }                                                                                                              \
     }                                                                                                                  \
     while( false )

--- a/unit-tests/log/test-log-level-race.cpp
+++ b/unit-tests/log/test-log-level-race.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <vector>
+#include <cstdio>
 
 // Regression test for RSDSO-21284 (github.com/realsenseai/librealsense/issues/14761):
 // changing the log level from one thread while another thread logs used to segfault.
@@ -26,8 +27,8 @@ TEST_CASE( "changing log level while logging from another thread", "[log]" )
         }
     } );
 
-    // Mimics the streaming thread logging frame-callback info (e.g. log_callback_end()).
-    // Severity is kept below WARN so nothing actually gets printed to the console.
+    // Mimics the streaming thread logging frame-callback info (e.g. log_callback_end()). Level changes
+    // aren't atomic from this thread's point of view, so some DEBUG lines may still leak to the console.
     std::vector< std::thread > loggers;
     for( int i = 0; i < 4; ++i )
         loggers.emplace_back( [&]() {
@@ -38,7 +39,40 @@ TEST_CASE( "changing log level while logging from another thread", "[log]" )
     std::this_thread::sleep_for( std::chrono::milliseconds( 300 ) );
     stop = true;
 
-    level_changer.join();
+    REQUIRE_NOTHROW( level_changer.join() );
     for( auto & t : loggers )
-        t.join();
+        REQUIRE_NOTHROW( t.join() );
+}
+
+
+// Same race, but through rs2::log_to_file(): Logger::configure() mutates m_unflushedCount before taking its
+// lock, and isFlushNeeded() (only reached when logging to a file) reads it under lock on another thread.
+TEST_CASE( "changing log file level while logging from another thread", "[log]" )
+{
+    const char * log_file_path = ".//log-level-race-file.log";
+    std::remove( log_file_path );
+
+    std::atomic<bool> stop( false );
+
+    std::thread level_changer( [&]() {
+        while( ! stop )
+        {
+            rs2::log_to_file( RS2_LOG_SEVERITY_DEBUG, log_file_path );
+            rs2::log_to_file( RS2_LOG_SEVERITY_ERROR, log_file_path );
+        }
+    } );
+
+    std::vector< std::thread > loggers;
+    for( int i = 0; i < 4; ++i )
+        loggers.emplace_back( [&]() {
+            while( ! stop )
+                rs2::log( RS2_LOG_SEVERITY_DEBUG, "callback finished" );
+        } );
+
+    std::this_thread::sleep_for( std::chrono::milliseconds( 300 ) );
+    stop = true;
+
+    REQUIRE_NOTHROW( level_changer.join() );
+    for( auto & t : loggers )
+        REQUIRE_NOTHROW( t.join() );
 }

--- a/unit-tests/log/test-log-level-race.cpp
+++ b/unit-tests/log/test-log-level-race.cpp
@@ -75,4 +75,6 @@ TEST_CASE( "changing log file level while logging from another thread", "[log]" 
     REQUIRE_NOTHROW( level_changer.join() );
     for( auto & t : loggers )
         REQUIRE_NOTHROW( t.join() );
+
+    std::remove( log_file_path );  // best-effort: ELPP may still hold the file open on some platforms
 }

--- a/unit-tests/log/test-log-level-race.cpp
+++ b/unit-tests/log/test-log-level-race.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "changing log level while logging from another thread", "[log]" )
                 rs2::log( RS2_LOG_SEVERITY_DEBUG, "callback finished" );
         } );
 
-    std::this_thread::sleep_for( std::chrono::seconds( 2 ) );
+    std::this_thread::sleep_for( std::chrono::milliseconds( 300 ) );
     stop = true;
 
     level_changer.join();

--- a/unit-tests/log/test-log-level-race.cpp
+++ b/unit-tests/log/test-log-level-race.cpp
@@ -1,0 +1,44 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#include "log-common.h"
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <vector>
+
+// Regression test for RSDSO-21284 (github.com/realsenseai/librealsense/issues/14761):
+// changing the log level from one thread while another thread logs used to segfault.
+// The LIBRS_LOG_/LIBRS_LOG_STR_ macros checked logger->enabled() without holding the
+// logger's lock, racing against Logger::configure() (triggered by rs2::log_to_console())
+// deleting and replacing the logger's TypedConfigurations from another thread.
+TEST_CASE( "changing log level while logging from another thread", "[log]" )
+{
+    std::atomic<bool> stop( false );
+
+    // Mimics an application repeatedly changing the console log level -- e.g. to suppress
+    // warnings while setting up a second camera -- while a first camera is streaming.
+    std::thread level_changer( [&]() {
+        while( ! stop )
+        {
+            rs2::log_to_console( RS2_LOG_SEVERITY_FATAL );
+            rs2::log_to_console( RS2_LOG_SEVERITY_WARN );
+        }
+    } );
+
+    // Mimics the streaming thread logging frame-callback info (e.g. log_callback_end()).
+    // Severity is kept below WARN so nothing actually gets printed to the console.
+    std::vector< std::thread > loggers;
+    for( int i = 0; i < 4; ++i )
+        loggers.emplace_back( [&]() {
+            while( ! stop )
+                rs2::log( RS2_LOG_SEVERITY_DEBUG, "callback finished" );
+        } );
+
+    std::this_thread::sleep_for( std::chrono::seconds( 2 ) );
+    stop = true;
+
+    level_changer.join();
+    for( auto & t : loggers )
+        t.join();
+}


### PR DESCRIPTION
**Overview:** Fixes a segfault that occurs when `rs2::log_to_console()` (or `log_to_file`/`log_to_callback`/`reset_logger`) is called from one thread while another thread is logging.

Tracked on [RSDSO-21284]

## Why
Reported in [GH #14761](https://github.com/realsenseai/librealsense/issues/14761): changing the log level while a camera streams intermittently segfaults, with crashes seen in `el::base::TypedConfigurations::enabled()`.

The `LIBRS_LOG_`/`LIBRS_LOG_STR_` macros (backing `LOG_DEBUG`, `rs2_log`, etc.) checked `logger->enabled(level)` without holding the logger's lock. Meanwhile, `Logger::configure()` (invoked by `rs2::log_to_console()` et al., via EasyLogging++'s `el::Loggers::reconfigureLogger()`) deletes and replaces the logger's `TypedConfigurations` object, and separately mutates `m_unflushedCount` (relevant to the `log_to_file` path), all without adequate synchronization against a concurrent reader.

## Summary
- **Read side** (`third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h`): added `rsutils::elpp_enabled()`, which checks `logger->enabled()` while holding the logger's own lock, instead of unlocked. Lock is held only for the check, not while building/streaming the message, avoiding a lock-order-inversion risk.
- **Write side** (`src/log.h`): every call site that triggers `Logger::configure()` (`open()`, `open_def()`, `reset_logger()`, `enable_rolling_log_file()`) now acquires that same per-`Logger` (recursive) lock *before* calling into `el::Loggers::reconfigureLogger()`. This fully serializes reconfiguration against concurrent logging **without modifying vendored EasyLogging++ code** — confirmed no newer upstream release fixes this (the project is archived; its final release, v9.97.1, has the identical bug).
- Removed a pre-existing, unused `std::mutex log_mutex` member that sat unused right next to this code.
- Added `unit-tests/log/test-log-level-race.cpp` with two regression tests: one via `log_to_console` (the originally reported path), one via `log_to_file` (a related race in the same function, found during review).

## Test plan
- [x] Both test cases in `unit-tests/log/test-log-level-race.cpp` reproduce real `SIGSEGV`s on the original code and pass cleanly with the fix.
- [x] Verified on Windows via instrumented crash-hook stack traces: no crash remains in the logging/reconfigure path post-fix (a separate, pre-existing, unrelated Windows-only crash in the test harness's own teardown is out of scope — reproduces identically with zero logging calls).
- [x] Verified on Linux (Ubuntu 22.04): reverting only `src/log.h` and rebuilding reliably reproduces `Segmentation fault (core dumped)`; with the fix, 5/5 clean runs (`All tests passed`, 10 assertions in 2 test cases).

---
🤖 Generated by AI