### PR TITLE
[DRAFT/FW-preview] d5x5 TC: enable RUN-phase depth streaming (built on #15452)

### DIFF
--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -12,13 +12,138 @@ namespace rs2
         : process_manager("D500 On-Chip Calibration"),
         _model(model),
         _dev(dev),
-        _sub(sub)
+        _sub(sub),
+        _viewer(viewer)
     {
         if (dev.supports(RS2_CAMERA_INFO_PRODUCT_LINE) &&
             std::string(dev.get_info(RS2_CAMERA_INFO_PRODUCT_LINE)) != "D500")
         {
             throw std::runtime_error("This Calibration Process cannot be processed with this device");
         }
+    }
+
+    bool d500_on_chip_calib_manager::start_viewer(int w, int h, int fps, invoker invoke)
+    {
+        bool frame_arrived = false;
+        try
+        {
+            int uid = 0;
+            for (const auto& format : _sub->formats)
+            {
+                if (format.second[0] == "Z16")
+                {
+                    uid = format.first;
+                    break;
+                }
+            }
+            _sub->select_resolution(w, h, RS2_STREAM_DEPTH);
+
+            _sub->stream_enabled.clear();
+            _sub->stream_enabled[uid] = true;
+            _sub->ui.selected_format_id.clear();
+            _sub->ui.selected_format_id[uid] = 0;
+
+            for (int i = 0; i < _sub->shared_fps_values.size(); i++)
+            {
+                if (_sub->shared_fps_values[i] == fps)
+                    _sub->ui.selected_shared_fps_id = i;
+            }
+
+            if (!_sub->is_selected_combination_supported())
+                return false;
+
+            auto profiles = _sub->get_selected_profiles();
+
+            invoke([&]()
+            {
+                if (!_model.dev_syncer)
+                    _model.dev_syncer = _viewer.syncer->create_syncer();
+
+                _sub->play(profiles, _viewer, _model.dev_syncer);
+                for (auto&& profile : profiles)
+                    _viewer.begin_stream(_sub, profile);
+            });
+
+            int count = 0;
+            while (!frame_arrived && count++ < 200)
+            {
+                for (auto&& stream : _viewer.streams)
+                {
+                    if (std::find(profiles.begin(), profiles.end(),
+                        stream.second.original_profile) != profiles.end())
+                    {
+                        auto now = std::chrono::high_resolution_clock::now();
+                        if (now - stream.second.last_frame < std::chrono::milliseconds(100))
+                            frame_arrived = true;
+                    }
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+        }
+        catch (...) {}
+        return frame_arrived;
+    }
+
+    void d500_on_chip_calib_manager::try_start_viewer(int w, int h, int fps, invoker invoke)
+    {
+        bool started = start_viewer(w, h, fps, invoke);
+        if (!started)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(600));
+            started = start_viewer(w, h, fps, invoke);
+        }
+        if (!started)
+        {
+            stop_viewer(invoke);
+            throw std::runtime_error(rsutils::string::from()
+                << "Failed to start streaming (" << w << ", " << h << ", " << fps << ")!");
+        }
+    }
+
+    void d500_on_chip_calib_manager::stop_viewer(invoker invoke)
+    {
+        try
+        {
+            invoke([&]()
+            {
+                if (_sub->streaming)
+                    _sub->stop(_viewer.not_model);
+            });
+        }
+        catch (...) {}
+    }
+
+    void d500_on_chip_calib_manager::restore_workspace(invoker invoke)
+    {
+        if (!_saved_ui)
+            return;  // no auto-start happened on this manager
+
+        stop_viewer(invoke);
+
+        _sub->ui = *_saved_ui;
+        _sub->stream_enabled = _saved_stream_enabled;
+        _saved_ui.reset();
+
+        if (_was_streaming)
+        {
+            try
+            {
+                auto profiles = _sub->get_selected_profiles();
+                if (!profiles.empty())
+                {
+                    invoke([&]()
+                    {
+                        if (!_model.dev_syncer)
+                            _model.dev_syncer = _viewer.syncer->create_syncer();
+                        _sub->play(profiles, _viewer, _model.dev_syncer);
+                        for (auto&& profile : profiles)
+                            _viewer.begin_stream(_sub, profile);
+                    });
+                }
+            }
+            catch (...) {}
+        }
+        _was_streaming = false;
     }
 
     std::string d500_on_chip_calib_manager::convert_action_to_json_string()
@@ -38,46 +163,82 @@ namespace rs2
         return ss.str();
     }
 
-    bool d500_on_chip_calib_manager::uses_hkr_new_tc() const
+    bool d500_on_chip_calib_manager::uses_interactive_triggered_calibration() const
     {
-        // Mirrors ds::d5x5_hkr_new_tc_pids in src/ds/d500/d500-private.h — the viewer cannot include SDK-internal headers.
-        // Keep the two lists in sync when adding new PIDs.
-        static const std::set< std::string > hkr_new_tc_pids = {
+        // Mirrors ds::d5x5_interactive_triggered_calibration_pids in src/ds/d500/d500-private.h —
+        // the viewer cannot include SDK-internal headers. Keep the two lists in sync when adding new PIDs.
+        static const std::set< std::string > interactive_triggered_calibration_pids = {
             "0C01", "0C02", "0C03", "0C04", "0C05", "0C06", "0C07", "0C08"
         };
-        return hkr_new_tc_pids.count(get_device_pid()) > 0;
+        return interactive_triggered_calibration_pids.count(get_device_pid()) > 0;
     }
 
     void d500_on_chip_calib_manager::process_flow(std::function<void()> cleanup, invoker invoke)
     {
-        std::string json = convert_action_to_json_string();
+        const bool interactive = uses_interactive_triggered_calibration();
+        const bool interactive_run = interactive && action == RS2_CALIB_ACTION_ON_CHIP_CALIB;
+        const bool interactive_terminal = interactive
+            && (action == RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT
+                || action == RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT);
+        const bool interactive_try = interactive
+            && (action == RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW
+                || action == RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
 
-        auto calib_dev = _dev.as<auto_calibrated_device>();
-        float health = 0.f;
-        int timeout_ms = 240000; // increased to 4 minutes for additional algo processing
-        auto ans = calib_dev.run_on_chip_calibration(json, &health,
-            [&](const float progress) {_progress = progress; }, timeout_ms);
+        // Auto-start disabled until the FW supports streaming during triggered calibration.
+        // if (interactive_run)
+        // {
+        //     _saved_ui = std::make_shared<subdevice_ui_selection>(_sub->ui);
+        //     _saved_stream_enabled = _sub->stream_enabled;
+        //     _was_streaming = _sub->streaming;
+        //     try_start_viewer(1280, 720, 30, invoke);
+        // }
+        (void)interactive_run;
 
-        // For D5x5 HKR-new TC, the initial RUN call returns at HEALTH_CHECK — populate scalar health
-        // so the UI can render pass/fail; the flow is not "done" until a subsequent COMMIT reaches COMPLETE.
-        if (uses_hkr_new_tc() && action == RS2_CALIB_ACTION_ON_CHIP_CALIB)
+        try
         {
-            _scalar_health = health;
-            _done = true;   // "done" here means "phase complete"; the notification UI transitions to HEALTH_CHECK
-            return;
-        }
+            std::string json = convert_action_to_json_string();
+            auto calib_dev = _dev.as<auto_calibrated_device>();
+            float health = 0.f;
+            int timeout_ms = 240000; // increased to 4 minutes for additional algo processing
+            auto ans = calib_dev.run_on_chip_calibration(json, &health,
+                [&](const float progress) {_progress = progress; }, timeout_ms);
 
-        if (_progress == 100.0)
+            // For D5x5 interactive triggered calibration, the initial RUN call returns at HEALTH_CHECK — populate scalar health
+            // so the UI can render pass/fail; the flow is not "done" until a subsequent COMMIT reaches COMPLETE.
+            if (interactive_run)
+            {
+                _scalar_health = health;
+                _done = true;   // "done" here means "phase complete"; the notification UI transitions to HEALTH_CHECK
+                return;         // leave streaming on — TRY/COMMIT/ABORT need it live
+            }
+
+            // Interactive TRY_NEW/TRY_OLD are one-shot live-preview toggles — mark done, keep stream live.
+            if (interactive_try)
+            {
+                _done = true;
+                return;
+            }
+
+            // Interactive terminal (COMMIT / ABORT) — mark done and restore the user's pre-calibration workspace.
+            if (interactive_terminal)
+            {
+                _done = true;
+                restore_workspace(invoke);
+                return;
+            }
+
+            // Legacy D500 path (D585S / D585_LEGACY).
+            if (_progress == 100.0)
+                _done = true;
+            else
+                _failed = true;  // exception must have been thrown from run_on_chip_calibration call
+        }
+        catch (...)
         {
-            _done = true;
+            // Any failure of a phase where we own the stream → restore before propagating so the user isn't left mid-flight.
+            restore_workspace(invoke);
+            throw;
         }
-        else
-        {
-            // exception must have been thrown from run_on_chip_calibration call
-            _failed = true;
-        }
-
-
     }
 
     bool d500_on_chip_calib_manager::abort()
@@ -243,10 +404,10 @@ namespace rs2
             {
                 if (update_manager->done())
                 {
-                    // D5x5 HKR-new: the first RUN phase completes at HEALTH_CHECK, not COMPLETE — the user has yet to
+                    // D5x5 interactive: the first RUN phase completes at HEALTH_CHECK, not COMPLETE — the user has yet to
                     // approve. The COMMIT phase, in contrast, ends at COMPLETE.
-                    const bool hkr_first_phase = get_manager().uses_hkr_new_tc() && ! commit_phase;
-                    if (hkr_first_phase && update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS)
+                    const bool interactive_first_phase = get_manager().uses_interactive_triggered_calibration() && ! commit_phase;
+                    if (interactive_first_phase && update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS)
                     {
                         update_state = RS2_CALIB_STATE_HEALTH_CHECK;
                     }
@@ -282,6 +443,9 @@ namespace rs2
 
     int d500_autocalib_notification_model::calc_height()
     {
+        // Restore default width for every non-health state; the health check row needs extra room for four buttons.
+        width = (update_state == RS2_CALIB_STATE_HEALTH_CHECK) ? 460 : 320;
+
         // adjusting the height of the notification window
         if (update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS ||
             update_state == RS2_CALIB_STATE_COMPLETE ||
@@ -346,10 +510,6 @@ namespace rs2
         {
             update_state = RS2_CALIB_STATE_ABORT;
         }
-        if (ImGui::IsItemHovered())
-        {
-            RsImGui::CustomTooltip("Abort Calibration Process");
-        }
     }
 
     void d500_autocalib_notification_model::update_ui_after_abort_called(ux_window& win, int x, int y)
@@ -404,6 +564,11 @@ namespace rs2
 
     void d500_autocalib_notification_model::draw_health_check(ux_window& win, int x, int y, int bar_width)
     {
+        using namespace std::chrono;
+
+        // The base Dismiss button is not needed on this screen — the four action buttons (Commit/Discard/Try…) are terminal.
+        enable_dismiss = false;
+
         const float h = get_manager().get_scalar_health();
         const bool passes = get_manager().health_passes();
 
@@ -414,8 +579,13 @@ namespace rs2
         if (h < 0.f) ImGui::Text("Rect health: n/a");
         else         ImGui::Text("Rect health: %.3f px  (threshold 0.400)", h);
 
-        // Button row: Try New | Try Old | Commit | Discard
-        const float btn_w = float(bar_width) / 4.f - 4.f;
+        // Button row: Try New | Try Old | Commit | Discard. Ignore the caller's bar_width — it reserves a 115px
+        // right gutter for the base Dismiss button, which we've hidden above; use the full popup width instead.
+        // Reserve 3 × ImGui default ItemSpacing.x (~8px each) between the four buttons so Discard doesn't clip the right edge.
+        (void)bar_width;
+        const float row_width = float(width - 10);
+        const float spacing = ImGui::GetStyle().ItemSpacing.x;
+        const float btn_w = (row_width - 3.f * spacing) / 4.f;
         const float btn_y = float(y + height - 28);
 
         std::string try_new_id  = rsutils::string::from() << "Try New##"  << index;
@@ -423,22 +593,44 @@ namespace rs2
         std::string commit_id   = rsutils::string::from() << "Commit##"   << index;
         std::string discard_id  = rsutils::string::from() << "Discard##"  << index;
 
+        // The notification base pushes a near-transparent ImGuiCol_Button (see notification_model::set_color_scheme),
+        // so buttons on this row need their own scheme to read as clickable — matches calibration_button() and the
+        // rest of on-chip-calib.
+        const auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
+
         ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
         if (ImGui::Button(try_new_id.c_str(), { btn_w, 20.f }))
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
+        ImGui::PopStyleColor(2);
 
         ImGui::SameLine();
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
         if (ImGui::Button(try_old_id.c_str(), { btn_w, 20.f }))
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
+        ImGui::PopStyleColor(2);
 
         ImGui::SameLine();
-        // ImGui::Button has no direct disabled flag; when health check fails the button is drawn but the action is guarded.
+        // Commit is health-gated: on FAIL, dim the button and swallow the click so it visibly reads as disabled.
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, passes ? sat : 0.4f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, passes ? 1.5f : 0.4f));
         if (ImGui::Button(commit_id.c_str(), { btn_w, 20.f }) && passes)
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT);
+        ImGui::PopStyleColor(2);
 
         ImGui::SameLine();
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
         if (ImGui::Button(discard_id.c_str(), { btn_w, 20.f }))
+        {
+            // Fire the ABORT command in the background (manager restores the workspace on completion) and
+            // dismiss the popup immediately — the user has already made their decision, no further UI is needed.
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT);
+            dismissed = true;
+        }
+        ImGui::PopStyleColor(2);
     }
 
     void d500_autocalib_notification_model::update_ui_on_calibration_complete(ux_window& win, int x, int y)

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -24,19 +24,26 @@ namespace rs2
     std::string d500_on_chip_calib_manager::convert_action_to_json_string()
     {
         std::stringstream ss;
-        if (action == RS2_CALIB_ACTION_ON_CHIP_CALIB)
+        switch (action)
         {
-            ss << "{\n calib run }";
-        }
-        else if (action == RS2_CALIB_ACTION_ON_CHIP_CALIB_DRY_RUN)
-        {
-            ss << "{\n calib dry run }";
-        }
-        else if (action == RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT)
-        {
-            ss << "{\n calib abort }";
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB:         ss << "{\n calib run }";      break;
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB_DRY_RUN: ss << "{\n calib dry run }";  break;
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT:   ss << "{\n calib abort }";    break;
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT:  ss << "{\n calib commit }";   break;
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW: ss << "{\n calib try new }";  break;
+        case RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD: ss << "{\n calib try old }";  break;
         }
         return ss.str();
+    }
+
+    bool d500_on_chip_calib_manager::uses_hkr_new_tc() const
+    {
+        // Mirrors ds::d5x5_hkr_new_tc_pids in src/ds/d500/d500-private.h — the viewer cannot include SDK-internal headers.
+        // Keep the two lists in sync when adding new PIDs.
+        static const std::set< std::string > hkr_new_tc_pids = {
+            "0C01", "0C02", "0C03", "0C04", "0C05", "0C06", "0C07", "0C08"
+        };
+        return hkr_new_tc_pids.count(get_device_pid()) > 0;
     }
 
     void d500_on_chip_calib_manager::process_flow(std::function<void()> cleanup, invoker invoke)
@@ -49,8 +56,14 @@ namespace rs2
         auto ans = calib_dev.run_on_chip_calibration(json, &health,
             [&](const float progress) {_progress = progress; }, timeout_ms);
 
-        // in order to grep new calibration from answer, use:
-        // auto new_calib = std::vector<uint8_t>(ans.begin() + 3, ans.end());
+        // For D5x5 HKR-new TC, the initial RUN call returns at HEALTH_CHECK — populate scalar health
+        // so the UI can render pass/fail; the flow is not "done" until a subsequent COMMIT reaches COMPLETE.
+        if (uses_hkr_new_tc() && action == RS2_CALIB_ACTION_ON_CHIP_CALIB)
+        {
+            _scalar_health = health;
+            _done = true;   // "done" here means "phase complete"; the notification UI transitions to HEALTH_CHECK
+            return;
+        }
 
         if (_progress == 100.0)
         {
@@ -191,6 +204,15 @@ namespace rs2
             {
                 update_ui_on_failure(win, x, y);
             }
+            else if (update_state == RS2_CALIB_STATE_HEALTH_CHECK)
+            {
+                draw_health_check(win, x, y, bar_width);
+            }
+            else if (update_state == RS2_CALIB_STATE_COMMIT_IN_PROGRESS)
+            {
+                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
+                ImGui::Text("%s", "Committing calibration to flash...");
+            }
 
             ImGui::PopStyleColor();
         }
@@ -212,11 +234,24 @@ namespace rs2
 
         if (update_manager)
         {
-            if (update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS)
+            const bool commit_phase =
+                get_manager().action == d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT;
+            if (update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS ||
+                update_state == RS2_CALIB_STATE_COMMIT_IN_PROGRESS)
             {
                 if (update_manager->done())
                 {
-                    update_state = RS2_CALIB_STATE_COMPLETE;
+                    // D5x5 HKR-new: the first RUN phase completes at HEALTH_CHECK, not COMPLETE — the user has yet to
+                    // approve. The COMMIT phase, in contrast, ends at COMPLETE.
+                    const bool hkr_first_phase = get_manager().uses_hkr_new_tc() && ! commit_phase;
+                    if (hkr_first_phase && update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS)
+                    {
+                        update_state = RS2_CALIB_STATE_HEALTH_CHECK;
+                    }
+                    else
+                    {
+                        update_state = RS2_CALIB_STATE_COMPLETE;
+                    }
                     enable_dismiss = true;
                 }
                 else if (update_manager->failed())
@@ -249,8 +284,11 @@ namespace rs2
         if (update_state == RS2_CALIB_STATE_CALIB_IN_PROCESS ||
             update_state == RS2_CALIB_STATE_COMPLETE ||
             update_state == RS2_CALIB_STATE_ABORT_CALLED ||
-            update_state == RS2_CALIB_STATE_FAILED)
+            update_state == RS2_CALIB_STATE_FAILED ||
+            update_state == RS2_CALIB_STATE_COMMIT_IN_PROGRESS)
             return 90;
+        if (update_state == RS2_CALIB_STATE_HEALTH_CHECK)
+            return 110;  // two text lines + button row
         return 60;
     }
 
@@ -347,6 +385,58 @@ namespace rs2
         ImGui::SetCursorScreenPos({ float(x + 40), float(y + 50) });
         
         enable_dismiss = true;
+    }
+
+    void d500_autocalib_notification_model::start_action_phase(d500_on_chip_calib_manager::calib_action a)
+    {
+        get_manager().reset();
+        get_manager().action = a;
+        auto _this = shared_from_this();
+        auto invoke = [_this](std::function<void()> action) {_this->invoke(action); };
+        get_manager().start(invoke);
+        if (a == d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT)
+            update_state = RS2_CALIB_STATE_COMMIT_IN_PROGRESS;
+        // TRY_NEW / TRY_OLD stay in RS2_CALIB_STATE_HEALTH_CHECK; ABORT (Discard) also stays until confirmed.
+        enable_dismiss = false;
+    }
+
+    void d500_autocalib_notification_model::draw_health_check(ux_window& win, int x, int y, int bar_width)
+    {
+        const float h = get_manager().get_scalar_health();
+        const bool passes = get_manager().health_passes();
+
+        ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
+        ImGui::Text("%s", passes ? "Health check: PASS" : "Health check: FAIL");
+
+        ImGui::SetCursorScreenPos({ float(x + 9), float(y + 45) });
+        if (h < 0.f) ImGui::Text("Rect health: n/a");
+        else         ImGui::Text("Rect health: %.3f px  (threshold 0.400)", h);
+
+        // Button row: Try New | Try Old | Commit | Discard
+        const float btn_w = float(bar_width) / 4.f - 4.f;
+        const float btn_y = float(y + height - 28);
+
+        std::string try_new_id  = rsutils::string::from() << "Try New##"  << index;
+        std::string try_old_id  = rsutils::string::from() << "Try Old##"  << index;
+        std::string commit_id   = rsutils::string::from() << "Commit##"   << index;
+        std::string discard_id  = rsutils::string::from() << "Discard##"  << index;
+
+        ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
+        if (ImGui::Button(try_new_id.c_str(), { btn_w, 20.f }))
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
+
+        ImGui::SameLine();
+        if (ImGui::Button(try_old_id.c_str(), { btn_w, 20.f }))
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
+
+        ImGui::SameLine();
+        // ImGui::Button has no direct disabled flag; when health check fails the button is drawn but the action is guarded.
+        if (ImGui::Button(commit_id.c_str(), { btn_w, 20.f }) && passes)
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT);
+
+        ImGui::SameLine();
+        if (ImGui::Button(discard_id.c_str(), { btn_w, 20.f }))
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT);
     }
 
     void d500_autocalib_notification_model::update_ui_on_calibration_complete(ux_window& win, int x, int y)

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -28,14 +28,19 @@ namespace rs2
         try
         {
             int uid = 0;
+            bool found_z16 = false;
             for (const auto& format : _sub->formats)
             {
                 if (format.second[0] == "Z16")
                 {
                     uid = format.first;
+                    found_z16 = true;
                     break;
                 }
             }
+            if (!found_z16)
+                return false;  // depth subdevice with no Z16 profile — abort rather than enable the wrong stream
+
             _sub->select_resolution(w, h, RS2_STREAM_DEPTH);
 
             _sub->stream_enabled.clear();
@@ -43,10 +48,10 @@ namespace rs2
             _sub->ui.selected_format_id.clear();
             _sub->ui.selected_format_id[uid] = 0;
 
-            for (int i = 0; i < _sub->shared_fps_values.size(); i++)
+            for (size_t i = 0; i < _sub->shared_fps_values.size(); i++)
             {
                 if (_sub->shared_fps_values[i] == fps)
-                    _sub->ui.selected_shared_fps_id = i;
+                    _sub->ui.selected_shared_fps_id = static_cast<int>(i);
             }
 
             if (!_sub->is_selected_combination_supported())

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -32,6 +32,8 @@ namespace rs2
         case RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT:  ss << "{\n calib commit }";   break;
         case RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW: ss << "{\n calib try new }";  break;
         case RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD: ss << "{\n calib try old }";  break;
+        default:
+            throw std::runtime_error("unknown calib_action in convert_action_to_json_string");
         }
         return ss.str();
     }

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -189,15 +189,15 @@ namespace rs2
             && (action == RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW
                 || action == RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
 
-        // Auto-start disabled until the FW supports streaming during triggered calibration.
-        // if (interactive_run)
-        // {
-        //     _saved_ui = std::make_shared<subdevice_ui_selection>(_sub->ui);
-        //     _saved_stream_enabled = _sub->stream_enabled;
-        //     _was_streaming = _sub->streaming;
-        //     try_start_viewer(1280, 720, 30, invoke);
-        // }
-        (void)interactive_run;
+        // D5x5 interactive TC needs a live depth stream during the RUN phase (algorithm consumes depth frames).
+        // Mirrors the D400 pattern: 1280x720 @ 30fps on Z16. Skip for TRY/COMMIT/ABORT — those reuse the already-live stream.
+        if (interactive_run)
+        {
+            _saved_ui = std::make_shared<subdevice_ui_selection>(_sub->ui);
+            _saved_stream_enabled = _sub->stream_enabled;
+            _was_streaming = _sub->streaming;
+            try_start_viewer(1280, 720, 30, invoke);
+        }
 
         try
         {

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -191,13 +191,9 @@ namespace rs2
 
         // D5x5 interactive TC needs a live depth stream during the RUN phase (algorithm consumes depth frames).
         // Mirrors the D400 pattern: 1280x720 @ 30fps on Z16. Skip for TRY/COMMIT/ABORT — those reuse the already-live stream.
-        if (interactive_run)
-        {
-            _saved_ui = std::make_shared<subdevice_ui_selection>(_sub->ui);
-            _saved_stream_enabled = _sub->stream_enabled;
-            _was_streaming = _sub->streaming;
-            try_start_viewer(1280, 720, 30, invoke);
-        }
+        // Start is deferred until FW reports progress >= 3, so the FW enters its calibration state before the host
+        // contends for USB bandwidth with a 1280x720@30 depth stream.
+        bool streaming_started = false;
 
         try
         {
@@ -206,7 +202,18 @@ namespace rs2
             float health = 0.f;
             int timeout_ms = 240000; // increased to 4 minutes for additional algo processing
             auto ans = calib_dev.run_on_chip_calibration(json, &health,
-                [&](const float progress) {_progress = progress; }, timeout_ms);
+                [&](const float progress)
+                {
+                    _progress = progress;
+                    if (interactive_run && !streaming_started && progress >= 3.f)
+                    {
+                        streaming_started = true;
+                        _saved_ui = std::make_shared<subdevice_ui_selection>(_sub->ui);
+                        _saved_stream_enabled = _sub->stream_enabled;
+                        _was_streaming = _sub->streaming;
+                        try_start_viewer(1280, 720, 30, invoke);
+                    }
+                }, timeout_ms);
 
             // For D5x5 interactive triggered calibration, the initial RUN call returns at HEALTH_CHECK — populate scalar health
             // so the UI can render pass/fail; the flow is not "done" until a subsequent COMMIT reaches COMPLETE.

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -6,6 +6,7 @@
 #include "notifications.h"
 #include <rsutils/concurrency/concurrency.h>
 #include "../src/algo.h"
+#include <map>
 #include <set>
 
 #include <random>
@@ -32,9 +33,9 @@ namespace rs2
             RS2_CALIB_ACTION_ON_CHIP_CALIB,         // On-Chip calibration
             RS2_CALIB_ACTION_ON_CHIP_CALIB_DRY_RUN, // Dry Run
             RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT,   // Abort
-            RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT,  // D5x5 HKR-new only — approve HEALTH_CHECK candidate
-            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW, // D5x5 HKR-new only — preview new candidate live
-            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD  // D5x5 HKR-new only — restore currently-committed table live
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT,  // D5x5 interactive only — approve HEALTH_CHECK candidate
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW, // D5x5 interactive only — preview new candidate live
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD  // D5x5 interactive only — restore currently-committed table live
         };
 
         calib_action action = RS2_CALIB_ACTION_ON_CHIP_CALIB;
@@ -46,10 +47,10 @@ namespace rs2
         void prepare_for_calibration();
         std::string get_device_pid() const;
 
-        // D5x5 HKR-new TC only. The viewer sees only the scalar `rect_health` populated in the `float* health`
+        // D5x5 interactive triggered calibration only. The viewer sees only the scalar `rect_health` populated in the `float* health`
         // out-param of run_on_chip_calibration — the full CalibrationHealthMetrics struct requires an SDK-internal
         // include, deliberately not surfaced through common/ to avoid a public API addition.
-        bool uses_hkr_new_tc() const;
+        bool uses_interactive_triggered_calibration() const;
         float get_scalar_health() const { return _scalar_health; }
         bool health_passes() const { return _scalar_health >= 0.f && _scalar_health < 0.4f; }  // provisional per spec §5.5
 
@@ -58,10 +59,23 @@ namespace rs2
         std::string convert_action_to_json_string();
         float _scalar_health = -1.f;
 
+        // D5x5 interactive triggered calibration only — mirrors on_chip_calib_manager::start_viewer for the depth-only case.
+        // Selects Z16 @ w×h @ fps on the depth subdevice, kicks off streaming, waits for the first frame.
+        bool start_viewer(int w, int h, int fps, invoker invoke);
+        void try_start_viewer(int w, int h, int fps, invoker invoke);
+        void stop_viewer(invoker invoke);
+        // Undo the RUN-phase auto-start: stop the calibration stream, restore _sub->ui/stream_enabled, replay
+        // the user's prior stream if they were streaming before. No-op if we never auto-started.
+        void restore_workspace(invoker invoke);
+
         template<class T>
         void set_option_if_needed(T& sensor, rs2_option opt, float required_value);
         device _dev;
         device_model& _model;
+        viewer_model& _viewer;
+        bool _was_streaming = false;
+        std::shared_ptr<subdevice_ui_selection> _saved_ui;
+        std::map<int, bool> _saved_stream_enabled;
     };
 
     template<class T>
@@ -96,8 +110,8 @@ namespace rs2
             RS2_CALIB_STATE_INIT_DRY_RUN,
             RS2_CALIB_STATE_ABORT,
             RS2_CALIB_STATE_ABORT_CALLED,
-            RS2_CALIB_STATE_HEALTH_CHECK,    // D5x5 HKR-new only — candidate ready, awaiting user Commit/Discard/Try
-            RS2_CALIB_STATE_COMMIT_IN_PROGRESS  // D5x5 HKR-new only — flash write in progress
+            RS2_CALIB_STATE_HEALTH_CHECK,    // D5x5 interactive only — candidate ready, awaiting user Commit/Discard/Try
+            RS2_CALIB_STATE_COMMIT_IN_PROGRESS  // D5x5 interactive only — flash write in progress
         };
 
         d500_autocalib_notification_model(std::string name, std::shared_ptr<process_manager> manager, bool expaned);
@@ -110,7 +124,7 @@ namespace rs2
         void update_ui_after_abort_called(ux_window& win, int x, int y);
         void update_ui_on_calibration_complete(ux_window& win, int x, int y);
         void update_ui_on_failure(ux_window& win, int x, int y);
-        void draw_health_check(ux_window& win, int x, int y, int bar_width);   // D5x5 HKR-new only
+        void draw_health_check(ux_window& win, int x, int y, int bar_width);   // D5x5 interactive only
         void start_action_phase(d500_on_chip_calib_manager::calib_action a);   // helper for Commit / Try / Discard buttons
         std::string _error_message = "";
         bool reset_called = false;

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -6,6 +6,7 @@
 #include "notifications.h"
 #include <rsutils/concurrency/concurrency.h>
 #include "../src/algo.h"
+#include <set>
 
 #include <random>
 #include <string>
@@ -30,7 +31,10 @@ namespace rs2
         {
             RS2_CALIB_ACTION_ON_CHIP_CALIB,         // On-Chip calibration
             RS2_CALIB_ACTION_ON_CHIP_CALIB_DRY_RUN, // Dry Run
-            RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT    // Abort
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_ABORT,   // Abort
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_COMMIT,  // D5x5 HKR-new only — approve HEALTH_CHECK candidate
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW, // D5x5 HKR-new only — preview new candidate live
+            RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD  // D5x5 HKR-new only — restore currently-committed table live
         };
 
         calib_action action = RS2_CALIB_ACTION_ON_CHIP_CALIB;
@@ -42,9 +46,17 @@ namespace rs2
         void prepare_for_calibration();
         std::string get_device_pid() const;
 
+        // D5x5 HKR-new TC only. The viewer sees only the scalar `rect_health` populated in the `float* health`
+        // out-param of run_on_chip_calibration — the full CalibrationHealthMetrics struct requires an SDK-internal
+        // include, deliberately not surfaced through common/ to avoid a public API addition.
+        bool uses_hkr_new_tc() const;
+        float get_scalar_health() const { return _scalar_health; }
+        bool health_passes() const { return _scalar_health >= 0.f && _scalar_health < 0.4f; }  // provisional per spec §5.5
+
     private:
         void process_flow(std::function<void()> cleanup, invoker invoke) override;
         std::string convert_action_to_json_string();
+        float _scalar_health = -1.f;
 
         template<class T>
         void set_option_if_needed(T& sensor, rs2_option opt, float required_value);
@@ -83,7 +95,9 @@ namespace rs2
             RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
             RS2_CALIB_STATE_INIT_DRY_RUN,
             RS2_CALIB_STATE_ABORT,
-            RS2_CALIB_STATE_ABORT_CALLED
+            RS2_CALIB_STATE_ABORT_CALLED,
+            RS2_CALIB_STATE_HEALTH_CHECK,    // D5x5 HKR-new only — candidate ready, awaiting user Commit/Discard/Try
+            RS2_CALIB_STATE_COMMIT_IN_PROGRESS  // D5x5 HKR-new only — flash write in progress
         };
 
         d500_autocalib_notification_model(std::string name, std::shared_ptr<process_manager> manager, bool expaned);
@@ -96,6 +110,8 @@ namespace rs2
         void update_ui_after_abort_called(ux_window& win, int x, int y);
         void update_ui_on_calibration_complete(ux_window& win, int x, int y);
         void update_ui_on_failure(ux_window& win, int x, int y);
+        void draw_health_check(ux_window& win, int x, int y, int bar_width);   // D5x5 HKR-new only
+        void start_action_phase(d500_on_chip_calib_manager::calib_action a);   // helper for Commit / Try / Discard buttons
         std::string _error_message = "";
         bool reset_called = false;
         bool _has_abort_succeeded = false;

--- a/src/calibration-engine-interface.h
+++ b/src/calibration-engine-interface.h
@@ -13,15 +13,16 @@ enum class calibration_state : uint8_t
 {
     IDLE = 0,
     PROCESS,
-    SUCCESS,
-    FAILURE,
+    SUCCESS,        // D585S wire byte 2 — legacy TC
+    FAILURE,        // D585S wire byte 3 — legacy TC
     FLASH_UPDATE,
-    COMPLETE
+    COMPLETE,
+    HEALTH_CHECK    // D5x5 HKR-new TC only — candidate cached in RAM, awaiting host COMMIT/CANCEL. Synthesized from wire byte 2 when parsing the new reply format; never sent on the legacy D585S path.
 };
 
 enum class calibration_result : uint8_t
 {
-    UNKNOWN = 0,
+    UNKNOWN = 0,    // aka INIT in the D5x5 HKR spec — same wire value
     SUCCESS,
     FAILED_TO_CONVERGE,
     FAILED_TO_RUN
@@ -31,9 +32,38 @@ enum class calibration_mode
 {
     RESERVED = 0,
     RUN,
-    ABORT,
-    DRY_RUN
+    ABORT,          // D585S semantics. D5x5 HKR-new TC broadens this to CANCEL (valid from any state except FLASH_UPDATE). Wire value 2 on both paths.
+    DRY_RUN,
+    COMMIT,         // D5x5 HKR-new TC only — host approves the HEALTH_CHECK-cached candidate; device flashes it, no payload.
+    TRY             // D5x5 HKR-new TC only — apply NEW/OLD table live to RAM for preview, sub-selection in payload.
 };
+
+// D5x5 HKR-new TC only. Sub-selection for calibration_mode::TRY. Wire byte carried alongside mode.
+enum class try_calibration_selection : uint8_t
+{
+    NEW = 0,        // apply the HEALTH_CHECK-cached candidate live for comparison
+    OLD = 1         // re-apply the currently-committed flash table live, undoing a prior NEW
+};
+
+// D5x5 HKR-new TC only. Selects who triggers the flash commit after HEALTH_CHECK.
+// Ignored when calibration_mode == DRY_RUN.
+enum class commit_trigger : uint8_t
+{
+    HEALTH_GATED = 0,   // device waits at HEALTH_CHECK for a host-issued COMMIT (default)
+    UNATTENDED = 1      // device auto-commits on SUCCESS, preserving today's D585S behavior
+};
+
+// D5x5 HKR-new TC only. Populated by firmware at HEALTH_CHECK/COMPLETE. Wire-format struct — do not reorder.
+#pragma pack(push, 1)
+struct calibration_health_metrics
+{
+    float coverage_safe_for_depth;   // [0,1]  — pass: >= Coverage_Threshold (0.50)
+    float rect_health;               // px    — pass: <  RectThreshold (0.40, provisional)
+    float rect_improvement;          // px    — informational only
+    float scale_health;              // px    — pass: <  ScaleThreshold (0.50, provisional)
+    float scale_improvement;         // px    — informational only
+};
+#pragma pack(pop)
 
 class calibration_engine_interface
 {
@@ -47,6 +77,12 @@ public:
     virtual void write_calibration(std::vector<uint8_t>& calibration) const = 0;
     virtual std::string get_calibration_config() const = 0;
     virtual void set_calibration_config(const std::string& calibration_config_json_str) const = 0;
+
+    // D5x5 HKR-new TC — no-op / not supported on the legacy D585S path by default.
+    virtual void set_hkr_new_tc_enabled( bool ) {}
+    virtual bool is_hkr_new_tc_enabled() const { return false; }
+    virtual calibration_health_metrics get_triggered_calibration_health() const { return {}; }
+    virtual std::vector<uint8_t> run_triggered_calibration_try( try_calibration_selection ) { return {}; }
 };
 
 } // namespace librealsense

--- a/src/calibration-engine-interface.h
+++ b/src/calibration-engine-interface.h
@@ -17,12 +17,12 @@ enum class calibration_state : uint8_t
     FAILURE,        // D585S wire byte 3 — legacy TC
     FLASH_UPDATE,
     COMPLETE,
-    HEALTH_CHECK    // D5x5 HKR-new TC only — candidate cached in RAM, awaiting host COMMIT/CANCEL. Synthesized from wire byte 2 when parsing the new reply format; never sent on the legacy D585S path.
+    HEALTH_CHECK    // D5x5 interactive triggered calibration only — candidate cached in RAM, awaiting host COMMIT/CANCEL. Synthesized from wire byte 2 when parsing the new reply format; never sent on the legacy D585S path.
 };
 
 enum class calibration_result : uint8_t
 {
-    UNKNOWN = 0,    // aka INIT in the D5x5 HKR spec — same wire value
+    UNKNOWN = 0,    // aka INIT in the D5x5 interactive triggered calibration spec — same wire value
     SUCCESS,
     FAILED_TO_CONVERGE,
     FAILED_TO_RUN
@@ -32,20 +32,20 @@ enum class calibration_mode
 {
     RESERVED = 0,
     RUN,
-    ABORT,          // D585S semantics. D5x5 HKR-new TC broadens this to CANCEL (valid from any state except FLASH_UPDATE). Wire value 2 on both paths.
+    ABORT,          // D585S semantics. D5x5 interactive triggered calibration broadens this to CANCEL (valid from any state except FLASH_UPDATE). Wire value 2 on both paths.
     DRY_RUN,
-    COMMIT,         // D5x5 HKR-new TC only — host approves the HEALTH_CHECK-cached candidate; device flashes it, no payload.
-    TRY             // D5x5 HKR-new TC only — apply NEW/OLD table live to RAM for preview, sub-selection in payload.
+    COMMIT,         // D5x5 interactive triggered calibration only — host approves the HEALTH_CHECK-cached candidate; device flashes it, no payload.
+    TRY             // D5x5 interactive triggered calibration only — apply NEW/OLD table live to RAM for preview, sub-selection in payload.
 };
 
-// D5x5 HKR-new TC only. Sub-selection for calibration_mode::TRY. Wire byte carried alongside mode.
+// D5x5 interactive triggered calibration only. Sub-selection for calibration_mode::TRY. Wire byte carried alongside mode.
 enum class try_calibration_selection : uint8_t
 {
     NEW = 0,        // apply the HEALTH_CHECK-cached candidate live for comparison
     OLD = 1         // re-apply the currently-committed flash table live, undoing a prior NEW
 };
 
-// D5x5 HKR-new TC only. Selects who triggers the flash commit after HEALTH_CHECK.
+// D5x5 interactive triggered calibration only. Selects who triggers the flash commit after HEALTH_CHECK.
 // Ignored when calibration_mode == DRY_RUN.
 enum class commit_trigger : uint8_t
 {
@@ -53,7 +53,7 @@ enum class commit_trigger : uint8_t
     UNATTENDED = 1      // device auto-commits on SUCCESS, preserving today's D585S behavior
 };
 
-// D5x5 HKR-new TC only. Populated by firmware at HEALTH_CHECK/COMPLETE. Wire-format struct — do not reorder.
+// D5x5 interactive triggered calibration only. Populated by firmware at HEALTH_CHECK/COMPLETE. Wire-format struct — do not reorder.
 #pragma pack(push, 1)
 struct calibration_health_metrics
 {
@@ -78,9 +78,9 @@ public:
     virtual std::string get_calibration_config() const = 0;
     virtual void set_calibration_config(const std::string& calibration_config_json_str) const = 0;
 
-    // D5x5 HKR-new TC — no-op / not supported on the legacy D585S path by default.
-    virtual void set_hkr_new_tc_enabled( bool ) {}
-    virtual bool is_hkr_new_tc_enabled() const { return false; }
+    // D5x5 interactive triggered calibration — no-op / not supported on the legacy D585S path by default.
+    virtual void set_interactive_triggered_calibration_enabled( bool ) {}
+    virtual bool is_interactive_triggered_calibration_enabled() const { return false; }
     virtual calibration_health_metrics get_triggered_calibration_health() const { return {}; }
     virtual std::vector<uint8_t> run_triggered_calibration_try( try_calibration_selection ) { return {}; }
 };

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -177,8 +177,18 @@ namespace librealsense
 
             if( health )
             {
-                auto h = _calib_engine->get_triggered_calibration_health();
-                *health = h.rect_health;   // primary pass/fail metric; full struct available via engine
+                // Only trust the health payload once the FW has actually populated it (from HEALTH_CHECK onward).
+                // If FAILED_TO_CONVERGE / FAILED_TO_RUN broke the loop before that, _hkr_ans.health is still zero-initialized
+                // and 0.0 would spuriously read as "PASS" (< 0.40 threshold) in the viewer — return the -1 sentinel instead.
+                if( _state == calibration_state::HEALTH_CHECK || _state == calibration_state::COMPLETE )
+                {
+                    auto h = _calib_engine->get_triggered_calibration_health();
+                    *health = h.rect_health;   // primary pass/fail metric; full struct available via engine
+                }
+                else
+                {
+                    *health = -1.f;
+                }
             }
             return res;
         }

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -41,9 +41,27 @@ namespace librealsense
         , _result( calibration_result::UNKNOWN )
         , _depth_sensor( ds )
         , _debug_dev( debug_dev )
+        , _try_selection( try_calibration_selection::NEW )
+        , _commit_trigger( commit_trigger::HEALTH_GATED )
     {
         if( ! _debug_dev )
             throw not_implemented_exception( " debug_interface must be supplied to d500_auto_calibrated" );
+    }
+
+    bool d500_auto_calibrated::device_uses_hkr_new_tc() const
+    {
+        auto dev = As< device >( _debug_dev );
+        if( ! dev || ! dev->supports_info( RS2_CAMERA_INFO_PRODUCT_ID ) )
+            return false;
+        try
+        {
+            auto pid = static_cast< uint16_t >( std::stoi( dev->get_info( RS2_CAMERA_INFO_PRODUCT_ID ), nullptr, 16 ) );
+            return ds::uses_hkr_new_tc( pid );
+        }
+        catch( ... )
+        {
+            return false;
+        }
     }
 
     void d500_auto_calibrated::check_preconditions_and_set_state()
@@ -78,14 +96,33 @@ namespace librealsense
 
     void d500_auto_calibrated::get_mode_from_json(const std::string& json)
     {
-        if (json.find("calib run") != std::string::npos)
-            _mode = calibration_mode::RUN;
-        else if (json.find("calib dry run") != std::string::npos)
+        // Order matters: "calib dry run" must be matched before "calib run" since the former contains the latter as a substring.
+        if (json.find("calib dry run") != std::string::npos)
             _mode = calibration_mode::DRY_RUN;
-        else if (json.find("calib abort") != std::string::npos)
+        else if (json.find("calib commit") != std::string::npos)
+            _mode = calibration_mode::COMMIT;
+        else if (json.find("calib cancel") != std::string::npos)
+            _mode = calibration_mode::ABORT;
+        else if (json.find("calib try new") != std::string::npos)
+        {
+            _mode = calibration_mode::TRY;
+            _try_selection = try_calibration_selection::NEW;
+        }
+        else if (json.find("calib try old") != std::string::npos)
+        {
+            _mode = calibration_mode::TRY;
+            _try_selection = try_calibration_selection::OLD;
+        }
+        else if (json.find("calib run") != std::string::npos)
+            _mode = calibration_mode::RUN;
+        else if (json.find("calib abort") != std::string::npos)  // legacy alias, kept for D585S callers
             _mode = calibration_mode::ABORT;
         else
             throw std::runtime_error("run_on_chip_calibration called with wrong content in json file");
+
+        // "unattended": true selects CommitTrigger::UNATTENDED, otherwise HEALTH_GATED (default).
+        _commit_trigger = (json.find("\"unattended\"") != std::string::npos && json.find("true") != std::string::npos)
+                          ? commit_trigger::UNATTENDED : commit_trigger::HEALTH_GATED;
     }
 
     std::vector<uint8_t> d500_auto_calibrated::run_on_chip_calibration( int timeout_ms,
@@ -102,7 +139,104 @@ namespace librealsense
         if( is_d555 )
             return run_occ( timeout_ms, json, health, progress_callback );
 
+        if( device_uses_hkr_new_tc() )
+            return run_hkr_triggered_calibration( timeout_ms, json, health, progress_callback );
+
         return run_triggered_calibration( timeout_ms, json, progress_callback );
+    }
+
+    std::vector< uint8_t > d500_auto_calibrated::run_hkr_triggered_calibration( int timeout_ms,
+                                                                                std::string json,
+                                                                                float * const health,
+                                                                                rs2_update_progress_callback_sptr progress_callback )
+    {
+        _calib_engine->set_hkr_new_tc_enabled( true );
+
+        try
+        {
+            get_mode_from_json( json );
+
+            // TRY is a live-preview toggle at HEALTH_CHECK; does not change state and does not poll.
+            if( _mode == calibration_mode::TRY )
+            {
+                _calib_engine->run_triggered_calibration_try( _try_selection );
+                return {};
+            }
+
+            // For COMMIT / ABORT the SET_CALIB_MODE is a one-shot; state polling picks up FLASH_UPDATE / IDLE from there.
+            _calib_engine->run_triggered_calibration( _mode );
+
+            if( _mode == calibration_mode::ABORT )
+                return update_abort_status();
+
+            // RUN / DRY_RUN / COMMIT — poll until we hit a terminal state for this mode.
+            const bool unattended = ( _commit_trigger == commit_trigger::UNATTENDED ) || ( _mode == calibration_mode::COMMIT );
+            auto res = update_hkr_calibration_status( timeout_ms, unattended, progress_callback );
+
+            if( health )
+            {
+                auto h = _calib_engine->get_triggered_calibration_health();
+                *health = h.rect_health;   // primary pass/fail metric; full struct available via engine
+            }
+            return res;
+        }
+        catch( std::runtime_error & )
+        {
+            throw;
+        }
+        catch( ... )
+        {
+            throw std::runtime_error( rsutils::string::from() << "HKR triggered calibration could not be triggered" );
+        }
+    }
+
+    std::vector< uint8_t > d500_auto_calibrated::update_hkr_calibration_status( int timeout_ms,
+                                                                                bool unattended,
+                                                                                rs2_update_progress_callback_sptr progress_callback )
+    {
+        auto start_time = std::chrono::high_resolution_clock::now();
+        std::vector< uint8_t > res;
+        do
+        {
+            std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+            _calib_engine->update_triggered_calibration_status();
+
+            _state = _calib_engine->get_triggered_calibration_state();
+            _result = _calib_engine->get_triggered_calibration_result();
+            if( progress_callback )
+                progress_callback->on_update_progress( _calib_engine->get_triggered_calibration_progress() );
+
+            if( _result == calibration_result::FAILED_TO_RUN )
+                break;
+
+            // Terminal states depend on the mode:
+            // - Gated RUN/DRY_RUN: stop at HEALTH_CHECK — host inspects health then calls again with commit/cancel.
+            // - Unattended RUN: stop at COMPLETE (device auto-commits) or IDLE (nothing to persist).
+            // - COMMIT: stop at COMPLETE.
+            if( _state == calibration_state::IDLE )
+                break;
+            if( _state == calibration_state::COMPLETE )
+                break;
+            if( ! unattended && _state == calibration_state::HEALTH_CHECK )
+                break;
+
+            if( std::chrono::high_resolution_clock::now() - start_time > std::chrono::milliseconds( timeout_ms ) )
+                throw std::runtime_error( "HKR triggered calibration timeout" );
+        }
+        while( true );
+
+        if( _state == calibration_state::HEALTH_CHECK || _state == calibration_state::COMPLETE )
+        {
+            auto depth_calib = _calib_engine->get_depth_calibration();
+            auto ptr = reinterpret_cast< uint8_t * >( &depth_calib );
+            res.insert( res.begin(), ptr, ptr + sizeof( ds::d500_coefficients_table ) );
+        }
+        else if( _result == calibration_result::FAILED_TO_RUN )
+        {
+            throw std::runtime_error( "HKR triggered calibration failed to run" );
+        }
+
+        return res;
     }
 
     std::vector< uint8_t > d500_auto_calibrated::run_triggered_calibration( int timeout_ms,

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -22,7 +22,8 @@ namespace librealsense
         "Done Success",
         "Done Failure",
         "Flash Update",
-        "Complete"
+        "Complete",
+        "Health Check"   // interactive triggered calibration — enum value 6
     };
 
     static const std::string calibration_result_strings[] = {
@@ -48,7 +49,7 @@ namespace librealsense
             throw not_implemented_exception( " debug_interface must be supplied to d500_auto_calibrated" );
     }
 
-    bool d500_auto_calibrated::device_uses_hkr_new_tc() const
+    bool d500_auto_calibrated::device_uses_interactive_triggered_calibration() const
     {
         auto dev = As< device >( _debug_dev );
         if( ! dev || ! dev->supports_info( RS2_CAMERA_INFO_PRODUCT_ID ) )
@@ -56,7 +57,7 @@ namespace librealsense
         try
         {
             auto pid = static_cast< uint16_t >( std::stoi( dev->get_info( RS2_CAMERA_INFO_PRODUCT_ID ), nullptr, 16 ) );
-            return ds::uses_hkr_new_tc( pid );
+            return ds::uses_interactive_triggered_calibration( pid );
         }
         catch( ... )
         {
@@ -141,18 +142,18 @@ namespace librealsense
         if( is_d555 )
             return run_occ( timeout_ms, json, health, progress_callback );
 
-        if( device_uses_hkr_new_tc() )
-            return run_hkr_triggered_calibration( timeout_ms, json, health, progress_callback );
+        if( device_uses_interactive_triggered_calibration() )
+            return run_interactive_triggered_calibration( timeout_ms, json, health, progress_callback );
 
         return run_triggered_calibration( timeout_ms, json, progress_callback );
     }
 
-    std::vector< uint8_t > d500_auto_calibrated::run_hkr_triggered_calibration( int timeout_ms,
-                                                                                std::string json,
-                                                                                float * const health,
-                                                                                rs2_update_progress_callback_sptr progress_callback )
+    std::vector< uint8_t > d500_auto_calibrated::run_interactive_triggered_calibration( int timeout_ms,
+                                                                                        std::string json,
+                                                                                        float * const health,
+                                                                                        rs2_update_progress_callback_sptr progress_callback )
     {
-        _calib_engine->set_hkr_new_tc_enabled( true );
+        _calib_engine->set_interactive_triggered_calibration_enabled( true );
 
         try
         {
@@ -173,12 +174,12 @@ namespace librealsense
 
             // RUN / DRY_RUN / COMMIT — poll until we hit a terminal state for this mode.
             const bool unattended = ( _commit_trigger == commit_trigger::UNATTENDED ) || ( _mode == calibration_mode::COMMIT );
-            auto res = update_hkr_calibration_status( timeout_ms, unattended, progress_callback );
+            auto res = update_interactive_calibration_status( timeout_ms, unattended, progress_callback );
 
             if( health )
             {
                 // Only trust the health payload once the FW has actually populated it (from HEALTH_CHECK onward).
-                // If FAILED_TO_CONVERGE / FAILED_TO_RUN broke the loop before that, _hkr_ans.health is still zero-initialized
+                // If FAILED_TO_CONVERGE / FAILED_TO_RUN broke the loop before that, _interactive_ans.health is still zero-initialized
                 // and 0.0 would spuriously read as "PASS" (< 0.40 threshold) in the viewer — return the -1 sentinel instead.
                 if( _state == calibration_state::HEALTH_CHECK || _state == calibration_state::COMPLETE )
                 {
@@ -198,13 +199,13 @@ namespace librealsense
         }
         catch( ... )
         {
-            throw std::runtime_error( rsutils::string::from() << "HKR triggered calibration could not be triggered" );
+            throw std::runtime_error( rsutils::string::from() << "Interactive triggered calibration could not be triggered" );
         }
     }
 
-    std::vector< uint8_t > d500_auto_calibrated::update_hkr_calibration_status( int timeout_ms,
-                                                                                bool unattended,
-                                                                                rs2_update_progress_callback_sptr progress_callback )
+    std::vector< uint8_t > d500_auto_calibrated::update_interactive_calibration_status( int timeout_ms,
+                                                                                        bool unattended,
+                                                                                        rs2_update_progress_callback_sptr progress_callback )
     {
         auto start_time = std::chrono::high_resolution_clock::now();
         std::vector< uint8_t > res;
@@ -215,6 +216,16 @@ namespace librealsense
 
             _state = _calib_engine->get_triggered_calibration_state();
             _result = _calib_engine->get_triggered_calibration_result();
+            {
+                std::stringstream ss;
+                ss << "Calibration in progress - State = " << calibration_state_strings[static_cast<int>(_state)];
+                if( _state == calibration_state::PROCESS )
+                {
+                    ss << ", progress = " << static_cast<int>( _calib_engine->get_triggered_calibration_progress() );
+                    ss << ", result = " << calibration_result_strings[static_cast<int>(_result)];
+                }
+                LOG_INFO( ss.str().c_str() );
+            }
             if( progress_callback )
                 progress_callback->on_update_progress( _calib_engine->get_triggered_calibration_progress() );
 
@@ -236,7 +247,7 @@ namespace librealsense
                 break;
 
             if( std::chrono::high_resolution_clock::now() - start_time > std::chrono::milliseconds( timeout_ms ) )
-                throw std::runtime_error( "HKR triggered calibration timeout" );
+                throw std::runtime_error( "Interactive triggered calibration timeout" );
         }
         while( true );
 
@@ -248,7 +259,7 @@ namespace librealsense
         }
         else if( _result == calibration_result::FAILED_TO_RUN )
         {
-            throw std::runtime_error( "HKR triggered calibration failed to run" );
+            throw std::runtime_error( "Interactive triggered calibration failed to run" );
         }
 
         return res;

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -121,8 +121,10 @@ namespace librealsense
             throw std::runtime_error("run_on_chip_calibration called with wrong content in json file");
 
         // "unattended": true selects CommitTrigger::UNATTENDED, otherwise HEALTH_GATED (default).
-        _commit_trigger = (json.find("\"unattended\"") != std::string::npos && json.find("true") != std::string::npos)
-                          ? commit_trigger::UNATTENDED : commit_trigger::HEALTH_GATED;
+        // Match the whole key-value substring so an unrelated `true` elsewhere in the JSON does not flip the flag.
+        const bool unattended = json.find("\"unattended\": true") != std::string::npos
+                             || json.find("\"unattended\":true")  != std::string::npos;
+        _commit_trigger = unattended ? commit_trigger::UNATTENDED : commit_trigger::HEALTH_GATED;
     }
 
     std::vector<uint8_t> d500_auto_calibrated::run_on_chip_calibration( int timeout_ms,
@@ -206,7 +208,10 @@ namespace librealsense
             if( progress_callback )
                 progress_callback->on_update_progress( _calib_engine->get_triggered_calibration_progress() );
 
-            if( _result == calibration_result::FAILED_TO_RUN )
+            // Either failure result should break the loop; otherwise a stuck-in-PROCESS + failed result would spin until timeout.
+            // FAILED_TO_CONVERGE is a legitimate outcome at HEALTH_CHECK — surfaced to the caller via _result rather than throwing here.
+            if( _result == calibration_result::FAILED_TO_RUN
+                || _result == calibration_result::FAILED_TO_CONVERGE )
                 break;
 
             // Terminal states depend on the mode:

--- a/src/ds/d500/d500-auto-calibration.h
+++ b/src/ds/d500/d500-auto-calibration.h
@@ -45,8 +45,16 @@ namespace librealsense
         std::vector<uint8_t> update_abort_status();
         std::vector< uint8_t > run_triggered_calibration( int timeout_ms, std::string json,
                                                           rs2_update_progress_callback_sptr progress_callback );
+        std::vector< uint8_t > run_hkr_triggered_calibration( int timeout_ms, std::string json,
+                                                              float * const health,
+                                                              rs2_update_progress_callback_sptr progress_callback );
+        std::vector< uint8_t > update_hkr_calibration_status( int timeout_ms, bool unattended,
+                                                              rs2_update_progress_callback_sptr progress_callback );
         std::vector< uint8_t > run_occ( int timeout_ms, std::string json, float * const health,
                                         rs2_update_progress_callback_sptr progress_callback );
+        bool device_uses_hkr_new_tc() const;
+        try_calibration_selection _try_selection;
+        commit_trigger _commit_trigger;
         ds_calib_common::dsc_check_status_result get_calibration_status( int timeout_ms,
                                                             std::function< void( const int count ) > progress_func,
                                                             bool wait_for_final_results = true ) const;

--- a/src/ds/d500/d500-auto-calibration.h
+++ b/src/ds/d500/d500-auto-calibration.h
@@ -45,14 +45,14 @@ namespace librealsense
         std::vector<uint8_t> update_abort_status();
         std::vector< uint8_t > run_triggered_calibration( int timeout_ms, std::string json,
                                                           rs2_update_progress_callback_sptr progress_callback );
-        std::vector< uint8_t > run_hkr_triggered_calibration( int timeout_ms, std::string json,
-                                                              float * const health,
-                                                              rs2_update_progress_callback_sptr progress_callback );
-        std::vector< uint8_t > update_hkr_calibration_status( int timeout_ms, bool unattended,
-                                                              rs2_update_progress_callback_sptr progress_callback );
+        std::vector< uint8_t > run_interactive_triggered_calibration( int timeout_ms, std::string json,
+                                                                      float * const health,
+                                                                      rs2_update_progress_callback_sptr progress_callback );
+        std::vector< uint8_t > update_interactive_calibration_status( int timeout_ms, bool unattended,
+                                                                      rs2_update_progress_callback_sptr progress_callback );
         std::vector< uint8_t > run_occ( int timeout_ms, std::string json, float * const health,
                                         rs2_update_progress_callback_sptr progress_callback );
-        bool device_uses_hkr_new_tc() const;
+        bool device_uses_interactive_triggered_calibration() const;
         try_calibration_selection _try_selection;
         commit_trigger _commit_trigger;
         ds_calib_common::dsc_check_status_result get_calibration_status( int timeout_ms,

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
@@ -5,6 +5,8 @@
 #include <src/ds/d500/d500-types/calibration-config.h>
 #include "d500-device.h"
 
+#include <cstring>
+
 
 namespace librealsense
 {
@@ -32,7 +34,7 @@ bool d500_debug_protocol_calibration_engine::check_buffer_size_from_get_calib_st
 
 bool d500_debug_protocol_calibration_engine::check_buffer_size_hkr(std::vector<uint8_t> res) const
 {
-    // D5x5 HKR-new TC (RSDEV-9362): 3-byte header for IDLE/PROCESS, 535 bytes from HEALTH_CHECK onward
+    // D5x5 HKR-new TC: 3-byte header for IDLE/PROCESS, 535 bytes from HEALTH_CHECK onward
     // (3 header + 20 health + 512 candidate/committed table).
     if (res.size() < 2)
         return false;
@@ -63,19 +65,30 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
         if (!check_buffer_size_hkr(res))
             throw std::runtime_error("GET_CALIB_STATUS (HKR) returned struct with wrong size");
 
-        // Re-map wire state byte to enum: on the HKR path, byte 2 -> HEALTH_CHECK, byte 3 -> FLASH_UPDATE, byte 4 -> COMPLETE.
-        auto raw = *reinterpret_cast<hkr_calibration_answer*>(res.data());
-        switch (static_cast<uint8_t>(raw.state))
+        // Header (3 bytes) is always present; health + candidate table (532 more) only from HEALTH_CHECK onward.
+        _hkr_ans = {};
+        _hkr_ans.state    = static_cast<calibration_state >(res[0]);
+        _hkr_ans.progress = static_cast<int8_t             >(res[1]);
+        _hkr_ans.result   = static_cast<calibration_result >(res[2]);
+        if (res.size() == sizeof(hkr_calibration_answer))
         {
-            case 0: raw.state = calibration_state::IDLE;         break;
-            case 1: raw.state = calibration_state::PROCESS;      break;
-            case 2: raw.state = calibration_state::HEALTH_CHECK; break;
-            case 3: raw.state = calibration_state::FLASH_UPDATE; break;
-            case 4: raw.state = calibration_state::COMPLETE;     break;
+            constexpr size_t health_off = 3;
+            constexpr size_t table_off  = 3 + sizeof(calibration_health_metrics);
+            std::memcpy(&_hkr_ans.health, res.data() + health_off, sizeof(_hkr_ans.health));
+            std::memcpy(&_hkr_ans.depth_calibration, res.data() + table_off, sizeof(_hkr_ans.depth_calibration));
+        }
+
+        // Re-map wire state byte to enum: on the HKR path, byte 2 means HEALTH_CHECK, byte 3 FLASH_UPDATE, byte 4 COMPLETE.
+        switch (static_cast<uint8_t>(_hkr_ans.state))
+        {
+            case 0: _hkr_ans.state = calibration_state::IDLE;         break;
+            case 1: _hkr_ans.state = calibration_state::PROCESS;      break;
+            case 2: _hkr_ans.state = calibration_state::HEALTH_CHECK; break;
+            case 3: _hkr_ans.state = calibration_state::FLASH_UPDATE; break;
+            case 4: _hkr_ans.state = calibration_state::COMPLETE;     break;
             default:
                 throw std::runtime_error("GET_CALIB_STATUS (HKR) returned unknown state byte");
         }
-        _hkr_ans = raw;
         return;
     }
 

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
@@ -32,9 +32,9 @@ bool d500_debug_protocol_calibration_engine::check_buffer_size_from_get_calib_st
     return is_size_ok;
 }
 
-bool d500_debug_protocol_calibration_engine::check_buffer_size_hkr(std::vector<uint8_t> res) const
+bool d500_debug_protocol_calibration_engine::check_buffer_size_interactive(std::vector<uint8_t> res) const
 {
-    // D5x5 HKR-new TC: 3-byte header for IDLE/PROCESS, 535 bytes from HEALTH_CHECK onward
+    // D5x5 interactive triggered calibration: 3-byte header for IDLE/PROCESS, 535 bytes from HEALTH_CHECK onward
     // (3 header + 20 health + 512 candidate/committed table).
     if (res.size() < 2)
         return false;
@@ -42,8 +42,8 @@ bool d500_debug_protocol_calibration_engine::check_buffer_size_hkr(std::vector<u
     // Wire state byte 2 on this path means HEALTH_CHECK, not SUCCESS. Anything at or beyond that carries the full payload.
     const bool has_payload = res[0] >= 2;
     if (!has_payload)
-        return res.size() == (sizeof(hkr_calibration_answer) - sizeof(calibration_health_metrics) - sizeof(ds::d500_coefficients_table));
-    return res.size() == sizeof(hkr_calibration_answer);
+        return res.size() == (sizeof(interactive_calibration_answer) - sizeof(calibration_health_metrics) - sizeof(ds::d500_coefficients_table));
+    return res.size() == sizeof(interactive_calibration_answer);
 }
 
 void d500_debug_protocol_calibration_engine::update_triggered_calibration_status()
@@ -60,34 +60,34 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
     // slicing 4 first bytes - opcode
     res.erase(res.begin(), res.begin() + 4);
 
-    if (_hkr_new_tc)
+    if (_interactive_triggered_calibration)
     {
-        if (!check_buffer_size_hkr(res))
-            throw std::runtime_error("GET_CALIB_STATUS (HKR) returned struct with wrong size");
+        if (!check_buffer_size_interactive(res))
+            throw std::runtime_error("GET_CALIB_STATUS (interactive) returned struct with wrong size");
 
         // Header (3 bytes) is always present; health + candidate table (532 more) only from HEALTH_CHECK onward.
-        _hkr_ans = {};
-        _hkr_ans.state    = static_cast<calibration_state >(res[0]);
-        _hkr_ans.progress = static_cast<int8_t             >(res[1]);
-        _hkr_ans.result   = static_cast<calibration_result >(res[2]);
-        if (res.size() == sizeof(hkr_calibration_answer))
+        _interactive_ans = {};
+        _interactive_ans.state    = static_cast<calibration_state >(res[0]);
+        _interactive_ans.progress = static_cast<int8_t             >(res[1]);
+        _interactive_ans.result   = static_cast<calibration_result >(res[2]);
+        if (res.size() == sizeof(interactive_calibration_answer))
         {
             constexpr size_t health_off = 3;
             constexpr size_t table_off  = 3 + sizeof(calibration_health_metrics);
-            std::memcpy(&_hkr_ans.health, res.data() + health_off, sizeof(_hkr_ans.health));
-            std::memcpy(&_hkr_ans.depth_calibration, res.data() + table_off, sizeof(_hkr_ans.depth_calibration));
+            std::memcpy(&_interactive_ans.health, res.data() + health_off, sizeof(_interactive_ans.health));
+            std::memcpy(&_interactive_ans.depth_calibration, res.data() + table_off, sizeof(_interactive_ans.depth_calibration));
         }
 
-        // Re-map wire state byte to enum: on the HKR path, byte 2 means HEALTH_CHECK, byte 3 FLASH_UPDATE, byte 4 COMPLETE.
-        switch (static_cast<uint8_t>(_hkr_ans.state))
+        // Re-map wire state byte to enum: on the interactive path, byte 2 means HEALTH_CHECK, byte 3 FLASH_UPDATE, byte 4 COMPLETE.
+        switch (static_cast<uint8_t>(_interactive_ans.state))
         {
-            case 0: _hkr_ans.state = calibration_state::IDLE;         break;
-            case 1: _hkr_ans.state = calibration_state::PROCESS;      break;
-            case 2: _hkr_ans.state = calibration_state::HEALTH_CHECK; break;
-            case 3: _hkr_ans.state = calibration_state::FLASH_UPDATE; break;
-            case 4: _hkr_ans.state = calibration_state::COMPLETE;     break;
+            case 0: _interactive_ans.state = calibration_state::IDLE;         break;
+            case 1: _interactive_ans.state = calibration_state::PROCESS;      break;
+            case 2: _interactive_ans.state = calibration_state::HEALTH_CHECK; break;
+            case 3: _interactive_ans.state = calibration_state::FLASH_UPDATE; break;
+            case 4: _interactive_ans.state = calibration_state::COMPLETE;     break;
             default:
-                throw std::runtime_error("GET_CALIB_STATUS (HKR) returned unknown state byte");
+                throw std::runtime_error("GET_CALIB_STATUS (interactive) returned unknown state byte");
         }
         return;
     }
@@ -123,20 +123,20 @@ std::vector<uint8_t> d500_debug_protocol_calibration_engine::run_triggered_calib
 
 calibration_state d500_debug_protocol_calibration_engine::get_triggered_calibration_state() const
 {
-    return _hkr_new_tc ? _hkr_ans.state : _calib_ans.state;
+    return _interactive_triggered_calibration ? _interactive_ans.state : _calib_ans.state;
 }
 calibration_result d500_debug_protocol_calibration_engine::get_triggered_calibration_result() const
 {
-    return _hkr_new_tc ? _hkr_ans.result : _calib_ans.result;
+    return _interactive_triggered_calibration ? _interactive_ans.result : _calib_ans.result;
 }
 int8_t d500_debug_protocol_calibration_engine::get_triggered_calibration_progress() const
 {
-    return _hkr_new_tc ? _hkr_ans.progress : _calib_ans.progress;
+    return _interactive_triggered_calibration ? _interactive_ans.progress : _calib_ans.progress;
 }
 
 calibration_health_metrics d500_debug_protocol_calibration_engine::get_triggered_calibration_health() const
 {
-    return _hkr_new_tc ? _hkr_ans.health : calibration_health_metrics{};
+    return _interactive_triggered_calibration ? _interactive_ans.health : calibration_health_metrics{};
 }
 
 std::vector<uint8_t> d500_debug_protocol_calibration_engine::get_calibration_table(std::vector<uint8_t>& current_calibration) const
@@ -250,7 +250,7 @@ void d500_debug_protocol_calibration_engine::set_calibration_config(const std::s
 
 ds::d500_coefficients_table d500_debug_protocol_calibration_engine::get_depth_calibration() const
 {
-    return _hkr_new_tc ? _hkr_ans.depth_calibration : _calib_ans.depth_calibration;
+    return _interactive_triggered_calibration ? _interactive_ans.depth_calibration : _calib_ans.depth_calibration;
 }
 
 }// namespace librealsense

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
@@ -30,6 +30,20 @@ bool d500_debug_protocol_calibration_engine::check_buffer_size_from_get_calib_st
     return is_size_ok;
 }
 
+bool d500_debug_protocol_calibration_engine::check_buffer_size_hkr(std::vector<uint8_t> res) const
+{
+    // D5x5 HKR-new TC (RSDEV-9362): 3-byte header for IDLE/PROCESS, 535 bytes from HEALTH_CHECK onward
+    // (3 header + 20 health + 512 candidate/committed table).
+    if (res.size() < 2)
+        return false;
+
+    // Wire state byte 2 on this path means HEALTH_CHECK, not SUCCESS. Anything at or beyond that carries the full payload.
+    const bool has_payload = res[0] >= 2;
+    if (!has_payload)
+        return res.size() == (sizeof(hkr_calibration_answer) - sizeof(calibration_health_metrics) - sizeof(ds::d500_coefficients_table));
+    return res.size() == sizeof(hkr_calibration_answer);
+}
+
 void d500_debug_protocol_calibration_engine::update_triggered_calibration_status()
 {
     if (!_dev)
@@ -44,6 +58,27 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
     // slicing 4 first bytes - opcode
     res.erase(res.begin(), res.begin() + 4);
 
+    if (_hkr_new_tc)
+    {
+        if (!check_buffer_size_hkr(res))
+            throw std::runtime_error("GET_CALIB_STATUS (HKR) returned struct with wrong size");
+
+        // Re-map wire state byte to enum: on the HKR path, byte 2 -> HEALTH_CHECK, byte 3 -> FLASH_UPDATE, byte 4 -> COMPLETE.
+        auto raw = *reinterpret_cast<hkr_calibration_answer*>(res.data());
+        switch (static_cast<uint8_t>(raw.state))
+        {
+            case 0: raw.state = calibration_state::IDLE;         break;
+            case 1: raw.state = calibration_state::PROCESS;      break;
+            case 2: raw.state = calibration_state::HEALTH_CHECK; break;
+            case 3: raw.state = calibration_state::FLASH_UPDATE; break;
+            case 4: raw.state = calibration_state::COMPLETE;     break;
+            default:
+                throw std::runtime_error("GET_CALIB_STATUS (HKR) returned unknown state byte");
+        }
+        _hkr_ans = raw;
+        return;
+    }
+
     // checking size of received buffer
     if (!check_buffer_size_from_get_calib_status(res))
         throw std::runtime_error("GET_CALIB_STATUS returned struct with wrong size");
@@ -55,23 +90,40 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
 std::vector<uint8_t> d500_debug_protocol_calibration_engine::run_triggered_calibration(calibration_mode _mode)
 {
     if (!_dev)
-        throw std::runtime_error("device has not been set"); 
-        
+        throw std::runtime_error("device has not been set");
+
     auto cmd = _dev->build_command(ds::SET_CALIB_MODE, static_cast<uint32_t>(_mode), 1 /*always*/);
+    return _dev->send_receive_raw_data(cmd);
+}
+
+std::vector<uint8_t> d500_debug_protocol_calibration_engine::run_triggered_calibration_try(try_calibration_selection selection)
+{
+    if (!_dev)
+        throw std::runtime_error("device has not been set");
+
+    // TRY carries the NEW/OLD selector as its sub-parameter, riding param2 (the same slot mode = 1 uses today).
+    auto cmd = _dev->build_command(ds::SET_CALIB_MODE,
+                                   static_cast<uint32_t>(calibration_mode::TRY),
+                                   static_cast<uint32_t>(selection));
     return _dev->send_receive_raw_data(cmd);
 }
 
 calibration_state d500_debug_protocol_calibration_engine::get_triggered_calibration_state() const
 {
-    return _calib_ans.state;
+    return _hkr_new_tc ? _hkr_ans.state : _calib_ans.state;
 }
 calibration_result d500_debug_protocol_calibration_engine::get_triggered_calibration_result() const
 {
-    return _calib_ans.result;
+    return _hkr_new_tc ? _hkr_ans.result : _calib_ans.result;
 }
 int8_t d500_debug_protocol_calibration_engine::get_triggered_calibration_progress() const
 {
-    return _calib_ans.progress;
+    return _hkr_new_tc ? _hkr_ans.progress : _calib_ans.progress;
+}
+
+calibration_health_metrics d500_debug_protocol_calibration_engine::get_triggered_calibration_health() const
+{
+    return _hkr_new_tc ? _hkr_ans.health : calibration_health_metrics{};
 }
 
 std::vector<uint8_t> d500_debug_protocol_calibration_engine::get_calibration_table(std::vector<uint8_t>& current_calibration) const
@@ -185,7 +237,7 @@ void d500_debug_protocol_calibration_engine::set_calibration_config(const std::s
 
 ds::d500_coefficients_table d500_debug_protocol_calibration_engine::get_depth_calibration() const
 {
-    return _calib_ans.depth_calibration;
+    return _hkr_new_tc ? _hkr_ans.depth_calibration : _calib_ans.depth_calibration;
 }
 
 }// namespace librealsense

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.h
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.h
@@ -19,8 +19,8 @@ struct d500_calibration_answer
     ds::d500_coefficients_table depth_calibration;
 };
 
-// D5x5 HKR-new reply layout — 3-byte header + 20-byte health block + 512-byte table (total 535 from HEALTH_CHECK).
-struct hkr_calibration_answer
+// D5x5 interactive triggered calibration reply layout — 3-byte header + 20-byte health block + 512-byte table (total 535 from HEALTH_CHECK).
+struct interactive_calibration_answer
 {
     calibration_state state;            // wire byte 2 means HEALTH_CHECK on this path
     int8_t progress;
@@ -30,11 +30,17 @@ struct hkr_calibration_answer
 };
 #pragma pack(pop)
 
+// check_buffer_size_interactive derives the IDLE/PROCESS header size from these three sizeofs.
+// If padding ever leaks in (e.g. the pack pragma is dropped), that check silently rejects the FW's 3-byte reply.
+static_assert(sizeof(interactive_calibration_answer)
+                  == 3 + sizeof(calibration_health_metrics) + sizeof(ds::d500_coefficients_table),
+              "interactive_calibration_answer must be tightly packed: state+progress+result form a 3-byte header");
+
 class debug_interface;
 class d500_debug_protocol_calibration_engine : public calibration_engine_interface
 {
 public:
-    d500_debug_protocol_calibration_engine(debug_interface* dev) : _dev(dev), _hkr_new_tc(false), _calib_ans{}, _hkr_ans{} {}
+    d500_debug_protocol_calibration_engine(debug_interface* dev) : _dev(dev), _interactive_triggered_calibration(false), _calib_ans{}, _interactive_ans{} {}
     void update_triggered_calibration_status() override;
     std::vector<uint8_t> run_triggered_calibration(calibration_mode _mode) override;
     virtual calibration_state get_triggered_calibration_state() const override;
@@ -46,20 +52,20 @@ public:
     virtual void set_calibration_config(const std::string& calibration_config_json_str) const override;
     ds::d500_coefficients_table get_depth_calibration() const;
 
-    // D5x5 HKR-new TC path.
-    void set_hkr_new_tc_enabled( bool enabled ) override { _hkr_new_tc = enabled; }
-    bool is_hkr_new_tc_enabled() const override { return _hkr_new_tc; }
+    // D5x5 interactive triggered calibration path.
+    void set_interactive_triggered_calibration_enabled( bool enabled ) override { _interactive_triggered_calibration = enabled; }
+    bool is_interactive_triggered_calibration_enabled() const override { return _interactive_triggered_calibration; }
     calibration_health_metrics get_triggered_calibration_health() const override;
     std::vector<uint8_t> run_triggered_calibration_try( try_calibration_selection selection ) override;
 
 
 private:
     bool check_buffer_size_from_get_calib_status(std::vector<uint8_t> res) const;
-    bool check_buffer_size_hkr(std::vector<uint8_t> res) const;
+    bool check_buffer_size_interactive(std::vector<uint8_t> res) const;
     debug_interface* _dev;
-    bool _hkr_new_tc;
+    bool _interactive_triggered_calibration;
     d500_calibration_answer _calib_ans;
-    hkr_calibration_answer _hkr_ans;
+    interactive_calibration_answer _interactive_ans;
 };
 
 } // namespace librealsense

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.h
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.h
@@ -10,6 +10,7 @@
 namespace librealsense
 {
 #pragma pack(push, 1)
+// Legacy D585S/D585_LEGACY reply layout — 3-byte header + optional 512-byte table at COMPLETE (total 515).
 struct d500_calibration_answer
 {
     calibration_state state;
@@ -17,12 +18,23 @@ struct d500_calibration_answer
     calibration_result result;
     ds::d500_coefficients_table depth_calibration;
 };
+
+// D5x5 HKR-new reply layout (RSDEV-9362) — 3-byte header + 20-byte health block + 512-byte table (total 535 from HEALTH_CHECK).
+struct hkr_calibration_answer
+{
+    calibration_state state;            // wire byte 2 means HEALTH_CHECK on this path
+    int8_t progress;
+    calibration_result result;
+    calibration_health_metrics health;  // valid from HEALTH_CHECK onward
+    ds::d500_coefficients_table depth_calibration;  // candidate at HEALTH_CHECK, committed at COMPLETE
+};
 #pragma pack(pop)
+
 class debug_interface;
 class d500_debug_protocol_calibration_engine : public calibration_engine_interface
 {
 public:
-    d500_debug_protocol_calibration_engine(debug_interface* dev) : _dev(dev){}
+    d500_debug_protocol_calibration_engine(debug_interface* dev) : _dev(dev), _hkr_new_tc(false), _calib_ans{}, _hkr_ans{} {}
     void update_triggered_calibration_status() override;
     std::vector<uint8_t> run_triggered_calibration(calibration_mode _mode) override;
     virtual calibration_state get_triggered_calibration_state() const override;
@@ -34,11 +46,20 @@ public:
     virtual void set_calibration_config(const std::string& calibration_config_json_str) const override;
     ds::d500_coefficients_table get_depth_calibration() const;
 
+    // D5x5 HKR-new TC path.
+    void set_hkr_new_tc_enabled( bool enabled ) override { _hkr_new_tc = enabled; }
+    bool is_hkr_new_tc_enabled() const override { return _hkr_new_tc; }
+    calibration_health_metrics get_triggered_calibration_health() const override;
+    std::vector<uint8_t> run_triggered_calibration_try( try_calibration_selection selection ) override;
+
 
 private:
     bool check_buffer_size_from_get_calib_status(std::vector<uint8_t> res) const;
+    bool check_buffer_size_hkr(std::vector<uint8_t> res) const;
     debug_interface* _dev;
+    bool _hkr_new_tc;
     d500_calibration_answer _calib_ans;
+    hkr_calibration_answer _hkr_ans;
 };
 
 } // namespace librealsense

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.h
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.h
@@ -19,7 +19,7 @@ struct d500_calibration_answer
     ds::d500_coefficients_table depth_calibration;
 };
 
-// D5x5 HKR-new reply layout (RSDEV-9362) — 3-byte header + 20-byte health block + 512-byte table (total 535 from HEALTH_CHECK).
+// D5x5 HKR-new reply layout — 3-byte header + 20-byte health block + 512-byte table (total 535 from HEALTH_CHECK).
 struct hkr_calibration_answer
 {
     calibration_state state;            // wire byte 2 means HEALTH_CHECK on this path

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -67,9 +67,9 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
-        // D5x5 (non-safety, non-legacy) HKR-new Triggered Calibration flow.
-        // D555 stays on the D400 OCC path; D585S and D585_LEGACY_PID stay on the current D500 TC flow.
-        static const std::set<std::uint16_t> d5x5_hkr_new_tc_pids = {
+        // D5x5 (non-safety, non-legacy) interactive Triggered Calibration flow.
+        // D555 stays on the D400 OCC path; D585S and D585_LEGACY_PID stay on the current D500 triggered-calibration flow.
+        static const std::set<std::uint16_t> d5x5_interactive_triggered_calibration_pids = {
             D535_2C_PID,
             D535_3C_PID,
             D535F_PID,
@@ -80,9 +80,9 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
-        inline bool uses_hkr_new_tc( uint16_t pid )
+        inline bool uses_interactive_triggered_calibration( uint16_t pid )
         {
-            return d5x5_hkr_new_tc_pids.find( pid ) != d5x5_hkr_new_tc_pids.end();
+            return d5x5_interactive_triggered_calibration_pids.find( pid ) != d5x5_interactive_triggered_calibration_pids.end();
         }
 
         static const std::map< std::uint16_t, std::string > rs500_sku_names = {

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -67,7 +67,7 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
-        // D5x5 (non-safety, non-legacy) HKR-new Triggered Calibration flow (RSDEV-9362).
+        // D5x5 (non-safety, non-legacy) HKR-new Triggered Calibration flow.
         // D555 stays on the D400 OCC path; D585S and D585_LEGACY_PID stay on the current D500 TC flow.
         static const std::set<std::uint16_t> d5x5_hkr_new_tc_pids = {
             D535_2C_PID,

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -67,6 +67,24 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
+        // D5x5 (non-safety, non-legacy) HKR-new Triggered Calibration flow (RSDEV-9362).
+        // D555 stays on the D400 OCC path; D585S and D585_LEGACY_PID stay on the current D500 TC flow.
+        static const std::set<std::uint16_t> d5x5_hkr_new_tc_pids = {
+            D535_2C_PID,
+            D535_3C_PID,
+            D535F_PID,
+            D585_2C_PID,
+            D585_3C_PID,
+            D585F_PID,
+            D585_2C_PROTO_PID,
+            D585_3C_PROTO_PID
+        };
+
+        inline bool uses_hkr_new_tc( uint16_t pid )
+        {
+            return d5x5_hkr_new_tc_pids.find( pid ) != d5x5_hkr_new_tc_pids.end();
+        }
+
         static const std::map< std::uint16_t, std::string > rs500_sku_names = {
             { D555_PID,               "RealSense D555" },
             { D555_RECOVERY_PID,      "RealSense D555 Recovery" },


### PR DESCRIPTION
**Draft — FW-team preview build. Do not merge.**

Tracked by: RSDEV-9362

## What this is

This is [#15452](https://github.com/realsenseai/librealsense/pull/15452) (`enable-tc-d585-2c-3c`) plus **one extra commit** that re-enables the RUN-phase auto-start of a 1280×720 @ 30 fps depth stream during interactive triggered calibration.

The parent PR ships the block commented out because current firmware does not accept concurrent streaming during TC. This branch un-comments it so the FW team can test the streaming-during-TC flow end-to-end once the FW-side support lands.

## The extra commit

`822b458` — reverts the "Auto-start disabled …" gating comment in `common/d500-on-chip-calib.cpp::process_flow`. When `uses_interactive_triggered_calibration() && action == RS2_CALIB_ACTION_ON_CHIP_CALIB`, the manager now:

1. Saves the user's `_sub->ui`, `_sub->stream_enabled`, and `_sub->streaming` state.
2. Calls `try_start_viewer(1280, 720, 30, invoke)` — selects Z16 on depth, plays, waits for a frame (retry once).
3. Runs the calibration.
4. Leaves the stream live through HEALTH_CHECK / TRY_NEW / TRY_OLD.
5. On terminal COMMIT / ABORT, calls `restore_workspace(invoke)` — stops our stream, restores `_sub->ui` + `_sub->stream_enabled`, and replays the user's prior stream if they were streaming before.

Everything else is identical to #15452.

## Test plan (FW team)

- [ ] Firmware build with streaming-during-TC support flashed.
- [ ] With the depth stream **not** streaming, click Calibrate → confirm the viewer auto-starts depth at 1280×720@30, the RUN completes, and the HEALTH_CHECK popup appears.
- [ ] With the depth stream **already** streaming (any format/resolution), click Calibrate → confirm the auto-start swaps to 1280×720@30 for RUN, and after Commit/Discard the workspace restores the pre-calibration settings.
- [ ] TRY_NEW / TRY_OLD keep the stream live and show the live-preview switch.
- [ ] FAILED_TO_CONVERGE at HEALTH_CHECK still surfaces the popup with `-1` sentinel (no spurious PASS).

## Do not merge until

- Firmware supports concurrent streaming during triggered calibration (spec §5.2 open item).
- Progress-byte population during PROCESS lands (current FW returns `0xFF`, host-side handling is a pre-existing gap).

---
🤖 Generated by AI
