### PR TITLE
Security: Fix critical and high vulnerabilities (Aikido automated scan)

### DIFF
--- a/wrappers/rest-api/tools/react-viewer/src-tauri/Cargo.lock
+++ b/wrappers/rest-api/tools/react-viewer/src-tauri/Cargo.lock
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",


### PR DESCRIPTION
Automated security fix from Aikido scan on 2026-07-31.

## Summary
This PR fixes 1 high-severity vulnerability found in the latest Aikido security scan.

## Changes
- Updated openssl from 0.10.79 to 0.10.80 (fixes CVE-2026-45784)

## Severity
- High: 1 issue fixed

## Verification
Scan results available at: https://app.aikido.dev/repositories/1218403