### PR TITLE
Do not register Emitter Always On on D500 dual-RGB (2C) devices

### DIFF
--- a/src/ds/d500/d500-active.cpp
+++ b/src/ds/d500/d500-active.cpp
@@ -30,16 +30,20 @@ namespace librealsense
 
         _ds_active_common->register_options();
 
-        // Emitter Always On (Laser Always On) - projector control common to all D500 active SKUs.
+        // Emitter Always On (Laser Always On) - projector control on the D500 active SKUs, except the dual-RGB (2C)
+        // ones where the strobe is FW controlled and keeping the laser on exposes its pattern on the color streams.
         // Newer 5x5 / D585 SKUs use the APM_STROBE opcodes; D555 uses the legacy LASERONCONST opcode.
-        fw_cmd emitter_get_opcode = APM_STROBE_GET;
-        fw_cmd emitter_set_opcode = APM_STROBE_SET;
-        if( get_pid() == D555_PID )
+        if( d500_dual_rgb_pids.find( get_pid() ) == d500_dual_rgb_pids.end() )
         {
-            emitter_get_opcode = LASERONCONST;
-            emitter_set_opcode = LASERONCONST;
+            fw_cmd emitter_get_opcode = APM_STROBE_GET;
+            fw_cmd emitter_set_opcode = APM_STROBE_SET;
+            if( get_pid() == D555_PID )
+            {
+                emitter_get_opcode = LASERONCONST;
+                emitter_set_opcode = LASERONCONST;
+            }
+            auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( _hw_monitor, emitter_get_opcode, emitter_set_opcode );
+            get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
         }
-        auto emitter_always_on_opt = std::make_shared<emitter_always_on_option>( _hw_monitor, emitter_get_opcode, emitter_set_opcode );
-        get_depth_sensor().register_option( RS2_OPTION_EMITTER_ALWAYS_ON, emitter_always_on_opt );
     }
 }

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -69,6 +69,13 @@ namespace librealsense
             D585_GMSL_PID
         };
 
+        // d500 dual-RGB (2C) SKUs - the projector strobe is driven by the FW, the host cannot keep the emitter on
+        static const std::set<std::uint16_t> d500_dual_rgb_pids = {
+            D535_2C_PID,
+            D585_2C_PID,
+            D585_2C_PROTO_PID
+        };
+
         // d500 PIDs that expose the projector temperature via HKR selector 0x16
         static const std::set<std::uint16_t> d500_projector_temperature_pids = {
             D585S_PID,


### PR DESCRIPTION
**Overview:** On D500 dual-RGB (2C) cameras the "Emitter Always On" control is no longer exposed, since the projector strobe is driven by the firmware on these SKUs.

Tracked on [RSDEV-13257]

## Why
The option was registered for every D500 active SKU. On 2C devices the strobe is FW controlled, and turning the option on left the laser pattern visible on the Color streams, making the RGB images unusable. Product confirmed the control is not supported in 2C mode.

## Summary
- Added a `d500_dual_rgb_pids` set in `d500-private.h` listing the 2C PIDs.
- `d500_active` skips the `RS2_OPTION_EMITTER_ALWAYS_ON` registration for those PIDs. All other D500 SKUs (D555, D585S, 3C, F) are unchanged.

## Test plan
- [ ] Build `realsense2` — done locally on Windows (Release).
- [ ] Viewer on a 2C device: "Emitter Always On" absent from Depth Control; `rs-enumerate-devices -o` does not list it.
- [ ] Viewer on a 3C / D555 device: option still present and functional.
- [ ] LibCI regression suite.

---
🤖 Generated by AI
