### PR TITLE
Stop device watcher before callback teardown

### DIFF
--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -103,6 +103,19 @@ public:
             { _callbacks.raise( old, curr ); } );
     }
 
+    ~device_watcher_singleton()
+    {
+        // The watcher callback captures this, so stop it before _callbacks is destroyed.
+        try
+        {
+            _device_watcher->stop();
+        }
+        catch( ... )
+        {
+            // Destructors must not propagate watcher shutdown failures.
+        }
+    }
+
     rsutils::subscription subscribe( platform::device_changed_callback && cb )
     {
         return _callbacks.subscribe( std::move( cb ) );


### PR DESCRIPTION
## What changed

- stop the backend device watcher before its callback storage is destroyed
- keep the singleton destructor non-throwing if watcher shutdown fails
- leave the existing dispatcher and active object APIs unchanged

The watcher callback captures the singleton. Explicit shutdown prevents the callback from reaching `_callbacks` during member destruction.

This supersedes #15242 and targets the current `development` branch.

## Validation

- built `realsense2` and `rs-enumerate-devices` on Apple Silicon macOS
- ran 20 consecutive context creation, D555 discovery, and teardown cycles over USB-C using the exact final library
- each cycle reported `devices=1`, exited with status 0, and had no mutex, dispatcher, abort, or exception error
- ran `scripts/api_check.sh`
- ran `git diff --check`
