### PR TITLE
Cherry-pick #15512: Fix D500 gyro physical-unit processing

### DIFF
--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -32,6 +32,11 @@ using rsutils::type::fourcc;
 using namespace librealsense;
 namespace librealsense
 {
+    namespace
+    {
+        constexpr double RAW_TO_DPS_SCALE = 10000.0;
+    }
+
     const std::map<fourcc::value_type, rs2_format> d500_motion_fourcc_to_rs2_format = {
         {fourcc('G','R','E','Y'), RS2_FORMAT_MOTION_XYZ32F},
     };
@@ -46,16 +51,25 @@ namespace librealsense
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
+    bool d500_motion::supports_physical_units() const
+    {
+        static const firmware_version min_fw_supporting_physical_units( "7.58.40672.12546" );
+        return get_pid() != ds::D585S_PID && ! _is_mipi_device
+            && _fw_version >= min_fw_supporting_physical_units;
+    }
+
+    bool d500_motion::is_imu_high_accuracy() const
+    {
+        return supports_physical_units();
+    }
+
     double d500_motion::get_gyro_default_scale() const
     {
-        // Raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB].
-        // Used by D585S (its own flow) and MIPI/UVC (gyro sensitivity not supported there).
-        if( _is_mipi_device || get_pid() == ds::D585S_PID )
-        {
-            return 0.003814697265625;
-        }
-        // Cameras on the HID (USB) path: FW ships values pre-scaled by 1000 in the HID feature report; combined with set_gyro_scale_factor(10000) yields [deg/sec].
-        return 0.0001;
+        if( supports_physical_units() )
+            return 1. / RAW_TO_DPS_SCALE;
+
+        // Legacy D500 reports signed 16-bit raw samples at a fixed 125 dps assumption.
+        return 125. / 32768.;
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
@@ -105,11 +119,8 @@ namespace librealsense
                 _motion_module_device_idx = static_cast<uint8_t>(add_sensor(sensor_ep));
                 sensor_ep->get_raw_sensor()->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&hid_header::timestamp));
                 register_gyro_sensitivity();
-                // Cameras on the HID (USB) path: mf-hid multiplies raw HID values by 10000 to undo the FW's 1000-scale packing.
-                // Combined with get_gyro_default_scale() = 0.0001 the pipeline gets [deg/sec].
-                // Skip on MIPI/UVC (get_raw_motion_sensor() returns nullptr on that path) and on D585S (its own scale flow).
-                if( get_pid() != D585S_PID && ! _is_mipi_device )
-                    get_raw_motion_sensor()->set_gyro_scale_factor( 10000.0 );
+                if( supports_physical_units() )
+                    get_raw_motion_sensor()->set_gyro_scale_factor( RAW_TO_DPS_SCALE );
             }
 #endif
         }
@@ -205,14 +216,14 @@ namespace librealsense
 
     void d500_motion::register_gyro_sensitivity()
     {
-        // D585S uses a different FW versioning line (8.58.x) and a different gyro output format; skip.
-        // MIPI/UVC transport has no HID feature-report path, so the option would register with a null
-        // backing hid_sensor and fail on every set() — skip too.
-        if( get_pid() == ds::D585S_PID || _is_mipi_device )
-            return;
-        if( _fw_version >= firmware_version( "7.58.40672.12546" ) && ! _has_motion_module_failed )
+        if( supports_physical_units() && ! _has_motion_module_failed )
+        {
+            auto raw_motion_sensor = get_raw_motion_sensor();
+            raw_motion_sensor->enable_gyro_sensitivity_range_index();
             register_feature(
-                std::make_shared< gyro_sensitivity_feature >( get_raw_motion_sensor(), get_motion_sensor() ) );
+                std::make_shared< gyro_sensitivity_feature >(
+                    raw_motion_sensor, get_motion_sensor(), 4.f ) );
+        }
     }
 
     void d500_motion::register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index)

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -18,6 +18,7 @@ namespace librealsense
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
+        bool is_imu_high_accuracy() const override;
         double get_gyro_default_scale() const override;
 
         std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
@@ -41,6 +42,7 @@ namespace librealsense
 
         ds_motion_sensor & get_motion_sensor();
         std::shared_ptr< hid_sensor > get_raw_motion_sensor();
+        bool supports_physical_units() const;
         void register_gyro_sensitivity();
 
     private:

--- a/src/ds/features/gyro-sensitivity-feature.cpp
+++ b/src/ds/features/gyro-sensitivity-feature.cpp
@@ -13,9 +13,10 @@ namespace librealsense {
 const feature_id gyro_sensitivity_feature::ID = "Gyro Sensitivity feature";
 
 gyro_sensitivity_feature::gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor,
-                                                   ds_motion_sensor & motion )
+                                                   ds_motion_sensor & motion,
+                                                   float default_value )
 {
-    option_range enable_range = { 0.f /*min*/, 4.f /*max*/, 1.f /*step*/, 1.f /*default*/ };
+    option_range enable_range = { 0.f /*min*/, 4.f /*max*/, 1.f /*step*/, default_value };
     auto imu_sensitivity_control = std::make_shared< gyro_sensitivity_option >( motion_sensor, enable_range );
     motion.register_option( RS2_OPTION_GYRO_SENSITIVITY, imu_sensitivity_control );
 }

--- a/src/ds/features/gyro-sensitivity-feature.h
+++ b/src/ds/features/gyro-sensitivity-feature.h
@@ -19,7 +19,9 @@ class gyro_sensitivity_feature : public feature_interface
 public:
     static const feature_id ID;
 
-    gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor, ds_motion_sensor & motion );
+    gyro_sensitivity_feature( std::shared_ptr< hid_sensor > motion_sensor,
+                              ds_motion_sensor & motion,
+                              float default_value = 1.f );
 
     feature_id get_id() const override;
 

--- a/src/hid-sensor.cpp
+++ b/src/hid-sensor.cpp
@@ -24,12 +24,6 @@ static const std::map< rs2_stream, fourcc::value_type > stream_and_fourcc
         { RS2_STREAM_ACCEL, fourcc( 'A', 'C', 'C', 'L' ) },
         { RS2_STREAM_GPIO,  fourcc( 'G', 'P', 'I', 'O' ) } };
 
-/*For gyro sensitivity - FW gets 0 for 61 millidegree/s/LSB resolution
- 0.1 for 30.5 millidegree/s/LSB 
- 0.2 for 15.3 millidegree/s/LSB 
- 0.3 for 7.6 millidegree/s/LSB 
- 0.4 for 3.8 millidegree/s/LSB 
- Currently it is intended for D400 devices, when this feature will be added to D500 the convert needs to be checked*/
 static const std::map< float, double > gyro_sensitivity_convert
     = { { 0.0f, 0 }, { 1.0f, 0.1 }, { 2.0f, 0.2 }, { 3.0f, 0.3 }, { 4.0f, 0.4 } };
 
@@ -369,18 +363,27 @@ void hid_sensor::set_gyro_scale_factor(double scale_factor)
     _hid_device->set_gyro_scale_factor( scale_factor );
 }
 
-/*For gyro sensitivity - FW expects 0/0.1/0.2/0.3/0.4 we convert the values from the enum 0/1/2/3/4
-the user chooses to the values FW expects using gyro_sensitivity_convert*/
 double hid_sensor::get_imu_sensitivity_values( rs2_stream stream )
 {
     if( _imu_sensitivity_per_rs2_stream.find( stream ) != _imu_sensitivity_per_rs2_stream.end() )
     {
-        return gyro_sensitivity_convert.at( _imu_sensitivity_per_rs2_stream[stream] );
+        const auto value = _imu_sensitivity_per_rs2_stream[stream];
+        if( stream == RS2_STREAM_GYRO )
+        {
+            if( _gyro_sensitivity_uses_range_index )
+                return value;
+            return gyro_sensitivity_convert.at( value );
+        }
+        return value;
     }
-    else
-        //FW recieve 0.1 and adjusts the gyro's sensitivity to its default setting of 1000.
-        //FW recieve 0.001 and adjusts the accel's sensitivity to its default setting of 4g.
-        return stream == RS2_STREAM_GYRO ? 0.1f : 0.001f;
+
+    if( stream == RS2_STREAM_GYRO )
+        // HKR range index 4 selects the default 125 dps range; D400 token 0.1
+        // selects its default 1000 dps range.
+        return _gyro_sensitivity_uses_range_index ? 4. : 0.1;
+
+    // FW receives 0.001 and adjusts the accelerometer sensitivity to its default setting of 4g.
+    return 0.001;
 }
 
 iio_hid_timestamp_reader::iio_hid_timestamp_reader()

--- a/src/hid-sensor.h
+++ b/src/hid-sensor.h
@@ -53,6 +53,10 @@ public:
     void stop() override;
     void set_imu_sensitivity( rs2_stream stream, float value );
     double get_imu_sensitivity_values( rs2_stream stream );
+    // HKR FW accepts the option value directly as a range index:
+    // 0/1/2/3/4 select 2000/1000/500/250/125 dps respectively.
+    // Other devices retain the D400 conversion to FW tokens 0/0.1/0.2/0.3/0.4.
+    void enable_gyro_sensitivity_range_index() { _gyro_sensitivity_uses_range_index = true; }
     void set_gyro_scale_factor(double scale_factor);
     std::vector< uint8_t > get_custom_report_data( const std::string & custom_sensor_name,
                                                    const std::string & report_name,
@@ -73,6 +77,7 @@ private:
     std::unique_ptr< frame_timestamp_reader > _custom_hid_timestamp_reader;
     //Keeps set sensitivity values for gyro and accel
     std::map< rs2_stream, float > _imu_sensitivity_per_rs2_stream;
+    bool _gyro_sensitivity_uses_range_index = false;
 
     stream_profiles get_sensor_profiles( std::string sensor_name ) const;
 


### PR DESCRIPTION
**Overview:** Cherry-pick of #15512 onto the `d585-ms3` branch (2.58.0.10852 base) so the D585 gyro physical-unit fix is available on the MS3 line.

## Why
`d585-ms3` was branched from the 2.58.0.10852 build point, which predates the gyro physical-unit processing fix merged to `development` on Aug 7.

## Summary
- Clean cherry-pick of #15512 (`d75c4cfce`), no conflicts, identical file set
- Gates the D500/HKR physical-unit IMU ABI by transport, PID, and FW version
- Selects 32-bit motion converter and fixed `0.0001 dps/count` gyro scale for the 38-byte report
- Encodes HKR gyro sensitivity as integer range indices `0..4` with default `4` (125 dps)

## Test plan
- [ ] Validated in original PR #15512 on D585 prototype (FW 7.58.40934.13309)
- [ ] CI build on this branch

---
🤖 Generated by AI
