### PR TITLE
Fix macOS external libusb CMake configuration

### DIFF
--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -25,7 +25,6 @@ ExternalProject_Add(
 
 add_library(usb INTERFACE)
 target_include_directories(usb INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/third-party/libusb/libusb/libusb>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libusb_install/include/libusb-1.0>
 )
 if(WIN32)

--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -24,8 +24,15 @@ ExternalProject_Add(
 )
 
 add_library(usb INTERFACE)
-target_include_directories(usb INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/third-party/libusb/libusb>)
-target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}libusb-1.0${CMAKE_STATIC_LIBRARY_SUFFIX})
+target_include_directories(usb INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/third-party/libusb/libusb/libusb>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libusb_install/include/libusb-1.0>
+)
+if(WIN32)
+    target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}libusb-1.0${CMAKE_STATIC_LIBRARY_SUFFIX})
+else()
+    target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/libusb-1.0${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
 set(USE_EXTERNAL_USB ON) # INTERFACE libraries can't have real deps, so targets that link with usb need to also depend on libusb
 
 set_target_properties( libusb PROPERTIES FOLDER "3rd Party")
@@ -33,5 +40,6 @@ set_target_properties( libusb PROPERTIES FOLDER "3rd Party")
 if (APPLE)
   find_library(corefoundation_lib CoreFoundation)
   find_library(iokit_lib IOKit)
-  target_link_libraries(usb INTERFACE objc ${corefoundation_lib} ${iokit_lib})
+  find_library(security_lib Security)
+  target_link_libraries(usb INTERFACE objc ${corefoundation_lib} ${iokit_lib} ${security_lib})
 endif()

--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -30,6 +30,7 @@ target_include_directories(usb INTERFACE
 if(WIN32)
     target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}libusb-1.0${CMAKE_STATIC_LIBRARY_SUFFIX})
 else()
+    # libusb-cmake installs libusb-1.0.a; the archive name already includes the Unix prefix.
     target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/libusb-1.0${CMAKE_STATIC_LIBRARY_SUFFIX})
 endif()
 set(USE_EXTERNAL_USB ON) # INTERFACE libraries can't have real deps, so targets that link with usb need to also depend on libusb
@@ -40,5 +41,8 @@ if (APPLE)
   find_library(corefoundation_lib CoreFoundation)
   find_library(iokit_lib IOKit)
   find_library(security_lib Security)
+  if(NOT corefoundation_lib OR NOT iokit_lib OR NOT security_lib)
+    message(FATAL_ERROR "CoreFoundation, IOKit, and Security frameworks are required on macOS")
+  endif()
   target_link_libraries(usb INTERFACE objc ${corefoundation_lib} ${iokit_lib} ${security_lib})
 endif()


### PR DESCRIPTION
## What changed

- use libusb-cmake's installed include directory
- avoid adding a second `lib` prefix to the Unix archive name
- link CoreFoundation, IOKit, and Security on macOS
- stop configuration if a required macOS framework is missing

This supersedes #15241. It targets the current `development` branch and leaves the unrelated global RPATH setting out.

## Validation

Built `realsense2` and `rs-enumerate-devices` on Apple Silicon macOS in three configurations:

- bundled libusb with shared librealsense
- bundled libusb with static librealsense
- system libusb 1.0.30 with shared librealsense

`scripts/api_check.sh` also passed.

`scripts/pr_check.sh` is not portable to stock macOS because it requires GNU `grep -P` and invokes `apt-get`. The changed CMake file passes `git diff --check`.
