### PR TITLE
CI: run the LibCI job on Ubuntu 26.04

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -413,8 +413,8 @@ jobs:
         python3 -m pytest unit-tests/ --color=no --debug -s --not-live --context "linux"
 
   #--------------------------------------------------------------------------------
-  U24_SH_Py_CI_SYS_JSON:  # Ubuntu 24.04, Shared, Python, LibCI with executables and system provided nlohmann_json library
-    runs-on: ubuntu-24.04
+  U26_SH_Py_CI_SYS_JSON:  # Ubuntu 26.04, Shared, Python, LibCI with executables and system provided nlohmann_json library
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -18,6 +18,11 @@ macro(os_set_flags)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat -Wformat-security")
 
+    # Default -ffp-contract=fast fuses a*b+c*d into an FMA wherever the ISA has one (x86-64-v3
+    # on Ubuntu 26.04, always on aarch64), dropping a rounding and shifting filter output 1 LSB.
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -ffp-contract=off")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off")
+
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE MACHINE)
     if(${MACHINE} MATCHES "arm64-*" OR ${MACHINE} MATCHES "aarch64-*")
         if(BUILD_WITH_NEON)


### PR DESCRIPTION
**Overview:** Moves the system-nlohmann_json LibCI job from Ubuntu 24.04 to 26.04, so the unit tests run against a current toolchain instead of being untested there — and fixes the floating-point contraction that the move exposed.

## Why

#15384 was a `test-types-pose` failure that only appears on Ubuntu 26.04, and it was invisible to this repo's CI. Only two Linux jobs run the untagged unit-test suite:

| job | runner | filter | runs `test-types-pose` |
|---|---|---|---|
| `U22_SH_Py_CI` | ubuntu-22.04 | `--context "linux"` | yes |
| `U24_SH_Py_CI_SYS_JSON` | ubuntu-24.04 | `--context "linux"` | yes |
| `U22_U24_SH_Py_DDS_CI` | 22.04, 24.04 | `--tag dds` | no |

`U-Latest_ST_Py_EX_CfU` does not help: it has no `LibCI` step, never passes `-DBUILD_UNIT_TESTS` (default `OFF`), and `ubuntu-latest` still resolves to `ubuntu-24.04` on GitHub runners today.

The failure itself came from GCC 15.2 on 26.04 contracting multiply-adds into FMAs under the default `-ffp-contract=fast`, which shifted an intermediate rounding by one ULP and broke an exact float comparison in the test. That is the class of breakage this job is meant to catch — it surfaces on a toolchain bump, not on a code change.

Moving the job promptly surfaced a second instance of the same class, in `post-processing/pytest-filters.py`, which this PR also fixes.

## Summary

- `U24_SH_Py_CI_SYS_JSON` becomes `U26_SH_Py_CI_SYS_JSON`, `runs-on: ubuntu-26.04`. All steps unchanged.
- Untagged Linux coverage becomes 22.04 + 26.04, bracketing 24.04.
- 24.04 keeps build coverage (`U22_U24_ST_Py_EX_CfU`) and DDS-tagged LibCI (`U22_U24_SH_Py_DDS_CI`). What it loses is the untagged suite.
- No new job, and no ruleset change — only `LRS_libci_trigger` is a required context.
- `CMake/unix_config.cmake` builds with `-ffp-contract=off`.

Chose the flip over adding a 26.04 matrix entry to keep the job count flat. The matrix alternative costs one extra job and would preserve untagged 24.04 coverage, if that tradeoff is preferred.

## The `-ffp-contract=off` fix

`pytest-filters.py` compares post-processing output byte-for-byte against a reference dataset. The spatial and temporal filters both compute `x * alpha + y * (1 - alpha)` in `float` (`src/proc/temporal-filter.h`, `src/proc/spatial-filter.{h,cpp}` — nine sites). GCC and Clang default to `-ffp-contract=fast`, which fuses one of those products into an FMA wherever the ISA has one, dropping an intermediate rounding. The 1-ULP drift is written back into the temporal filter's history buffer and compounds across a frame sequence; a few pixels per frame survive truncation to `uint16` as a ±1 depth difference.

This is **not** specific to Ubuntu 26.04. FMA is in the base aarch64 ISA, so the same four cases already differ on `ubuntu-24.04-arm` with GCC 13.3 — identical cases, identical pixel counts. Jetson and Apple-Silicon builds have been producing filter output 1 LSB away from x86 and Windows all along; it went unnoticed because the Jetson LibCI stage runs `--live`, which skips this test. The 26.04 job made an existing cross-platform inconsistency visible rather than creating one.

`-ffp-contract=off` restores bit-identical results across toolchains. Where the ISA has no FMA — x86 up to 24.04, and Windows/MSVC — there is nothing to fuse, so codegen is unchanged and existing byte-exact jobs are unaffected. A source-level fix was rejected: `-ffp-contract=fast` ignores statement boundaries, so splitting the expression into temporaries does not reliably prevent fusion, and `=on` still fuses because it is a single expression.

Only the `unix_config.cmake` platforms are changed, since those are the ones measured here.

## Test plan

- [x] Reproduced #15384 on an `ubuntu-26.04` runner and confirmed the merged test fix resolves it — three arms differing only in the line under test (upstream `pose.h` + exact compare: fail; contributor `pose.h` + exact compare: fail; + approximate compare: pass)
- [x] Confirmed the mechanism on the runner: `gcc 15.2.0`, `-ffp-contract=fast`, `__FP_FAST_FMA` defined; measured error 4.77e-07 against an `eq()` tolerance of 2.03e-06
- [x] Isolated the `pytest-filters` failure to FMA contraction with a six-arm experiment on `ubuntu-26.04`: `-ffp-contract=off` byte-exact; `-fno-tree-vectorize` and `-O2` still failing (so not vectorization or optimization level); `gcc-13` on 26.04 byte-exact; both runner CPU models present in passing and failing arms
- [x] Confirmed the same four cases fail on `ubuntu-24.04-arm` (aarch64, GCC 13.3) with identical pixel counts, and go byte-exact with the flag
- [x] Verified the flag reaches the real compile line from `os_set_flags` (not a command-line override) and that all fourteen cases are byte-exact on `ubuntu-26.04`, `ubuntu-24.04-arm`, and `ubuntu-24.04`
- [ ] This PR's own `U26_SH_Py_CI_SYS_JSON` job green — first full-suite run on GCC 15.2, so unrelated failures are possible
- [ ] LibCI run

---
🤖 Generated by AI
