### PR TITLE
Cherry-pick #15521: Fix IMU HW FPS 0 for D500 GMSL

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1671,11 +1671,11 @@ namespace librealsense
                                                 uint8_t md_size = buf_mgr.metadata_size();
                                                 void* md_start = buf_mgr.metadata_start();
 
-                                                // D457 development - hid over uvc - md size for IMU is 64
+                                                // IMU node (mi=4) delivers data with no metadata node, synthesize the metadata from the payload.
+                                                // Frame size is 64 bytes on D400 but 256 on D500.
                                                 metadata_hid_raw meta_data{};
-                                                if (md_size == 0 && buffer->get_length_frame_only() <= 64)
+                                                if (md_size == 0 && _info.mi == 4)
                                                 {
-                                                    // Populate HID IMU data - Header
                                                     populate_imu_data(meta_data, buffer->get_frame_start(), md_size, &md_start);
                                                 }
 


### PR DESCRIPTION
**Overview:** Cherry-pick of #15521 onto `d585-ms3` so the D585 GMSL IMU reports valid hardware timestamps (Viewer FPS no longer stuck at 0).

Tracked on [RSDEV-13410]

## Why
D500 GMSL IMU frames are 256 bytes, but the V4L2 backend only synthesized IMU metadata for frames up to 64 bytes (D400). Without metadata, all motion frames share one frozen timestamp and the Viewer FPS counter shows 0.

## Summary
- Clean cherry-pick of #15521 (`97b64db57`), no conflicts, single file (`src/linux/backend-v4l2.cpp`)
- Gate IMU metadata synthesis by interface number (mi == 4) instead of frame size

## Test plan
- [x] Reproduced on D585 GMSL (JP6, MIPI driver 1.0.5.17, FW 7.58.40917.13221) without this fix: no frame_timestamp metadata, identical frozen timestamp on all motion frames
- [x] Retested same bench with this fix (on top of #15538): frame_timestamp metadata present, timestamps advance per frame; accel 169.7 Hz / gyro 22.8 Hz delivered, stationary gyro max norm 0.011 rad/s, accel norm 9.83 m/s²

---
🤖 Generated by AI
