### PR TITLE
Python: expose combined motion orientation

### DIFF
--- a/unit-tests/sw-dev/pytest-combined-motion.py
+++ b/unit-tests/sw-dev/pytest-combined-motion.py
@@ -17,6 +17,9 @@ def test_combined_motion_orientation():
     motion.orientation = orientation
 
     assert motion.orientation == orientation
+    assert repr(motion).endswith(
+        "orientation[0.123457,-0.234568,0.345679,0.987654]"
+    )
 
 
 def test_combined_motion_orientation_requires_four_values():

--- a/unit-tests/sw-dev/pytest-combined-motion.py
+++ b/unit-tests/sw-dev/pytest-combined-motion.py
@@ -1,0 +1,26 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+import pytest
+import pyrealsense2 as rs
+
+
+def test_combined_motion_orientation():
+    motion = rs.combined_motion()
+    orientation = (
+        0.123456789012345,
+        -0.234567890123456,
+        0.345678901234567,
+        0.987654321098765,
+    )
+
+    motion.orientation = orientation
+
+    assert motion.orientation == orientation
+
+
+def test_combined_motion_orientation_requires_four_values():
+    motion = rs.combined_motion()
+
+    with pytest.raises(ValueError, match="orientation must contain four values"):
+        motion.orientation = (0.0, 0.0, 0.0)

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -183,7 +183,9 @@ void init_c_files(py::module &m) {
                   std::ostringstream ss;
                   ss << "gyro[" << self.angular_velocity.x << "," << self.angular_velocity.y << ","
                       << self.angular_velocity.z << "] accel[" << self.linear_acceleration.x << ","
-                      << self.linear_acceleration.y << "," << self.linear_acceleration.z << "]";
+                      << self.linear_acceleration.y << "," << self.linear_acceleration.z << "] orientation["
+                      << self.orientation.x << "," << self.orientation.y << "," << self.orientation.z << ","
+                      << self.orientation.w << "]";
                   return ss.str();
               } );
 

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -136,6 +136,26 @@ void init_c_files(py::module &m) {
     py::class_< rs2_combined_motion > combined_motion( m, "combined_motion", "IMU combined GYRO & ACCEL data" );
     combined_motion.def( py::init<>() )
         .def_property(
+            "orientation",
+            []( rs2_combined_motion const & self )
+            {
+                return py::make_tuple( self.orientation.x,
+                                       self.orientation.y,
+                                       self.orientation.z,
+                                       self.orientation.w );
+            },
+            []( rs2_combined_motion & self, py::sequence const & value )
+            {
+                if( py::len( value ) != 4 )
+                    throw py::value_error( "orientation must contain four values" );
+
+                self.orientation = { value[0].cast< double >(),
+                                     value[1].cast< double >(),
+                                     value[2].cast< double >(),
+                                     value[3].cast< double >() };
+            },
+            "Quaternion represented as (x, y, z, w)." )
+        .def_property(
             "angular_velocity",
             []( rs2_combined_motion const & self )
             {


### PR DESCRIPTION
`rs2_combined_motion` stores orientation as four double-precision values, but the Python binding exposed only angular velocity and linear acceleration.

This change:

- adds an `orientation` property with an `(x, y, z, w)` getter;
- accepts a four-value Python sequence in the setter;
- preserves double precision;
- includes orientation in `repr`;
- raises `ValueError` for invalid sequence lengths.

The pytest covers property access, double-precision round trips, invalid lengths, and the visible representation.

Tested with:

```text
python -m pytest -q unit-tests/sw-dev/pytest-combined-motion.py
2 passed
```

This replaces the Python orientation portion of #15393 and #15398. The macOS Viewer and device support changes are handled separately.

One unrelated Ubuntu DDS hardware job failed while exercising mismatched connected devices. A maintainer rerun has been requested; this PR will remain a draft until the check is green.