### PR TITLE
Cherry-pick #15528: gate DETECTION_DISTANCE XU registration on min FW version

### DIFF
--- a/src/ds/d500/d500-object-detection.cpp
+++ b/src/ds/d500/d500-object-detection.cpp
@@ -81,11 +81,14 @@ namespace librealsense
 
         od_ep->register_option( RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option );
 
-        auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
-                                                                               ds::inference_xu,
-                                                                               ds::d500_xu_id::DETECTION_DISTANCE,
-                                                                               "Enable firmware distance calculation for detections" );
-        od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        if( _fw_version >= firmware_version( "7.58.40802.12738" ) )
+        {
+            auto detection_distance = std::make_shared< uvc_xu_option< uint8_t > >(raw_od_ep,
+                                                                                   ds::inference_xu,
+                                                                                   ds::d500_xu_id::DETECTION_DISTANCE,
+                                                                                   "Enable firmware distance calculation for detections" );
+            od_ep->register_option( RS2_OPTION_DETECTION_DISTANCE, detection_distance );
+        }
 
         od_ep->register_info( RS2_CAMERA_INFO_PHYSICAL_PORT, od_devices_info.front().device_path );
 


### PR DESCRIPTION
**Overview:** Partial cherry-pick of #15528 onto `d585-ms3` — only register the D500 `RS2_OPTION_DETECTION_DISTANCE` option when the FW is new enough to expose its backing XU control, so older FW no longer surfaces a non-functional option or floods the log with `xioctl(UVCIOC_CTRL_QUERY) failed` errors.

## Why
`d585-ms3` registers `DETECTION_DISTANCE` unconditionally; on FW older than 7.58.40802.12738 the XU control does not exist.

## Summary
- Cherry-pick of #15528 (`c63c914b0`) with the `DUAL_RGB_MODE` hunk dropped: the `SENSORS_CONFIG_MODE` registration it gates entered `development` after this branch's base cut and does not exist here
- `DETECTION_DISTANCE` registration now gated on FW >= 7.58.40802.12738 (`src/ds/d500/d500-object-detection.cpp`)

## Test plan
- [ ] Validated in original PR #15528 on development
- [ ] CI build on this branch

---
🤖 Generated by AI
