### PR TITLE
Shrink or truncate the device panel name to fit the header width

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2360,11 +2360,11 @@ namespace rs2
                 {
                     usb_desc = dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
                     is_usb_badge = true;
-                    badge_text = rsutils::string::from() << "    " << textual_icons::usb << " " << usb_desc;
+                    badge_text = rsutils::string::from() << "   " << textual_icons::usb << " " << usb_desc;
                 }
                 else
                 {
-                    badge_text = rsutils::string::from() << "    " << connection_type;
+                    badge_text = rsutils::string::from() << "   " << connection_type;
                 }
             }
 

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2240,18 +2240,18 @@ namespace rs2
         struct fitted_name
         {
             std::string text;
-            bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
-
-            // Backstop: guarantees the window font scale is restored even if the caller's own
-            // reset gets skipped by an early return or an exception between the two.
-            ~fitted_name() { ImGui::SetWindowFontScale(1.0f); }
+            bool truncated; // full name is available via tooltip
         };
 
-        // Truncates text with a trailing ellipsis so " text" renders within max_width pixels
-        // (current font). Uses a binary search on the character count rather than trimming one
-        // character at a time, since this runs every frame the name doesn't fit.
-        std::string truncate_to_width(const std::string& text, float max_width)
+        // Truncates text with a trailing ellipsis so " text" fits within max_width pixels (current
+        // font). Uses a binary search on the character count rather than trimming one character at
+        // a time, since this runs every frame the name doesn't fit.
+        fitted_name fit_name_to_width(const std::string& text, float max_width)
         {
+            std::string display = " " + text;
+            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
+                return { display, false };
+
             const std::string ellipsis = "...";
             size_t lo = 0, hi = text.size();
             while (lo < hi)
@@ -2262,25 +2262,7 @@ namespace rs2
                 else
                     hi = mid - 1;
             }
-            return " " + text.substr(0, lo) + ellipsis;
-        }
-
-        // Shrinks the current window's font scale so " text" fits within max_width; only truncates
-        // (with ellipsis) if it still doesn't fit once the scale hits min_font_scale. The returned
-        // object restores the window font scale to 1.0 once it goes out of scope.
-        fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
-        {
-            std::string display = " " + text;
-            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
-                return { display, false };
-
-            float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
-            ImGui::SetWindowFontScale(scale);
-
-            if (ImGui::CalcTextSize(display.c_str()).x > max_width)
-                display = truncate_to_width(text, max_width);
-
-            return { display, true };
+            return { " " + text.substr(0, lo) + ellipsis, true };
         }
     }
 
@@ -2329,7 +2311,6 @@ namespace rs2
         ////////////////////////////////////////
         const ImVec2 name_pos = { pos.x + 9, pos.y + 17 };
         const float name_area_right_margin = 55.f; // leave room for the remove (X) button
-        const float min_name_font_scale = 0.9f; // below this the name shrinks to illegibility - truncate instead
         ImGui::SetCursorPos(name_pos);
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
@@ -2337,10 +2318,9 @@ namespace rs2
         if (is_ip_device)
         {
             std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));
-            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin, min_name_font_scale);
+            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin);
             ImGui::Text("%s", name.text.c_str());
-            ImGui::SetWindowFontScale(1.0f);
-            if (name.condensed && ImGui::IsItemHovered())
+            if (name.truncated && ImGui::IsItemHovered())
                 RsImGui::CustomTooltip(" %s", full_name.c_str());
 
             ImGui::PushFont(window.get_font());
@@ -2370,17 +2350,14 @@ namespace rs2
 
             // Reserve a full space-width gap between the name and the badge, on top of the badge's own width.
             float badge_gap = badge_text.empty() ? 0.f : ImGui::CalcTextSize(" ").x + ImGui::CalcTextSize(badge_text.c_str()).x;
-            auto name = fit_name_to_width(full_name,
-                panel_width - name_pos.x - name_area_right_margin - badge_gap,
-                min_name_font_scale);
+            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin - badge_gap);
             ImGui::Text("%s", name.text.c_str());
-            ImGui::SetWindowFontScale(1.0f);
-            if (name.condensed && ImGui::IsItemHovered())
+            if (name.truncated && ImGui::IsItemHovered())
                 RsImGui::CustomTooltip(" %s", full_name.c_str());
 
             if (!badge_text.empty())
             {
-                ImGui::SameLine(0.0f, ImGui::CalcTextSize(" ").x); // guarantee a space-width gap regardless of name scale
+                ImGui::SameLine(0.0f, ImGui::CalcTextSize(" ").x); // guarantee a space-width gap before the badge
                 if (is_usb_badge)
                 {
                     if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2341,6 +2341,7 @@ namespace rs2
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
             ss << dev.get_info(RS2_CAMERA_INFO_NAME);
+        ss.str("Realsense D585 Proto Dual RGB"); // RSDEV-13403 TEMP TEST HACK - revert this commit before merging
         if (is_ip_device)
         {
             std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2240,18 +2240,18 @@ namespace rs2
         struct fitted_name
         {
             std::string text;
-            bool truncated; // full name is available via tooltip
+            bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
+
+            // Backstop: guarantees the window font scale is restored even if the caller's own
+            // reset gets skipped by an early return or an exception between the two.
+            ~fitted_name() { ImGui::SetWindowFontScale(1.0f); }
         };
 
         // Truncates text with a trailing ellipsis so " text" fits within max_width pixels (current
         // font). Uses a binary search on the character count rather than trimming one character at
         // a time, since this runs every frame the name doesn't fit.
-        fitted_name fit_name_to_width(const std::string& text, float max_width)
+        std::string truncate_to_width(const std::string& text, float max_width)
         {
-            std::string display = " " + text;
-            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
-                return { display, false };
-
             const std::string ellipsis = "...";
             size_t lo = 0, hi = text.size();
             while (lo < hi)
@@ -2262,7 +2262,25 @@ namespace rs2
                 else
                     hi = mid - 1;
             }
-            return { " " + text.substr(0, lo) + ellipsis, true };
+            return " " + text.substr(0, lo) + ellipsis;
+        }
+
+        // Shrinks the current window's font scale so " text" fits within max_width; only truncates
+        // (with ellipsis) if it still doesn't fit once the scale hits min_font_scale. The returned
+        // object restores the window font scale to 1.0 once it goes out of scope.
+        fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
+        {
+            std::string display = " " + text;
+            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
+                return { display, false };
+
+            float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
+            ImGui::SetWindowFontScale(scale);
+
+            if (ImGui::CalcTextSize(display.c_str()).x > max_width)
+                display = truncate_to_width(text, max_width);
+
+            return { display, true };
         }
     }
 
@@ -2311,6 +2329,7 @@ namespace rs2
         ////////////////////////////////////////
         const ImVec2 name_pos = { pos.x + 9, pos.y + 17 };
         const float name_area_right_margin = 55.f; // leave room for the remove (X) button
+        const float min_name_font_scale = 0.9f; // below this the name shrinks to illegibility - truncate instead
         ImGui::SetCursorPos(name_pos);
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
@@ -2318,9 +2337,10 @@ namespace rs2
         if (is_ip_device)
         {
             std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));
-            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin);
+            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin, min_name_font_scale);
             ImGui::Text("%s", name.text.c_str());
-            if (name.truncated && ImGui::IsItemHovered())
+            ImGui::SetWindowFontScale(1.0f);
+            if (name.condensed && ImGui::IsItemHovered())
                 RsImGui::CustomTooltip(" %s", full_name.c_str());
 
             ImGui::PushFont(window.get_font());
@@ -2348,16 +2368,17 @@ namespace rs2
                 }
             }
 
-            // Reserve a full space-width gap between the name and the badge, on top of the badge's own width.
-            float badge_gap = badge_text.empty() ? 0.f : ImGui::CalcTextSize(" ").x + ImGui::CalcTextSize(badge_text.c_str()).x;
-            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin - badge_gap);
+            auto name = fit_name_to_width(full_name,
+                panel_width - name_pos.x - name_area_right_margin - ImGui::CalcTextSize(badge_text.c_str()).x,
+                min_name_font_scale);
             ImGui::Text("%s", name.text.c_str());
-            if (name.truncated && ImGui::IsItemHovered())
+            ImGui::SetWindowFontScale(1.0f);
+            if (name.condensed && ImGui::IsItemHovered())
                 RsImGui::CustomTooltip(" %s", full_name.c_str());
 
             if (!badge_text.empty())
             {
-                ImGui::SameLine(0.0f, ImGui::CalcTextSize(" ").x); // guarantee a space-width gap before the badge
+                ImGui::SameLine();
                 if (is_usb_badge)
                 {
                     if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2235,41 +2235,53 @@ namespace rs2
         return false;
     }
 
-    // Shorten text with a trailing ellipsis so it renders within max_width pixels (current font)
-    static std::string fit_text_to_width(const std::string& text, float max_width)
+    namespace
     {
-        if (max_width <= 0 || ImGui::CalcTextSize(text.c_str()).x <= max_width)
-            return text;
+        struct fitted_name
+        {
+            std::string text;
+            bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
 
-        const std::string ellipsis = "...";
-        std::string fitted = text;
-        while (!fitted.empty() && ImGui::CalcTextSize((fitted + ellipsis).c_str()).x > max_width)
-            fitted.pop_back();
-        return fitted.empty() ? ellipsis : fitted + ellipsis;
-    }
+            // Backstop: guarantees the window font scale is restored even if the caller's own
+            // reset gets skipped by an early return or an exception between the two.
+            ~fitted_name() { ImGui::SetWindowFontScale(1.0f); }
+        };
 
-    struct fitted_name
-    {
-        std::string text;
-        bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
-    };
+        // Truncates text with a trailing ellipsis so " text" renders within max_width pixels
+        // (current font). Uses a binary search on the character count rather than trimming one
+        // character at a time, since this runs every frame the name doesn't fit.
+        std::string truncate_to_width(const std::string& text, float max_width)
+        {
+            const std::string ellipsis = "...";
+            size_t lo = 0, hi = text.size();
+            while (lo < hi)
+            {
+                size_t mid = (lo + hi + 1) / 2;
+                if (ImGui::CalcTextSize((" " + text.substr(0, mid) + ellipsis).c_str()).x <= max_width)
+                    lo = mid;
+                else
+                    hi = mid - 1;
+            }
+            return " " + text.substr(0, lo) + ellipsis;
+        }
 
-    // Shrinks the current window's font scale so " text" fits within max_width; only truncates (with
-    // ellipsis) if it still doesn't fit once the scale hits min_font_scale. Caller must reset the
-    // window font scale back to 1.0 after drawing, since it stays in effect for the whole window.
-    static fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
-    {
-        std::string display = " " + text;
-        if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
-            return { display, false };
+        // Shrinks the current window's font scale so " text" fits within max_width; only truncates
+        // (with ellipsis) if it still doesn't fit once the scale hits min_font_scale. The returned
+        // object restores the window font scale to 1.0 once it goes out of scope.
+        fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
+        {
+            std::string display = " " + text;
+            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
+                return { display, false };
 
-        float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
-        ImGui::SetWindowFontScale(scale);
+            float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
+            ImGui::SetWindowFontScale(scale);
 
-        if (ImGui::CalcTextSize(display.c_str()).x > max_width)
-            display = " " + fit_text_to_width(text, max_width);
+            if (ImGui::CalcTextSize(display.c_str()).x > max_width)
+                display = truncate_to_width(text, max_width);
 
-        return { display, true };
+            return { display, true };
+        }
     }
 
     void device_model::draw_controls(float panel_width, float panel_height,

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2341,7 +2341,6 @@ namespace rs2
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
             ss << dev.get_info(RS2_CAMERA_INFO_NAME);
-        ss.str("Realsense D585 Proto Dual RGB"); // RSDEV-13403 TEMP TEST HACK - revert this commit before merging
         if (is_ip_device)
         {
             std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2329,7 +2329,7 @@ namespace rs2
         ////////////////////////////////////////
         const ImVec2 name_pos = { pos.x + 9, pos.y + 17 };
         const float name_area_right_margin = 55.f; // leave room for the remove (X) button
-        const float min_name_font_scale = 0.7f; // below this the name shrinks to illegibility - truncate instead
+        const float min_name_font_scale = 0.9f; // below this the name shrinks to illegibility - truncate instead
         ImGui::SetCursorPos(name_pos);
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
@@ -2368,8 +2368,10 @@ namespace rs2
                 }
             }
 
+            // Reserve a full space-width gap between the name and the badge, on top of the badge's own width.
+            float badge_gap = badge_text.empty() ? 0.f : ImGui::CalcTextSize(" ").x + ImGui::CalcTextSize(badge_text.c_str()).x;
             auto name = fit_name_to_width(full_name,
-                panel_width - name_pos.x - name_area_right_margin - ImGui::CalcTextSize(badge_text.c_str()).x,
+                panel_width - name_pos.x - name_area_right_margin - badge_gap,
                 min_name_font_scale);
             ImGui::Text("%s", name.text.c_str());
             ImGui::SetWindowFontScale(1.0f);
@@ -2378,7 +2380,7 @@ namespace rs2
 
             if (!badge_text.empty())
             {
-                ImGui::SameLine();
+                ImGui::SameLine(0.0f, ImGui::CalcTextSize(" ").x); // guarantee a space-width gap regardless of name scale
                 if (is_usb_badge)
                 {
                     if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2243,21 +2243,27 @@ namespace rs2
         // Any font scale this object applies is restored to 1.0 as soon as it goes out of scope -
         // callers control how long the scale should stay in effect (e.g. through a badge drawn
         // alongside the text) simply by choosing where that scope ends.
+        //
+        // trailing_width is the scale-1.0 width of other content (e.g. a badge) drawn right after
+        // this text at the same font scale - it competes for the same max_width and shrinks by the
+        // same factor, so it's folded into the fit instead of being reserved at full size.
         class fitted_string
         {
         public:
-            fitted_string(const std::string& text, float max_width, float min_font_scale)
+            fitted_string(const std::string& text, float max_width, float min_font_scale, float trailing_width = 0.f)
                 : _full(text), _display(" " + text)
             {
-                if (max_width <= 0 || ImGui::CalcTextSize(_display.c_str()).x <= max_width)
+                float text_width = ImGui::CalcTextSize(_display.c_str()).x;
+                if (max_width <= 0 || text_width + trailing_width <= max_width)
                     return;
 
-                float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(_display.c_str()).x);
+                float scale = std::max(min_font_scale, max_width / (text_width + trailing_width));
                 ImGui::SetWindowFontScale(scale);
                 _condensed = true;
 
-                if (ImGui::CalcTextSize(_display.c_str()).x > max_width)
-                    _display = truncate(text, max_width);
+                float text_budget = max_width - scale * trailing_width;
+                if (ImGui::CalcTextSize(_display.c_str()).x > text_budget)
+                    _display = truncate(text, text_budget);
             }
 
             ~fitted_string() { ImGui::SetWindowFontScale(1.0f); }
@@ -2376,38 +2382,43 @@ namespace rs2
                 }
             }
 
-            fitted_string name(full_name,
-                panel_width - name_pos.x - name_area_right_margin - ImGui::CalcTextSize(badge_text.c_str()).x,
-                min_name_font_scale);
-            ImGui::Text("%s", name.text());
-            if (name.condensed() && ImGui::IsItemHovered())
-                RsImGui::CustomTooltip(" %s", name.full_text());
+            {   // Dedicated scope: name and badge share the font scale fitted_string applies, and
+                // its destructor restores scale to 1.0 right after the badge - any code added below
+                // this scope, still inside the outer else, is guaranteed to run at normal scale.
+                fitted_string name(full_name,
+                    panel_width - name_pos.x - name_area_right_margin,
+                    min_name_font_scale,
+                    ImGui::CalcTextSize(badge_text.c_str()).x);
+                ImGui::Text("%s", name.text());
+                if (name.condensed() && ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip(" %s", name.full_text());
 
-            if (!badge_text.empty())
-            {
-                ImGui::SameLine();
-                if (is_usb_badge)
+                if (!badge_text.empty())
                 {
-                    if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);
-                    else ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
-                    ImGui::Text("%s", badge_text.c_str());
-                    ImGui::PopStyleColor();
-                    ss.str("");
-                    ss << "The camera was detected by the OS as connected to a USB " << usb_desc << " port";
-                    ImGui::PushFont(window.get_font());
-                    ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
-                    if (ImGui::IsItemHovered())
-                        RsImGui::CustomTooltip(" %s", ss.str().c_str());
-                    ImGui::PopStyleColor();
-                    ImGui::PopFont();
+                    ImGui::SameLine();
+                    if (is_usb_badge)
+                    {
+                        if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);
+                        else ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+                        ImGui::Text("%s", badge_text.c_str());
+                        ImGui::PopStyleColor();
+                        ss.str("");
+                        ss << "The camera was detected by the OS as connected to a USB " << usb_desc << " port";
+                        ImGui::PushFont(window.get_font());
+                        ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+                        if (ImGui::IsItemHovered())
+                            RsImGui::CustomTooltip(" %s", ss.str().c_str());
+                        ImGui::PopStyleColor();
+                        ImGui::PopFont();
+                    }
+                    else
+                    {
+                        ImGui::PushStyleColor(ImGuiCol_Text, white);
+                        ImGui::Text("%s", badge_text.c_str());
+                        ImGui::PopStyleColor();
+                    }
                 }
-                else
-                {
-                    ImGui::PushStyleColor(ImGuiCol_Text, white);
-                    ImGui::Text("%s", badge_text.c_str());
-                    ImGui::PopStyleColor();
-                }
-            } // name's destructor restores the font scale here, after the badge is drawn at the same scale
+            }
         }
 
         ImGui::PopFont();

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2237,16 +2237,10 @@ namespace rs2
 
     namespace
     {
-        // Fits text into max_width pixels for the device header: first shrinking the current
-        // window's font scale down to min_font_scale, then truncating with an ellipsis if it still
-        // doesn't fit at that floor. The full (untruncated) text stays available for a tooltip.
-        // Any font scale this object applies is restored to 1.0 as soon as it goes out of scope -
-        // callers control how long the scale should stay in effect (e.g. through a badge drawn
-        // alongside the text) simply by choosing where that scope ends.
-        //
-        // trailing_width is the scale-1.0 width of other content (e.g. a badge) drawn right after
-        // this text at the same font scale - it competes for the same max_width and shrinks by the
-        // same factor, so it's folded into the fit instead of being reserved at full size.
+        // Fits text (plus an optional trailing_width, e.g. a badge drawn alongside it at the same
+        // scale) into max_width pixels: shrinks the window's font scale down to min_font_scale,
+        // then truncates with an ellipsis if it still doesn't fit. Font scale resets to 1.0 when
+        // this object goes out of scope, so callers control its lifetime by choosing that scope.
         class fitted_string
         {
         public:

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2237,51 +2237,58 @@ namespace rs2
 
     namespace
     {
-        struct fitted_name
+        // Fits text into max_width pixels for the device header: first shrinking the current
+        // window's font scale down to min_font_scale, then truncating with an ellipsis if it still
+        // doesn't fit at that floor. The full (untruncated) text stays available for a tooltip.
+        // Any font scale this object applies is restored to 1.0 as soon as it goes out of scope -
+        // callers control how long the scale should stay in effect (e.g. through a badge drawn
+        // alongside the text) simply by choosing where that scope ends.
+        class fitted_string
         {
-            std::string text;
-            bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
-
-            // Backstop: guarantees the window font scale is restored even if the caller's own
-            // reset gets skipped by an early return or an exception between the two.
-            ~fitted_name() { ImGui::SetWindowFontScale(1.0f); }
-        };
-
-        // Truncates text with a trailing ellipsis so " text" fits within max_width pixels (current
-        // font). Uses a binary search on the character count rather than trimming one character at
-        // a time, since this runs every frame the name doesn't fit.
-        std::string truncate_to_width(const std::string& text, float max_width)
-        {
-            const std::string ellipsis = "...";
-            size_t lo = 0, hi = text.size();
-            while (lo < hi)
+        public:
+            fitted_string(const std::string& text, float max_width, float min_font_scale)
+                : _full(text), _display(" " + text)
             {
-                size_t mid = (lo + hi + 1) / 2;
-                if (ImGui::CalcTextSize((" " + text.substr(0, mid) + ellipsis).c_str()).x <= max_width)
-                    lo = mid;
-                else
-                    hi = mid - 1;
+                if (max_width <= 0 || ImGui::CalcTextSize(_display.c_str()).x <= max_width)
+                    return;
+
+                float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(_display.c_str()).x);
+                ImGui::SetWindowFontScale(scale);
+                _condensed = true;
+
+                if (ImGui::CalcTextSize(_display.c_str()).x > max_width)
+                    _display = truncate(text, max_width);
             }
-            return " " + text.substr(0, lo) + ellipsis;
-        }
 
-        // Shrinks the current window's font scale so " text" fits within max_width; only truncates
-        // (with ellipsis) if it still doesn't fit once the scale hits min_font_scale. The returned
-        // object restores the window font scale to 1.0 once it goes out of scope.
-        fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
-        {
-            std::string display = " " + text;
-            if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
-                return { display, false };
+            ~fitted_string() { ImGui::SetWindowFontScale(1.0f); }
 
-            float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
-            ImGui::SetWindowFontScale(scale);
+            const char* text() const { return _display.c_str(); }
+            const char* full_text() const { return _full.c_str(); }
+            bool condensed() const { return _condensed; } // full text is available via tooltip
 
-            if (ImGui::CalcTextSize(display.c_str()).x > max_width)
-                display = truncate_to_width(text, max_width);
+        private:
+            // Truncates text with a trailing ellipsis so " text" fits within max_width pixels
+            // (current font). Uses a binary search on the character count rather than trimming one
+            // character at a time, since this runs every frame the name doesn't fit.
+            static std::string truncate(const std::string& text, float max_width)
+            {
+                const std::string ellipsis = "...";
+                size_t lo = 0, hi = text.size();
+                while (lo < hi)
+                {
+                    size_t mid = (lo + hi + 1) / 2;
+                    if (ImGui::CalcTextSize((" " + text.substr(0, mid) + ellipsis).c_str()).x <= max_width)
+                        lo = mid;
+                    else
+                        hi = mid - 1;
+                }
+                return " " + text.substr(0, lo) + ellipsis;
+            }
 
-            return { display, true };
-        }
+            std::string _full;
+            std::string _display;
+            bool _condensed = false;
+        };
     }
 
     void device_model::draw_controls(float panel_width, float panel_height,
@@ -2337,11 +2344,12 @@ namespace rs2
         if (is_ip_device)
         {
             std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));
-            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin, min_name_font_scale);
-            ImGui::Text("%s", name.text.c_str());
-            ImGui::SetWindowFontScale(1.0f);
-            if (name.condensed && ImGui::IsItemHovered())
-                RsImGui::CustomTooltip(" %s", full_name.c_str());
+            {
+                fitted_string name(full_name, panel_width - name_pos.x - name_area_right_margin, min_name_font_scale);
+                ImGui::Text("%s", name.text());
+                if (name.condensed() && ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip(" %s", name.full_text());
+            } // name's destructor restores the font scale before the network-device line below
 
             ImGui::PushFont(window.get_font());
             ImGui::Text("\tNetwork Device at %s", dev.get_info(RS2_CAMERA_INFO_IP_ADDRESS));
@@ -2360,21 +2368,20 @@ namespace rs2
                 {
                     usb_desc = dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
                     is_usb_badge = true;
-                    badge_text = rsutils::string::from() << "   " << textual_icons::usb << " " << usb_desc;
+                    badge_text = rsutils::string::from() << "  " << textual_icons::usb << " " << usb_desc;
                 }
                 else
                 {
-                    badge_text = rsutils::string::from() << "   " << connection_type;
+                    badge_text = rsutils::string::from() << "  " << connection_type;
                 }
             }
 
-            auto name = fit_name_to_width(full_name,
+            fitted_string name(full_name,
                 panel_width - name_pos.x - name_area_right_margin - ImGui::CalcTextSize(badge_text.c_str()).x,
                 min_name_font_scale);
-            ImGui::Text("%s", name.text.c_str());
-            ImGui::SetWindowFontScale(1.0f);
-            if (name.condensed && ImGui::IsItemHovered())
-                RsImGui::CustomTooltip(" %s", full_name.c_str());
+            ImGui::Text("%s", name.text());
+            if (name.condensed() && ImGui::IsItemHovered())
+                RsImGui::CustomTooltip(" %s", name.full_text());
 
             if (!badge_text.empty())
             {
@@ -2400,7 +2407,7 @@ namespace rs2
                     ImGui::Text("%s", badge_text.c_str());
                     ImGui::PopStyleColor();
                 }
-            }
+            } // name's destructor restores the font scale here, after the badge is drawn at the same scale
         }
 
         ImGui::PopFont();

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2235,6 +2235,43 @@ namespace rs2
         return false;
     }
 
+    // Shorten text with a trailing ellipsis so it renders within max_width pixels (current font)
+    static std::string fit_text_to_width(const std::string& text, float max_width)
+    {
+        if (max_width <= 0 || ImGui::CalcTextSize(text.c_str()).x <= max_width)
+            return text;
+
+        const std::string ellipsis = "...";
+        std::string fitted = text;
+        while (!fitted.empty() && ImGui::CalcTextSize((fitted + ellipsis).c_str()).x > max_width)
+            fitted.pop_back();
+        return fitted.empty() ? ellipsis : fitted + ellipsis;
+    }
+
+    struct fitted_name
+    {
+        std::string text;
+        bool condensed; // shrunk and/or truncated to fit - full name is available via tooltip
+    };
+
+    // Shrinks the current window's font scale so " text" fits within max_width; only truncates (with
+    // ellipsis) if it still doesn't fit once the scale hits min_font_scale. Caller must reset the
+    // window font scale back to 1.0 after drawing, since it stays in effect for the whole window.
+    static fitted_name fit_name_to_width(const std::string& text, float max_width, float min_font_scale)
+    {
+        std::string display = " " + text;
+        if (max_width <= 0 || ImGui::CalcTextSize(display.c_str()).x <= max_width)
+            return { display, false };
+
+        float scale = std::max(min_font_scale, max_width / ImGui::CalcTextSize(display.c_str()).x);
+        ImGui::SetWindowFontScale(scale);
+
+        if (ImGui::CalcTextSize(display.c_str()).x > max_width)
+            display = " " + fit_text_to_width(text, max_width);
+
+        return { display, true };
+    }
+
     void device_model::draw_controls(float panel_width, float panel_height,
         ux_window& window,
         std::string& error_message,
@@ -2279,13 +2316,20 @@ namespace rs2
         // Draw device name
         ////////////////////////////////////////
         const ImVec2 name_pos = { pos.x + 9, pos.y + 17 };
+        const float name_area_right_margin = 55.f; // leave room for the remove (X) button
+        const float min_name_font_scale = 0.7f; // below this the name shrinks to illegibility - truncate instead
         ImGui::SetCursorPos(name_pos);
         std::stringstream ss;
         if (dev.supports(RS2_CAMERA_INFO_NAME))
             ss << dev.get_info(RS2_CAMERA_INFO_NAME);
         if (is_ip_device)
         {
-            ImGui::Text(" %s", ss.str().substr(0, ss.str().find("\n IP Device")).c_str());
+            std::string full_name = ss.str().substr(0, ss.str().find("\n IP Device"));
+            auto name = fit_name_to_width(full_name, panel_width - name_pos.x - name_area_right_margin, min_name_font_scale);
+            ImGui::Text("%s", name.text.c_str());
+            ImGui::SetWindowFontScale(1.0f);
+            if (name.condensed && ImGui::IsItemHovered())
+                RsImGui::CustomTooltip(" %s", full_name.c_str());
 
             ImGui::PushFont(window.get_font());
             ImGui::Text("\tNetwork Device at %s", dev.get_info(RS2_CAMERA_INFO_IP_ADDRESS));
@@ -2293,22 +2337,44 @@ namespace rs2
         }
         else
         {
-            ImGui::Text(" %s", ss.str().c_str());
+            std::string full_name = ss.str();
+            std::string badge_text; // includes the same leading spaces the old inline "% s" formatting produced
+            std::string usb_desc;
+            bool is_usb_badge = false;
             if (dev.supports(RS2_CAMERA_INFO_CONNECTION_TYPE))
             {
                 std::string connection_type = dev.get_info(RS2_CAMERA_INFO_CONNECTION_TYPE);
                 if (connection_type == "USB" && dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
                 {
-                    std::string desc = dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
-                    ss.str("");
-                    ss << "   " << textual_icons::usb << " " << desc;
-                    ImGui::SameLine();
-                    if (!starts_with(desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);
+                    usb_desc = dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
+                    is_usb_badge = true;
+                    badge_text = rsutils::string::from() << "    " << textual_icons::usb << " " << usb_desc;
+                }
+                else
+                {
+                    badge_text = rsutils::string::from() << "    " << connection_type;
+                }
+            }
+
+            auto name = fit_name_to_width(full_name,
+                panel_width - name_pos.x - name_area_right_margin - ImGui::CalcTextSize(badge_text.c_str()).x,
+                min_name_font_scale);
+            ImGui::Text("%s", name.text.c_str());
+            ImGui::SetWindowFontScale(1.0f);
+            if (name.condensed && ImGui::IsItemHovered())
+                RsImGui::CustomTooltip(" %s", full_name.c_str());
+
+            if (!badge_text.empty())
+            {
+                ImGui::SameLine();
+                if (is_usb_badge)
+                {
+                    if (!starts_with(usb_desc, "3.")) ImGui::PushStyleColor(ImGuiCol_Text, yellow);
                     else ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
-                    ImGui::Text(" %s", ss.str().c_str());
+                    ImGui::Text("%s", badge_text.c_str());
                     ImGui::PopStyleColor();
                     ss.str("");
-                    ss << "The camera was detected by the OS as connected to a USB " << desc << " port";
+                    ss << "The camera was detected by the OS as connected to a USB " << usb_desc << " port";
                     ImGui::PushFont(window.get_font());
                     ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
                     if (ImGui::IsItemHovered())
@@ -2318,17 +2384,13 @@ namespace rs2
                 }
                 else
                 {
-                    ss.str("");
-                    ss << "   " << connection_type;
-                    ImGui::SameLine();
                     ImGui::PushStyleColor(ImGuiCol_Text, white);
-                    ImGui::Text(" %s", ss.str().c_str());
+                    ImGui::Text("%s", badge_text.c_str());
                     ImGui::PopStyleColor();
                 }
             }
         }
 
-        //ImGui::Text(" %s", dev.get_info(RS2_CAMERA_INFO_NAME));
         ImGui::PopFont();
 
         ////////////////////////////////////////


### PR DESCRIPTION
**Overview:** The device panel header now shrinks or truncates an overly long device name (and the connection badge alongside it) so it fits the panel width, instead of overflowing and hiding the USB/connection badge.

Tracked on [RSDEV-13403]

## Why
Some new camera names are long and don't fit in the device panel header alongside the connection info - the name overflows, pushing the USB type badge and remove (X) button out of view.

## Summary
- Added a `fitted_string` class that encapsulates the fit/shrink/truncate logic: it shrinks the current window's font scale (floor of 0.9x) so text fits, falls back to ellipsis truncation (binary search on character count) if it still doesn't fit at that floor, and restores the font scale to 1.0 via its destructor once it goes out of scope.
- The connection-type/USB badge is now drawn while the same `fitted_string` is still in scope, so it scales down alongside the name rather than staying full-size next to a shrunk name.
- Available width accounts for the badge's own width and the remove button margin before deciding whether to shrink/truncate.
- When the name is shrunk or truncated, hovering it shows the full name in a tooltip (same pattern already used for the USB descriptor and playback filename in that header).
- Applies to both the regular and IP-device name paths.

## Test plan
- [x] Built `realsense-viewer` (Release, MSVC) clean with no new warnings.
- [x] Manually verified via a temporary local-only harness (simulated long device name, reverted before each commit): moderately long names shrink (name + badge together) to fit on one line; names still too long even at the minimum scale fall back to ellipsis truncation with the full name shown in a tooltip on hover.
- [x] Verified against real hardware with a long device name (temporary test-name override was pushed, verified, then reverted - see PR comments).
- [ ] CI

---
🤖 Generated by AI