### PR TITLE
d500 interactive TC: include D585S in the gate

### DIFF
--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -170,10 +170,11 @@ namespace rs2
 
     bool d500_on_chip_calib_manager::uses_interactive_triggered_calibration() const
     {
-        // Mirrors ds::d5x5_family_pids in src/ds/d500/d500-private.h — the viewer cannot include
-        // SDK-internal headers. Keep the two lists in sync when adding new PIDs.
+        // Mirrors ds::uses_interactive_triggered_calibration in src/ds/d500/d500-private.h — the viewer cannot
+        // include SDK-internal headers. Keep the two lists in sync when adding new PIDs.
+        // 0C01-0C08: D5x5 family (D535/D585 2C/3C/F/proto). 0B6B: D585S safety.
         static const std::set< std::string > interactive_triggered_calibration_pids = {
-            "0C01", "0C02", "0C03", "0C04", "0C05", "0C06", "0C07", "0C08"
+            "0C01", "0C02", "0C03", "0C04", "0C05", "0C06", "0C07", "0C08", "0B6B"
         };
         return interactive_triggered_calibration_pids.count(get_device_pid()) > 0;
     }
@@ -265,7 +266,7 @@ namespace rs2
                 return;
             }
 
-            // Legacy D500 path (D585S / D585_LEGACY).
+            // Legacy D500 path (D585_LEGACY).
             if (_progress == 100.0)
                 _done = true;
             else

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -76,10 +76,8 @@ namespace librealsense
         };
 
         // D5x5 (non-safety, non-legacy) SKU family: D535 and D585 in their 2C/3C/F/proto variants.
-        // Used to gate features that are only exposed by the modern D5x5 FW branch — currently:
-        //   - interactive Triggered Calibration flow (D555 stays on the D400 OCC path;
-        //     D585S and D585_LEGACY_PID stay on the current D500 triggered-calibration flow)
-        //   - the DUAL_RGB_MODE XU (0x12) selector that toggles Dual-RGB (2C) vs Dedicated-Color (3C)
+        // Gates the DUAL_RGB_MODE XU (0x12) selector that toggles Dual-RGB (2C) vs Dedicated-Color (3C).
+        // D585S has no dual-RGB variant, so it stays out of this set — see uses_interactive_triggered_calibration below.
         static const std::set<std::uint16_t> d5x5_family_pids = {
             D535_2C_PID,
             D535_3C_PID,
@@ -91,9 +89,11 @@ namespace librealsense
             D585_3C_PROTO_PID
         };
 
+        // Interactive Triggered Calibration eligibility: D5x5 family + D585S safety.
+        // D555 stays on the D400 OCC path; D585_LEGACY_PID stays on the current D500 triggered-calibration flow.
         inline bool uses_interactive_triggered_calibration( uint16_t pid )
         {
-            return d5x5_family_pids.find( pid ) != d5x5_family_pids.end();
+            return d5x5_family_pids.count( pid ) || pid == D585S_PID;
         }
 
         static const std::map< std::uint16_t, std::string > rs500_sku_names = {


### PR DESCRIPTION
Tracked by: RSDEV-13534

**Overview:** Route D585S through the interactive triggered-calibration flow instead of the legacy D500 triggered-calibration path, matching the FW-side rollout tracked on RSDEV-13472.

## Why
The interactive TC flow (Step2) is now supported by D585S firmware. Prior to this change, `uses_interactive_triggered_calibration()` only returned true for the D5x5 family (D535/D585 in 2C/3C/F/proto variants) and D585S fell through to the legacy `run_triggered_calibration` path. This PR adds D585S to the eligibility gate on both SDK and viewer sides.

## Summary
- `src/ds/d500/d500-private.h` — `uses_interactive_triggered_calibration(pid)` now returns true for `d5x5_family_pids` **plus `D585S_PID`**. `d5x5_family_pids` itself is unchanged (it still gates the `DUAL_RGB_MODE` XU, which D585S does not have).
- `common/d500-on-chip-calib.cpp` — viewer PID-string mirror set gains `"0B6B"` (D585S). Comment on the legacy fallback branch updated to reference D585_LEGACY only.
- D555 still stays on the D400 OCC path; D585_LEGACY_PID still stays on the legacy D500 triggered-calibration flow.

## Test plan
- [ ] Interactive TC end-to-end on a real D585S: RUN → HEALTH_CHECK → TRY_NEW/TRY_OLD → COMMIT → COMPLETE
- [ ] Confirm the D585S post-COMPLETE `reset_device()` in `d500_autocalib_notification_model::draw_content` still applies the new flash calibration on the interactive path (may become a follow-up simplification)
- [ ] Regression: interactive TC on D585 2C/3C — no behavior change expected
- [ ] Regression: legacy TC on D585_LEGACY (D585 non-safety demo) still works

---
🤖 Generated by AI