### PR TITLE
d500 OD: gate DETECTION_DISTANCE XU registration on min FW 7.58.40802.12738

### DIFF
--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -81,7 +81,7 @@ namespace librealsense
 
         od_ep->register_option( RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option );
 
-        if( _fw_version >= firmware_version( "7.58.40024.11293" ) )
+        if( _fw_version >= firmware_version( "7.58.40802.12738" ) )
         {
             auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
                                                                                    ds::inference_xu,

--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -81,11 +81,14 @@ namespace librealsense
 
         od_ep->register_option( RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option );
 
-        auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
-                                                                               ds::inference_xu,
-                                                                               ds::d500_xu_id::DETECTION_DISTANCE,
-                                                                               "Enable firmware distance calculation for detections" );
-        od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        if( _fw_version >= firmware_version( "7.58.40024.11293" ) )
+        {
+            auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
+                                                                                   ds::inference_xu,
+                                                                                   ds::d500_xu_id::DETECTION_DISTANCE,
+                                                                                   "Enable firmware distance calculation for detections" );
+            od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        }
 
         od_ep->register_info( RS2_CAMERA_INFO_PHYSICAL_PORT, od_devices_info.front().device_path );
 


### PR DESCRIPTION
**Overview:** Only register `RS2_OPTION_DETECTION_DISTANCE` when the device FW is new enough to expose the inference XU control (selector 0x01); older FW no longer floods the log with `xioctl(UVCIOC_CTRL_QUERY) failed on control 1` when the viewer polls the option range.

## Why
`RS2_OPTION_DETECTION_DISTANCE` was added recently (commit 4256bc12c, 2026-07-09) and registered unconditionally on every D500 device that exposes the object-detection stream (MI=9). Older FW advertises the OD stream but does not implement the `DETECTION_DISTANCE` XU control (0x01), so every `get_xu` / `get_xu_range` call — three at startup and one per viewer poll — throws and logs an error. Same pattern as the DUAL_RGB_MODE gate in PR #15528.

## Summary
- Gate the `RS2_OPTION_DETECTION_DISTANCE` registration in `d500-object-detection.cpp` on `_fw_version >= 7.58.40802.12738`, mirroring existing D5x5 FW-version guards (`d500-active.cpp` alternating-emitter, `d500-factory.cpp` close-range-filter).

Getting logs error before this change when working with old fw - not with this change

---
🤖 Generated by AI