### PR TITLE
d500: gate DUAL_RGB_MODE and DETECTION_DISTANCE XU registrations on min FW versions

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -567,7 +567,8 @@ namespace librealsense
                 depth_sensor.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE, proj_temperature);
             }
 
-            if (d5x5_family_pids.count(_pid))
+            if( d5x5_family_pids.count( _pid )
+                && _fw_version >= firmware_version( "7.58.40897.13078" ) )
             {
                 depth_sensor.register_option( RS2_OPTION_SENSORS_CONFIG_MODE,
                     std::make_shared< uvc_xu_option< uint8_t > >(

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -81,11 +81,14 @@ namespace librealsense
 
         od_ep->register_option( RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option );
 
-        auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
-                                                                               ds::inference_xu,
-                                                                               ds::d500_xu_id::DETECTION_DISTANCE,
-                                                                               "Enable firmware distance calculation for detections" );
-        od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        if( _fw_version >= firmware_version( "7.58.40802.12738" ) )
+        {
+            auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
+                                                                                   ds::inference_xu,
+                                                                                   ds::d500_xu_id::DETECTION_DISTANCE,
+                                                                                   "Enable firmware distance calculation for detections" );
+            od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        }
 
         od_ep->register_info( RS2_CAMERA_INFO_PHYSICAL_PORT, od_devices_info.front().device_path );
 


### PR DESCRIPTION
**Overview:** Only register the D5x5 `RS2_OPTION_SENSORS_CONFIG_MODE` and `RS2_OPTION_DETECTION_DISTANCE` options when the device FW is new enough to expose their backing XU controls, so older FW no longer surfaces non-functional options or floods the log with `xioctl(UVCIOC_CTRL_QUERY) failed on control ...`.

## Why
Two D500 XU-backed options are registered unconditionally today:
- `DUAL_RGB_MODE` (depth XU 0x12) — backs `RS2_OPTION_SENSORS_CONFIG_MODE` on the D5x5 family; only implemented from FW `7.58.40897.13078`. On older FW the option was exposed but the device could not honor it.
- `DETECTION_DISTANCE` (inference XU 0x01) — backs `RS2_OPTION_DETECTION_DISTANCE` on every D500 with the OD stream; only implemented from FW `7.58.40802.12738`. On older FW every `get_xu` / `get_xu_range` (three at startup and one per viewer poll) throws and logs an error.

## Summary
- Gate the `RS2_OPTION_SENSORS_CONFIG_MODE` registration in `d500-device.cpp` on `_fw_version >= 7.58.40897.13078`.
- Gate the `RS2_OPTION_DETECTION_DISTANCE` registration in `d500-object-detection.cpp` on `_fw_version >= 7.58.40802.12738`.
- Both mirror the inline pattern already used for other D500 FW-gated features (`d500-active.cpp` alternating-emitter, `d500-factory.cpp` close-range-filter).



---
🤖 Generated by AI