### PR TITLE
Freeze 2.58.4: bump version

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    58
-#define RS2_API_PATCH_VERSION    0
+#define RS2_API_PATCH_VERSION    4
 #define RS2_API_BUILD_VERSION    0
 
 #ifndef STRINGIFY

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 <package format="2">
   <name>librealsense2</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>2.58.0</version>
+  <version>2.58.4</version>
   <description>
   Library for controlling and capturing data from the RealSense depth streaming devices.
   </description>


### PR DESCRIPTION
**Overview:** freeze 2.58.4 - bump the version on the `r/2.58.4` release branch.
