### PR TITLE
[RSDEV-13232] Declare D585 2C streams before STREAMON

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -127,6 +127,145 @@ namespace librealsense
         , _owner(owner)
         , _depth_units(-1)
     {
+        uvc_sensor->register_before_stream_on(
+            [this]( const std::vector< platform::stream_profile > & configurations )
+            {
+                declare_expected_streams( configurations );
+            } );
+    }
+
+    void d500_depth_sensor::declare_expected_streams(
+        const std::vector< platform::stream_profile > & configurations )
+    {
+        if( ! _owner || _owner->_pid != ds::D585_2C_PROTO_PID || ! _owner->_hw_monitor )
+            return;
+
+        struct manifest_entry
+        {
+            bool valid = false;
+            uint8_t branch = 0;
+            platform::stream_profile profile = {};
+        };
+        manifest_entry entries[4];
+        uint8_t expected_mask = 0;
+        uint8_t count = 0;
+
+        for( auto const & configuration : configurations )
+        {
+            std::shared_ptr< stream_profile_interface > identity;
+            for( auto const & raw : get_raw_stream_profiles() )
+            {
+                auto const * backend = dynamic_cast< backend_stream_profile const * >( raw.get() );
+                if( backend && backend->get_backend_profile() == configuration )
+                {
+                    identity = raw;
+                    break;
+                }
+            }
+            if( ! identity )
+            {
+                LOG_WARNING( "D585 2C stream transaction: no identity for committed pin "
+                             << configuration.pin_index << "; using legacy admission" );
+                return;
+            }
+
+            int branch = -1;
+            if( identity->get_stream_type() == RS2_STREAM_DEPTH )
+                branch = 0;
+            else if( identity->get_stream_type() == RS2_STREAM_INFRARED )
+                branch = 1;
+            // SDK color indexes are arranged to match the IR imagers, while
+            // the FW transaction mask names physical USB branches. On 0C07,
+            // Color 1 is carried by EP8 and Color 2 by EP4.
+            else if( identity->get_stream_type() == RS2_STREAM_COLOR
+                     && identity->get_stream_index() == 1 )
+                branch = 3;
+            else if( identity->get_stream_type() == RS2_STREAM_COLOR
+                     && identity->get_stream_index() == 2 )
+                branch = 2;
+            else
+                continue;
+
+            if( entries[branch].valid )
+            {
+                LOG_WARNING( "D585 2C stream transaction: duplicate branch "
+                             << branch << "; using legacy admission" );
+                return;
+            }
+            entries[branch].valid = true;
+            entries[branch].branch = static_cast< uint8_t >( branch );
+            entries[branch].profile = configuration;
+            expected_mask |= static_cast< uint8_t >( 1U << branch );
+            ++count;
+        }
+        if( count == 0 )
+            return;
+
+        uint32_t transaction_id = ++_next_stream_transaction_id;
+        if( transaction_id == 0 )
+            transaction_id = ++_next_stream_transaction_id;
+
+        std::vector< uint8_t > payload;
+        payload.reserve( 8U + static_cast< size_t >( count ) * 12U );
+        auto append_u16 = [&payload]( uint16_t value )
+        {
+            payload.push_back( static_cast< uint8_t >( value & 0xffU ) );
+            payload.push_back( static_cast< uint8_t >( ( value >> 8U ) & 0xffU ) );
+        };
+        auto append_u32 = [&payload]( uint32_t value )
+        {
+            payload.push_back( static_cast< uint8_t >( value & 0xffU ) );
+            payload.push_back( static_cast< uint8_t >( ( value >> 8U ) & 0xffU ) );
+            payload.push_back( static_cast< uint8_t >( ( value >> 16U ) & 0xffU ) );
+            payload.push_back( static_cast< uint8_t >( ( value >> 24U ) & 0xffU ) );
+        };
+
+        payload.push_back( 1U );
+        payload.push_back( count );
+        payload.push_back( expected_mask );
+        payload.push_back( 0U );
+        append_u32( transaction_id );
+        for( auto const & entry : entries )
+        {
+            if( ! entry.valid )
+                continue;
+            if( entry.profile.width > 0xffffU || entry.profile.height > 0xffffU
+                || entry.profile.fps > 0xffffU )
+            {
+                LOG_WARNING( "D585 2C stream transaction: profile exceeds wire limits" );
+                return;
+            }
+            payload.push_back( entry.branch );
+            payload.push_back( 0U );
+            append_u16( static_cast< uint16_t >( entry.profile.width ) );
+            append_u16( static_cast< uint16_t >( entry.profile.height ) );
+            append_u16( static_cast< uint16_t >( entry.profile.fps ) );
+            append_u32( entry.profile.format );
+        }
+
+        command cmd( ds::STREAM_GROUP_TRANSACTION, 1U );
+        cmd.data = std::move( payload );
+        cmd.timeout_ms = 15000;
+        hwmon_response_type response = 0;
+        try
+        {
+            _owner->_hw_monitor->send( cmd, &response );
+            if( response != _owner->_hw_monitor_response->success_value() )
+            {
+                LOG_WARNING( "D585 2C stream transaction " << transaction_id
+                             << " rejected (" << response
+                             << "); using legacy admission" );
+                return;
+            }
+            LOG_INFO( "D585 2C stream transaction " << transaction_id
+                      << " prepared mask=0x" << std::hex
+                      << static_cast< unsigned >( expected_mask ) << std::dec );
+        }
+        catch( std::exception const & e )
+        {
+            LOG_WARNING( "D585 2C stream transaction unavailable: " << e.what()
+                         << "; using legacy admission" );
+        }
     }
 
     processing_blocks d500_depth_sensor::get_recommended_processing_blocks() const

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -65,6 +65,9 @@ namespace librealsense
         float _stereo_baseline_mm;
 
     private:
+        void declare_expected_streams(
+            const std::vector< platform::stream_profile > & configurations );
+        uint32_t _next_stream_transaction_id = 0;
         embedded_filters _embedded_filters;
         std::vector< std::shared_ptr< stream_interface > > _extra_streams;
     };

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -125,6 +125,7 @@ namespace librealsense
             GET_FW_LOGS              = 0xB4, // Get FW logs extended format
             SET_CALIB_MODE           = 0xB8, // Set Calibration Mode
             GET_CALIB_STATUS         = 0xB9, // Get Calibration Status
+            STREAM_GROUP_TRANSACTION = 0xBD,
         };
 
         inline std::string d500_fw_cmd2str(const d500_fw_cmd state)

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -372,6 +372,9 @@ void uvc_sensor::open( const stream_profiles & requests )
     if( _on_open )
         _on_open( _internal_config );
 
+    if( _before_stream_on )
+        _before_stream_on( _internal_config );
+
     _power = std::move( on );
     _is_opened = true;
 

--- a/src/uvc-sensor.h
+++ b/src/uvc-sensor.h
@@ -44,6 +44,10 @@ public:
                                                      rs2_stream & type,
                                                      int & index ) >;
     void set_stream_id_resolver( stream_id_resolver resolver ) { _stream_id_resolver = std::move( resolver ); }
+    void register_before_stream_on( on_open callback )
+    {
+        _before_stream_on = std::move( callback );
+    }
 
     std::vector< platform::stream_profile > get_configuration() const { return _internal_config; }
     std::shared_ptr< platform::uvc_device > get_uvc_device() { return _device; }
@@ -115,6 +119,7 @@ private:
 
     std::shared_ptr< platform::uvc_device > _device;
     stream_id_resolver _stream_id_resolver;
+    on_open _before_stream_on;
     std::vector< platform::stream_profile > _internal_config;
     std::atomic< int > _user_count;
     std::mutex _power_lock;


### PR DESCRIPTION
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/434
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-device-mgr/pull/437
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/239
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/247
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-hkr-apps/pull/249
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/489
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/499
Depends-On: https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/504

## Summary

- add a UVC callback after profile commitment and before STREAMON
- for exact D585 2C PID `0C07`, map committed SDK profiles to the four physical branches
- send one versioned stream-group manifest to firmware before endpoint start
- preserve legacy behavior for other devices and when firmware does not support the command

## Why

Firmware cannot infer a complete multi-endpoint stream request from independently scheduled STREAMON ioctls. The SDK already owns the committed profile set, so it is the smallest layer that can declare the expected cohort before streaming starts.

## Validation

- clean Release build from current `development`, including tools and Python bindings
- tested against full-flash FW `7.58.40928.13271`
- 30/30 randomized cycles with all 15 physical stream masks covered twice
- every cycle verified frames, exact transaction masks, cleared stop state, and unchanged USB identity

The corresponding firmware PRs are required for explicit admission; older firmware continues through the legacy fallback.

