### PR TITLE
hdr test: assert the queried exposure/gain only on FW that restores them

### DIFF
--- a/unit-tests/live/d400/pytest-hdr-long.py
+++ b/unit-tests/live/d400/pytest-hdr-long.py
@@ -33,6 +33,20 @@ def _skip_if_fw_unsupported(dev):
     require_min_fw_version(dev, rsutils.version(5, 17, 2, 11))
 
 
+# First FW that restores the pre-HDR manual exposure AND gain into the UVC control DB itself when the
+# HDR sub-preset is disabled, so a query after HDR off reports them.
+#
+# Below this version librealsense compensates host-side (hdr_config::_use_workaround) and that
+# workaround restores EXPOSURE ONLY -- there is no _pre_hdr_gain -- so the queried gain legitimately
+# still reads the last HDR sub-preset gain, which for the default config is gain_range.min (16 on
+# D435). Whether the FW happens to restore it below this version varies by FW build, so the queried
+# values are only a contract from here up.
+#
+# Keep in sync with hdr_exposure_restore_firmware_version in src/ds/d400/d400-device.cpp -- that gate
+# decides who performs the restore, this one decides whether the test may assert on it.
+FW_RESTORES_QUERIED_EXPOSURE_AND_GAIN = rsutils.version(5, 17, 4, 13)
+
+
 def retry_on_exception(func, max_retries=10):
     last_exception = None
     for attempt in range(max_retries):
@@ -476,6 +490,12 @@ def _hdr_start_stop_recover_manual_exposure_and_gain(dev, ctx):
     # connected device; without enable_device(sn) the pipeline picks the first match.
     cfg.enable_device(dev.get_info(rs.camera_info.serial_number))
     cfg.enable_stream(rs.stream.depth)
+    # Who restores the queried exposure/gain depends on the FW - see the constant's comment.
+    fw_version = rsutils.version(dev.get_info(rs.camera_info.firmware_version))
+    expect_queried_restore = fw_version >= FW_RESTORES_QUERIED_EXPOSURE_AND_GAIN
+    log.info(f"FW {fw_version}: queried exposure/gain restore is "
+             f"{'asserted (FW restores it)' if expect_queried_restore else 'not asserted (SDK workaround restores exposure only)'}")
+
     pipe = rs.pipeline(ctx)
     pipe.start(cfg)
     queried_values_checked = False
@@ -507,7 +527,7 @@ def _hdr_start_stop_recover_manual_exposure_and_gain(dev, ctx):
                     log.info(f"iteration_to_check_after_disable: {iteration_to_check_after_disable}")
                     check.is_true(frame_exposure == exposure_before_hdr)
 
-                    if not queried_values_checked:
+                    if expect_queried_restore and not queried_values_checked:
                         # The frames already carry the restored exposure/gain at this point, but the
                         # queried (UVC control-DB) value is restored by a separate FW path. Query it
                         # too, or the test stays green on FW that leaves the query stuck at the last
@@ -521,10 +541,11 @@ def _hdr_start_stop_recover_manual_exposure_and_gain(dev, ctx):
     finally:
         pipe.stop()
 
-    # the queried check is the only one that measures the FW restore path - a run in which it never
-    # executed proves nothing, so fail loudly instead of reporting a green test
-    assert queried_values_checked, "queried exposure/gain check never ran - no depth frame after " \
-                                   "HDR disable carried sequence_id metadata"
+    # On FW that performs the restore, the queried check is the only one that measures it - a run in
+    # which it never executed proves nothing, so fail loudly instead of reporting a green test.
+    if expect_queried_restore:
+        assert queried_values_checked, "queried exposure/gain check never ran - no depth frame " \
+                                       "after HDR disable carried sequence_id metadata"
 
 
 def test_hdr_start_stop_recover_manual_exposure_and_gain(function_scoped_device, test_context):


### PR DESCRIPTION
## Fix nightly golden-FW failure in `test_hdr_start_stop_recover_manual_exposure_and_gain`

Follow-up to #15508. That PR added a queried (UVC control-DB) exposure/gain assertion so the test
measures the FW rather than the SDK. The **gain** half of it fails on older FW, which broke the
golden-FW nightly leg.

### The failure

`LRS_libci_pipeline` [#17581](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/17581/) →
`LRS_windows_compile_pipeline` [#116070](https://rsjenkins.realsenseai.com/job/LRS_windows_compile_pipeline/116070/):

```
unit-tests/live/d400/pytest-hdr-long.py::test_hdr_start_stop_recover_manual_exposure_and_gain[D435-728612070268] FAILED
AssertionError: FAILURE: check 16.0 == 50
```

D435 on FW **5.17.3.10**. `Failed Checks: 1` — every metadata assertion passed; only the queried
**gain** check failed.

The two nightly legs differ exactly at the gate #15508 introduced:

| leg | libci | D435 FW | `_use_workaround` | result |
|---|---|---|---|---|
| RS-Latest | [17580](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/17580/) | flashed to 5.17.4.14 | off — FW restores | PASSED |
| golden | [17581](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/17581/) | left on 5.17.3.10 | on — SDK restores | **FAILED** |

### Why the gain check cannot hold below the gate

`hdr_config`'s host-side workaround saves and restores **exposure only** — `_pre_hdr_exposure`
exists, there is no `_pre_hdr_gain` (`src/hdr-config.cpp:278`, `:317-320`). Meanwhile the default
HDR config sets sub-preset slot 1 gain to `_gain_range.min` (`src/hdr-config.cpp:46-48`), which is
**16** on D435 — and the test never configures the slots itself, so it gets that default.

So when the workaround is on and the FW does not restore the control-DB gain, the queried gain is
left at 16 and nothing host-side puts 50 back. Whether a given pre-gate FW restores it varies by
build: 5.17.3.25 does, 5.17.3.10 does not — which is why this passed on the rig used to validate
#15508 and only surfaced on the CI golden camera.

The queried **exposure** half is fine on every FW: the workaround restores it below the gate, the FW
restores it above.

### The change

Assert the queried values only on FW that performs the restore:

```python
FW_RESTORES_QUERIED_EXPOSURE_AND_GAIN = rsutils.version(5, 17, 4, 13)
...
expect_queried_restore = fw_version >= FW_RESTORES_QUERIED_EXPOSURE_AND_GAIN
```

The metadata assertions stay unconditional for every FW, so golden loses no coverage — only the two
`check.equal` lines and their `assert queried_values_checked` guard become conditional. Above the
gate the behavior is byte-for-byte what #15508 shipped.

Note this constant must track `hdr_exposure_restore_firmware_version` in
`src/ds/d400/d400-device.cpp`; there is a comment at each site pointing at the other. Not ideal —
alternative would be dropping the queried-gain assertion entirely (safe on all FW, since the
workaround covers exposure) at the cost of losing coverage of the FW fix's gain half. Happy to
switch if reviewers prefer one less constant over that coverage.

### Validation — rs-nuc01

**The failing line is unreachable at 5.17.3.10.** Predicate imported from the module under test (not
a copy) and evaluated against the exact CI firmware versions:

| FW | `expect_queried_restore` | queried gain check | leg |
|---|---|---|---|
| **5.17.3.10** | False | **skipped** | golden — the D435 that failed |
| 5.17.4.14 | True | asserts | latest — the D435 that passed |
| 5.17.4.13 | True | asserts | exact boundary |
| 5.17.4.12 | False | skipped | one below |
| 5.17.3.25 | False | skipped | rs-nuc01 today |

With the CI log showing the queried gain as the *only* failed check, and nothing else in the test
depending on FW-side gain restore, the golden leg goes green.

**No regression, both branches exercised:**

| leg | camera | branch taken | result |
|---|---|---|---|
| below gate (real FW) | D455 `213622301050` @ 5.17.3.25 | `not asserted (SDK workaround restores exposure only)` | **32/32 passed** |
| above gate (constant forced to 5.0.0.0) | same camera | `asserted (FW restores it)` | **passed**, checks ran |
| above gate (real FW, #15508 code) | D455 `013322250138` @ 5.17.4.13 | asserted | **32/32 passed** (recorded on #15508) |

Suites: `pytest -v --context nightly --device <sn> live/d400/pytest-hdr-sanity.py
live/d400/pytest-hdr-long.py live/hdr/` — covers `hdr-sanity`, `hdr-long`, `hdr-configurations`,
`hdr-performance`, `hdr-preset`.

### Not validated
The original failure was **not reproduced on hardware** — all four rs-nuc01 cameras restore both
exposure and gain on 5.17.3.25 (`qExp=5000 qGain=50`), so none of them fails the pre-fix assertion.
The rig has no FW old enough; that is the same blind spot that let this through on #15508. The
golden-leg argument above rests on executing the shipped predicate against the CI FW string plus the
CI log's own failure inventory, not on a reproduction.

The above-gate real-FW row is from #15508's run: `013322250138` has since been restored to its
5.17.3.25 pin, so no camera above the gate was available today. This commit is a no-op on that path
(same checks, same guard), so it is unchanged by definition.
