### PR TITLE
test: reclassify two known, ticketed multistream defects instead of red CI

### DIFF
--- a/unit-tests/live/frames/pytest-fps-performance.py
+++ b/unit-tests/live/frames/pytest-fps-performance.py
@@ -1689,6 +1689,21 @@ def test_ir_configurations(settled_device, coverage_tier):
         f"All supported IR configurations accuracy test - {len(ir_config_results) if ir_config_results else 0} configurations tested"
 
 
+def describe_multistream_failure(result):
+    """One-line description of a failed combination, for the assertion message."""
+    stats = result['stats']
+    if 'error' in stats:
+        return f"{result['config_name']} -> {stats['error']}"
+
+    depth_stats = stats['depth']
+    color_stats = stats['color']
+    return (f"{result['config_name']} -> "
+            f"depth {depth_stats['actual_fps']:.1f}/{depth_stats['expected_fps']} fps "
+            f"({depth_stats['deviation']*100:.1f}% dev), "
+            f"color {color_stats['actual_fps']:.1f}/{color_stats['expected_fps']} fps "
+            f"({color_stats['deviation']*100:.1f}% dev)")
+
+
 @pytest.mark.timeout(14400)
 def test_multistream_configurations(settled_device, coverage_tier):
     """Test depth + color multi-stream FPS accuracy for all supported configurations"""
@@ -1701,8 +1716,13 @@ def test_multistream_configurations(settled_device, coverage_tier):
 
     if multistream_results:
         print_multistream_test_summary(multistream_results, multistream_tests_passed, product_line)
+        # Name the offending combinations in the assertion itself: the message is all that reaches
+        # the JUnit report, and without it triage means downloading the per-device artifact log.
+        failed = [r for r in multistream_results if not r['passed']]
         assert multistream_tests_passed, \
-            f"Depth + color multi-stream configurations (all combinations) accuracy test - {len(multistream_results)} combinations tested"
+            (f"Depth + color multi-stream configurations (all combinations) accuracy test - "
+             f"{len(multistream_results)} combinations tested, {len(failed)} failed: "
+             + "; ".join(describe_multistream_failure(r) for r in failed))
     else:
         # Check if device has no color sensor (like D421, D405)
         product_name = dev.get_info(rs.camera_info.name)

--- a/unit-tests/live/frames/pytest-fps-performance.py
+++ b/unit-tests/live/frames/pytest-fps-performance.py
@@ -1409,6 +1409,22 @@ def get_depth_color_combinations(device, max_combinations=None):
     return combinations
 
 
+def _is_rsdso_21810_pattern(device_name, depth_fps, color_fps):
+    """RSDSO-21810 (open): on D455, depth throughput degrades to ~70-84% of target whenever
+    colour is also configured at 90 fps - confirmed combined-frame-rate triggered and
+    resolution-independent, not a bandwidth limit. Scoped to D455 + 90/90 only, matching the
+    evidence on file; do not widen without new data. Remove this predicate once the ticket
+    is closed and confirm the combination fails again first (see the XPASS note below)."""
+    return 'D455' in device_name and depth_fps == 90 and color_fps == 90
+
+
+def _is_zero_frame_start_failure(stats):
+    """RSDSO-21811 (open): intermittent GMSL/MIPI stream-start race where one stream delivers
+    zero frames. Distinct from an FPS-deviation failure, so safe to retry once without masking
+    a real rate regression. Remove this retry once the ticket is closed."""
+    return 'error' in stats and 'got 0 frames' in stats['error']
+
+
 def check_multistream_configurations_comprehensive(device, max_combinations=None):
     """
     Test all depth + color multi-stream configurations.
@@ -1422,6 +1438,8 @@ def check_multistream_configurations_comprehensive(device, max_combinations=None
         Tuple[bool, List[Dict]]: (all_passed, results_list)
     """
     log.info("\nTesting all depth + color multi-stream configurations...")
+
+    device_name = device.get_info(rs.camera_info.name) if device.supports(rs.camera_info.name) else ""
 
     # Get combinations
     combinations = get_depth_color_combinations(device, max_combinations)
@@ -1451,27 +1469,39 @@ def check_multistream_configurations_comprehensive(device, max_combinations=None
                 device, depth_config, color_config, test_duration, tolerance
             )
 
+            if not passed and _is_zero_frame_start_failure(stats):
+                log.warning(f"  RETRY: {config_name} -> {stats['error']} (RSDSO-21811), retrying once")
+                passed, stats = check_multistream_fps_accuracy(
+                    device, depth_config, color_config, test_duration, tolerance
+                )
+
+            known_issue = (not passed) and _is_rsdso_21810_pattern(device_name, depth_fps, color_fps)
+
             result = {
                 "depth_config": depth_config,
                 "color_config": color_config,
                 "config_name": config_name,
                 "passed": passed,
+                "known_issue": known_issue,
                 "stats": stats
             }
 
             all_results.append(result)
 
             if not passed:
-                all_passed = False
+                if not known_issue:
+                    all_passed = False
+                log_fn = log.warning if known_issue else log.error
+                tag = " (known issue: RSDSO-21810, not counted as a CI failure)" if known_issue else ""
                 if 'error' in stats:
-                    log.error(f"  ERROR: {stats['error']}")
+                    log_fn(f"  ERROR{tag}: {stats['error']}")
                 else:
                     depth_stats = stats['depth']
                     color_stats = stats['color']
-                    log.error(f"  FAILED:")
-                    log.error(f"    Depth: Expected {depth_stats['expected_fps']} FPS, got {depth_stats['actual_fps']:.1f} FPS "
+                    log_fn(f"  FAILED{tag}:")
+                    log_fn(f"    Depth: Expected {depth_stats['expected_fps']} FPS, got {depth_stats['actual_fps']:.1f} FPS "
                           f"(deviation: {depth_stats['deviation']*100:.1f}%)")
-                    log.error(f"    Color: Expected {color_stats['expected_fps']} FPS, got {color_stats['actual_fps']:.1f} FPS "
+                    log_fn(f"    Color: Expected {color_stats['expected_fps']} FPS, got {color_stats['actual_fps']:.1f} FPS "
                           f"(deviation: {color_stats['deviation']*100:.1f}%)")
             else:
                 depth_stats = stats['depth']
@@ -1481,6 +1511,9 @@ def check_multistream_configurations_comprehensive(device, max_combinations=None
                       f"(deviation: {depth_stats['deviation']*100:.1f}%)")
                 log.info(f"    Color: Expected {color_stats['expected_fps']} FPS, got {color_stats['actual_fps']:.1f} FPS "
                       f"(deviation: {color_stats['deviation']*100:.1f}%)")
+                if _is_rsdso_21810_pattern(device_name, depth_fps, color_fps):
+                    log.warning(f"  NOTE: {config_name} matches the RSDSO-21810 known-issue pattern but PASSED - "
+                                f"the bug may be fixed; check before relying on the workaround")
 
         except Exception as e:
             log.error(f"  ERROR testing {config_name}: {e}")
@@ -1489,6 +1522,7 @@ def check_multistream_configurations_comprehensive(device, max_combinations=None
                 "color_config": color_config,
                 "config_name": config_name,
                 "passed": False,
+                "known_issue": False,
                 "stats": {"error": str(e)}
             }
             all_results.append(result)
@@ -1718,11 +1752,17 @@ def test_multistream_configurations(settled_device, coverage_tier):
         print_multistream_test_summary(multistream_results, multistream_tests_passed, product_line)
         # Name the offending combinations in the assertion itself: the message is all that reaches
         # the JUnit report, and without it triage means downloading the per-device artifact log.
-        failed = [r for r in multistream_results if not r['passed']]
-        assert multistream_tests_passed, \
-            (f"Depth + color multi-stream configurations (all combinations) accuracy test - "
-             f"{len(multistream_results)} combinations tested, {len(failed)} failed: "
-             + "; ".join(describe_multistream_failure(r) for r in failed))
+        # known_issue failures (open tickets, see check_multistream_configurations_comprehensive)
+        # don't count toward multistream_tests_passed, but are still listed for visibility.
+        failed = [r for r in multistream_results if not r['passed'] and not r.get('known_issue')]
+        known_issues = [r for r in multistream_results if r.get('known_issue')]
+        msg = (f"Depth + color multi-stream configurations (all combinations) accuracy test - "
+               f"{len(multistream_results)} combinations tested, {len(failed)} failed: "
+               + "; ".join(describe_multistream_failure(r) for r in failed))
+        if known_issues:
+            msg += (f" [{len(known_issues)} additional known-issue failure(s) excluded: "
+                    + "; ".join(describe_multistream_failure(r) for r in known_issues) + "]")
+        assert multistream_tests_passed, msg
     else:
         # Check if device has no color sensor (like D421, D405)
         product_name = dev.get_info(rs.camera_info.name)


### PR DESCRIPTION
**Stacked on #15489** - this branch includes that commit plus the one below. Diff will show both until #15489 merges; the second commit is the one to review here.

## Summary
Two real, still-open hardware/driver defects currently fail `test_multistream_configurations` on every affected run: RSDSO-21810 (D455 depth throughput degrades when colour is also 90fps) and RSDSO-21811 (intermittent GMSL zero-frame stream start). Neither is a test bug, but both make the nightly red in a way that gives no actionable signal beyond "known issue, still open."

This does **not** widen the 20% tolerance or change which combinations are tested. It adds two narrow, ticket-tied mechanisms instead:

- **RSDSO-21810** - reclassified as a known issue, scoped to the exact evidence on file: device name contains `D455` AND depth==90fps AND color==90fps. Still logged as a failure (now at WARNING), just excluded from the assertion. If a matching combination unexpectedly *passes*, a distinct NOTE is logged so an accidental fix doesn't go unnoticed.
- **RSDSO-21811** - the zero-frame stream-start signature specifically (`'got 0 frames' in stats['error']`) gets one bounded retry before being recorded as failed. FPS-deviation failures are never retried - only this exact signature. Every retry is logged at WARNING so recurrence rate stays visible even when the retry succeeds.

Both predicates carry the ticket number and explicit removal instructions in their docstrings.

## Validation
- `ast.parse` + isolated predicate unit tests (D455/90/90 -> True, D457/90/90 -> False, zero-frame error -> True, other errors -> False).
- Live run on `fw-orin-nano-1` (D457 + D401 GMSL rig): 3x `test_multistream_configurations --context nightly --device D457` - all 6/6 pass, no regression, no false known-issue tagging (D457 correctly not matched by the D455-scoped predicate).
- Integration harness (device + accuracy functions faked, real module logic exercised): confirmed the D455 90+90 failure is excluded from `all_passed` while logged; confirmed the zero-frame combo retries once and recovers; confirmed the *identical* 90+90 failure on a faked D457 is **not** excused (device-scoping verified, not just the predicate in isolation).

## What this explicitly does not do
- Does not widen the 20% tolerance globally.
- Does not skip or exclude the affected combinations - full visibility is preserved in the log either way.
- Does not touch firmware, driver, or hardware.

## Test plan
- [x] `ast.parse`
- [x] Predicate unit tests
- [x] Live D457 runs on fw-orin-nano-1 (3x, nightly tier)
- [x] Synthetic integration harness (both scenarios)
- [ ] CI run on this branch
- [ ] Remove the RSDSO-21810 predicate once that ticket is closed (confirm the pattern fails again first)
- [ ] Remove the RSDSO-21811 retry once that ticket is closed