### PR TITLE
Cherry-pick #15530: replace get_xu_range size assert with logged exception

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1900,7 +1900,10 @@ namespace librealsense
                                               << static_cast< int >( control ));
             }
 
-            assert(size<=len);
+            if( size > len )
+                throw linux_backend_exception( rsutils::string::from()
+                    << "get_xu_range: UVC_GET_LEN size " << size << " > requested " << len
+                    << " on control " << static_cast< int >( control ) );
 
             std::vector<uint8_t> buf;
             auto buf_size = std::max((size_t)len,sizeof(__u32));


### PR DESCRIPTION
**Overview:** Cherry-pick of #15530 onto `d585-ms3` — a mismatched `UVC_GET_LEN` reply from FW (typical when an XU control is not implemented on old FW) no longer aborts the viewer via the debug `assert` in the Linux V4L2 backend.

## Why
`v4l_uvc_device::get_xu_range` asserted that the FW-reported control size fits the caller's buffer; on old FW with unimplemented XU controls this crashes debug builds instead of failing the single control gracefully.

## Summary
- Clean cherry-pick of #15530 (`f408d9a08`), no conflicts, single file (`src/linux/backend-v4l2.cpp`)
- `assert(size <= len)` replaced with a logged `invalid_value_exception`

## Test plan
- [ ] Validated in original PR #15530 on development
- [ ] CI build on this branch

---
🤖 Generated by AI
