### PR TITLE
Zerocopy tests

### DIFF
--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -6,9 +6,6 @@
 
 option(ENABLE_CCACHE "Build with ccache." ON)
 option(BUILD_WITH_CUDA "Enable CUDA" OFF)
-# Zero-copy GPU memory path. Requires BUILD_WITH_CUDA, so the default follows it: ON whenever CUDA
-# is enabled, OFF otherwise. It only engages at runtime on an integrated GPU (Jetson); on x86 /
-# discrete it stays inert. Plain option(): an explicit -DBUILD_WITH_CUDA_ZEROCOPY overrides.
 option(BUILD_WITH_CUDA_ZEROCOPY "Enable zero-copy GPU memory path (Jetson/integrated GPU only, requires BUILD_WITH_CUDA)" ${BUILD_WITH_CUDA})
 option(BUILD_GLSL_EXTENSIONS "Build GLSL extensions API" ON)
 option(BUILD_WITH_OPENMP "Use OpenMP" OFF)

--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -6,11 +6,10 @@
 
 option(ENABLE_CCACHE "Build with ccache." ON)
 option(BUILD_WITH_CUDA "Enable CUDA" OFF)
-# Zero-copy GPU memory path (Jetson / integrated-GPU only). Requires BUILD_WITH_CUDA.
-# Eliminates the per-frame CPU->frame copy (capture) and the GPU host<->device round-trips.
-# Activates at runtime only on integrated GPUs; discrete GPUs keep the copy path. Default OFF
-# so a plain CUDA build is byte-for-byte identical to today.
-option(BUILD_WITH_CUDA_ZEROCOPY "Enable zero-copy GPU memory path (Jetson/integrated GPU only, requires BUILD_WITH_CUDA)" OFF)
+# Zero-copy GPU memory path. Requires BUILD_WITH_CUDA, so the default follows it: ON whenever CUDA
+# is enabled, OFF otherwise. It only engages at runtime on an integrated GPU (Jetson); on x86 /
+# discrete it stays inert. Plain option(): an explicit -DBUILD_WITH_CUDA_ZEROCOPY overrides.
+option(BUILD_WITH_CUDA_ZEROCOPY "Enable zero-copy GPU memory path (Jetson/integrated GPU only, requires BUILD_WITH_CUDA)" ${BUILD_WITH_CUDA})
 option(BUILD_GLSL_EXTENSIONS "Build GLSL extensions API" ON)
 option(BUILD_WITH_OPENMP "Use OpenMP" OFF)
 option(BUILD_EASYLOGGINGPP "Build EasyLogging++ as a part of the build" ON)

--- a/unit-tests/live/frames/pytest-zero-copy.py
+++ b/unit-tests/live/frames/pytest-zero-copy.py
@@ -1,0 +1,88 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+"""
+Coverage for the CUDA zero-copy GPU frame path (RSDSO-21841 / RSDEV-12094).
+
+Exercises the public GPU-frame API on a live frame:
+  - frame.get_gpu_data_or_upload() always yields a usable device pointer on a CUDA build,
+    with copied=False for a true zero-copy frame and copied=True for the upload fallback.
+  - the gpu_frame extension (rs.gpu_frame(frame)) and the strict frame.get_gpu_data() through
+    it resolve ONLY when the frame is GPU-resident, and are null/invalid otherwise.
+  - the CPU-side frame data stays fully readable and the expected size, i.e. the mapped
+    allocator behaves like the default one (allocator correctness).
+
+Degrades gracefully (Definition of Done):
+  - Non-CUDA / non-RS2_USE_CUDA_ZEROCOPY build: get_gpu_data_or_upload() returns None -> the
+    test skips, so every existing (non-zero-copy) LibCI leg skips cleanly.
+  - Discrete / non-integrated GPU (or a buffer that is not GPU-mapped): the path intentionally
+    falls back to an upload (copied=True); the zero-copy-only assertions are gated off there,
+    while the always-usable _or_upload contract and the null-safety of the strict API are
+    still checked.
+"""
+
+import pytest
+import numpy as np
+import pyrealsense2 as rs
+import logging
+log = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.device("D400*")
+
+WIDTH, HEIGHT, FPS = 640, 480, 30
+WARMUP = 30  # exclude first frames (AWB / one-time CUDA init) before probing GPU data
+
+
+def test_zero_copy_gpu_frame_path(test_device):
+    dev, ctx = test_device
+    if not hasattr(rs.frame, "get_gpu_data_or_upload") or not hasattr(rs, "gpu_frame"):
+        pytest.skip("pyrealsense2 built without the GPU-frame API")
+
+    pipe = rs.pipeline(ctx)
+    cfg = rs.config()
+    cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
+    cfg.enable_stream(rs.stream.depth, WIDTH, HEIGHT, rs.format.z16, FPS)
+    pipe.start(cfg)
+    try:
+        f = None
+        for _ in range(WARMUP + 10):
+            f = pipe.wait_for_frames().get_depth_frame()
+        assert f, "no depth frame received"
+
+        # --- allocator correctness: size + full CPU-side readability ---
+        # frame::data uses frame_data_allocator, which under zero-copy is CUDA host-mapped
+        # memory. It must still report the same logical size and be readable end to end on the
+        # CPU (touching the last element exercises the buffer right up to its tail).
+        expected = f.get_stride_in_bytes() * f.get_height()
+        assert f.get_data_size() == expected, \
+            "get_data_size() {} != stride*height {} (allocator/size regression)".format(f.get_data_size(), expected)
+        arr = np.asanyarray(f.get_data())
+        assert arr.size > 0
+        assert int(arr.flat[0]) >= 0 and int(arr.flat[-1]) >= 0  # read head + tail, no fault
+
+        # --- get_gpu_data_or_upload(): always usable on a CUDA build ---
+        r = f.get_gpu_data_or_upload()
+        if r is None:
+            pytest.skip("no CUDA / RS2_USE_CUDA_ZEROCOPY build: GPU device pointer unavailable")
+        addr, copied = r
+        assert isinstance(addr, int) and addr != 0, "expected a non-null CUDA device address"
+        assert isinstance(copied, bool)
+
+        # --- gpu_frame extension + strict get_gpu_data(): only when GPU-resident ---
+        gf = rs.gpu_frame(f)
+        strict = gf.get_gpu_data() if gf else None
+        # The extension, the strict pointer, and the copied flag must all agree.
+        assert bool(gf) == (strict is not None), "gpu_frame validity must match get_gpu_data() null-ness"
+        assert bool(gf) == (not copied), "gpu_frame is reported iff the frame is GPU-resident (not uploaded)"
+
+        if not copied:
+            # true zero-copy (integrated GPU, GPU-mapped frame)
+            assert strict == addr, "zero-copy: strict get_gpu_data() must equal the _or_upload address"
+            log.info("zero-copy ACTIVE: device ptr 0x%x (no host->device copy)", addr)
+        else:
+            # CUDA build but the frame is not GPU-mapped (discrete GPU, or a non-mapped backend
+            # buffer): the strict API is null and the _or_upload path uploaded a copy.
+            assert strict is None, "strict get_gpu_data() must be null when the frame is not GPU-resident"
+            log.info("zero-copy fell back to upload (frame not GPU-resident); _or_upload address 0x%x", addr)
+    finally:
+        pipe.stop()

--- a/unit-tests/live/frames/pytest-zero-copy.py
+++ b/unit-tests/live/frames/pytest-zero-copy.py
@@ -21,13 +21,20 @@ Degrades gracefully (Definition of Done):
     still checked.
 """
 
+import platform
 import pytest
 import numpy as np
 import pyrealsense2 as rs
 import logging
 log = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.device("D400*")
+pytestmark = [
+    pytest.mark.device("D400*"),
+    # zero-copy needs CUDA, and only Jetson (aarch64) builds CUDA on CI. Skip at collection
+    # on every other platform so we don't stream then skip, and don't need a device there.
+    pytest.mark.skipif(platform.machine() != "aarch64",
+                       reason="zero-copy needs CUDA; only Jetson (aarch64) builds CUDA on CI"),
+]
 
 WIDTH, HEIGHT, FPS = 640, 480, 30
 WARMUP = 30  # exclude first frames (AWB / one-time CUDA init) before probing GPU data

--- a/unit-tests/live/frames/pytest-zero-copy.py
+++ b/unit-tests/live/frames/pytest-zero-copy.py
@@ -44,45 +44,52 @@ def test_zero_copy_gpu_frame_path(test_device):
     cfg.enable_stream(rs.stream.depth, WIDTH, HEIGHT, rs.format.z16, FPS)
     pipe.start(cfg)
     try:
-        f = None
-        for _ in range(WARMUP + 10):
-            f = pipe.wait_for_frames().get_depth_frame()
-        assert f, "no depth frame received"
+        # Warm up (AWB / one-time CUDA init), then grab one valid depth frame; retry on a
+        # dropped/null frame and fail fast if none arrives (instead of asserting only the last).
+        for _ in range(WARMUP):
+            pipe.wait_for_frames()
+        frame = None
+        for _ in range(30):
+            depth = pipe.wait_for_frames().get_depth_frame()
+            if depth:
+                frame = depth
+                break
+        assert frame, "no valid depth frame received"
 
         # --- allocator correctness: size + full CPU-side readability ---
         # frame::data uses frame_data_allocator, which under zero-copy is CUDA host-mapped
         # memory. It must still report the same logical size and be readable end to end on the
         # CPU (touching the last element exercises the buffer right up to its tail).
-        expected = f.get_stride_in_bytes() * f.get_height()
-        assert f.get_data_size() == expected, \
-            "get_data_size() {} != stride*height {} (allocator/size regression)".format(f.get_data_size(), expected)
-        arr = np.asanyarray(f.get_data())
-        assert arr.size > 0
-        assert int(arr.flat[0]) >= 0 and int(arr.flat[-1]) >= 0  # read head + tail, no fault
+        expected_size = frame.get_stride_in_bytes() * frame.get_height()
+        assert frame.get_data_size() == expected_size, \
+            "get_data_size() {} != stride*height {} (allocator/size regression)".format(frame.get_data_size(), expected_size)
+        data = np.asanyarray(frame.get_data())
+        assert data.size > 0
+        assert int(data.flat[0]) >= 0 and int(data.flat[-1]) >= 0  # read head + tail, no fault
 
         # --- get_gpu_data_or_upload(): always usable on a CUDA build ---
-        r = f.get_gpu_data_or_upload()
-        if r is None:
+        gpu_data = frame.get_gpu_data_or_upload()
+        if gpu_data is None:
             pytest.skip("no CUDA / RS2_USE_CUDA_ZEROCOPY build: GPU device pointer unavailable")
-        addr, copied = r
-        assert isinstance(addr, int) and addr != 0, "expected a non-null CUDA device address"
+        dev_addr, copied = gpu_data
+        assert isinstance(dev_addr, int) and dev_addr != 0, "expected a non-null CUDA device address"
         assert isinstance(copied, bool)
 
         # --- gpu_frame extension + strict get_gpu_data(): only when GPU-resident ---
-        gf = rs.gpu_frame(f)
-        strict = gf.get_gpu_data() if gf else None
+        gpu_ext = rs.gpu_frame(frame)
+        strict_addr = gpu_ext.get_gpu_data() if gpu_ext else None
         # The extension, the strict pointer, and the copied flag must all agree.
-        assert bool(gf) == (strict is not None), "gpu_frame validity must match get_gpu_data() null-ness"
-        assert bool(gf) == (not copied), "gpu_frame is reported iff the frame is GPU-resident (not uploaded)"
+        assert bool(gpu_ext) == (strict_addr is not None), "gpu_frame validity must match get_gpu_data() null-ness"
+        assert bool(gpu_ext) == (not copied), "gpu_frame is reported iff the frame is GPU-resident (not uploaded)"
 
         if not copied:
             # true zero-copy (integrated GPU, GPU-mapped frame)
-            assert strict == addr, "zero-copy: strict get_gpu_data() must equal the _or_upload address"
-            log.info("zero-copy ACTIVE: device ptr 0x%x (no host->device copy)", addr)
+            assert strict_addr == dev_addr, "zero-copy: strict get_gpu_data() must equal the _or_upload address"
+            log.info("zero-copy ACTIVE: device ptr 0x%x (no host->device copy)", dev_addr)
         else:
             # CUDA build but the frame is not GPU-mapped (discrete GPU, or a non-mapped backend
             # buffer): the strict API is null and the _or_upload path uploaded a copy.
-            assert strict is None, "strict get_gpu_data() must be null when the frame is not GPU-resident"
-            log.info("zero-copy fell back to upload (frame not GPU-resident); _or_upload address 0x%x", addr)
+            assert strict_addr is None, "strict get_gpu_data() must be null when the frame is not GPU-resident"
+            log.info("zero-copy fell back to upload (frame not GPU-resident); _or_upload address 0x%x", dev_addr)
     finally:
         pipe.stop()


### PR DESCRIPTION
## What
Enables the CUDA zero-copy GPU frame path by default on CUDA builds, and adds the first test coverage for it.

Follow-up to RSDEV-12094 (the zero-copy path itself). Addresses RSDSO-21841.

## Changes
- **CMake default** (`CMake/lrs_options.cmake`): `BUILD_WITH_CUDA_ZEROCOPY` default now follows `BUILD_WITH_CUDA` (ON whenever CUDA is enabled, OFF otherwise). It stays a plain `option()`, so `-DBUILD_WITH_CUDA_ZEROCOPY=OFF` still overrides. The flag already requires CUDA (CMake FATAL_ERRORs otherwise), and the path only engages at runtime on an integrated GPU (Jetson), so it stays inert on x86/discrete.
- **Tests** (`unit-tests/live/frames/pytest-zero-copy.py`): live pytest covering the public GPU-frame API:
  - `frame.get_gpu_data_or_upload()` returns a usable device address plus the `copied` flag on a CUDA build.
  - the `gpu_frame` extension and strict `frame.get_gpu_data()` resolve only when the frame is GPU-resident, and agree with `copied`.
  - CPU-side frame data stays fully readable and the expected size (allocator correctness).
  - Skips cleanly when `get_gpu_data_or_upload()` returns None (non-CUDA / non-zero-copy build), so existing legs skip.

## Impact
No behavior change for non-CUDA or x86 builds. CUDA builds now compile the mapped allocator by default; the feature only activates at runtime on an integrated GPU.

## Testing
- Verified the CMake default by configure: aarch64 + CUDA=ON -> ON; CUDA=OFF -> OFF; x86 + CUDA=ON -> ON (uniform, per design).
- Test assertions validated against a live D435 on a Jetson Orin zero-copy build (upload-fallback branch: `copied=True`, `gpu_frame` invalid, correct `data_size`).
