### PR TITLE
Fix rotation filter crash on streams without intrinsics

### DIFF
--- a/src/proc/rotation-filter.cpp
+++ b/src/proc/rotation-filter.cpp
@@ -148,9 +148,21 @@ namespace librealsense {
         if( ! tgt_vspi )
             throw std::runtime_error( "Profile is not video stream profile" );
 
-        // Get intrinsics and set up new ones based on the rotation value.
-        rs2_intrinsics src_intrin = src_vspi->get_intrinsics();
-        rs2_intrinsics tgt_intrin = tgt_vspi->get_intrinsics();
+        // Some profiles (e.g. unrectified Y16 infrared) have no intrinsics registered; fall back to the
+        // profile's own dimensions for those and skip updating intrinsics on the target profile.
+        rs2_intrinsics src_intrin{};
+        bool has_intrinsics = true;
+        try
+        {
+            src_intrin = src_vspi->get_intrinsics();
+        }
+        catch( const not_implemented_exception & )
+        {
+            has_intrinsics = false;
+            src_intrin.width = src_vspi->get_width();
+            src_intrin.height = src_vspi->get_height();
+        }
+        rs2_intrinsics tgt_intrin = src_intrin;
 
         int rotated_width = 0;
         int rotated_height = 0;
@@ -183,12 +195,14 @@ namespace librealsense {
         }
         else { throw std::invalid_argument( "Unsupported rotation angle" ); }
 
-        // Update dimensions for the intrinsics.
-        tgt_intrin.width = rotated_width;
-        tgt_intrin.height = rotated_height;
-
-        tgt_vspi->set_intrinsics( [tgt_intrin]() { return tgt_intrin; } );
         tgt_vspi->set_dims( rotated_width, rotated_height );
+        if( has_intrinsics )
+        {
+            // Update dimensions for the intrinsics.
+            tgt_intrin.width = rotated_width;
+            tgt_intrin.height = rotated_height;
+            tgt_vspi->set_intrinsics( [tgt_intrin]() { return tgt_intrin; } );
+        }
 
         _last_rotation_values[stream_key] = value;
         _target_stream_profiles[stream_key] = target_profile;
@@ -209,9 +223,8 @@ namespace librealsense {
         if( ! video_profile )
             throw std::runtime_error( "Target profile is not a video stream profile interface" );
 
-        rs2_intrinsics intrin = video_profile->get_intrinsics();
-        out_width = intrin.width;
-        out_height = intrin.height;
+        out_width = video_profile->get_width();
+        out_height = video_profile->get_height();
 
         auto ret = source.allocate_video_frame( target_profile,
                                                 f,

--- a/src/proc/rotation-filter.cpp
+++ b/src/proc/rotation-filter.cpp
@@ -148,57 +148,65 @@ namespace librealsense {
         if( ! tgt_vspi )
             throw std::runtime_error( "Profile is not video stream profile" );
 
-        // Some profiles (e.g. unrectified Y16 infrared) have no intrinsics registered; fall back to the
-        // profile's own dimensions for those and skip updating intrinsics on the target profile.
+        // Some profiles (e.g. unrectified Y16/Y12I infrared) have no usable intrinsics; get_intrinsics() can
+        // fail in more than one way (never registered, or the calibration lookup itself rejects the stream),
+        // so treat any failure the same: fall back to the profile's own dimensions and skip target intrinsics.
         rs2_intrinsics src_intrin{};
         bool has_intrinsics = true;
         try
         {
             src_intrin = src_vspi->get_intrinsics();
         }
-        catch( const not_implemented_exception & )
+        catch( const std::exception & )
         {
             has_intrinsics = false;
-            src_intrin.width = src_vspi->get_width();
-            src_intrin.height = src_vspi->get_height();
         }
-        rs2_intrinsics tgt_intrin = src_intrin;
+
+        int src_width = has_intrinsics ? src_intrin.width : src_vspi->get_width();
+        int src_height = has_intrinsics ? src_intrin.height : src_vspi->get_height();
 
         int rotated_width = 0;
         int rotated_height = 0;
-        if( value == 90 )
+        if( value == 90 || value == -90 )
         {
-            rotated_width = src_intrin.height;
-            rotated_height = src_intrin.width;
-            tgt_intrin.fx = src_intrin.fy;
-            tgt_intrin.fy = src_intrin.fx;
-            tgt_intrin.ppx = src_intrin.height - src_intrin.ppy;
-            tgt_intrin.ppy = src_intrin.ppx;
-        }
-        else if( value == -90 )
-        {
-            rotated_width = src_intrin.height;
-            rotated_height = src_intrin.width;
-            tgt_intrin.fx = src_intrin.fy;
-            tgt_intrin.fy = src_intrin.fx;
-            tgt_intrin.ppx = src_intrin.ppy;
-            tgt_intrin.ppy = src_intrin.width - src_intrin.ppx;
+            rotated_width = src_height;
+            rotated_height = src_width;
         }
         else if( value == 180 )
         {
-            rotated_width = src_intrin.width;
-            rotated_height = src_intrin.height;
-            tgt_intrin.fx = src_intrin.fx;
-            tgt_intrin.fy = src_intrin.fy;
-            tgt_intrin.ppx = src_intrin.width - src_intrin.ppx;
-            tgt_intrin.ppy = src_intrin.height - src_intrin.ppy;
+            rotated_width = src_width;
+            rotated_height = src_height;
         }
         else { throw std::invalid_argument( "Unsupported rotation angle" ); }
 
         tgt_vspi->set_dims( rotated_width, rotated_height );
+
         if( has_intrinsics )
         {
-            // Update dimensions for the intrinsics.
+            // The target profile was cloned from the source, so its intrinsics start identical; only the
+            // fields affected by rotation need adjusting.
+            rs2_intrinsics tgt_intrin = src_intrin;
+            if( value == 90 )
+            {
+                tgt_intrin.fx = src_intrin.fy;
+                tgt_intrin.fy = src_intrin.fx;
+                tgt_intrin.ppx = src_intrin.height - src_intrin.ppy;
+                tgt_intrin.ppy = src_intrin.ppx;
+            }
+            else if( value == -90 )
+            {
+                tgt_intrin.fx = src_intrin.fy;
+                tgt_intrin.fy = src_intrin.fx;
+                tgt_intrin.ppx = src_intrin.ppy;
+                tgt_intrin.ppy = src_intrin.width - src_intrin.ppx;
+            }
+            else  // 180
+            {
+                tgt_intrin.fx = src_intrin.fx;
+                tgt_intrin.fy = src_intrin.fy;
+                tgt_intrin.ppx = src_intrin.width - src_intrin.ppx;
+                tgt_intrin.ppy = src_intrin.height - src_intrin.ppy;
+            }
             tgt_intrin.width = rotated_width;
             tgt_intrin.height = rotated_height;
             tgt_vspi->set_intrinsics( [tgt_intrin]() { return tgt_intrin; } );


### PR DESCRIPTION
**Overview:** Fixes the Rotation Filter throwing and failing to rotate frames on streams that have no registered intrinsics (e.g. unrectified `Y16`/`Y12I` infrared).

Tracked on [RSDEV-12744]

## Why
At max resolution (e.g. 1280x800) D400/D430/D457 GMSL depth sensors stream infrared as unrectified `Y16`/`Y12I`, which by design never get intrinsics registered (see `d400-device.cpp`). `rotation_filter::update_output_profile()` unconditionally called `get_intrinsics()` on the source/target profiles to compute the rotated width/height and principal point, which throws `not_implemented_exception` for these streams. The failure happens before the filter records success, so it re-throws on every single frame: the image never rotates and the log floods with "No intrinsics are available for this stream profile!".

## Summary
- `update_output_profile()` now falls back to the profile's own width/height when intrinsics aren't available, and only updates the target profile's intrinsics when they exist.
- `prepare_target_frame()` now reads output dimensions from the profile's stored width/height instead of round-tripping through `get_intrinsics()`, removing that dependency entirely.

## Test plan
- [x] Manual: D457 GMSL, Stereo Module, Infrared, 1280x800, Rotation Filter at 90°/180°/-90° — rotates correctly, no log errors (previously threw "No intrinsics are available" every frame).
- [x] Manual: Infrared at 640x480 and 1280x720 unaffected (regression check).
- [ ] `unit-tests/post-processing/pytest-rotation-filter.py` (rectified depth path, has real intrinsics) — needs a run to confirm no regression.

---
🤖 Generated by AI