### PR TITLE
rest-api: support Python 3.10 through 3.14 in requirements pins

### DIFF
--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -52,7 +52,7 @@ It simplifies remote control and data streaming from RealSense devices by handli
 
 ### API Server Setup
 
-Requires Python 3.10 - 3.14.
+Requires Python 3.10+ (tested through 3.14).
 
 1. **Create a virtual environment:**
 

--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -52,6 +52,8 @@ It simplifies remote control and data streaming from RealSense devices by handli
 
 ### API Server Setup
 
+Requires Python 3.10 - 3.14.
+
 1. **Create a virtual environment:**
 
    ```bash

--- a/wrappers/rest-api/requirements.txt
+++ b/wrappers/rest-api/requirements.txt
@@ -1,13 +1,15 @@
 fastapi==0.120.1;        platform_machine != "aarch64"
 uvicorn==0.34.0;         platform_machine != "aarch64"
-pydantic==2.10.6;        platform_machine != "aarch64"
+pydantic==2.12.5;        platform_machine != "aarch64"
 python-multipart==0.0.29; platform_machine != "aarch64" # Used internally by FastAPI to parse file uploads (e.g. FW update endpoint)
 #pyrealsense2==2.56.4.9191; platform_machine != "aarch64"
 
 # aiortc pulls av>=14 which needs FFmpeg 7 to build from source; force the prebuilt wheel
 --only-binary=av
-aiortc==1.11.0;          platform_machine != "aarch64"
+aiortc==1.15.0;          platform_machine != "aarch64"
 
 opencv-python==4.11.0.86; platform_machine != "aarch64"
-numpy==2.2.4;            platform_machine != "aarch64"
+# numpy dropped 3.10 in 2.3.0, and its first 3.14 wheel is 2.3.2 - no single version covers both
+numpy==2.2.4;            platform_machine != "aarch64" and python_version < "3.11"
+numpy==2.3.5;            platform_machine != "aarch64" and python_version >= "3.11"
 python-socketio==5.13.0; platform_machine != "aarch64"

--- a/wrappers/rest-api/requirements.txt
+++ b/wrappers/rest-api/requirements.txt
@@ -4,7 +4,7 @@ pydantic==2.12.5;        platform_machine != "aarch64"
 python-multipart==0.0.29; platform_machine != "aarch64" # Used internally by FastAPI to parse file uploads (e.g. FW update endpoint)
 #pyrealsense2==2.56.4.9191; platform_machine != "aarch64"
 
-# aiortc pulls av>=14 which needs FFmpeg 7 to build from source; force the prebuilt wheel
+# aiortc pulls av (currently >=14,<18) which needs FFmpeg to build from source; force the prebuilt wheel
 --only-binary=av
 aiortc==1.15.0;          platform_machine != "aarch64"
 

--- a/wrappers/rest-api/tools/react-viewer/DESKTOP_BUILD.md
+++ b/wrappers/rest-api/tools/react-viewer/DESKTOP_BUILD.md
@@ -38,7 +38,7 @@ FastAPI Backend
 
 - Node.js 18+
 - Rust 1.56+ (install from https://rustup.rs/)
-- Python 3.8+ (for FastAPI backend)
+- Python 3.10+ (for FastAPI backend)
 - **Linux only:** the apt prerequisites listed in the README
   (`libwebkit2gtk-4.0-dev`, `libgtk-3-dev`, `libsoup2.4-dev`,
   `libayatana-appindicator3-dev`, `librsvg2-dev`, `libssl-dev`,

--- a/wrappers/rest-api/tools/react-viewer/LICENSE-THIRD-PARTY.md
+++ b/wrappers/rest-api/tools/react-viewer/LICENSE-THIRD-PARTY.md
@@ -30,8 +30,8 @@ This application is built using only open source dependencies with permissive li
 | Pydantic           | 2.x       | MIT            | Request / response validation                  |
 | Uvicorn            | 0.34.x    | BSD-3-Clause   | ASGI server                                    |
 | python-socketio    | 5.x       | MIT            | Socket.IO server                               |
-| aiortc             | 1.11.x    | BSD-3-Clause   | WebRTC stack (PeerConnection, video tracks)    |
-| PyAV (`av`)        | 14.x      | BSD-3-Clause   | Pulled transitively by aiortc (FFmpeg wheel binding) |
+| aiortc             | 1.15.x    | BSD-3-Clause   | WebRTC stack (PeerConnection, video tracks)    |
+| PyAV (`av`)        | 17.x      | BSD-3-Clause   | Pulled transitively by aiortc (FFmpeg wheel binding) |
 | OpenCV (`opencv-python`) | 4.11.x | Apache-2.0  | Image processing wheel                         |
 | numpy              | 2.x       | BSD-3-Clause   | Numeric arrays                                 |
 | pyrealsense2       | 2.x       | Apache-2.0     | RealSense SDK Python bindings (in-house)       |
@@ -83,7 +83,8 @@ This application is built using only open source dependencies with permissive li
 - All shipped runtime dependencies are MIT, Apache-2.0, BSD or ISC — all OSI-approved permissive licenses.
 - Rust ecosystem packages are commonly dual-licensed (`Apache-2.0 OR MIT`); recipients may choose either.
 - **PyInstaller** is GPL-2.0+ but its [bootloader exception](https://pyinstaller.org/en/stable/license.html) means generated executables are **not subject to GPL**.
-- No copyleft or non-commercial dependencies are bundled into the produced artifacts.
+- The **PyAV** and **opencv-python** wheels bundle prebuilt **FFmpeg** shared libraries, licensed **LGPL-2.1+** (built without GPL components). They are redistributed unmodified as dynamically-linked libraries, which satisfies the LGPL for the packaged application; the FFmpeg license text ships inside the respective wheels.
+- Apart from the LGPL FFmpeg binaries noted above, no copyleft or non-commercial dependencies are bundled into the produced artifacts.
 - The list above covers **direct** dependencies declared in `requirements.txt`, `package.json`, and `Cargo.toml`. Transitive dependencies inherit the same permissive license classes; the full transitive set is enumerated in the respective lockfiles (`package-lock.json`, `Cargo.lock`).
 
 ---

--- a/wrappers/rest-api/tools/react-viewer/README.md
+++ b/wrappers/rest-api/tools/react-viewer/README.md
@@ -191,7 +191,7 @@ Both scripts produce, under the repository root:
   - Linux: `.deb` + `.AppImage`
   - macOS: `.dmg`
 
-Prerequisites: Node.js 18+, Python 3.8+, Rust 1.56+ (https://rustup.rs/), PyInstaller
+Prerequisites: Node.js 18+, Python 3.10+, Rust 1.56+ (https://rustup.rs/), PyInstaller
 (`pip install pyinstaller`).
 
 **Linux distro support (Tauri 1.5).** This project currently uses Tauri 1.5, which

--- a/wrappers/rest-api/tools/react-viewer/build-all.ps1
+++ b/wrappers/rest-api/tools/react-viewer/build-all.ps1
@@ -26,7 +26,7 @@ Output Locations:
 
 Requirements:
   - Node.js 18+
-  - Python 3.13+
+  - Python 3.10+
   - Rust 1.56+
   - PyInstaller (pip install pyinstaller)
 

--- a/wrappers/rest-api/tools/react-viewer/build-all.sh
+++ b/wrappers/rest-api/tools/react-viewer/build-all.sh
@@ -33,7 +33,7 @@ Output Locations (relative to the repository root):
 
 Requirements:
   - Node.js 18+
-  - Python 3.8+
+  - Python 3.10+
   - Rust 1.56+ (install from https://rustup.rs/)
   - PyInstaller (pip install pyinstaller)
 EOF


### PR DESCRIPTION
**Overview:** `python3 install.py` in `wrappers/rest-api` failed on Python 3.14 because no `av` wheel existed for the version `aiortc` pinned. The dependency pins now install cleanly on Python 3.10 through 3.14.

## Why

On Python 3.14 the install aborts:

```
ERROR: Could not find a version that satisfies the requirement av<15.0.0,>=14.0.0 (from aiortc)
       (from versions: 15.1.0, 16.0.0, ...)
```

`aiortc==1.11.0` pins `av<15`, and `av` 14.x ships no cp314 wheel. Two more pins fail right behind it: `numpy==2.2.4` (first cp314 wheel is 2.3.2) and `pydantic==2.10.6`, whose `pydantic-core==2.27.2` has no cp314 wheel either. With `--only-binary=av` there is no source-build fallback.

## Summary

- `aiortc` 1.11.0 -> 1.15.0 — pins `av<18`, resolving `av 17.1.0`, which has wheels for 3.10 through 3.14
- `pydantic` 2.10.6 -> 2.12.5 — brings `pydantic-core 2.41.5` (cp39 through cp314 wheels)
- `numpy` split by marker: 2.2.4 below 3.11, 2.3.5 from 3.11 up. numpy dropped 3.10 in 2.3.0 and its first 3.14 wheel is 2.3.2, so no single version spans both
- Documented the supported range. The previously stated "Python 3.8+" was already wrong before this change: `python-multipart==0.0.29` is `Requires-Python >=3.10`, so 3.9 could not install the old file either

`fastapi`, `uvicorn`, `python-multipart`, `python-socketio` and `opencv-python` are unchanged. The `platform_machine != "aarch64"` markers are untouched, so aarch64 behavior is unaffected.

## Test plan

- [x] `install.py` in a clean venv on **3.10.12** (Ubuntu 22.04), **3.13.0** and **3.14.3** (Windows) — all resolve to prebuilt wheels, no source builds. Marker split verified live: 3.10 selects numpy 2.2.4, 3.11+ selects 2.3.5
- [x] Resolver check with `--only-binary=:all:` for 3.10 / 3.11 / 3.12 / 3.13 / 3.14 on both `win_amd64` and `manylinux_x86_64`
- [x] `pytest tests/` on 3.10 with two cameras attached: **48 passed**
- [x] REST smoke on 3.10: `/docs` 200, `/api/v1/openapi.json` 200, `/api/v1/devices/` 200 (two devices enumerated), `/sensors/` 200
- [x] WebRTC end-to-end on 3.10 against a live D455 — offer/answer negotiated, ICE `completed`, 15 frames decoded at 640x480, session closed cleanly. This is the path most exposed by the 4-minor-version `aiortc` jump
- [x] On a machine with no camera, 5 device-dependent tests fail identically with the old and the new pins (2 failed / 42 passed / 1 skipped / 3 errors, all asserting on an empty device list) — camera absence, not a regression

---
🤖 Generated by AI
