### PR TITLE
Identify D500 GMSL devices by actual PID

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -410,7 +410,7 @@ namespace librealsense
 
         auto raw_sensor = get_raw_depth_sensor();
         _pid = group.uvc_devices.front().pid;
-        _is_mipi_device = ( ds::d500_mipi_device_pid.count( _pid ) > 0 );
+        _is_mipi_device = group.uvc_devices.front().mipi;
 
         _color_calib_table_raw = [this]()
         {

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -410,7 +410,7 @@ namespace librealsense
 
         auto raw_sensor = get_raw_depth_sensor();
         _pid = group.uvc_devices.front().pid;
-        _is_mipi_device = group.uvc_devices.front().mipi;
+        _is_mipi_device = group.uvc_devices.front().is_mipi;
 
         _color_calib_table_raw = [this]()
         {

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -475,6 +475,7 @@ namespace librealsense
         auto dev_info = std::dynamic_pointer_cast< const d500_info >( shared_from_this() );
 
         auto pid = _group.uvc_devices.front().pid;
+        bool is_mipi = _group.uvc_devices.front().mipi;
 
         try
         {
@@ -490,13 +491,14 @@ namespace librealsense
             case ds::D585_2C_PID:
             case ds::D585_2C_PROTO_PID:
                 return std::make_shared< rs5x5_device >( dev_info );
-            case ds::D585_GMSL_PID:
-                return std::make_shared< rs5x5_gmsl_dedicated_color_device >( dev_info );
             case ds::D535_3C_PID:
             case ds::D535F_PID:
             case ds::D585_3C_PID:
             case ds::D585F_PID:
             case ds::D585_3C_PROTO_PID:
+                // On MIPI/GMSL the color and IMU are exposed as dedicated V4L2 nodes.
+                if( is_mipi )
+                    return std::make_shared< rs5x5_gmsl_dedicated_color_device >( dev_info );
                 return std::make_shared< rs5x5_dedicated_color_device >( dev_info );
             default:
                 throw std::runtime_error( rsutils::string::from() << "unsupported D500 PID 0x" << hexdump( pid ) );

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -475,7 +475,7 @@ namespace librealsense
         auto dev_info = std::dynamic_pointer_cast< const d500_info >( shared_from_this() );
 
         auto pid = _group.uvc_devices.front().pid;
-        bool is_mipi = _group.uvc_devices.front().mipi;
+        bool is_mipi = _group.uvc_devices.front().is_mipi;
 
         try
         {

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -71,8 +71,7 @@ namespace librealsense
             D585_3C_PID,
             D585F_PID,
             D585_2C_PROTO_PID,
-            D585_3C_PROTO_PID,
-            D585_GMSL_PID
+            D585_3C_PROTO_PID
         };
 
         // D5x5 (non-safety, non-legacy) interactive Triggered Calibration flow.

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -31,8 +31,7 @@ namespace librealsense
         const uint16_t D585F_PID              = 0x0C06; // 3C with IR only L/R cover
         const uint16_t D585_2C_PROTO_PID      = 0x0C07;
         const uint16_t D585_3C_PROTO_PID      = 0x0C08;
-        const uint16_t D585_GMSL_PID          = 0xBAAA; // D585 GMSL (MIPI)
-   
+
         enum d500_xu_id : uint8_t // Note: some values may differ from the D400-family depth_xu selectors in ds-private.h.
         {
             DETECTION_DISTANCE    = 0x01,  // Enable FW depth-derived distance for detections
@@ -59,14 +58,7 @@ namespace librealsense
             D585_3C_PID,
             D585F_PID,
             D585_2C_PROTO_PID,
-            D585_3C_PROTO_PID,
-            D585_GMSL_PID
-        };
-
-        // d500 MIPI (GMSL) devices - color and IMU are exposed as separate V4L2 nodes rather than
-        // the USB layout (color on a dedicated mi=3 node, IMU over HID).
-        static const std::set<std::uint16_t> d500_mipi_device_pid = {
-            D585_GMSL_PID
+            D585_3C_PROTO_PID
         };
 
         // d500 PIDs that expose the projector temperature via HKR selector 0x16
@@ -116,8 +108,7 @@ namespace librealsense
             { D585_3C_PID,            "RealSense D585" },
             { D585F_PID,              "RealSense D585F" },
             { D585_2C_PROTO_PID,      "RealSense D585 Proto Dual RGB" },
-            { D585_3C_PROTO_PID,      "RealSense D585 Prototype" },
-            { D585_GMSL_PID,          "RealSense D585 GMSL" }
+            { D585_3C_PROTO_PID,      "RealSense D585 Prototype" }
         };
 
         // D500-only HWM opcodes. Shared opcodes are in ds::fw_cmd (ds/ds-private.h).

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -993,6 +993,7 @@ namespace librealsense
                 }
             }
             info.conn_spec = usb_undefined;
+            info.mipi = true;
             info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
 
             return info;
@@ -2822,7 +2823,7 @@ namespace librealsense
 
         std::shared_ptr<uvc_device> v4l_backend::create_uvc_device(uvc_device_info info) const
         {
-            bool mipi_device = is_mipi_pid(info.pid);
+            bool mipi_device = info.mipi;
 
             auto v4l_uvc_dev =        mipi_device ?         std::make_shared<v4l_mipi_device>(info) :
                               ((!info.has_metadata_node) ?  std::make_shared<v4l_uvc_device>(info) :

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -937,7 +937,7 @@ namespace librealsense
             info.unique_id = busnum + "-" + devpath + "-" + devnum;
             // Find the USB specification (USB2/3) type from the underlying device, traversing from
             // /sys/devices/.../M-N/3-6:1.0/video4linux/video0 up to /sys/devices/.../M-N/version
-            info.conn_spec = v4l_usb_logic::get_usb_connection_type(video_path + "/../../../");
+            info.usb_conn_spec = v4l_usb_logic::get_usb_connection_type(video_path + "/../../../");
             info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
 
             return info;
@@ -992,8 +992,8 @@ namespace librealsense
                     break;
                 }
             }
-            info.conn_spec = usb_undefined;
-            info.mipi = true;
+            info.usb_conn_spec = usb_undefined;
+            info.is_mipi = true;
             info.uvc_capabilities = get_dev_capabilities(dev_name).device_caps;
 
             return info;
@@ -1223,7 +1223,7 @@ namespace librealsense
         v4l_uvc_device::v4l_uvc_device(const uvc_device_info& info, bool use_memory_map)
             : _name(info.id), 
               _device_path(info.device_path),
-              _device_usb_spec(info.conn_spec),
+              _device_usb_spec(info.usb_conn_spec),
               _info(info),
               _is_capturing(false),
               _is_alive(true),
@@ -2823,7 +2823,7 @@ namespace librealsense
 
         std::shared_ptr<uvc_device> v4l_backend::create_uvc_device(uvc_device_info info) const
         {
-            bool mipi_device = info.mipi;
+            bool mipi_device = info.is_mipi;
 
             auto v4l_uvc_dev =        mipi_device ?         std::make_shared<v4l_mipi_device>(info) :
                               ((!info.has_metadata_node) ?  std::make_shared<v4l_uvc_device>(info) :

--- a/src/linux/camera-identifier-v4l.cpp
+++ b/src/linux/camera-identifier-v4l.cpp
@@ -8,6 +8,7 @@
 #include <src/librealsense-exception.h>
 
 #include <rsutils/number/crc32.h>
+#include <rsutils/string/from.h>
 
 #include <sstream>
 #include <cstring>
@@ -38,7 +39,7 @@ namespace librealsense
             const uint8_t * gvd_struct = gvd.data() + GVD_OPCODE_HEADER;
             uint16_t payload_size = gvd_struct[D500_GVD_PAYLOAD_SIZE_OFFSET]
                                   | ( gvd_struct[D500_GVD_PAYLOAD_SIZE_OFFSET + 1] << 8 );
-            if( GVD_OPCODE_HEADER + D500_GVD_HEADER_SIZE + payload_size > gvd.size() )
+            if( payload_size == 0 || GVD_OPCODE_HEADER + D500_GVD_HEADER_SIZE + payload_size > gvd.size() )
                 return false;
             uint32_t stored_crc;
             std::memcpy( &stored_crc, gvd_struct + D500_GVD_CRC32_OFFSET, sizeof( stored_crc ) );
@@ -76,8 +77,8 @@ namespace librealsense
             case GVD_PID_D415_GMSL: device_pid = D415_GMSL_PID; break;
             case GVD_PID_D401_GMSL: device_pid = D401_GMSL_PID; break;
             default:
-                LOG_WARNING( "Unidentified MIPI device product id: 0x" << std::hex << (int)gvd[4 + GVD_PID_OFFSET] );
-                break;
+                throw linux_backend_exception( rsutils::string::from()
+                    << "Unidentified MIPI device product id: 0x" << std::hex << (int)gvd[4 + GVD_PID_OFFSET] );
             }
 
             _vid = 0x8086;

--- a/src/linux/camera-identifier-v4l.cpp
+++ b/src/linux/camera-identifier-v4l.cpp
@@ -7,8 +7,10 @@
 
 #include <src/librealsense-exception.h>
 
+#include <rsutils/number/crc32.h>
+
 #include <sstream>
-#include <set>
+#include <cstring>
 
 namespace librealsense
 {
@@ -19,76 +21,67 @@ namespace librealsense
         const uint16_t D415_GMSL_PID = 0xABCF;
         const uint16_t D401_GMSL_PID = 0xABCC;
 
-        const uint16_t D585_GMSL_PID = 0xBAAA;  // TODO - replace with the real D585 GMSL PID
+        // The MIPI GVD control returns a 4-byte HW-monitor opcode header before the GVD struct.
+        static constexpr size_t GVD_OPCODE_HEADER = 4;
+        // D500 GVD struct field offsets, relative to the struct start.
+        static constexpr size_t D500_GVD_PAYLOAD_SIZE_OFFSET = 0x02;  // uint16
+        static constexpr size_t D500_GVD_CRC32_OFFSET        = 0x04;  // uint32
+        static constexpr size_t D500_GVD_HEADER_SIZE         = 0x08;  // version + payload size + CRC32
+        static constexpr size_t D500_GVD_VID_OFFSET          = 0x0C;  // uint16
+        static constexpr size_t D500_GVD_PID_OFFSET          = 0x0E;  // uint16
 
-        static const std::set< uint16_t > mipi_devices_pid = {
-            D457_PID,
-            D430_GMSL_PID,
-            D415_GMSL_PID,
-            D401_GMSL_PID,
-            D585_GMSL_PID
-        };
-
-        bool is_mipi_pid( uint16_t pid )
+        // A D500 GVD is recognized by validating its CRC32 over the payload sized by its own size field.
+        static bool is_d500_gvd( const std::vector< uint8_t > & gvd )
         {
-            return mipi_devices_pid.count( pid ) > 0;
+            if( gvd.size() < GVD_OPCODE_HEADER + D500_GVD_HEADER_SIZE )
+                return false;
+            const uint8_t * gvd_struct = gvd.data() + GVD_OPCODE_HEADER;
+            uint16_t payload_size = gvd_struct[D500_GVD_PAYLOAD_SIZE_OFFSET]
+                                  | ( gvd_struct[D500_GVD_PAYLOAD_SIZE_OFFSET + 1] << 8 );
+            if( GVD_OPCODE_HEADER + D500_GVD_HEADER_SIZE + payload_size > gvd.size() )
+                return false;
+            uint32_t stored_crc;
+            std::memcpy( &stored_crc, gvd_struct + D500_GVD_CRC32_OFFSET, sizeof( stored_crc ) );
+            return rsutils::number::calc_crc32( gvd_struct + D500_GVD_HEADER_SIZE, payload_size ) == stored_crc;
         }
 
         void camera_identifier_v4l_mipi::resolve( const std::string & dev_name )
         {
-            // GVD product ID
-            const uint8_t GVD_PID_OFFSET = 4;
+            std::vector< uint8_t > gvd = v4l_mipi_logic::get_gvd( dev_name );
 
+            if( is_d500_gvd( gvd ) )
+            {
+                // d500 MIPI (e.g. D585 GMSL): the real USB VID/PID are stored in the GVD struct.
+                const uint8_t * gvd_struct = gvd.data() + GVD_OPCODE_HEADER;
+                _vid = gvd_struct[D500_GVD_VID_OFFSET] | ( gvd_struct[D500_GVD_VID_OFFSET + 1] << 8 );
+                _pid = gvd_struct[D500_GVD_PID_OFFSET] | ( gvd_struct[D500_GVD_PID_OFFSET + 1] << 8 );
+                return;
+            }
+
+            // d400 MIPI GVD: a single-byte product id maps to the MIPI/GMSL PID, under the Intel VID.
+            const uint8_t GVD_PID_OFFSET = 4;
             const uint8_t GVD_PID_D457 = 0x12;
             const uint8_t GVD_PID_D401_GMSL = 0x13;
             const uint8_t GVD_PID_D430_GMSL = 0x0F;
             const uint8_t GVD_PID_D415_GMSL = 0x06;
 
-            uint16_t device_pid = 0;
-
-            std::vector< uint8_t > gvd = v4l_mipi_logic::get_gvd( dev_name );
-            if( gvd.size() < 18 )  // need bytes up to the embedded VID at 16-17
+            if( gvd.size() <= 4u + GVD_PID_OFFSET )
                 throw linux_backend_exception( "GVD response too short to identify device" );
 
-            // d500 MIPI (e.g. D585 GMSL) uses a different GVD layout than d400 GMSL:
-            // byte 8 holds the CRC32, and the RealSense VID/PID are embedded at bytes 16-19.
-            // TODO - temp WA for D585 GMSL, until the GVD layout is fixed to match the D400 GMSL layout
-            uint16_t embedded_vid = gvd[16] | ( gvd[17] << 8 );
-            if( embedded_vid == 0x38e5 )  // RealSense VID identifies the d500 GMSL family
+            uint16_t device_pid = 0;
+            switch( gvd[4 + GVD_PID_OFFSET] )
             {
-                device_pid = D585_GMSL_PID;
-            }
-            else
-            {
-                uint8_t product_pid = gvd[4 + GVD_PID_OFFSET];
-
-                switch( product_pid )
-                {
-                case( GVD_PID_D457 ):
-                    device_pid = D457_PID;
-                    break;
-
-                case( GVD_PID_D430_GMSL ):
-                    device_pid = D430_GMSL_PID;
-                    break;
-
-                case( GVD_PID_D415_GMSL ):
-                    device_pid = D415_GMSL_PID;
-                    break;
-
-                case( GVD_PID_D401_GMSL ):
-                    device_pid = D401_GMSL_PID;
-                    break;
-
-                default:
-                    LOG_WARNING( "Unidentified MIPI device product id: 0x" << std::hex << (int)product_pid );
-                    device_pid = 0x0000;
-                    break;
-                }
+            case GVD_PID_D457:      device_pid = D457_PID;      break;
+            case GVD_PID_D430_GMSL: device_pid = D430_GMSL_PID; break;
+            case GVD_PID_D415_GMSL: device_pid = D415_GMSL_PID; break;
+            case GVD_PID_D401_GMSL: device_pid = D401_GMSL_PID; break;
+            default:
+                LOG_WARNING( "Unidentified MIPI device product id: 0x" << std::hex << (int)gvd[4 + GVD_PID_OFFSET] );
+                break;
             }
 
+            _vid = 0x8086;
             _pid = device_pid;
-            _vid = ( _pid == D585_GMSL_PID ) ? 0x38e5 : 0x8086;  // D585 GMSL uses RealSense VID
         }
 
         void camera_identifier_v4l_usb::resolve( const std::string & name )

--- a/src/linux/camera-identifier-v4l.h
+++ b/src/linux/camera-identifier-v4l.h
@@ -12,9 +12,6 @@ namespace librealsense
 {
     namespace platform
     {
-        // True if pid is a known RealSense MIPI/GMSL product id.
-        bool is_mipi_pid( uint16_t pid );
-
         // Holds the USB-style VID/PID for a V4L2 device.
         class camera_identifier_v4l : public camera_identifier
         {

--- a/src/platform/uvc-device-info.h
+++ b/src/platform/uvc-device-info.h
@@ -26,6 +26,7 @@ struct uvc_device_info
     uint32_t uvc_capabilities = 0;
     bool has_metadata_node = false;
     std::string metadata_node_id;
+    bool mipi = false;  // enumerated over a MIPI/GMSL V4L2 node rather than USB
 
     operator std::string() const
     {
@@ -33,7 +34,7 @@ struct uvc_device_info
         s << "id- " << id << "\nvid- " << std::hex << vid << "\npid- " << std::hex << pid << "\nmi- " << std::dec << mi
           << "\nunique_id- " << unique_id << "\npath- " << device_path << "\nUVC capabilities- " << std::hex
           << uvc_capabilities << "\nUVC specification- " << std::hex << (uint16_t)conn_spec << std::dec
-          << ( has_metadata_node ? ( "\nmetadata node-" + metadata_node_id ) : "" ) << std::endl;
+          << ( has_metadata_node ? ( "\nmetadata node-" + metadata_node_id ) : "" ) << ( mipi ? "\nmipi" : "" ) << std::endl;
 
         return s.str();
     }

--- a/src/platform/uvc-device-info.h
+++ b/src/platform/uvc-device-info.h
@@ -22,19 +22,19 @@ struct uvc_device_info
     std::string device_path;
     std::string dfu_device_path; // for mipi multiple cameras
     std::string serial;
-    usb_spec conn_spec = usb_undefined;
+    usb_spec usb_conn_spec = usb_undefined;
     uint32_t uvc_capabilities = 0;
     bool has_metadata_node = false;
     std::string metadata_node_id;
-    bool mipi = false;  // enumerated over a MIPI/GMSL V4L2 node rather than USB
+    bool is_mipi = false;  // enumerated over a MIPI/GMSL V4L2 node rather than USB
 
     operator std::string() const
     {
         std::ostringstream s;
         s << "id- " << id << "\nvid- " << std::hex << vid << "\npid- " << std::hex << pid << "\nmi- " << std::dec << mi
           << "\nunique_id- " << unique_id << "\npath- " << device_path << "\nUVC capabilities- " << std::hex
-          << uvc_capabilities << "\nUVC specification- " << std::hex << (uint16_t)conn_spec << std::dec
-          << ( has_metadata_node ? ( "\nmetadata node-" + metadata_node_id ) : "" ) << ( mipi ? "\nmipi" : "" ) << std::endl;
+          << uvc_capabilities << "\nUVC specification- " << std::hex << (uint16_t)usb_conn_spec << std::dec
+          << ( has_metadata_node ? ( "\nmetadata node-" + metadata_node_id ) : "" ) << ( is_mipi ? "\nmipi" : "" ) << std::endl;
 
         return s.str();
     }
@@ -49,7 +49,7 @@ struct uvc_device_info
 inline bool operator==( const uvc_device_info & a, const uvc_device_info & b )
 {
     return ( a.vid == b.vid ) && ( a.pid == b.pid ) && ( a.mi == b.mi ) && ( a.unique_id == b.unique_id )
-        && ( a.id == b.id ) && ( a.device_path == b.device_path ) && ( a.conn_spec == b.conn_spec );
+        && ( a.id == b.id ) && ( a.device_path == b.device_path ) && ( a.usb_conn_spec == b.usb_conn_spec );
 }
 
 

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -56,7 +56,7 @@ namespace librealsense
                 device_info.mi = info.mi;
                 device_info.unique_id = info.unique_id;
                 device_info.device_path = info.id;
-                device_info.conn_spec = info.conn_spec;
+                device_info.usb_conn_spec = info.conn_spec;
                 //LOG_INFO("Found UVC device: " << std::string(device_info).c_str());
                 rv.push_back(device_info);
             }
@@ -350,7 +350,7 @@ namespace librealsense
 
         usb_spec rs_uvc_device::get_usb_specification() const
         {
-            // On Win7, USB type is determined only when the USB device is created, _info.conn_spec holds wrong information
+            // On Win7 the cached uvc_device_info.usb_conn_spec is wrong, so read it live from the USB device's own info
             return _usb_device->get_info().conn_spec; 
         }
 


### PR DESCRIPTION
Tracked on [RSDEV-9251]

**Refactor MIPI GVD device identification**

* Detect a D500 GVD by validating its CRC32 over the payload sized by its own size field, instead of the embedded-VID check.
* On a valid D500 GVD, read the real VID/PID straight from the struct; otherwise fall through to the D400 GVD path unchanged.
* Drop the synthetic D585_GMSL_PID (0xBAAA) and its PID-based routing, since the struct now carries the true product PID.
* Signal GMSL vs USB transport via a new uvc_device_info::mipi flag set at enumeration, and drive _is_mipi_device and the D500 factory's device-class choice from it.
