### PR TITLE
pre-release: move industrial_ci host container off EOL noetic/focal

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -59,12 +59,8 @@ jobs:
       PRERELEASE: true
       BASEDIR: ${{ github.workspace }}/.work
       # industrial_ci defaults the prerelease host container to ros:noetic-ros-core
-      # (Ubuntu focal, EOL — its apt archives are no longer reliably reachable).
-      # This container only generates and launches the prerelease script; the actual
-      # binarydeb builds run in nested containers whose OS comes from ROS_DISTRO,
-      # so the host image is independent of the distro being tested. Must stay a
-      # ros:* image: setting DOCKER_IMAGE disables industrial_ci's ROS apt setup,
-      # so colcon has to already be available.
+      # (focal, EOL). Must stay a ros:* image — setting DOCKER_IMAGE disables
+      # industrial_ci's ROS apt setup, so colcon must be installable already.
       DOCKER_IMAGE: ros:jazzy-ros-core
 
     steps:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -58,6 +58,14 @@ jobs:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       PRERELEASE: true
       BASEDIR: ${{ github.workspace }}/.work
+      # industrial_ci defaults the prerelease host container to ros:noetic-ros-core
+      # (Ubuntu focal, EOL — its apt archives are no longer reliably reachable).
+      # This container only generates and launches the prerelease script; the actual
+      # binarydeb builds run in nested containers whose OS comes from ROS_DISTRO,
+      # so the host image is independent of the distro being tested. Must stay a
+      # ros:* image: setting DOCKER_IMAGE disables industrial_ci's ROS apt setup,
+      # so colcon has to already be available.
+      DOCKER_IMAGE: ros:jazzy-ros-core
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4


### PR DESCRIPTION
**Overview:** Pins the pre-release workflow's industrial_ci host container to `ros:jazzy-ros-core`, replacing the upstream default of `ros:noetic-ros-core` (Ubuntu focal, EOL since 2025-05).

Tracked on [RSDSO-21821]

## Why

industrial_ci defaults the prerelease **host** container to `ros:noetic-ros-core`. That default was set upstream in 2020 and never bumped, so the workflow depends on focal apt archives more than a year past EOL.

On 2026-08-04, ~14:00–17:00 UTC, every leg on every branch failed at the industrial_ci `init` step — before any build — because those archives were unreachable:

```
$ sudo apt-get update -qq
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal/InRelease  Connection failed [IP: 91.189.91.81 80]
E: Unable to correct problems, you have held broken packages.
'init' returned with code '100'
```

That outage has since resolved on its own — `development` passed at 07:11 UTC today still on noetic. So this is hardening against an EOL suite, not repair of an active failure. Focal will keep degrading toward `old-releases`, and the next occurrence costs the same diagnosis time, since today the host image is an invisible upstream default with no mention in our config.

## Summary

- Set `DOCKER_IMAGE: ros:jazzy-ros-core` in the workflow `env` block.
- The host container only installs docker/python/colcon, generates the prerelease script, and launches it. The actual binarydeb builds run in nested containers whose OS is derived from `ROS_DISTRO` (humble→jammy, jazzy/kilted→noble, lyrical/rolling→resolute), so the host image is independent of the distro under test. Confirmed in this PR's humble log: host pulls `ros:jazzy-ros-core`, nested build starts `FROM ubuntu:jammy`.
- `docker.sh` only back-infers `ROS_DISTRO` from the image when unset; it is set per matrix leg here, so there is no distro leakage.
- Must stay a `ros:*` image: setting `DOCKER_IMAGE` disables industrial_ci's ROS apt-repo setup, and `colcon` is not preinstalled in `ros-core` — it is apt-installed from the ROS repo baked into `ros:*` images. A plain `ubuntu:noble` would fail at `colcon_setup`.
- Not upstreamed-and-waited-on: we are SHA-pinned to industrial_ci `125164b`, so an upstream default change would not reach us until the pin is bumped by hand. The explicit value also keeps winning if upstream later changes its default.

## Test plan

- [x] All five `pre-release` legs (rolling, lyrical, kilted, jazzy, humble) pass on this PR — the workflow triggers on `pull_request` to `development` and runs from the merge ref, so it exercises the new image directly.
- [x] No other workflow touched.

---
🤖 Generated by AI
