### PR TITLE
Add support to more D500 GMSL controls

### DIFF
--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -197,15 +197,6 @@ namespace librealsense
 
         _ds_color_common->register_color_options();
 
-        // The D585 GMSL MIPI V4L2 backend has no working control for these color PUs
-        // (querying them fails), so drop them from the shared set rather than expose dead controls.
-        if( _is_mipi_device )
-        {
-            color_ep.unregister_option( RS2_OPTION_BRIGHTNESS );
-            color_ep.unregister_option( RS2_OPTION_CONTRAST );
-            color_ep.unregister_option( RS2_OPTION_GAMMA );
-        }
-
         std::map< float, std::string > description_per_value = std::map<float, std::string>{
             { 0.f, "Disabled"},
             { 1.f, "50Hz" },

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -145,28 +145,11 @@ namespace librealsense
         switch( _native_format )
         {
         case RS2_FORMAT_YUYV:
-        {
-            auto platform_dev = get_raw_color_sensor()->get_uvc_device();
-            if( _is_mipi_device && platform_dev->is_platform_jetson() )
-            {
-                // On Jetson deserializer bytes are received swapped so YUYV is received as UYVY.
-                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< uyvy_converter >(
-                    RS2_FORMAT_YUYV,
-                    map_supported_color_formats( RS2_FORMAT_YUYV, false ),
-                    RS2_STREAM_COLOR ) );
-                color_ep.register_processing_block( { { RS2_FORMAT_YUYV } },
-                                                    { { RS2_FORMAT_YUYV, RS2_STREAM_COLOR } },
-                                                    []() { return std::make_shared< uyvy_to_yuyv >(); } );
-            }
-            else
-            {
-                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
-                    RS2_FORMAT_YUYV,
-                    map_supported_color_formats( RS2_FORMAT_YUYV ),
-                    RS2_STREAM_COLOR ) );
-            }
+            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
+                RS2_FORMAT_YUYV,
+                map_supported_color_formats( RS2_FORMAT_YUYV ),
+                RS2_STREAM_COLOR ) );
             break;
-            }
         case RS2_FORMAT_M420:
         case RS2_FORMAT_NV12:
             // NV12 registered before M420 so RGB targets resolve to NV12 when present, and to M420 when it is not

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -545,55 +545,44 @@ namespace librealsense
                 depth_sensor->register_option(RS2_OPTION_DEPTH_UNITS, depth_scale);
             }
 
-            // Temperature depth-XU selectors (PVT 0x15, OHM 0x17, Projector 0x16) have no CID in the
-            // MIPI V4L2 backend, so skip them on D585 GMSL.
-            // TODO - to be solved XU
-            if (!_is_mipi_device)
+            // defining the temperature options
+            auto pvt_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                                                                             depth_xu,
+                                                                             d500_xu_id::PVT_TEMPERATURE,
+                                                                             "PVT Temperature");
+
+            auto ohm_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                                                                             depth_xu,
+                                                                             d500_xu_id::OHM_TEMPERATURE,
+                                                                             "OHM Temperature");
+
+            // registering the temperature options
+            depth_sensor.register_option(RS2_OPTION_SOC_PVT_TEMPERATURE, pvt_temperature);
+            depth_sensor.register_option(RS2_OPTION_OHM_TEMPERATURE, ohm_temperature);
+
+            if (d500_projector_temperature_pids.count(_pid))
             {
-                // defining the temperature options
-                auto pvt_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
-                                                                                 depth_xu,
-                                                                                 d500_xu_id::PVT_TEMPERATURE,
-                                                                                 "PVT Temperature");
-
-                auto ohm_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
-                                                                                 depth_xu,
-                                                                                 d500_xu_id::OHM_TEMPERATURE,
-                                                                                 "OHM Temperature");
-
-                // registering the temperature options
-                depth_sensor.register_option(RS2_OPTION_SOC_PVT_TEMPERATURE, pvt_temperature);
-                depth_sensor.register_option(RS2_OPTION_OHM_TEMPERATURE, ohm_temperature);
-
-                if (d500_projector_temperature_pids.count(_pid))
-                {
-                    auto proj_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
-                                                                                      depth_xu,
-                                                                                      d500_xu_id::PROJECTOR_TEMPERATURE,
-                                                                                      "Projector Temperature");
-                    depth_sensor.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE, proj_temperature);
-                }
+                auto proj_temperature = std::make_shared< temperature_xu_option >(raw_depth_sensor,
+                                                                                  depth_xu,
+                                                                                  d500_xu_id::PROJECTOR_TEMPERATURE,
+                                                                                  "Projector Temperature");
+                depth_sensor.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE, proj_temperature);
             }
 
-            // Error-reporting depth-XU selector (0x07) has no CID in the MIPI V4L2 backend, so skip it on D585 GMSL.
-            // TODO - to be solved XU
-            if (!_is_mipi_device)
-            {
-                auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,
-                                                                                   depth_xu,
-                                                                                   DS5_ERROR_REPORTING,
-                                                                                   "Error reporting" );
+            auto error_control = std::make_shared< uvc_xu_option< uint8_t > >( raw_depth_sensor,
+                                                                               depth_xu,
+                                                                               DS5_ERROR_REPORTING,
+                                                                               "Error reporting" );
 
-                _polling_error_handler = std::make_shared< polling_error_handler >(
-                    1000,
-                    error_control,
-                    std::weak_ptr<std::atomic<bool>>( _device_alive ),
-                    raw_depth_sensor->get_notifications_processor(),
-                    std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
+            _polling_error_handler = std::make_shared< polling_error_handler >(
+                1000,
+                error_control,
+                std::weak_ptr<std::atomic<bool>>( _device_alive ),
+                raw_depth_sensor->get_notifications_processor(),
+                std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
 
-                depth_sensor.register_option( RS2_OPTION_ERROR_POLLING_ENABLED,
-                                              std::make_shared< polling_errors_disable >( _polling_error_handler ) );
-            }
+            depth_sensor.register_option( RS2_OPTION_ERROR_POLLING_ENABLED,
+                                          std::make_shared< polling_errors_disable >( _polling_error_handler ) );
 
         }); //group_multiple_fw_calls
 

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -79,7 +79,8 @@ namespace librealsense
             D585_3C_PID,
             D585F_PID,
             D585_2C_PROTO_PID,
-            D585_3C_PROTO_PID
+            D585_3C_PROTO_PID,
+            D585_GMSL_PID
         };
 
         // D5x5 (non-safety, non-legacy) interactive Triggered Calibration flow.

--- a/src/ds/ds-options.cpp
+++ b/src/ds/ds-options.cpp
@@ -378,9 +378,6 @@ namespace librealsense
     float depth_scale_option::query() const
     {
         auto table = get_depth_table(ds::GET_VAL);
-        // TODO D585 MIPI: proto FW reports depth_units=0 over GMSL; fall back to 1mm default until FW/HWM is fixed.
-        if( table.depth_units == 0 )
-            return 0.001f;
         return (float)(0.000001 * (float)table.depth_units);
     }
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -70,46 +70,7 @@
 
 const double DEFAULT_KPI_FRAME_DROPS_PERCENTAGE = 0.05;
 
-//D457 Dev. TODO -shall be refactored into the kernel headers.
-constexpr uint32_t RS_STREAM_CONFIG_0                       = 0x4000;
-constexpr uint32_t RS_CAMERA_CID_BASE                       = (V4L2_CTRL_CLASS_CAMERA | RS_STREAM_CONFIG_0);
-constexpr uint32_t RS_CAMERA_CID_LASER_POWER                = (RS_CAMERA_CID_BASE+1);
-constexpr uint32_t RS_CAMERA_CID_MANUAL_LASER_POWER         = (RS_CAMERA_CID_BASE+2);
-constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_GET    = (RS_CAMERA_CID_BASE+3);
-constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_SET    = (RS_CAMERA_CID_BASE+4);
-constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_GET    = (RS_CAMERA_CID_BASE+5);
-constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_SET    = (RS_CAMERA_CID_BASE+6);
-constexpr uint32_t RS_CAMERA_CID_FW_VERSION                 = (RS_CAMERA_CID_BASE+7);
-constexpr uint32_t RS_CAMERA_CID_GVD                        = (RS_CAMERA_CID_BASE+8);
-constexpr uint32_t RS_CAMERA_CID_AE_ROI_GET                 = (RS_CAMERA_CID_BASE+9);
-constexpr uint32_t RS_CAMERA_CID_AE_ROI_SET                 = (RS_CAMERA_CID_BASE+10);
-constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_GET            = (RS_CAMERA_CID_BASE+11);
-constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_SET            = (RS_CAMERA_CID_BASE+12);
-constexpr uint32_t RS_CAMERA_CID_ERB                        = (RS_CAMERA_CID_BASE+13);
-constexpr uint32_t RS_CAMERA_CID_EWB                        = (RS_CAMERA_CID_BASE+14);
-constexpr uint32_t RS_CAMERA_CID_HWMC_LEGACY                = (RS_CAMERA_CID_BASE+15);
-constexpr uint32_t RS_CAMERA_CID_SYNC_MODE                  = (RS_CAMERA_CID_BASE+16);
 
-//const uint32_t RS_CAMERA_GENERIC_XU                     = (RS_CAMERA_CID_BASE+15); // RS_CAMERA_CID_HWMC duplicate??
-constexpr uint32_t RS_CAMERA_CID_MANUAL_EXPOSURE            = (RS_CAMERA_CID_BASE+17);
-constexpr uint32_t RS_CAMERA_CID_LASER_POWER_LEVEL          = (RS_CAMERA_CID_BASE+18); // RS_CAMERA_CID_MANUAL_LASER_POWER ??
-constexpr uint32_t RS_CAMERA_CID_EXPOSURE_MODE              = (RS_CAMERA_CID_BASE+19);
-constexpr uint32_t RS_CAMERA_CID_WHITE_BALANCE_MODE         = (RS_CAMERA_CID_BASE+20); // Similar to RS_CAMERA_CID_EWB ??
-constexpr uint32_t RS_CAMERA_CID_PRESET                     = (RS_CAMERA_CID_BASE+21);
-constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY          = (RS_CAMERA_CID_BASE+22); // [MIPI - Select projector frequency values: 0->57[KHZ], 1->91[KHZ]
-constexpr uint32_t RS_CAMERA_CID_HWMC                       = (RS_CAMERA_CID_BASE+32);
-constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING            = (RS_CAMERA_CID_BASE+34);
-constexpr uint32_t RS_CAMERA_CID_AE_MODE                    = (RS_CAMERA_CID_BASE+35);
-/* refe4rence for kernel 4.9 to be removed
-#define UVC_CID_GENERIC_XU          (V4L2_CID_PRIVATE_BASE+15)
-#define UVC_CID_LASER_POWER_MODE    (V4L2_CID_PRIVATE_BASE+16)
-#define UVC_CID_MANUAL_EXPOSURE     (V4L2_CID_PRIVATE_BASE+17)
-#define UVC_CID_LASER_POWER_LEVEL   (V4L2_CID_PRIVATE_BASE+18)
-#define UVC_CID_EXPOSURE_MODE       (V4L2_CID_PRIVATE_BASE+19)
-#define UVC_CID_WHITE_BALANCE_MODE  (V4L2_CID_PRIVATE_BASE+20)
-#define UVC_CID_PRESET              (V4L2_CID_PRIVATE_BASE+21)
-UVC_CID_MANUAL_EXPOSURE
-*/
 #ifdef ANDROID
 
 // https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/lockf.h
@@ -2697,28 +2658,9 @@ namespace librealsense
         v4l_mipi_device::~v4l_mipi_device()
         {}
 
-        // D457 controls map- temporal solution to bypass backend interface with actual codes
-        // DS5 depth XU identifiers
-        const uint8_t RS_HWMONITOR                       = 1;
-        const uint8_t RS_DEPTH_EMITTER_ENABLED           = 2;
-        const uint8_t RS_EXPOSURE                        = 3;
-        const uint8_t RS_LASER_POWER                     = 4;
-        const uint8_t RS_HARDWARE_PRESET                 = 6;
-        const uint8_t RS_ERROR_REPORTING                 = 7;
-        const uint8_t RS_EXT_TRIGGER                     = 8;
-        const uint8_t RS_ASIC_AND_PROJECTOR_TEMPERATURES = 9;
-        const uint8_t RS_ENABLE_AUTO_WHITE_BALANCE       = 0xA;
-        const uint8_t RS_ENABLE_AUTO_EXPOSURE            = 0xB;
-        const uint8_t RS_LED_PWR                         = 0xE;
-        const uint8_t RS_EMITTER_FREQUENCY               = 0x10; // Match to DS5_EMITTER_FREQUENCY
-        const uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
-        const uint8_t RS_EXTERNAL_SYNC                   = 0x12;
-        const uint8_t RS_READOUT_SHAPING                 = 0x13;
-
-
         bool v4l_mipi_device::get_pu(rs2_option opt, int32_t& value) const
         {
-            v4l2_ext_control control{get_cid(opt), 0, 0, 0};
+            v4l2_ext_control control{v4l_mipi_logic::option_to_cid(opt), 0, 0, 0};
             // Extract the control group from the underlying control query
             v4l2_ext_controls ctrls_block { control.id&0xffff0000, 1, 0, 0, 0, &control};
 
@@ -2741,7 +2683,7 @@ namespace librealsense
 
         bool v4l_mipi_device::set_pu(rs2_option opt, int32_t value)
         {
-            v4l2_ext_control control{get_cid(opt), 0, 0, value};
+            v4l2_ext_control control{v4l_mipi_logic::option_to_cid(opt), 0, 0, value};
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
                 control.value = value ? V4L2_EXPOSURE_APERTURE_PRIORITY : V4L2_EXPOSURE_MANUAL;
 
@@ -2762,7 +2704,7 @@ namespace librealsense
 
         bool v4l_mipi_device::set_xu(const extension_unit& xu, uint8_t control, const uint8_t* data, int size)
         {
-            v4l2_ext_control xctrl{xu_to_cid(xu,control), uint32_t(size), 0, 0};
+            v4l2_ext_control xctrl{v4l_mipi_logic::xu_to_cid(xu,control), uint32_t(size), 0, 0};
             switch (size)
             {
                 case 1: xctrl.value   = *(reinterpret_cast<const uint8_t*>(data)); break;
@@ -2773,7 +2715,7 @@ namespace librealsense
                     xctrl.p_u8 = const_cast<uint8_t*>(data); // TODO aggregate initialization with union
             }
 
-            if (control == RS_ENABLE_AUTO_EXPOSURE)
+            if (v4l_mipi_logic::is_auto_exposure_control(control))
                 xctrl.value = xctrl.value ? V4L2_EXPOSURE_APERTURE_PRIORITY : V4L2_EXPOSURE_MANUAL;
 
             // Extract the control group from the underlying control query
@@ -2794,7 +2736,7 @@ namespace librealsense
 
         bool v4l_mipi_device::get_xu(const extension_unit& xu, uint8_t control, uint8_t* data, int size) const
         {
-            v4l2_ext_control xctrl{xu_to_cid(xu,control), uint32_t(size), 0, 0};
+            v4l2_ext_control xctrl{v4l_mipi_logic::xu_to_cid(xu,control), uint32_t(size), 0, 0};
             xctrl.p_u8 = data;
 
             v4l2_ext_controls ext {xctrl.id & 0xffff0000, 1, 0, 0, 0, &xctrl};
@@ -2811,7 +2753,7 @@ namespace librealsense
                     continue;
                 }
 
-                if (control == RS_ENABLE_AUTO_EXPOSURE)
+                if (v4l_mipi_logic::is_auto_exposure_control(control))
                   xctrl.value = (V4L2_EXPOSURE_MANUAL == xctrl.value) ? 0 : 1;
 
                 // used to parse the data when only a value is returned (e.g. laser power),
@@ -2831,7 +2773,7 @@ namespace librealsense
         control_range v4l_mipi_device::get_xu_range(const extension_unit& xu, uint8_t control, int len) const
         {
             v4l2_query_ext_ctrl xctrl_query{};
-            xctrl_query.id = xu_to_cid(xu,control);
+            xctrl_query.id = v4l_mipi_logic::xu_to_cid(xu,control);
 
             if(0 > ioctl(_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query)){
                 throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
@@ -2846,7 +2788,7 @@ namespace librealsense
                     << xctrl_query.default_value << ", " << xctrl_query.step
                     << "\n Elements = " << xctrl_query.elems);
 
-            if (control == RS_ENABLE_AUTO_EXPOSURE)
+            if (v4l_mipi_logic::is_auto_exposure_control(control))
                 return {0, 1, 1, 1};
             return { static_cast<int32_t>(xctrl_query.minimum), static_cast<int32_t>(xctrl_query.maximum),
                      static_cast<int32_t>(xctrl_query.step), static_cast<int32_t>(xctrl_query.default_value)};
@@ -2864,7 +2806,7 @@ namespace librealsense
             }
 
             struct v4l2_query_ext_ctrl query = {};
-            query.id = get_cid(option);
+            query.id = v4l_mipi_logic::option_to_cid(option);
             if (xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query) < 0)
             {
                 // Some controls (exposure, auto exposure, auto hue) do not seem to work on V4L2
@@ -2876,61 +2818,6 @@ namespace librealsense
             control_range range(query.minimum, query.maximum, query.step, query.default_value);
 
             return range;
-        }
-
-        uint32_t v4l_mipi_device::get_cid(rs2_option option) const
-        {
-            switch(option)
-            {
-                case RS2_OPTION_BACKLIGHT_COMPENSATION: return V4L2_CID_BACKLIGHT_COMPENSATION;
-                case RS2_OPTION_BRIGHTNESS: return V4L2_CID_BRIGHTNESS;
-                case RS2_OPTION_CONTRAST: return V4L2_CID_CONTRAST;
-                case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE; // Is this actually valid? I'm getting a lot of VIDIOC error 22s...
-                case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903; // v4l2-ctl --list-ctrls -d /dev/video0
-                case RS2_OPTION_GAMMA: return V4L2_CID_GAMMA;
-                // case RS2_OPTION_HUE: return V4L2_CID_HUE;
-                case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
-                case RS2_OPTION_EMITTER_ENABLED: return V4L2_CID_EXPOSURE_AUTO;
-                case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;
-                case RS2_OPTION_SHARPNESS: return V4L2_CID_SHARPNESS;
-                case RS2_OPTION_WHITE_BALANCE: return V4L2_CID_WHITE_BALANCE_TEMPERATURE;
-                case RS2_OPTION_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; // Automatic gain/exposure control
-                case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return V4L2_CID_AUTO_WHITE_BALANCE;
-                case RS2_OPTION_POWER_LINE_FREQUENCY : return V4L2_CID_POWER_LINE_FREQUENCY;
-                case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return V4L2_CID_EXPOSURE_AUTO_PRIORITY;
-                default: throw linux_backend_exception(rsutils::string::from() << "no v4l2 mipi mapping cid for option " << option);
-            }
-        }
-
-        // D457 controls map - temporal solution to bypass backend interface with actual codes
-        uint32_t v4l_mipi_device::xu_to_cid(const extension_unit& xu, uint8_t control) const
-        {
-            if (0==xu.subdevice)
-            {
-                switch(control)
-                {
-                    case RS_HWMONITOR: return RS_CAMERA_CID_HWMC;
-                    case RS_DEPTH_EMITTER_ENABLED: return RS_CAMERA_CID_LASER_POWER;
-                    case RS_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE;//RS_CAMERA_CID_MANUAL_EXPOSURE; V4L2_CID_EXPOSURE_ABSOLUTE
-                    case RS_LASER_POWER: return RS_CAMERA_CID_MANUAL_LASER_POWER;
-                    case RS_ENABLE_AUTO_WHITE_BALANCE : return RS_CAMERA_CID_WHITE_BALANCE_MODE;
-                    case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; //RS_CAMERA_CID_EXPOSURE_MODE;
-                    case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
-                    case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
-                    case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;
-                    case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
-                    case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
-                    // D457 Missing functionality
-                    //case RS_ERROR_REPORTING: TBD;
-                    //case RS_EXT_TRIGGER: TBD;
-                    //case RS_ASIC_AND_PROJECTOR_TEMPERATURES: TBD;
-                    //case RS_LED_PWR: TBD;
-
-                    default: throw linux_backend_exception(rsutils::string::from() << "no v4l2 mipi cid for XU depth control " << std::dec << int(control));
-                }
-            }
-            else
-                throw linux_backend_exception(rsutils::string::from() << "MIPI Controls mapping is for Depth XU only, requested for subdevice " << xu.subdevice);
         }
 
         std::shared_ptr<uvc_device> v4l_backend::create_uvc_device(uvc_device_info info) const

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -529,9 +529,6 @@ namespace librealsense
             control_range get_pu_range(rs2_option option) const override;
             void set_metadata_attributes(buffers_mgr& buf_mgr, __u32 bytesused, uint8_t* md_start) override;
             bool is_platform_jetson() const override;
-        protected:
-            virtual uint32_t get_cid(rs2_option option) const;
-            uint32_t xu_to_cid(const extension_unit& xu, uint8_t control) const; // Find the mapping of XU to the underlying control
         };
 
         class v4l_backend : public backend

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -51,9 +51,14 @@ namespace librealsense
             static constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING         = ( RS_CAMERA_CID_BASE + 34 );
             static constexpr uint32_t RS_CAMERA_CID_AE_MODE                 = ( RS_CAMERA_CID_BASE + 35 );
 
+            static constexpr uint32_t RS_CAMERA_CID_SOC_PVT_TEMPERATURE     = ( RS_CAMERA_CID_BASE + 0x18 );
+            static constexpr uint32_t RS_CAMERA_CID_PROJECTOR_TEMPERATURE   = ( RS_CAMERA_CID_BASE + 0x19 );
+            static constexpr uint32_t RS_CAMERA_CID_OHM_TEMPERATURE         = ( RS_CAMERA_CID_BASE + 0x1A );
+            static constexpr uint32_t RS_CAMERA_CID_ERROR_CODE              = ( RS_CAMERA_CID_BASE + 0x1B );
+
             static constexpr uint8_t GVD_VALID_OPCODE = 0x10;
 
-            // D5xx / D457 MIPI depth-XU selector identifiers (subdevice 0).
+            // MIPI depth-XU selector identifiers (subdevice 0).
             static constexpr uint8_t RS_HWMONITOR                       = 1;
             static constexpr uint8_t RS_DEPTH_EMITTER_ENABLED           = 2;
             static constexpr uint8_t RS_EXPOSURE                        = 3;
@@ -69,6 +74,9 @@ namespace librealsense
             static constexpr uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
             static constexpr uint8_t RS_EXTERNAL_SYNC                   = 0x12;
             static constexpr uint8_t RS_READOUT_SHAPING                 = 0x13;
+            static constexpr uint8_t RS_PVT_TEMPERATURE                 = 0x15;
+            static constexpr uint8_t RS_PROJECTOR_TEMPERATURE           = 0x16;
+            static constexpr uint8_t RS_OHM_TEMPERATURE                 = 0x17;
 
             bool is_auto_exposure_control( uint8_t control )
             {
@@ -304,8 +312,11 @@ namespace librealsense
                     case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;
                     case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
                     case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
+                    case RS_PVT_TEMPERATURE : return RS_CAMERA_CID_SOC_PVT_TEMPERATURE;
+                    case RS_OHM_TEMPERATURE : return RS_CAMERA_CID_OHM_TEMPERATURE;
+                    case RS_PROJECTOR_TEMPERATURE : return RS_CAMERA_CID_PROJECTOR_TEMPERATURE;
+                    case RS_ERROR_REPORTING : return RS_CAMERA_CID_ERROR_CODE;
                     // D457 Missing functionality
-                    //case RS_ERROR_REPORTING: TBD;
                     //case RS_EXT_TRIGGER: TBD;
                     //case RS_ASIC_AND_PROJECTOR_TEMPERATURES: TBD;
                     //case RS_LED_PWR: TBD;

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -25,51 +25,50 @@ namespace librealsense
             // MIPI/GMSL V4L2 control ids. Mirrors the driver's RS_CAMERA_CID_BASE range.
             static constexpr uint32_t RS_STREAM_CONFIG_0                    = 0x4000;
             static constexpr uint32_t RS_CAMERA_CID_BASE                    = ( V4L2_CTRL_CLASS_CAMERA | RS_STREAM_CONFIG_0 );
-            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER             = ( RS_CAMERA_CID_BASE + 1 );
-            static constexpr uint32_t RS_CAMERA_CID_MANUAL_LASER_POWER      = ( RS_CAMERA_CID_BASE + 2 );
-            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 3 );
-            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 4 );
-            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 5 );
-            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 6 );
-            static constexpr uint32_t RS_CAMERA_CID_FW_VERSION              = ( RS_CAMERA_CID_BASE + 7 );
-            static constexpr uint32_t RS_CAMERA_CID_GVD                     = ( RS_CAMERA_CID_BASE + 8 );
-            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_GET              = ( RS_CAMERA_CID_BASE + 9 );
-            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_SET              = ( RS_CAMERA_CID_BASE + 10 );
-            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_GET         = ( RS_CAMERA_CID_BASE + 11 );
-            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_SET         = ( RS_CAMERA_CID_BASE + 12 );
-            static constexpr uint32_t RS_CAMERA_CID_ERB                     = ( RS_CAMERA_CID_BASE + 13 );
-            static constexpr uint32_t RS_CAMERA_CID_EWB                     = ( RS_CAMERA_CID_BASE + 14 );
-            static constexpr uint32_t RS_CAMERA_CID_HWMC_LEGACY             = ( RS_CAMERA_CID_BASE + 15 );
-            static constexpr uint32_t RS_CAMERA_CID_SYNC_MODE               = ( RS_CAMERA_CID_BASE + 16 );
-            static constexpr uint32_t RS_CAMERA_CID_MANUAL_EXPOSURE         = ( RS_CAMERA_CID_BASE + 17 );
-            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER_LEVEL       = ( RS_CAMERA_CID_BASE + 18 ); // RS_CAMERA_CID_MANUAL_LASER_POWER ??
-            static constexpr uint32_t RS_CAMERA_CID_EXPOSURE_MODE           = ( RS_CAMERA_CID_BASE + 19 );
-            static constexpr uint32_t RS_CAMERA_CID_WHITE_BALANCE_MODE      = ( RS_CAMERA_CID_BASE + 20 ); // Similar to RS_CAMERA_CID_EWB ??
-            static constexpr uint32_t RS_CAMERA_CID_PRESET                  = ( RS_CAMERA_CID_BASE + 21 );
-            static constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY       = ( RS_CAMERA_CID_BASE + 22 ); // [MIPI - Select projector frequency values: 0->57[KHZ], 1->91[KHZ]
-            static constexpr uint32_t RS_CAMERA_CID_HWMC                    = ( RS_CAMERA_CID_BASE + 32 );
-            static constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING         = ( RS_CAMERA_CID_BASE + 34 );
-            static constexpr uint32_t RS_CAMERA_CID_AE_MODE                 = ( RS_CAMERA_CID_BASE + 35 );
-
+            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER             = ( RS_CAMERA_CID_BASE + 0x01 );
+            static constexpr uint32_t RS_CAMERA_CID_MANUAL_LASER_POWER      = ( RS_CAMERA_CID_BASE + 0x02 );
+            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 0x03 );
+            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 0x04 );
+            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 0x05 );
+            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 0x06 );
+            static constexpr uint32_t RS_CAMERA_CID_FW_VERSION              = ( RS_CAMERA_CID_BASE + 0x07 );
+            static constexpr uint32_t RS_CAMERA_CID_GVD                     = ( RS_CAMERA_CID_BASE + 0x08 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_GET              = ( RS_CAMERA_CID_BASE + 0x09 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_SET              = ( RS_CAMERA_CID_BASE + 0x0A );
+            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_GET         = ( RS_CAMERA_CID_BASE + 0x0B );
+            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_SET         = ( RS_CAMERA_CID_BASE + 0x0C );
+            static constexpr uint32_t RS_CAMERA_CID_ERB                     = ( RS_CAMERA_CID_BASE + 0x0D );
+            static constexpr uint32_t RS_CAMERA_CID_EWB                     = ( RS_CAMERA_CID_BASE + 0x0E );
+            static constexpr uint32_t RS_CAMERA_CID_HWMC_LEGACY             = ( RS_CAMERA_CID_BASE + 0x0F );
+            static constexpr uint32_t RS_CAMERA_CID_SYNC_MODE               = ( RS_CAMERA_CID_BASE + 0x10 );
+            static constexpr uint32_t RS_CAMERA_CID_MANUAL_EXPOSURE         = ( RS_CAMERA_CID_BASE + 0x11 );
+            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER_LEVEL       = ( RS_CAMERA_CID_BASE + 0x12 );
+            static constexpr uint32_t RS_CAMERA_CID_EXPOSURE_MODE           = ( RS_CAMERA_CID_BASE + 0x13 );
+            static constexpr uint32_t RS_CAMERA_CID_WHITE_BALANCE_MODE      = ( RS_CAMERA_CID_BASE + 0x14 );
+            static constexpr uint32_t RS_CAMERA_CID_PRESET                  = ( RS_CAMERA_CID_BASE + 0x15 );
+            static constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY       = ( RS_CAMERA_CID_BASE + 0x16 ); // MIPI projector frequency: 0->57[KHz], 1->91[KHz]
             static constexpr uint32_t RS_CAMERA_CID_SOC_PVT_TEMPERATURE     = ( RS_CAMERA_CID_BASE + 0x18 );
             static constexpr uint32_t RS_CAMERA_CID_PROJECTOR_TEMPERATURE   = ( RS_CAMERA_CID_BASE + 0x19 );
             static constexpr uint32_t RS_CAMERA_CID_OHM_TEMPERATURE         = ( RS_CAMERA_CID_BASE + 0x1A );
             static constexpr uint32_t RS_CAMERA_CID_ERROR_CODE              = ( RS_CAMERA_CID_BASE + 0x1B );
+            static constexpr uint32_t RS_CAMERA_CID_HWMC                    = ( RS_CAMERA_CID_BASE + 0x20 );
+            static constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING         = ( RS_CAMERA_CID_BASE + 0x22 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_MODE                 = ( RS_CAMERA_CID_BASE + 0x23 );
 
             static constexpr uint8_t GVD_VALID_OPCODE = 0x10;
 
             // MIPI depth-XU selector identifiers (subdevice 0).
-            static constexpr uint8_t RS_HWMONITOR                       = 1;
-            static constexpr uint8_t RS_DEPTH_EMITTER_ENABLED           = 2;
-            static constexpr uint8_t RS_EXPOSURE                        = 3;
-            static constexpr uint8_t RS_LASER_POWER                     = 4;
-            static constexpr uint8_t RS_HARDWARE_PRESET                 = 6;
-            static constexpr uint8_t RS_ERROR_REPORTING                 = 7;
-            static constexpr uint8_t RS_EXT_TRIGGER                     = 8;
-            static constexpr uint8_t RS_ASIC_AND_PROJECTOR_TEMPERATURES = 9;
-            static constexpr uint8_t RS_ENABLE_AUTO_WHITE_BALANCE       = 0xA;
-            static constexpr uint8_t RS_ENABLE_AUTO_EXPOSURE            = 0xB;
-            static constexpr uint8_t RS_LED_PWR                         = 0xE;
+            static constexpr uint8_t RS_HWMONITOR                       = 0x01;
+            static constexpr uint8_t RS_DEPTH_EMITTER_ENABLED           = 0x02;
+            static constexpr uint8_t RS_EXPOSURE                        = 0x03;
+            static constexpr uint8_t RS_LASER_POWER                     = 0x04;
+            static constexpr uint8_t RS_HARDWARE_PRESET                 = 0x06;
+            static constexpr uint8_t RS_ERROR_REPORTING                 = 0x07;
+            static constexpr uint8_t RS_EXT_TRIGGER                     = 0x08;
+            static constexpr uint8_t RS_ASIC_AND_PROJECTOR_TEMPERATURES = 0x09;
+            static constexpr uint8_t RS_ENABLE_AUTO_WHITE_BALANCE       = 0x0A;
+            static constexpr uint8_t RS_ENABLE_AUTO_EXPOSURE            = 0x0B;
+            static constexpr uint8_t RS_LED_PWR                         = 0x0E;
             static constexpr uint8_t RS_EMITTER_FREQUENCY               = 0x10; // Match to DS5_EMITTER_FREQUENCY
             static constexpr uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
             static constexpr uint8_t RS_EXTERNAL_SYNC                   = 0x12;
@@ -277,8 +276,8 @@ namespace librealsense
                 case RS2_OPTION_BACKLIGHT_COMPENSATION: return V4L2_CID_BACKLIGHT_COMPENSATION;
                 case RS2_OPTION_BRIGHTNESS: return V4L2_CID_BRIGHTNESS;
                 case RS2_OPTION_CONTRAST: return V4L2_CID_CONTRAST;
-                case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE; // Is this actually valid? I'm getting a lot of VIDIOC error 22s...
-                case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903; // v4l2-ctl --list-ctrls -d /dev/video0
+                case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE;
+                case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903;
                 case RS2_OPTION_GAMMA: return V4L2_CID_GAMMA;
                 // case RS2_OPTION_HUE: return V4L2_CID_HUE;
                 case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
@@ -303,10 +302,10 @@ namespace librealsense
                     {
                     case RS_HWMONITOR: return RS_CAMERA_CID_HWMC;
                     case RS_DEPTH_EMITTER_ENABLED: return RS_CAMERA_CID_LASER_POWER;
-                    case RS_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE;//RS_CAMERA_CID_MANUAL_EXPOSURE; V4L2_CID_EXPOSURE_ABSOLUTE
+                    case RS_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE;
                     case RS_LASER_POWER: return RS_CAMERA_CID_MANUAL_LASER_POWER;
                     case RS_ENABLE_AUTO_WHITE_BALANCE : return RS_CAMERA_CID_WHITE_BALANCE_MODE;
-                    case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; //RS_CAMERA_CID_EXPOSURE_MODE;
+                    case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO;
                     case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
                     case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
                     case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -4,6 +4,9 @@
 #include "v4l-mipi-logic.h"
 #include "backend-v4l2.h"  // xioctl(), linux_backend_exception
 
+#include <src/platform/uvc-device.h>  // extension_unit
+#include <rsutils/string/from.h>
+
 #include <linux/media.h>  // media_device_info, MEDIA_IOC_DEVICE_INFO
 
 #include <cstring>
@@ -19,12 +22,58 @@ namespace librealsense
     {
         namespace v4l_mipi_logic
         {
-            // MIPI GVD control id.
-            static constexpr uint32_t RS_STREAM_CONFIG_0 = 0x4000;
-            static constexpr uint32_t RS_CAMERA_CID_BASE = ( V4L2_CTRL_CLASS_CAMERA | RS_STREAM_CONFIG_0 );
-            static constexpr uint32_t RS_CAMERA_CID_GVD = ( RS_CAMERA_CID_BASE + 8 );
+            // MIPI/GMSL V4L2 control ids. Mirrors the driver's RS_CAMERA_CID_BASE range.
+            static constexpr uint32_t RS_STREAM_CONFIG_0                    = 0x4000;
+            static constexpr uint32_t RS_CAMERA_CID_BASE                    = ( V4L2_CTRL_CLASS_CAMERA | RS_STREAM_CONFIG_0 );
+            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER             = ( RS_CAMERA_CID_BASE + 1 );
+            static constexpr uint32_t RS_CAMERA_CID_MANUAL_LASER_POWER      = ( RS_CAMERA_CID_BASE + 2 );
+            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 3 );
+            static constexpr uint32_t RS_CAMERA_DEPTH_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 4 );
+            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_GET = ( RS_CAMERA_CID_BASE + 5 );
+            static constexpr uint32_t RS_CAMERA_COEFF_CALIBRATION_TABLE_SET = ( RS_CAMERA_CID_BASE + 6 );
+            static constexpr uint32_t RS_CAMERA_CID_FW_VERSION              = ( RS_CAMERA_CID_BASE + 7 );
+            static constexpr uint32_t RS_CAMERA_CID_GVD                     = ( RS_CAMERA_CID_BASE + 8 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_GET              = ( RS_CAMERA_CID_BASE + 9 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_ROI_SET              = ( RS_CAMERA_CID_BASE + 10 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_GET         = ( RS_CAMERA_CID_BASE + 11 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_SETPOINT_SET         = ( RS_CAMERA_CID_BASE + 12 );
+            static constexpr uint32_t RS_CAMERA_CID_ERB                     = ( RS_CAMERA_CID_BASE + 13 );
+            static constexpr uint32_t RS_CAMERA_CID_EWB                     = ( RS_CAMERA_CID_BASE + 14 );
+            static constexpr uint32_t RS_CAMERA_CID_HWMC_LEGACY             = ( RS_CAMERA_CID_BASE + 15 );
+            static constexpr uint32_t RS_CAMERA_CID_SYNC_MODE               = ( RS_CAMERA_CID_BASE + 16 );
+            static constexpr uint32_t RS_CAMERA_CID_MANUAL_EXPOSURE         = ( RS_CAMERA_CID_BASE + 17 );
+            static constexpr uint32_t RS_CAMERA_CID_LASER_POWER_LEVEL       = ( RS_CAMERA_CID_BASE + 18 ); // RS_CAMERA_CID_MANUAL_LASER_POWER ??
+            static constexpr uint32_t RS_CAMERA_CID_EXPOSURE_MODE           = ( RS_CAMERA_CID_BASE + 19 );
+            static constexpr uint32_t RS_CAMERA_CID_WHITE_BALANCE_MODE      = ( RS_CAMERA_CID_BASE + 20 ); // Similar to RS_CAMERA_CID_EWB ??
+            static constexpr uint32_t RS_CAMERA_CID_PRESET                  = ( RS_CAMERA_CID_BASE + 21 );
+            static constexpr uint32_t RS_CAMERA_CID_EMITTER_FREQUENCY       = ( RS_CAMERA_CID_BASE + 22 ); // [MIPI - Select projector frequency values: 0->57[KHZ], 1->91[KHZ]
+            static constexpr uint32_t RS_CAMERA_CID_HWMC                    = ( RS_CAMERA_CID_BASE + 32 );
+            static constexpr uint32_t RS_CAMERA_CID_READOUT_SHAPING         = ( RS_CAMERA_CID_BASE + 34 );
+            static constexpr uint32_t RS_CAMERA_CID_AE_MODE                 = ( RS_CAMERA_CID_BASE + 35 );
 
             static constexpr uint8_t GVD_VALID_OPCODE = 0x10;
+
+            // D5xx / D457 MIPI depth-XU selector identifiers (subdevice 0).
+            static constexpr uint8_t RS_HWMONITOR                       = 1;
+            static constexpr uint8_t RS_DEPTH_EMITTER_ENABLED           = 2;
+            static constexpr uint8_t RS_EXPOSURE                        = 3;
+            static constexpr uint8_t RS_LASER_POWER                     = 4;
+            static constexpr uint8_t RS_HARDWARE_PRESET                 = 6;
+            static constexpr uint8_t RS_ERROR_REPORTING                 = 7;
+            static constexpr uint8_t RS_EXT_TRIGGER                     = 8;
+            static constexpr uint8_t RS_ASIC_AND_PROJECTOR_TEMPERATURES = 9;
+            static constexpr uint8_t RS_ENABLE_AUTO_WHITE_BALANCE       = 0xA;
+            static constexpr uint8_t RS_ENABLE_AUTO_EXPOSURE            = 0xB;
+            static constexpr uint8_t RS_LED_PWR                         = 0xE;
+            static constexpr uint8_t RS_EMITTER_FREQUENCY               = 0x10; // Match to DS5_EMITTER_FREQUENCY
+            static constexpr uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
+            static constexpr uint8_t RS_EXTERNAL_SYNC                   = 0x12;
+            static constexpr uint8_t RS_READOUT_SHAPING                 = 0x13;
+
+            bool is_auto_exposure_control( uint8_t control )
+            {
+                return control == RS_ENABLE_AUTO_EXPOSURE;
+            }
 
             std::vector< uint8_t > get_gvd( const std::string & dev_name )
             {
@@ -211,6 +260,61 @@ namespace librealsense
             std::string rs_enum_dfu_node_path( int cam_idx )
             {
                 return "/dev/d4xx-dfu-" + std::to_string( cam_idx );
+            }
+
+            uint32_t option_to_cid( rs2_option option )
+            {
+                switch( option )
+                {
+                case RS2_OPTION_BACKLIGHT_COMPENSATION: return V4L2_CID_BACKLIGHT_COMPENSATION;
+                case RS2_OPTION_BRIGHTNESS: return V4L2_CID_BRIGHTNESS;
+                case RS2_OPTION_CONTRAST: return V4L2_CID_CONTRAST;
+                case RS2_OPTION_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE; // Is this actually valid? I'm getting a lot of VIDIOC error 22s...
+                case RS2_OPTION_GAIN: return V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x903; // v4l2-ctl --list-ctrls -d /dev/video0
+                case RS2_OPTION_GAMMA: return V4L2_CID_GAMMA;
+                // case RS2_OPTION_HUE: return V4L2_CID_HUE;
+                case RS2_OPTION_LASER_POWER: return V4L2_CID_EXPOSURE_ABSOLUTE;
+                case RS2_OPTION_EMITTER_ENABLED: return V4L2_CID_EXPOSURE_AUTO;
+                case RS2_OPTION_SATURATION: return V4L2_CID_SATURATION;
+                case RS2_OPTION_SHARPNESS: return V4L2_CID_SHARPNESS;
+                case RS2_OPTION_WHITE_BALANCE: return V4L2_CID_WHITE_BALANCE_TEMPERATURE;
+                case RS2_OPTION_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; // Automatic gain/exposure control
+                case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return V4L2_CID_AUTO_WHITE_BALANCE;
+                case RS2_OPTION_POWER_LINE_FREQUENCY : return V4L2_CID_POWER_LINE_FREQUENCY;
+                case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return V4L2_CID_EXPOSURE_AUTO_PRIORITY;
+                default: throw linux_backend_exception( rsutils::string::from() << "no v4l2 mipi mapping cid for option " << option );
+                }
+            }
+
+            // D457 controls map - temporal solution to bypass backend interface with actual codes
+            uint32_t xu_to_cid( const extension_unit & xu, uint8_t control )
+            {
+                if( 0 == xu.subdevice )
+                {
+                    switch( control )
+                    {
+                    case RS_HWMONITOR: return RS_CAMERA_CID_HWMC;
+                    case RS_DEPTH_EMITTER_ENABLED: return RS_CAMERA_CID_LASER_POWER;
+                    case RS_EXPOSURE: return V4L2_CID_EXPOSURE_ABSOLUTE;//RS_CAMERA_CID_MANUAL_EXPOSURE; V4L2_CID_EXPOSURE_ABSOLUTE
+                    case RS_LASER_POWER: return RS_CAMERA_CID_MANUAL_LASER_POWER;
+                    case RS_ENABLE_AUTO_WHITE_BALANCE : return RS_CAMERA_CID_WHITE_BALANCE_MODE;
+                    case RS_ENABLE_AUTO_EXPOSURE: return V4L2_CID_EXPOSURE_AUTO; //RS_CAMERA_CID_EXPOSURE_MODE;
+                    case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
+                    case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
+                    case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;
+                    case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
+                    case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
+                    // D457 Missing functionality
+                    //case RS_ERROR_REPORTING: TBD;
+                    //case RS_EXT_TRIGGER: TBD;
+                    //case RS_ASIC_AND_PROJECTOR_TEMPERATURES: TBD;
+                    //case RS_LED_PWR: TBD;
+
+                    default: throw linux_backend_exception( rsutils::string::from() << "no v4l2 mipi cid for XU depth control " << std::dec << int( control ) );
+                    }
+                }
+                else
+                    throw linux_backend_exception( rsutils::string::from() << "MIPI Controls mapping is for Depth XU only, requested for subdevice " << xu.subdevice );
             }
         }  // namespace v4l_mipi_logic
     }  // namespace platform

--- a/src/linux/v4l-mipi-logic.h
+++ b/src/linux/v4l-mipi-logic.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <librealsense2/h/rs_option.h>  // rs2_option
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -11,9 +13,20 @@ namespace librealsense
 {
     namespace platform
     {
+        struct extension_unit;
+
         // Low-level V4L2 MIPI/GMSL primitives: raw device queries and node naming conventions.
         namespace v4l_mipi_logic
         {
+            // Translate a USB like XU (subdevice, selector) to its V4L2 control id. Throws on an unmapped selector.
+            uint32_t xu_to_cid( const extension_unit & xu, uint8_t control );
+
+            // Translate an rs2_option (processing-unit control) to its V4L2 control id. Throws on an unmapped option.
+            uint32_t option_to_cid( rs2_option option );
+
+            // Whether an XU selector is the auto-exposure control, which the backend maps to/from V4L2 enum values.
+            bool is_auto_exposure_control( uint8_t control );
+
             // Read the device's raw GVD buffer. Validates the response opcode, retrying as needed. Throws on failure.
             std::vector< uint8_t > get_gvd( const std::string & dev_name );
 
@@ -25,8 +38,8 @@ namespace librealsense
             // Trailing index of a video node name (e.g. "video2" -> 2). Throws if the name has no index.
             int parse_video_index( const std::string & name );
 
-            // Map a video node index to its camera id and interface indicator (video/metadata/IMU). Throws on
-            // an index that does not fit the per-camera node layout.
+            // Map a video node index to its camera id and interface indicator (video/metadata/IMU).
+            // Throws on an index that does not fit the per-camera node layout.
             void derive_mi_and_cam_id( int video_index, uint16_t & mi, int & cam_id );
 
             // rs-enum link naming conventions


### PR DESCRIPTION
Tracked on [RSDEV-13153], [RSDEV-13154], [RSDEV-13155]

Enable D585 GMSL depth/color controls and refactor MIPI CID mapping

* Refactor: moved all MIPI/GMSL V4L2 control-id definitions and the XU→CID / option→CID translation out of backend-v4l2 into v4l-mipi-logic; the backend now delegates to it.
* Enabled over GMSL, previously skipped on MIPI: depth SOC PVT / OHM / Projector temperatures, color Brightness / Contrast / Gamma, and Error Polling Enabled.
*Added the corresponding depth-XU CIDs (temperatures, error code) and added D585_GMSL_PID to the projector-temperature PID set.
*Removed the depth_units==0 fallback in depth_scale_option::query() — FW now reports a valid value.
*Removed the Jetson YUYV→UYVY byte-swap workaround in d500-color; YUYV uses the standard converter path.
*Verified on D585 GMSL (driver 1.0.5.14): temperatures, color controls, and depth units read correctly; color image confirmed correct in the viewer.
