### PR TITLE
Recognize NIGHTLY-style FW filenames in extract_version_from_filename

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -59,6 +59,7 @@ def extract_version_from_filename(file_path):
     FlashGeneratedImage_Image5_16_7_0.bin -> 5.16.7
     FlashGeneratedImage_RELEASE_DS5_5_16_3_1.bin -> 5.16.3.1
     rvp-flash-dfu-release-7.56.37749.4831.img -> 7.56.37749.4831
+    20260727_7.58.40846.12889.img (NIGHTLY build) -> 7.58.40846.12889
 
     Args:
         file_path (str): Full path to the file.
@@ -78,8 +79,11 @@ def extract_version_from_filename(file_path):
     # FlashGeneratedImage_RELEASE_DS5_5_16_3_1.bin -> 5.16.3.1
     match = re.search(r'(\d+)_(\d+)_(\d+)_(\d+)\.(bin|img)$', filename)
     if not match:
-        # Match patterns like rvp-flash-dfu-release-7.56.37749.4831.img -> 7.56.37749.4831
-        match = re.search(r'-(\d+)\.(\d+)\.(\d+)\.(\d+)\.(bin|img)$', filename)
+        # Match a dot-separated x.y.z.w version immediately before the extension,
+        # regardless of what precedes it (hyphen, underscore, a date prefix, etc.), e.g.:
+        # rvp-flash-dfu-release-7.56.37749.4831.img -> 7.56.37749.4831
+        # 20260727_7.58.40846.12889.img (NIGHTLY build) -> 7.58.40846.12889
+        match = re.search(r'(?<!\d)(\d+)\.(\d+)\.(\d+)\.(\d+)\.(bin|img)$', filename)
         if not match:
             log.i(f"Version not found in filename: {filename}")
             return None


### PR DESCRIPTION
## Summary
- `test-fw-update.py`'s `extract_version_from_filename()` only recognized two filename shapes: `N_N_N_N.bin/img` and `-N.N.N.N.bin/img` (requiring a literal hyphen right before the version).
- RS500 NIGHTLY-folder builds are named `<date>_x.y.z.w.img` (e.g. `20260727_7.58.40846.12889.img`), matching neither pattern, so the function silently returned `None`.
- That guarantees `test.check_equal(current_fw_version, custom_fw_version)` fails at the end of the test regardless of whether the actual FW flash succeeded -- surfaced while wiring up D585 golden/latest FW in librealsense-deploy (RSDEV-13152), testing against a NIGHTLY build.

## Fix
Generalize the second pattern to match any `x.y.z.w` sequence immediately before the extension, regardless of what precedes it (hyphen, underscore, a date prefix, etc.), guarded by a negative lookbehind so matching can't start mid-way through an adjacent number.

## Test plan
- [x] Verified in isolation against all previously-supported filename shapes (`FlashGeneratedImage_Image5_16_7_0.bin`, `FlashGeneratedImage_RELEASE_DS5_5_16_3_1.bin`, `rvp-flash-dfu-release-7.56.37749.4831.img`) -- unchanged results.
- [x] Verified against the new NIGHTLY shape (`20260727_7.58.40846.12889.img` -> `7.58.40846.12889`) and a signed variant (`rvp-flash-dfu-release-signed-7.58.40380.12054.img`).
- [ ] Re-run `test-fw-update.py` against a real NIGHTLY-sourced D585 image in CI to confirm the version check now passes end-to-end.