### PR TITLE
Reuse project_shader for unmapped GL pointcloud

### DIFF
--- a/src/gl/pointcloud-gl.cpp
+++ b/src/gl/pointcloud-gl.cpp
@@ -426,6 +426,13 @@ const librealsense::float3* pointcloud_gl::depth_to_points(
     }, [&]{
         _enabled = false;
     });
+
+    // With no texture mapped the base class skips get_texture_map, leaving the output empty.
+    // Render here instead against the depth stream itself, so the shader passes UVs through.
+    if (!_extrinsics || !_other_intrinsics)
+        get_texture_map(output, nullptr, depth_frame.get_width(), depth_frame.get_height(),
+                        depth_intrinsics, identity_matrix(), nullptr);
+
     return nullptr;
 }
 

--- a/src/gl/pointcloud-gl.cpp
+++ b/src/gl/pointcloud-gl.cpp
@@ -423,17 +423,17 @@ const librealsense::float3* pointcloud_gl::depth_to_points(
         _depth_data = depth_frame;
         _depth_scale = depth_frame.get_units();
         _depth_intr = depth_intrinsics;
+
+        // With no texture mapped the base class skips get_texture_map, leaving the output empty.
+        // Render here instead against the depth stream itself, so the shader passes UVs through.
+        if (!_extrinsics || !_other_intrinsics)
+        {
+            get_texture_map(output, nullptr, depth_frame.get_width(), depth_frame.get_height(),
+                            depth_intrinsics, identity_matrix(), nullptr);
+        }
     }, [&]{
         _enabled = false;
     });
-
-    // With no texture mapped the base class skips get_texture_map, leaving the output empty.
-    // Render here instead against the depth stream itself, so the shader passes UVs through.
-    if (!_extrinsics || !_other_intrinsics)
-    {
-        get_texture_map(output, nullptr, depth_frame.get_width(), depth_frame.get_height(),
-                        depth_intrinsics, identity_matrix(), nullptr);
-    }
 
     return nullptr;
 }

--- a/src/gl/pointcloud-gl.cpp
+++ b/src/gl/pointcloud-gl.cpp
@@ -430,8 +430,10 @@ const librealsense::float3* pointcloud_gl::depth_to_points(
     // With no texture mapped the base class skips get_texture_map, leaving the output empty.
     // Render here instead against the depth stream itself, so the shader passes UVs through.
     if (!_extrinsics || !_other_intrinsics)
+    {
         get_texture_map(output, nullptr, depth_frame.get_width(), depth_frame.get_height(),
                         depth_intrinsics, identity_matrix(), nullptr);
+    }
 
     return nullptr;
 }


### PR DESCRIPTION
**Overview:** The GLSL point cloud returned no points when no texture stream was mapped to it. Applications that only need geometry — such as realsense-ros with no color texture configured — got an empty point cloud. It now returns the same geometry as the CPU implementation.

## Why

Reported in IntelRealSense/realsense-ros#3206.

`pointcloud::process_depth_frame` splits the work in two:

```cpp
const float3* points = depth_to_points(res, *_depth_intrinsics, depth);  // deproject Z16 -> XYZ
...
if (map_texture)                                                         // only when map_to() was called
    get_texture_map(res, points, width, height, mapped_intr, extr, pixels_ptr);
```

That split works for the CPU implementation, where `depth_to_points` writes the vertices and `get_texture_map` only adds texture coordinates on top.

It does not work for `pointcloud_gl`. On the GPU a single shader pass emits XYZ and UV together, so all of the work lives in `get_texture_map`, and `depth_to_points` only stashes state and returns `nullptr`. With no texture mapped, the second step is skipped and nothing runs at all — the output frame is returned untouched.

## Summary

- `pointcloud_gl::depth_to_points` now renders directly when no texture is mapped, passing the depth stream's own intrinsics and identity extrinsics.
- No new shader is needed. `project_fragment_text` already has a no-texture mode: `get_texture_map` clears its `needs_projection` uniform when the target intrinsics match depth and the extrinsics are identity, which makes it a pure deprojection pass and emits pass-through UVs.
- Identity extrinsics also make `occlusion_filter::is_same_sensor` true, so the occlusion pass is correctly skipped.
- The new condition is the exact complement of the base class's `map_texture`, so `get_texture_map` runs exactly once on either path.

Both GPU texture slots are populated, which matters for consumers beyond CPU readback: `pointcloud_renderer` requires slot 0 and slot 1 or it renders nothing, `rs2_gl_frame_get_texture_id(f, 1)` would otherwise throw, and `points::get_texture_coordinates()` would return a region the frame never writes.

### Relation to #13462

Same bug, smaller fix. #13462 adds a second shader plus a second copy of the FBO setup; its 38 lines of deprojection math are byte-identical to the existing shader's. It also emits only XYZ, leaving the UV texture slot unpopulated. This change reuses the existing shader instead — 9 lines, and both slots populated.

## Test plan

Verified on Ubuntu with Mesa/Intel GL, comparing against the CPU `pointcloud` on the same depth frame.

| | valid points (of 307200) | texcoords | max deviation vs CPU |
|---|---|---|---|
| before, no `map_to` | **0** | 0% | — |
| after, no `map_to` | **286603** | 100% | 0.0117 m |
| CPU reference, no `map_to` | 286603 | 0% | — |
| with `map_to`, before vs after | 241271 / 241271 | 85.2% / 85.2% | unchanged |

The residual deviation is the half-float precision of the `GL_RGB16F` XYZ texture, which the mapped path already has.

- [x] `single_depth_color_640x480.bag` — valid-point count matches the CPU implementation exactly; 850 of 286603 shared pixels deviate by more than 1 cm.
- [x] Live D455 at 640x480 — all three point clouds computed from one depth frame after warm-up: 285926 valid points matching CPU, max deviation 0.0072 m, no pixel over 1 cm.
- [x] GPU texture slots 0 (XYZ) and 1 (UV) both present with and without `map_to`.
- [x] Mapped path unchanged versus `development` — same valid-point and texcoord counts, so no regression to the existing path.
- [ ] realsense-viewer 3D view — cycle texture source, toggle occlusion invalidation, switch shaders, mouse-pick, export PLY. Note the viewer always supplies a texture source (`is_rasterizeable` accepts Z16, so depth-only streaming maps depth to itself), so this is a regression check and does not exercise the fixed path.

---
🤖 Generated by AI
