### PR TITLE
d5x5 TC: post-merge host fixes + FW-side COMMIT-persistence diagnostic (RSDEV-13186)

### DIFF
--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -667,6 +667,11 @@ namespace rs2
         // BeginDisabled blocks both the click AND the widget's internal _try_side write while a phase is in flight.
         // The action is deferred until AFTER EndDisabled so a throw from start_action_phase() (thread ctor,
         // allocation) cannot leak the disabled stack across frames.
+        // Capture _try_side BEFORE the RadioButton widgets get a chance to overwrite it — ImGui returns pressed=true
+        // on any click, including on the already-selected radio, so `1 - _try_side` (the previous version's guess)
+        // is only correct when the click actually changes selection. A re-click on the same radio would otherwise
+        // roll the UI to the opposite side on failure — precisely the inverse of what we want.
+        const int try_side_before_click = _try_side;
         ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
         ImGui::BeginDisabled(in_flight);
         const bool try_new_clicked = ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0);
@@ -675,12 +680,12 @@ namespace rs2
         ImGui::EndDisabled();
         if (try_new_clicked)
         {
-            _pending_try_revert_to = 1;   // roll back to OLD if this TRY fails
+            _pending_try_revert_to = try_side_before_click;
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
         }
         else if (try_old_clicked)
         {
-            _pending_try_revert_to = 0;   // roll back to NEW if this TRY fails
+            _pending_try_revert_to = try_side_before_click;
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
         }
 

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -238,9 +238,25 @@ namespace rs2
                 return;         // leave streaming on — TRY/COMMIT/ABORT need it live
             }
 
-            // Interactive TRY_NEW/TRY_OLD are one-shot live-preview toggles — mark done, keep stream live.
+            // Interactive TRY_NEW/TRY_OLD switch the FW's active depth table in RAM. The running stream keeps the
+            // intrinsics it computed at start(), so the preview is invisible unless we stop and restart it — same
+            // problem the D500 auto-calibration flow has after write_calibration(). Only touch the stream if it was
+            // us who started it (auto-start recorded state in _saved_ui); otherwise leave the user's stream alone.
             if (interactive_try)
             {
+                if (_saved_ui)
+                {
+                    stop_viewer(invoke);
+                    try
+                    {
+                        try_start_viewer(1280, 720, 30, invoke);
+                    }
+                    catch (const std::exception & e)
+                    {
+                        LOG_WARNING("Interactive TC: depth restart on TRY failed (" << e.what()
+                                    << ") — preview will not reflect the switch until stream is restarted manually");
+                    }
+                }
                 _done = true;
                 return;
             }

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -627,10 +627,9 @@ namespace rs2
                                  d500_on_chip_calib_manager::k_rect_health_pass_threshold_px);
 
         // Row: [radio Try New] [radio Try Old] [Commit] [Discard]. Ignore the caller's bar_width — it reserves a 115px
-        // right gutter for the base Dismiss button, which we've hidden above; use the full popup width instead.
+        // right gutter for the base Dismiss button, which we've hidden above; radio buttons + fixed-width buttons fit
+        // in the popup natively (ImGui::SameLine + ImGui default spacing).
         (void)bar_width;
-        const float row_width = float(width - 10);
-        const float spacing = ImGui::GetStyle().ItemSpacing.x;
         const float btn_y = float(y + height - 28);
         const float btn_w = 100.f;   // Commit/Discard fixed; radio buttons occupy the remaining space
 
@@ -648,17 +647,19 @@ namespace rs2
 
         // Radio pair — user selects which candidate is live. Each toggle fires the matching TRY action so FW switches
         // the RAM-active depth table; the currently-selected radio then shows which table is being previewed.
-        // BeginDisabled blocks both the click AND the visual state change while a phase is in flight — using a plain
-        // `&& !in_flight` on the click check would let RadioButton mutate _try_side inside the widget call, showing
-        // the wrong side selected until the next redraw.
+        // BeginDisabled blocks both the click AND the widget's internal _try_side write while a phase is in flight.
+        // The action is deferred until AFTER EndDisabled so a throw from start_action_phase() (thread ctor,
+        // allocation) cannot leak the disabled stack across frames.
         ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
         ImGui::BeginDisabled(in_flight);
-        if (ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0))
-            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
+        const bool try_new_clicked = ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0);
         ImGui::SameLine();
-        if (ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1))
-            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
+        const bool try_old_clicked = ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1);
         ImGui::EndDisabled();
+        if (try_new_clicked)
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
+        else if (try_old_clicked)
+            start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
 
         ImGui::SameLine();
         // Commit is health-gated AND in-flight-gated: dim on either condition; swallow the click accordingly.

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -234,8 +234,20 @@ namespace rs2
             if (interactive_run)
             {
                 _scalar_health = health;
-                _done = true;   // "done" here means "phase complete"; the notification UI transitions to HEALTH_CHECK
-                return;         // leave streaming on — TRY/COMMIT/ABORT need it live
+                // `health < 0.f` is the SDK's sentinel for "FW did not report SUCCESS" (see
+                // d500_auto_calibrated::run_interactive_triggered_calibration). In that case there is no meaningful
+                // candidate to Commit/Try/Discard — surface the run as failed so the notification model shows the
+                // FAILED popup (update_ui_on_failure) instead of the HEALTH_CHECK screen, matching the D585S legacy UX.
+                if (health < 0.f)
+                {
+                    restore_workspace(invoke);   // stop the auto-started depth stream, restore user's prior stream
+                    _failed = true;
+                }
+                else
+                {
+                    _done = true;   // "done" here means "phase complete"; the notification UI transitions to HEALTH_CHECK
+                }
+                return;             // on success, leave streaming on — TRY/COMMIT/ABORT need it live
             }
 
             // Interactive TRY_NEW/TRY_OLD switch the FW's active depth table in RAM. The running stream keeps the

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -626,14 +626,13 @@ namespace rs2
         else         ImGui::Text("Rect health: %.3f px  (threshold %.3f)", h,
                                  d500_on_chip_calib_manager::k_rect_health_pass_threshold_px);
 
-        // Button row: Try New | Try Old | Commit | Discard. Ignore the caller's bar_width — it reserves a 115px
+        // Row: [radio Try New] [radio Try Old] [Commit] [Discard]. Ignore the caller's bar_width — it reserves a 115px
         // right gutter for the base Dismiss button, which we've hidden above; use the full popup width instead.
-        // Reserve 3 × ImGui default ItemSpacing.x (~8px each) between the four buttons so Discard doesn't clip the right edge.
         (void)bar_width;
         const float row_width = float(width - 10);
         const float spacing = ImGui::GetStyle().ItemSpacing.x;
-        const float btn_w = (row_width - 3.f * spacing) / 4.f;
         const float btn_y = float(y + height - 28);
+        const float btn_w = 100.f;   // Commit/Discard fixed; radio buttons occupy the remaining space
 
         std::string try_new_id  = rsutils::string::from() << "Try New##"  << index;
         std::string try_old_id  = rsutils::string::from() << "Try Old##"  << index;
@@ -642,24 +641,19 @@ namespace rs2
 
         // The notification base pushes a near-transparent ImGuiCol_Button (see notification_model::set_color_scheme),
         // so buttons on this row need their own scheme to read as clickable — matches calibration_button() and the
-        // rest of on-chip-calib.
+        // rest of on-chip-calib. Radio buttons use their own ImGui colors so no push is needed for them.
         const auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
-        const float active_sat  = in_flight ? 0.4f : sat;
-        const float hover_sat   = in_flight ? 0.4f : 1.5f;
+        const float active_sat = in_flight ? 0.4f : sat;
+        const float hover_sat  = in_flight ? 0.4f : 1.5f;
 
+        // Radio pair — user selects which candidate is live. Each toggle fires the matching TRY action so FW switches
+        // the RAM-active depth table; the currently-selected radio then shows which table is being previewed.
         ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
-        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, active_sat));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, hover_sat));
-        if (ImGui::Button(try_new_id.c_str(), { btn_w, 20.f }) && !in_flight)
+        if (ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0) && !in_flight)
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
-        ImGui::PopStyleColor(2);
-
         ImGui::SameLine();
-        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, active_sat));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, hover_sat));
-        if (ImGui::Button(try_old_id.c_str(), { btn_w, 20.f }) && !in_flight)
+        if (ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1) && !in_flight)
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
-        ImGui::PopStyleColor(2);
 
         ImGui::SameLine();
         // Commit is health-gated AND in-flight-gated: dim on either condition; swallow the click accordingly.

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -648,12 +648,17 @@ namespace rs2
 
         // Radio pair — user selects which candidate is live. Each toggle fires the matching TRY action so FW switches
         // the RAM-active depth table; the currently-selected radio then shows which table is being previewed.
+        // BeginDisabled blocks both the click AND the visual state change while a phase is in flight — using a plain
+        // `&& !in_flight` on the click check would let RadioButton mutate _try_side inside the widget call, showing
+        // the wrong side selected until the next redraw.
         ImGui::SetCursorScreenPos({ float(x + 5), btn_y });
-        if (ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0) && !in_flight)
+        ImGui::BeginDisabled(in_flight);
+        if (ImGui::RadioButton(try_new_id.c_str(), &_try_side, 0))
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
         ImGui::SameLine();
-        if (ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1) && !in_flight)
+        if (ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1))
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
+        ImGui::EndDisabled();
 
         ImGui::SameLine();
         // Commit is health-gated AND in-flight-gated: dim on either condition; swallow the click accordingly.

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -250,25 +250,9 @@ namespace rs2
                 return;             // on success, leave streaming on — TRY/COMMIT/ABORT need it live
             }
 
-            // Interactive TRY_NEW/TRY_OLD switch the FW's active depth table in RAM. The running stream keeps the
-            // intrinsics it computed at start(), so the preview is invisible unless we stop and restart it — same
-            // problem the D500 auto-calibration flow has after write_calibration(). Only touch the stream if it was
-            // us who started it (auto-start recorded state in _saved_ui); otherwise leave the user's stream alone.
+            // TRY_NEW/TRY_OLD: do not stop/restart the stream — the USB reconfigure prevents FW from applying the switch.
             if (interactive_try)
             {
-                if (_saved_ui)
-                {
-                    stop_viewer(invoke);
-                    try
-                    {
-                        try_start_viewer(1280, 720, 30, invoke);
-                    }
-                    catch (const std::exception & e)
-                    {
-                        LOG_WARNING("Interactive TC: depth restart on TRY failed (" << e.what()
-                                    << ") — preview will not reflect the switch until stream is restarted manually");
-                    }
-                }
                 _done = true;
                 return;
             }

--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -618,6 +618,23 @@ namespace rs2
                             && !update_manager->failed();
         const bool commit_enabled = passes && !in_flight;
 
+        // Settle a pending TRY: if the phase finished, either roll _try_side back (on failure) or clear the flag
+        // (on success). Without this, RadioButton's inline write leaves the UI asserting a candidate is active
+        // while FW never actually switched — same UI-lies-about-FW-state hazard as the in-flight race, reached
+        // via the failure path.
+        if (_pending_try_revert_to != -1 && update_manager)
+        {
+            if (update_manager->failed())
+            {
+                _try_side = _pending_try_revert_to;
+                _pending_try_revert_to = -1;
+            }
+            else if (update_manager->done())
+            {
+                _pending_try_revert_to = -1;
+            }
+        }
+
         ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
         ImGui::Text("%s", passes ? "Health check: PASS" : "Health check: FAIL");
 
@@ -657,9 +674,15 @@ namespace rs2
         const bool try_old_clicked = ImGui::RadioButton(try_old_id.c_str(), &_try_side, 1);
         ImGui::EndDisabled();
         if (try_new_clicked)
+        {
+            _pending_try_revert_to = 1;   // roll back to OLD if this TRY fails
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_NEW);
+        }
         else if (try_old_clicked)
+        {
+            _pending_try_revert_to = 0;   // roll back to NEW if this TRY fails
             start_action_phase(d500_on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB_TRY_OLD);
+        }
 
         ImGui::SameLine();
         // Commit is health-gated AND in-flight-gated: dim on either condition; swallow the click accordingly.

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -138,6 +138,11 @@ namespace rs2
         // "apply the HEALTH_CHECK-cached candidate live". So on entry the active table is the flashed (OLD) one; the
         // user must click NEW to preview the candidate. Pending FW confirmation; flip to 0 if FW auto-applies at HC.
         int _try_side = 1;
+        // Side to restore _try_side to if the currently-pending TRY fails on the FW side. -1 = no TRY pending.
+        // ImGui::RadioButton mutates _try_side inside the widget call, so on a failure the UI would keep asserting
+        // the wrong side without this rollback. draw_health_check reads update_manager->done()/failed() to detect
+        // settlement and restores or clears the pending state accordingly.
+        int _pending_try_revert_to = -1;
     };
 
 }

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -52,7 +52,9 @@ namespace rs2
         // include, deliberately not surfaced through common/ to avoid a public API addition.
         bool uses_interactive_triggered_calibration() const;
         float get_scalar_health() const { return _scalar_health; }
-        static constexpr float k_rect_health_pass_threshold_px = 0.4f;   // provisional per spec §5.5
+        // Must match librealsense::rect_health_pass_threshold_px in src/calibration-engine-interface.h.
+        // The viewer cannot include that SDK-internal header, so the value is mirrored here.
+        static constexpr float k_rect_health_pass_threshold_px = 0.4f;
         bool health_passes() const { return _scalar_health >= 0.f && _scalar_health < k_rect_health_pass_threshold_px; }
 
     private:

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -132,6 +132,10 @@ namespace rs2
         std::string _error_message = "";
         bool reset_called = false;
         bool _has_abort_succeeded = false;
+        // Radio-button state on the HEALTH_CHECK screen: 0 = NEW (candidate) is active, 1 = OLD (flashed) is active.
+        // Initialized to NEW to match FW's default at HEALTH_CHECK entry. Toggled by the user, and each toggle fires
+        // the matching TRY action to swap the FW's RAM-active depth table.
+        int _try_side = 0;
     };
 
 }

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -133,9 +133,11 @@ namespace rs2
         bool reset_called = false;
         bool _has_abort_succeeded = false;
         // Radio-button state on the HEALTH_CHECK screen: 0 = NEW (candidate) is active, 1 = OLD (flashed) is active.
-        // Initialized to NEW to match FW's default at HEALTH_CHECK entry. Toggled by the user, and each toggle fires
-        // the matching TRY action to swap the FW's RAM-active depth table.
-        int _try_side = 0;
+        // Initialised to OLD because per the SDK enum docs (src/calibration-engine-interface.h) the HEALTH_CHECK
+        // state "caches" the candidate awaiting COMMIT/CANCEL — cached is not applied — and TRY_NEW is documented as
+        // "apply the HEALTH_CHECK-cached candidate live". So on entry the active table is the flashed (OLD) one; the
+        // user must click NEW to preview the candidate. Pending FW confirmation; flip to 0 if FW auto-applies at HC.
+        int _try_side = 1;
     };
 
 }

--- a/src/calibration-engine-interface.h
+++ b/src/calibration-engine-interface.h
@@ -49,20 +49,18 @@ enum class try_calibration_selection : uint8_t
 #pragma pack(push, 1)
 struct calibration_health_metrics
 {
-    float coverage_safe_for_depth;   // [0,1]  — pass: >= coverage_safe_for_depth_pass_threshold
+    float coverage_safe_for_depth;   // [0,1]  — informational; pass gate TBD (spec §5.5, ~0.50)
     float rect_health;               // px    — pass: <  rect_health_pass_threshold_px
     float rect_improvement;          // px    — informational only
-    float scale_health;              // px    — pass: <  scale_health_pass_threshold_px
+    float scale_health;              // px    — informational; pass gate TBD (spec §5.5, ~0.50)
     float scale_improvement;         // px    — informational only
 };
 #pragma pack(pop)
 
-// Provisional pass thresholds per spec §5.5 (subject to FW-team tuning). Kept out of the packed wire struct
-// above so future adjustments don't accidentally shift its layout. The viewer mirrors these in
-// common/d500-on-chip-calib.h — keep the two in sync.
-static constexpr float rect_health_pass_threshold_px           = 0.4f;
-static constexpr float scale_health_pass_threshold_px          = 0.5f;
-static constexpr float coverage_safe_for_depth_pass_threshold  = 0.5f;
+// Provisional pass threshold per spec §5.5. Only rect_health is host-gated today — coverage and scale
+// remain informational until the multi-metric gate lands (add matching constants at that time).
+// The viewer mirrors this in common/d500-on-chip-calib.h — keep the two in sync.
+static constexpr float rect_health_pass_threshold_px = 0.4f;
 
 class calibration_engine_interface
 {

--- a/src/calibration-engine-interface.h
+++ b/src/calibration-engine-interface.h
@@ -49,13 +49,20 @@ enum class try_calibration_selection : uint8_t
 #pragma pack(push, 1)
 struct calibration_health_metrics
 {
-    float coverage_safe_for_depth;   // [0,1]  — pass: >= Coverage_Threshold (0.50)
-    float rect_health;               // px    — pass: <  RectThreshold (0.40, provisional)
+    float coverage_safe_for_depth;   // [0,1]  — pass: >= coverage_safe_for_depth_pass_threshold
+    float rect_health;               // px    — pass: <  rect_health_pass_threshold_px
     float rect_improvement;          // px    — informational only
-    float scale_health;              // px    — pass: <  ScaleThreshold (0.50, provisional)
+    float scale_health;              // px    — pass: <  scale_health_pass_threshold_px
     float scale_improvement;         // px    — informational only
 };
 #pragma pack(pop)
+
+// Provisional pass thresholds per spec §5.5 (subject to FW-team tuning). Kept out of the packed wire struct
+// above so future adjustments don't accidentally shift its layout. The viewer mirrors these in
+// common/d500-on-chip-calib.h — keep the two in sync.
+static constexpr float rect_health_pass_threshold_px           = 0.4f;
+static constexpr float scale_health_pass_threshold_px          = 0.5f;
+static constexpr float coverage_safe_for_depth_pass_threshold  = 0.5f;
 
 class calibration_engine_interface
 {

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -69,6 +69,10 @@ namespace librealsense
             LOG_WARNING( "Interactive TC: CANCEL / status poll failed (" << e.what()
                          << ") — FW may not be in Idle when this returns" );
         }
+        catch( ... )
+        {
+            LOG_WARNING( "Interactive TC: CANCEL / status poll failed (non-std exception) — swallowed to keep cancel_and_wait_for_idle non-throwing" );
+        }
 
         // Belt-and-suspenders: on some FW builds CANCEL does not restore the flashed depth table into the RAM
         // slot that the depth pipeline reads, so the stream can end up rendering a half-baked candidate that
@@ -79,7 +83,9 @@ namespace librealsense
         {
             std::vector< uint8_t > dummy;
             auto flash_table = _calib_engine->get_calibration_table( dummy );
-            if( flash_table.size() >= sizeof( ds::table_header ) )
+            // Require an exact size match — matches set_calibration_table's own guard. A longer-than-expected HWM
+            // reply must not be pushed verbatim into the RAM slot the depth pipeline reads.
+            if( flash_table.size() == sizeof( ds::d500_coefficients_table ) )
             {
                 auto hdr = reinterpret_cast< const ds::table_header * >( flash_table.data() );
                 auto cmd = _debug_dev->build_command(
@@ -94,11 +100,24 @@ namespace librealsense
                 for( auto & cb : _depth_write_callbacks )
                     cb();
             }
+            else if( ! flash_table.empty() )
+            {
+                LOG_WARNING( "Interactive TC: flash→RAM revert skipped — GET_HKR_CONFIG_TABLE returned "
+                             << flash_table.size() << " bytes, expected "
+                             << sizeof( ds::d500_coefficients_table ) );
+            }
         }
         catch( const std::exception & e )
         {
             LOG_WARNING( "Interactive TC: flash→RAM revert failed (" << e.what()
                          << ") — depth stream may still reflect the candidate table until next stream restart" );
+        }
+        catch( ... )
+        {
+            // Preserve the pre-refactor non-throwing property of this helper — the pre-run auto-cancel path relied
+            // on it. Non-std exceptions here are pathological (there is no code that throws non-std types on this
+            // path today), but a bare catch is cheap insurance.
+            LOG_WARNING( "Interactive TC: flash→RAM revert failed (non-std exception) — swallowed to keep cancel_and_wait_for_idle non-throwing" );
         }
     }
 

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -12,6 +12,8 @@
 #include <rsutils/json.h>
 #include <rsutils/string/from.h>
 
+#include <sstream>   // std::stringstream + drags <ios> for std::hex / std::dec used in the CRC diagnostic logs
+
 namespace librealsense
 {
     static constexpr const size_t hwm_header_size = 4;
@@ -62,29 +64,41 @@ namespace librealsense
                     break;
             }
         }
-        catch( ... )
+        catch( const std::exception & e )
         {
-            // best-effort — leave FW where it is if CANCEL itself fails
+            LOG_WARNING( "Interactive TC: CANCEL / status poll failed (" << e.what()
+                         << ") — FW may not be in Idle when this returns" );
         }
 
         // Belt-and-suspenders: on some FW builds CANCEL does not restore the flashed depth table into the RAM
         // slot that the depth pipeline reads, so the stream can end up rendering a half-baked candidate that
-        // looks visibly worse than the pre-RUN calibration. Copy the flashed table back into RAM ourselves and
-        // fire the depth-write observers so host caches (intrinsics) re-fetch on next query.
+        // looks visibly worse than the pre-RUN calibration. Write the flashed depth table back to the RAM slot
+        // ourselves via SET_HKR_CONFIG_TABLE — issued directly rather than through set_calibration_table() so we
+        // don't clobber _curr_calibration, which is the shared staging buffer for the manual-calibration API.
         try
         {
             std::vector< uint8_t > dummy;
             auto flash_table = _calib_engine->get_calibration_table( dummy );
-            if( ! flash_table.empty() )
+            if( flash_table.size() >= sizeof( ds::table_header ) )
             {
-                set_calibration_table( flash_table );
+                auto hdr = reinterpret_cast< const ds::table_header * >( flash_table.data() );
+                auto cmd = _debug_dev->build_command(
+                    ds::SET_HKR_CONFIG_TABLE,
+                    static_cast< int >( ds::d500_calib_location::d500_calib_ram_memory ),
+                    static_cast< int >( hdr->table_type ),
+                    static_cast< int >( ds::d500_calib_type::d500_calib_dynamic ),
+                    0,
+                    flash_table.data(),
+                    flash_table.size() );
+                _debug_dev->send_receive_raw_data( cmd );
                 for( auto & cb : _depth_write_callbacks )
                     cb();
             }
         }
-        catch( ... )
+        catch( const std::exception & e )
         {
-            // best-effort — the depth stream may still look wrong if FW didn't revert, but nothing else we can do
+            LOG_WARNING( "Interactive TC: flash→RAM revert failed (" << e.what()
+                         << ") — depth stream may still reflect the candidate table until next stream restart" );
         }
     }
 
@@ -277,8 +291,10 @@ namespace librealsense
                 const std::string sel = ( _try_selection == try_calibration_selection::NEW ) ? "NEW" : "OLD";
                 log_ram_depth_crc( ( "before TRY " + sel ).c_str() );
                 _calib_engine->run_triggered_calibration_try( _try_selection );
-                // FW switched the active table in RAM — invalidate host-side calibration caches so any
-                // subsequent get_intrinsics() re-reads from FW.
+                // FW switched the active table in RAM — invalidate host-side calibration caches so any subsequent
+                // get_intrinsics() re-reads. The viewer does NOT restart the depth stream (per FW-team guidance —
+                // a USB reconfigure at this point prevents FW from applying the swap), so the running pipeline
+                // keeps its baked intrinsics until the next stream restart; only a fresh query sees the switch.
                 for( auto & cb : _depth_write_callbacks )
                     cb();
                 log_ram_depth_crc( ( "after TRY " + sel ).c_str() );
@@ -304,15 +320,18 @@ namespace librealsense
             }
 
             // A RUN or COMMIT that didn't reach a clean terminal (SUCCESS + expected state) leaves FW in a non-IDLE
-            // state (HEALTH_CHECK with a stale candidate on failed RUN, mid-FLASH_UPDATE on failed COMMIT, PROCESS
-            // on FAILED_TO_RUN, etc.). Send a best-effort CANCEL so FW returns to IDLE and the next RUN's precondition
-            // guard doesn't reject the retry.
+            // state (HEALTH_CHECK with a stale candidate on failed RUN, PROCESS on FAILED_TO_RUN, etc.). Send a
+            // best-effort CANCEL so FW returns to IDLE and the next RUN's precondition guard doesn't reject the retry.
+            //
+            // Hard exception: never issue CANCEL while FW is in FLASH_UPDATE — spec §5.2 explicitly forbids it, and
+            // interrupting a mid-flash write has bricked devices in the field. Reachable here via the
+            // FAILED_TO_RUN/FAILED_TO_CONVERGE break in the poll loop, which fires before the state check.
             const bool run_failed    = ( _mode == calibration_mode::RUN || _mode == calibration_mode::DRY_RUN )
                                     && _result != calibration_result::SUCCESS;
             const bool commit_failed = _mode == calibration_mode::COMMIT
                                     && ( _state != calibration_state::COMPLETE
                                          || _result != calibration_result::SUCCESS );
-            if( run_failed || commit_failed )
+            if( ( run_failed || commit_failed ) && _state != calibration_state::FLASH_UPDATE )
             {
                 cancel_and_wait_for_idle();
             }

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -170,6 +170,11 @@ namespace librealsense
             if( _mode == calibration_mode::TRY )
             {
                 _calib_engine->run_triggered_calibration_try( _try_selection );
+                // FW switched the active table in RAM — invalidate host-side calibration caches so any
+                // subsequent get_intrinsics() re-reads from FW. The viewer stops+restarts its depth stream
+                // right after this returns so the preview actually reflects the switch.
+                for( auto & cb : _depth_write_callbacks )
+                    cb();
                 return {};
             }
 
@@ -182,12 +187,23 @@ namespace librealsense
             // RUN / DRY_RUN / COMMIT — poll until we hit a terminal state for this mode.
             auto res = update_interactive_calibration_status( timeout_ms, progress_callback );
 
+            // COMMIT flashed a new depth calibration — invalidate host caches. Callers restart streams
+            // (see viewer's restore_workspace) so the new table is picked up on the next intrinsics query.
+            if( _mode == calibration_mode::COMMIT && _state == calibration_state::COMPLETE )
+            {
+                for( auto & cb : _depth_write_callbacks )
+                    cb();
+            }
+
             if( health )
             {
-                // Only trust the health payload once the FW has actually populated it (from HEALTH_CHECK onward).
-                // If FAILED_TO_CONVERGE / FAILED_TO_RUN broke the loop before that, _interactive_ans.health is still zero-initialized
-                // and 0.0 would spuriously read as "PASS" (< 0.40 threshold) in the viewer — return the -1 sentinel instead.
-                if( _state == calibration_state::HEALTH_CHECK || _state == calibration_state::COMPLETE )
+                // Trust health only when FW reports SUCCESS and populated the HEALTH_CHECK/COMPLETE payload.
+                // Anything else (UNKNOWN because FW never wrote the result byte, FAILED_TO_CONVERGE, FAILED_TO_RUN,
+                // or a mid-run terminal state) → -1.f sentinel so the viewer's health_passes() locks the Commit
+                // button rather than treating a zero-initialized rect_health as PASS.
+                const bool have_payload = _state == calibration_state::HEALTH_CHECK
+                                       || _state == calibration_state::COMPLETE;
+                if( have_payload && _result == calibration_result::SUCCESS )
                 {
                     auto h = _calib_engine->get_triggered_calibration_health();
                     *health = h.rect_health;   // primary pass/fail metric; full struct available via engine

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -273,11 +273,16 @@ namespace librealsense
                 log_flashed_depth_crc( "after COMMIT" );
             }
 
-            // A RUN that ended without SUCCESS leaves FW in a non-IDLE state (typically HEALTH_CHECK with a
-            // stale candidate, or PROCESS on FAILED_TO_RUN). Send a best-effort CANCEL so FW returns to IDLE,
-            // matching the pre-run recovery above.
-            if( ( _mode == calibration_mode::RUN || _mode == calibration_mode::DRY_RUN )
-                && _result != calibration_result::SUCCESS )
+            // A RUN or COMMIT that didn't reach a clean terminal (SUCCESS + expected state) leaves FW in a non-IDLE
+            // state (HEALTH_CHECK with a stale candidate on failed RUN, mid-FLASH_UPDATE on failed COMMIT, PROCESS
+            // on FAILED_TO_RUN, etc.). Send a best-effort CANCEL so FW returns to IDLE and the next RUN's precondition
+            // guard doesn't reject the retry.
+            const bool run_failed    = ( _mode == calibration_mode::RUN || _mode == calibration_mode::DRY_RUN )
+                                    && _result != calibration_result::SUCCESS;
+            const bool commit_failed = _mode == calibration_mode::COMMIT
+                                    && ( _state != calibration_state::COMPLETE
+                                         || _result != calibration_result::SUCCESS );
+            if( run_failed || commit_failed )
             {
                 cancel_and_wait_for_idle();
             }

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -48,6 +48,46 @@ namespace librealsense
             throw not_implemented_exception( " debug_interface must be supplied to d500_auto_calibrated" );
     }
 
+    void d500_auto_calibrated::cancel_and_wait_for_idle()
+    {
+        try
+        {
+            _calib_engine->run_triggered_calibration( calibration_mode::ABORT );
+            // SET_CALIB_MODE is one-shot; FW takes a moment to settle back to IDLE.
+            for( int i = 0; i < 20; ++i )
+            {
+                std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+                _calib_engine->update_triggered_calibration_status();
+                if( _calib_engine->get_triggered_calibration_state() == calibration_state::IDLE )
+                    break;
+            }
+        }
+        catch( ... )
+        {
+            // best-effort — leave FW where it is if CANCEL itself fails
+        }
+
+        // Belt-and-suspenders: on some FW builds CANCEL does not restore the flashed depth table into the RAM
+        // slot that the depth pipeline reads, so the stream can end up rendering a half-baked candidate that
+        // looks visibly worse than the pre-RUN calibration. Copy the flashed table back into RAM ourselves and
+        // fire the depth-write observers so host caches (intrinsics) re-fetch on next query.
+        try
+        {
+            std::vector< uint8_t > dummy;
+            auto flash_table = _calib_engine->get_calibration_table( dummy );
+            if( ! flash_table.empty() )
+            {
+                set_calibration_table( flash_table );
+                for( auto & cb : _depth_write_callbacks )
+                    cb();
+            }
+        }
+        catch( ... )
+        {
+            // best-effort — the depth stream may still look wrong if FW didn't revert, but nothing else we can do
+        }
+    }
+
     bool d500_auto_calibrated::device_uses_interactive_triggered_calibration() const
     {
         auto dev = As< device >( _debug_dev );
@@ -147,23 +187,60 @@ namespace librealsense
     {
         _calib_engine->set_interactive_triggered_calibration_enabled( true );
 
+        // Diagnostic: read the currently flashed depth calibration table and log its CRC32. Called before RUN and
+        // after COMMIT so users can tell whether the FW actually flashed a new table (differing CRC across the
+        // two log lines) or silently no-op'd (same CRC → intrinsics won't visibly change even after COMMIT).
+        auto log_flashed_depth_crc = [this]( const char * label )
+        {
+            try
+            {
+                std::vector< uint8_t > dummy;
+                auto raw = _calib_engine->get_calibration_table( dummy );
+                if( raw.size() >= sizeof( ds::table_header ) )
+                {
+                    auto hdr = reinterpret_cast< const ds::table_header * >( raw.data() );
+                    LOG_INFO( "Interactive TC: depth calibration CRC32 "
+                              << label << " = 0x" << std::hex << hdr->crc32 << std::dec );
+                }
+            }
+            catch( ... )
+            {
+                // best-effort diagnostic — silence
+            }
+        };
+
         try
         {
             get_mode_from_json( json );
 
-            // RUN / DRY_RUN require the device to be in a fresh state (IDLE) or coming off a prior COMPLETE.
-            // Skipping this check would let a RUN issued mid-PROCESS silently stack a second calibration.
+            // RUN / DRY_RUN require the device to be in IDLE. Some FW builds silently no-op SET_CALIB_MODE(RUN)
+            // when the state is HEALTH_CHECK (stale candidate) or COMPLETE (prior successful run), leaving the
+            // poll loop seeing the previous terminal state immediately and reporting a bogus "1-second RUN".
+            // Send a CANCEL first — spec §5.2 says CANCEL is valid from any state except FLASH_UPDATE — so the
+            // subsequent SET_CALIB_MODE(RUN) hits a clean IDLE and the algorithm actually starts.
             if( _mode == calibration_mode::RUN || _mode == calibration_mode::DRY_RUN )
             {
                 _calib_engine->update_triggered_calibration_status();
                 _state = _calib_engine->get_triggered_calibration_state();
-                if( _state != calibration_state::IDLE && _state != calibration_state::COMPLETE )
+
+                if( _state == calibration_state::HEALTH_CHECK || _state == calibration_state::COMPLETE )
+                {
+                    LOG_INFO( "Interactive TC: FW at "
+                              << calibration_state_strings[static_cast<int>(_state)]
+                              << " — sending CANCEL to return to Idle before RUN" );
+                    cancel_and_wait_for_idle();
+                    _state = _calib_engine->get_triggered_calibration_state();
+                }
+
+                if( _state != calibration_state::IDLE )
                 {
                     LOG_ERROR( "Interactive TC RUN rejected: state = "
                                << calibration_state_strings[static_cast<int>(_state)]
-                               << " (expected Idle or Complete)" );
-                    throw std::runtime_error( "Interactive TC RUN requires state to be Idle or Complete" );
+                               << " (expected Idle)" );
+                    throw std::runtime_error( "Interactive TC RUN requires state to be Idle" );
                 }
+
+                log_flashed_depth_crc( "before RUN" );
             }
 
             // TRY is a live-preview toggle at HEALTH_CHECK; does not change state and does not poll.
@@ -193,6 +270,16 @@ namespace librealsense
             {
                 for( auto & cb : _depth_write_callbacks )
                     cb();
+                log_flashed_depth_crc( "after COMMIT" );
+            }
+
+            // A RUN that ended without SUCCESS leaves FW in a non-IDLE state (typically HEALTH_CHECK with a
+            // stale candidate, or PROCESS on FAILED_TO_RUN). Send a best-effort CANCEL so FW returns to IDLE,
+            // matching the pre-run recovery above.
+            if( ( _mode == calibration_mode::RUN || _mode == calibration_mode::DRY_RUN )
+                && _result != calibration_result::SUCCESS )
+            {
+                cancel_and_wait_for_idle();
             }
 
             if( health )
@@ -244,6 +331,17 @@ namespace librealsense
                 {
                     ss << ", progress = " << static_cast<int>( _calib_engine->get_triggered_calibration_progress() );
                     ss << ", result = " << calibration_result_strings[static_cast<int>(_result)];
+                }
+                else if( _state == calibration_state::HEALTH_CHECK
+                      || _state == calibration_state::COMPLETE )
+                {
+                    ss << ", result = " << calibration_result_strings[static_cast<int>(_result)];
+                    if( _state == calibration_state::HEALTH_CHECK )
+                    {
+                        auto h = _calib_engine->get_triggered_calibration_health();
+                        ss << ", rect_health = " << h.rect_health << " px"
+                           << " (pass range = [0, " << rect_health_pass_threshold_px << ") px)";
+                    }
                 }
                 LOG_INFO( ss.str().c_str() );
             }

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -209,6 +209,34 @@ namespace librealsense
             }
         };
 
+        // Diagnostic: read the RAM-active depth calibration table (as opposed to the flashed one above) and log its
+        // CRC32. Used around TRY_NEW / TRY_OLD to tell whether the FW is actually switching the RAM-active table on
+        // TRY — CRC change confirms the switch; same CRC means FW acked the TRY but didn't swap the active table.
+        auto log_ram_depth_crc = [this]( const char * label )
+        {
+            try
+            {
+                auto cmd = _debug_dev->build_command(
+                    ds::GET_HKR_CONFIG_TABLE,
+                    static_cast< int >( ds::d500_calib_location::d500_calib_ram_memory ),
+                    static_cast< int >( ds::d500_calibration_table_id::depth_calibration_id ),
+                    static_cast< int >( ds::d500_calib_type::d500_calib_dynamic ) );
+                auto raw = _debug_dev->send_receive_raw_data( cmd );
+                // Slice the 4-byte opcode prefix that HW-monitor commands echo back.
+                if( raw.size() > 4 + sizeof( ds::table_header ) )
+                {
+                    raw.erase( raw.begin(), raw.begin() + 4 );
+                    auto hdr = reinterpret_cast< const ds::table_header * >( raw.data() );
+                    LOG_INFO( "Interactive TC: RAM depth calibration CRC32 "
+                              << label << " = 0x" << std::hex << hdr->crc32 << std::dec );
+                }
+            }
+            catch( ... )
+            {
+                // best-effort diagnostic — silence
+            }
+        };
+
         try
         {
             get_mode_from_json( json );
@@ -246,12 +274,14 @@ namespace librealsense
             // TRY is a live-preview toggle at HEALTH_CHECK; does not change state and does not poll.
             if( _mode == calibration_mode::TRY )
             {
+                const std::string sel = ( _try_selection == try_calibration_selection::NEW ) ? "NEW" : "OLD";
+                log_ram_depth_crc( ( "before TRY " + sel ).c_str() );
                 _calib_engine->run_triggered_calibration_try( _try_selection );
                 // FW switched the active table in RAM — invalidate host-side calibration caches so any
-                // subsequent get_intrinsics() re-reads from FW. The viewer stops+restarts its depth stream
-                // right after this returns so the preview actually reflects the switch.
+                // subsequent get_intrinsics() re-reads from FW.
                 for( auto & cb : _depth_write_callbacks )
                     cb();
+                log_ram_depth_crc( ( "after TRY " + sel ).c_str() );
                 return {};
             }
 

--- a/src/ds/d500/d500-auto-calibration.h
+++ b/src/ds/d500/d500-auto-calibration.h
@@ -53,6 +53,7 @@ namespace librealsense
         std::vector< uint8_t > run_occ( int timeout_ms, std::string json, float * const health,
                                         rs2_update_progress_callback_sptr progress_callback );
         bool device_uses_interactive_triggered_calibration() const;
+        void cancel_and_wait_for_idle();   // best-effort SET_CALIB_MODE(ABORT) + poll until IDLE (or ~2s)
         try_calibration_selection _try_selection;
         ds_calib_common::dsc_check_status_result get_calibration_status( int timeout_ms,
                                                             std::function< void( const int count ) > progress_func,

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
@@ -6,8 +6,6 @@
 #include "d500-device.h"
 
 #include <cstring>
-#include <iomanip>
-#include <sstream>
 
 
 namespace librealsense
@@ -66,19 +64,6 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
     {
         if (!check_buffer_size_interactive(res))
             throw std::runtime_error("GET_CALIB_STATUS (interactive) returned struct with wrong size");
-
-        // Temporary debug: dump the header + health block (first 23 bytes) so we can tell whether the FW
-        // is populating the health payload at all. Rect_health is coming back as 0.000 on the current FW image,
-        // and either the FW isn't writing it or the parser reads the wrong offset — this log resolves it.
-        // Remove once the source is confirmed.
-        if (res.size() >= 23)
-        {
-            std::stringstream hex;
-            hex << "GET_CALIB_STATUS (interactive) hdr+health [" << res.size() << " bytes]:";
-            for (size_t i = 0; i < 23; ++i)
-                hex << " " << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(res[i]);
-            LOG_DEBUG(hex.str().c_str());
-        }
 
         // Header (3 bytes) is always present; health + candidate table (532 more) only from HEALTH_CHECK onward.
         _interactive_ans = {};

--- a/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
+++ b/src/ds/d500/d500-debug-protocol-calibration-engine.cpp
@@ -6,6 +6,8 @@
 #include "d500-device.h"
 
 #include <cstring>
+#include <iomanip>
+#include <sstream>
 
 
 namespace librealsense
@@ -64,6 +66,19 @@ void d500_debug_protocol_calibration_engine::update_triggered_calibration_status
     {
         if (!check_buffer_size_interactive(res))
             throw std::runtime_error("GET_CALIB_STATUS (interactive) returned struct with wrong size");
+
+        // Temporary debug: dump the header + health block (first 23 bytes) so we can tell whether the FW
+        // is populating the health payload at all. Rect_health is coming back as 0.000 on the current FW image,
+        // and either the FW isn't writing it or the parser reads the wrong offset — this log resolves it.
+        // Remove once the source is confirmed.
+        if (res.size() >= 23)
+        {
+            std::stringstream hex;
+            hex << "GET_CALIB_STATUS (interactive) hdr+health [" << res.size() << " bytes]:";
+            for (size_t i = 0; i < 23; ++i)
+                hex << " " << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(res[i]);
+            LOG_DEBUG(hex.str().c_str());
+        }
 
         // Header (3 bytes) is always present; health + candidate table (532 more) only from HEALTH_CHECK onward.
         _interactive_ans = {};

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -693,6 +693,11 @@ namespace librealsense
         {
             _coefficients_table_raw.reset();
             _new_calib_table_raw.reset();
+            // _left_right_extrinsics is derived from _coefficients_table_raw (baseline in mm), but its own lazy<>
+            // caches the computed rs2_extrinsics — without this reset, get_extrinsics(depth, right_ir) keeps
+            // returning the pre-calibration baseline forever, even though the coefficients table cache is fresh.
+            if( _left_right_extrinsics )
+                _left_right_extrinsics->reset();
         } );
     }
 


### PR DESCRIPTION
Tracked by: RSDEV-13186

**Post-merge host-side fixes for the D5x5 interactive triggered calibration flow** landed in #15452.

## Symptoms observed on-device

Testing #15452's flow against real FW surfaced a batch of host-side gaps plus one confirmed FW gap (see the "For FW team" section below):

1. **Health-check popup opened even when the algorithm didn't converge** — `rect_health = 0` (zero-initialised because FW hadn't populated the metric) passed the `< 0.4` gate, so Commit was live on a non-converged calibration.
2. **After a failed RUN, retrying was blocked** — FW parked at `HEALTH_CHECK`; the RUN precondition guard added in #15452 then rejected every retry with "state = Health Check (expected Idle or Complete)" until reboot.
3. **After a "clean" RUN → COMMIT, depth extrinsics / intrinsics reported unchanged** — even the CRC32 of the flashed depth calibration table was identical before RUN and after COMMIT.
4. **Try New / Try Old showed no visible change** on the depth stream.
5. **RUN sometimes "completed" in <1 s reporting `Complete, result = Success` on the very first poll** — turned out to be a stale terminal state from the previous run: `SET_CALIB_MODE(RUN)` was being issued from state `COMPLETE` and being silently no-op'd.

## What this PR changes (host-side)

- **`common/d500-on-chip-calib.cpp` `process_flow`** — when the SDK returns `*health = -1.f` (its sentinel for "FW did not report SUCCESS"), the manager now sets `_failed = true` + calls `restore_workspace(invoke)` instead of `_done = true`. The notification transitions directly to the `RS2_CALIB_STATE_FAILED` popup (same one D585S uses), skipping the HEALTH_CHECK screen with its four action buttons entirely. Closes symptom #1.
- **`src/ds/d500/d500-auto-calibration.cpp` `run_interactive_triggered_calibration`** — gates the `*health` write on both `_state ∈ {HEALTH_CHECK, COMPLETE}` **and** `_result == calibration_result::SUCCESS`. UNKNOWN / FAILED_TO_CONVERGE / FAILED_TO_RUN → `-1.f` sentinel. Belt: the viewer's `health_passes()` already requires `>= 0.f`. Braces: the manager-side surface (previous bullet).
- **New helper `cancel_and_wait_for_idle()`** — `SET_CALIB_MODE(ABORT)` + poll ≤ 2 s for `IDLE`, then write the flashed depth table back into the RAM slot (`SET_HKR_CONFIG_TABLE(ram_memory, …)` issued directly, without going through `set_calibration_table()` so `_curr_calibration` isn't clobbered), plus fire `_depth_write_callbacks` so host caches drop any candidate-driven intrinsics. Guards against FW builds where a CANCEL doesn't restore the flashed table into the RAM slot the pipeline reads (this observably left the depth stream visibly worse than pre-RUN in earlier testing before the flash→RAM copy). Both catch blocks `LOG_WARNING` rather than swallow silently.
- **Pre-run auto-cancel** — before rejecting a non-IDLE state, if `_state ∈ {HEALTH_CHECK, COMPLETE}` the RUN precondition now calls `cancel_and_wait_for_idle()`, re-reads state, and only throws on genuinely-non-IDLE. Closes symptom #2, and eliminates symptom #5 (COMPLETE-from-prior-run being interpreted as instant success by the new RUN).
- **Post-run auto-cancel** — after a RUN/DRY_RUN whose `_result != SUCCESS`, **or** a COMMIT that didn't reach `Complete + Success`, the same helper is called so FW doesn't remain parked at HEALTH_CHECK/FLASH_UPDATE across the failure popup. **Hard-guarded against `FLASH_UPDATE`** — spec §5.2 forbids CANCEL there, and interrupting a mid-flash write has bricked devices in the field.
- **`src/ds/d500/d500-device.cpp` `add_depth_write_observer`** — the observer already reset `_coefficients_table_raw` + `_new_calib_table_raw`, but `_left_right_extrinsics` (its own `lazy<rs2_extrinsics>` computed from `_coefficients_table_raw`'s `baseline`) kept its own cache. Added `_left_right_extrinsics->reset()`. Closes the extrinsics half of symptom #3.  
  *Behavior note*: this observer fires on every D500 SKU's `write_calibration()` / `reset_to_factory_calibration()` — not just interactive PIDs. D585S / D555 will now also see fresh extrinsics after those calls where they previously stayed stale. Not a regression (it fixes a latent bug on those paths too), but explicitly a legacy-path behavior change.
- **`src/ds/d500/d500-auto-calibration.cpp` interactive TRY branch** — after `run_triggered_calibration_try(...)` returns, fire `_depth_write_callbacks` so host caches (including the newly-reset extrinsic lazy) refresh for the next intrinsics query.
- **`common/d500-on-chip-calib.cpp` interactive TRY branch** — per FW-team guidance the depth stream is **not** stopped and restarted on TRY_NEW / TRY_OLD; a USB reconfigure at this point prevents FW from applying the switch. Consequence documented below in the test plan.
- **`common/d500-on-chip-calib.{h,cpp}` health-check UI** — Try New / Try Old replaced with a radio-button pair sharing `_try_side` on the notification model, so the currently-previewed candidate is visually indicated. Each toggle fires the matching TRY action (with in-flight guard).
- **`src/calibration-engine-interface.h`** — new named constant `rect_health_pass_threshold_px = 0.4f`. Only rect_health is host-gated today; coverage and scale remain informational until the multi-metric gate lands. The viewer mirrors this constant as `d500_on_chip_calib_manager::k_rect_health_pass_threshold_px` (same "viewer cannot include SDK-internal headers" pattern as the PID list).
- **Diagnostic logs** — during the polling loop the SDK now logs, per iteration:
  - always: `Calibration in progress - State = <...>` (existing).
  - at `PROCESS`: `progress = N, result = <...>` (existing).
  - at `HEALTH_CHECK` / `COMPLETE`: `result = <...>`.
  - at `HEALTH_CHECK`: `rect_health = X.XXX px (pass range = [0, T) px)` — value read from FW, T read from the constant.
  - once before RUN and once after COMMIT: `depth calibration CRC32 = 0x...` — the FW-computed `table_header.crc32` of the currently *flashed* depth calibration table.
  - once before and once after each Try New / Try Old click: `RAM depth calibration CRC32 = 0x...` — the CRC of the *RAM-active* depth table, so we can tell whether FW is actually switching on TRY.
  
  These are permanent `LOG_INFO` — intentional instrumentation while FW-side persistence / RAM-swap situations are being characterised. Two extra HW-monitor round-trips per RUN/COMMIT and per TRY-click; acceptable given the flow is user-triggered and not a hot path.

## For the FW team

The host-side is now consistent — everything above is verified to fire correctly and host caches invalidate on every code path that changes calibration. During earlier end-to-end testing on this branch, however, the depth calibration in flash was **not** actually modified even though the FW reported a full successful COMMIT. The FW team has since reported a fix on the persistence path; the diagnostic logs the host now emits let you verify it.

**How to read the log**

In the viewer's log (`realsense-viewer.log` or the Log panel with severity ≥ INFO) look for lines the SDK emits from `d500_auto_calibrated::run_interactive_triggered_calibration`:

```
[Info] ...d500-auto-calibration.cpp - Interactive TC: depth calibration CRC32 before RUN   = 0x7f8ad338
   ... (35 s of Calibration in progress - State = In Process ...)
[Info] ...d500-auto-calibration.cpp - Calibration in progress - State = Health Check, result = Success, rect_health = 0.083 px (pass range = [0, 0.4) px)
   ... (user clicks Commit)
[Info] ...d500-auto-calibration.cpp - Calibration in progress - State = Complete, result = Success
[Info] ...d500-auto-calibration.cpp - Interactive TC: depth calibration CRC32 after COMMIT = 0x7f8ad338
```

Both CRC32 values are `table_header.crc32` of the current *flashed* depth calibration table, read via `GET_HKR_CONFIG_TABLE(location=d500_calib_flash_memory, table_id=depth_calibration_id, type=d500_calib_dynamic)`. If those two values are identical despite the algorithm reporting `Success`, the COMMIT didn't persist.

For Try New / Try Old, the equivalent RAM-side signal:

```
[Info] Interactive TC: RAM depth calibration CRC32 before TRY NEW = 0x...
[Info] Interactive TC: RAM depth calibration CRC32 after  TRY NEW = 0x...
```

Same field, but read from `d500_calib_location::d500_calib_ram_memory` — this is what actually drives FW's on-device rectification. Different CRCs means FW swapped the RAM-active table; same CRCs means the TRY was acked but not applied.

**Open question for the FW team** (pending — please answer):
On the legacy D585S flow, the viewer calls `hardware_reset()` after COMMIT (see `common/d500-on-chip-calib.cpp:423`, gated on `pid == 0B6B`). D400 does the same at `common/on-chip-calib.cpp:2222`. On D5x5 interactive TC (PIDs `0C01..0C08`) that reset does **not** fire; the assumption is that with the flashed table + host-cache invalidation the depth engine picks up the new calibration for its next frame. If the FW's depth engine actually needs a reset to reload its rectification state from the fresh flash, host plumbing alone won't make the depth image visibly change even after a CRC-verified COMMIT. Please confirm whether a hardware reset (or a lighter opcode) is required post-COMMIT on interactive PIDs.

## Test plan

- [x] D5x5 with a FW build that persists COMMIT: full RUN → HEALTH_CHECK → Commit → confirm the two `depth calibration CRC32` log lines differ and a subsequent `get_intrinsics()` returns new values.
- [x] Failure retry: force a FAILED_TO_CONVERGE, dismiss the failure popup, click Calibrate again — precondition guard should auto-cancel FW back to IDLE and start a fresh RUN.
- [ ] TRY New / TRY Old — RAM-swap signal: the two `RAM depth calibration CRC32` log lines around each click should differ. **Whether the depth stream visually reflects the switch is currently pending**: the FW-team guidance was to NOT stop+restart the stream on TRY, so a running pipeline keeps its baked intrinsics from `play()` and only a subsequent `get_intrinsics()` observes the new values. Visual verification will require either a FW-side mid-stream reload or a coordinated host-side restart hooked up when the pending question above is resolved.
- [x] D585S (0x0B6B) legacy TC and D555 OCC — behavior unchanged on those flow's dispatchers; note the extrinsics observer fix in `d500-device.cpp` will refresh `_left_right_extrinsics` on any `write_calibration()` for these SKUs too (a latent-bug fix, not a regression — see the corresponding bullet in "What this PR changes" above).

---
🤖 Generated by AI
