### PR TITLE
Enable D500 motion streaming on macOS

### DIFF
--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -92,7 +92,6 @@ namespace librealsense
 
             using namespace ds;
 
-#if !defined(__APPLE__) // Motion sensors not supported on macOS
             std::shared_ptr<synthetic_sensor> sensor_ep;
             if( _is_mipi_device )
             {
@@ -122,7 +121,6 @@ namespace librealsense
                 if( supports_physical_units() )
                     get_raw_motion_sensor()->set_gyro_scale_factor( RAW_TO_DPS_SCALE );
             }
-#endif
         }
         catch (const std::exception& e)
         {
@@ -197,21 +195,13 @@ namespace librealsense
 
     ds_motion_sensor & d500_motion::get_motion_sensor()
     {
-#if defined(__APPLE__)
-        throw std::runtime_error( "Motion sensors are not supported on macOS" );
-#else
         return dynamic_cast< ds_motion_sensor & >( get_sensor( _motion_module_device_idx.value() ) );
-#endif
     }
 
     std::shared_ptr< hid_sensor > d500_motion::get_raw_motion_sensor()
     {
-#if defined(__APPLE__)
-        return nullptr;
-#else
         auto raw_sensor = get_motion_sensor().get_raw_sensor();
         return std::dynamic_pointer_cast< hid_sensor >( raw_sensor );
-#endif
     }
 
     void d500_motion::register_gyro_sensitivity()

--- a/src/hid/CMakeLists.txt
+++ b/src/hid/CMakeLists.txt
@@ -6,20 +6,3 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/hid-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/hid-device.cpp"
 )
-
-if(APPLE)
-
-    find_library(CoreFoundationLib CoreFoundation)
-    find_library(IOKitLib IOKit)
-
-    target_sources(${LRS_TARGET}
-        PRIVATE
-            "${CMAKE_CURRENT_LIST_DIR}/../../third-party/hidapi/hidapi.h"
-            "${CMAKE_CURRENT_LIST_DIR}/../../third-party/hidapi/hidapi.cpp"
-    )
-
-    target_include_directories(${LRS_TARGET} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../../third-party/hidapi/)
-
-    target_link_libraries(${LRS_TARGET} PRIVATE ${CoreFoundationLib} ${IOKitLib})
-
-endif()

--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -65,24 +65,11 @@ namespace librealsense
             _sensor_to_id[gyro] = REPORT_ID_GYROMETER_3D;
             _sensor_to_id[accel] = REPORT_ID_ACCELEROMETER_3D;
             _sensor_to_id[custom] = REPORT_ID_CUSTOM;
-#ifdef __APPLE__
-            hidapi_device_info *devices = hid_enumerate(0x8086, 0x0);
-            if(devices)
-            {
-                _hidapi_device = hid_open(devices[0].vendor_id, devices[0].product_id, devices[0].serial_number);
-                hidapi_PowerDevice(REPORT_ID_ACCELEROMETER_3D);
-                hidapi_PowerDevice(REPORT_ID_GYROMETER_3D);
-            }
-#endif
             _action_dispatcher.start();
         }
 
         rs_hid_device::~rs_hid_device()
         {
-#ifdef __APPLE__
-            if( _hidapi_device )
-                hid_close( _hidapi_device );
-#endif
             _action_dispatcher.stop();
         }
 
@@ -117,7 +104,6 @@ namespace librealsense
             {
                 if(!_running)
                     return;
-#ifndef __APPLE__
                 _request_callback->cancel();
 
                 _queue.clear();
@@ -126,11 +112,8 @@ namespace librealsense
                     _messenger->cancel_request(r);
 
                 _requests.clear();
-#endif
                 _handle_interrupts_thread->stop();
-#ifndef __APPLE__
                 _messenger.reset();
-#endif
                _running = false;
             }, [this](){ return !_running; }, true);
         }
@@ -143,10 +126,12 @@ namespace librealsense
                     return;
 
                 _callback = callback;
-#ifndef __APPLE__
                 auto in = get_hid_interface()->get_number();
                 _messenger = _usb_device->open(in);
-#endif
+                if( ! _messenger )
+                    throw std::runtime_error( rsutils::string::from()
+                                              << "failed to open HID interface " << static_cast< int >( in ) );
+
                 _handle_interrupts_thread = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
                 {
                     handle_interrupt();
@@ -154,7 +139,6 @@ namespace librealsense
 
                 _handle_interrupts_thread->start();
 
-#ifndef __APPLE__
                 _request_callback = std::make_shared<usb_request_callback>([&](platform::rs_usb_request r)
                     {
                         _action_dispatcher.invoke([this, r](dispatcher::cancellable_timer c)
@@ -210,12 +194,9 @@ namespace librealsense
                     r->set_buffer(std::vector<uint8_t>(sizeof(REALSENSE_HID_REPORT)));
                     r->set_callback(_request_callback);
                 }
-#endif
                 _running = true;
-#ifndef __APPLE__
                 for(auto&& r : _requests)
                     _messenger->submit_request(r);
-#endif
 
             }, [this](){ return _running; }, true);
         }
@@ -229,46 +210,6 @@ namespace librealsense
             // For FW >= 5.16 we can just use memcpy as the structs size match
            
 
-#ifdef __APPLE__
-            unsigned char tmp_buffer[100] = { 0 };
-            hid_read( _hidapi_device, tmp_buffer, _realsense_hid_report_actual_size );
-            if( _realsense_hid_report_actual_size != sizeof( REALSENSE_HID_REPORT ) )
-            {
-               
-                // x,y,z are all short with: x at offset 10
-                //                           y at offset 12
-                //                           z at offset 14
-                memcpy( &report, tmp_buffer, 10 );
-                const int16_t * x = reinterpret_cast< const int16_t * >( tmp_buffer + 10 );
-                const int16_t * y = reinterpret_cast< const int16_t * >( tmp_buffer + 12 );
-                const int16_t * z = reinterpret_cast< const int16_t * >( tmp_buffer + 14 );
-                report.x = *x;
-                report.y = *y;
-                report.z = *z;
-
-                // the rest of the data in the old struct size (after z element) starts from offset 16 and has 16 bytes till end
-                memcpy( &report.customValue1, tmp_buffer + 16, 16 );
-            }
-            else
-            {
-                memcpy( &report, tmp_buffer, sizeof( REALSENSE_HID_REPORT ) );
-            }
-
-            sensor_data data{};
-            data.sensor = { _id_to_sensor[report.reportId] };
-
-            hid_data hid{};
-            hid.x = report.x;
-            hid.y = report.y;
-            hid.z = report.z;
-
-            data.fo.pixels = &(hid.x);
-            data.fo.metadata = &(report.timeStamp);
-            data.fo.frame_size = sizeof(REALSENSE_HID_REPORT);
-            data.fo.metadata_size = sizeof(report.timeStamp);
-
-            _callback(data);
-#else
             if(_queue.dequeue(&report, 10))
             {
                 if(std::find_if(_configured_profiles.begin(), _configured_profiles.end(), [&](hid_profile& p)
@@ -293,7 +234,6 @@ namespace librealsense
                     _callback(data);
                 }
             }
-#endif
         }
 
         usb_status rs_hid_device::set_feature_report( unsigned char power, int report_id, int fps, double sensitivity)
@@ -374,56 +314,6 @@ namespace librealsense
             }
             return res;
         }
-
-#ifdef __APPLE__
-        int rs_hid_device::hidapi_PowerDevice(unsigned char reportId)
-        {
-            if (_hidapi_device == NULL)
-                return -1;
-
-            REALSENSE_FEATURE_REPORT featureReport;
-            int ret;
-
-            memset(&featureReport,0, sizeof(featureReport));
-            featureReport.reportId = reportId;
-            // Reading feature report.
-            ret = hid_get_feature_report(_hidapi_device, (unsigned char *)
-                                         &featureReport ,sizeof(featureReport) );
-
-            if (ret == -1) {
-                LOG_ERROR("fail to read feature report from device");
-                return ret;
-            }
-
-            // change report to power the device to D0
-
-            featureReport.power = DEVICE_POWER_D0;
-
-            // Write feature report back.
-            ret = hid_send_feature_report(_hidapi_device, (unsigned char *) &featureReport, sizeof(featureReport));
-
-            if (ret == -1) {
-                LOG_ERROR("fail to write feature report from device");
-                return ret;
-            }
-
-            ret = hid_get_feature_report(_hidapi_device, (unsigned char *) &featureReport ,sizeof(featureReport) );
-
-            if (ret == -1) {
-                LOG_ERROR("fail to read feature report from device");
-                return ret;
-            }
-
-            if (featureReport.power == DEVICE_POWER_D0) {
-                LOG_INFO("Device is powered up");
-            } else {
-                LOG_INFO("Device is powered off");
-                return -1;
-            }
-
-            return 0;
-        }
-#endif
 
         rs_usb_interface rs_hid_device::get_hid_interface()
         {

--- a/src/hid/hid-device.h
+++ b/src/hid/hid-device.h
@@ -17,10 +17,6 @@
 #include <thread>
 #include "../types.h"
 
-#ifdef __APPLE__
-#include <hidapi.h>
-#endif
-
 namespace librealsense
 {
     namespace platform
@@ -51,22 +47,14 @@ namespace librealsense
             rs_usb_interface get_hid_interface();
             //for gyro sensitivity the default value we set in feature report is 0.1, which is mapped in FW to 30.5 millideg/sec
             usb_status set_feature_report( unsigned char power, int report_id, int fps = 0, double sensitivity = 0.1 );
-#ifdef __APPLE__
-           int hidapi_PowerDevice(unsigned char reportId);
-#endif
-
             bool _running = false;
             dispatcher _action_dispatcher;
 
             hid_callback _callback;
             rs_usb_device _usb_device;
-#ifdef __APPLE__
-            hidapi_device* _hidapi_device = nullptr;
-#else
             rs_usb_messenger _messenger;
             std::vector<rs_usb_request> _requests;
             std::shared_ptr<platform::usb_request_callback> _request_callback;
-#endif
 
             std::vector<hid_profile> _hid_profiles;
             std::map<int, std::string> _id_to_sensor;

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -99,8 +99,8 @@ if(${FORCE_RSUSB_BACKEND})
     )
     if(APPLE)
         list(APPEND RAW_RS
-            ../../third-party/hidapi/hidapi.cpp
-            ../../third-party/hidapi/hidapi.h
+            ../../src/libusb/darwin-device-capture.cpp
+            ../../src/libusb/darwin-device-capture.h
         )
     endif()
 endif()
@@ -141,12 +141,6 @@ if( BUILD_LEGACY_PYBACKEND )
             FOLDER Library/Python
         )
     target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
-
-    if(${FORCE_RSUSB_BACKEND})
-        if(APPLE)
-            target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../third-party/hidapi/)
-        endif()
-    endif()
 
     if(${BACKEND} STREQUAL RS2_USE_V4L2_BACKEND)
         if(UDEV_FOUND)


### PR DESCRIPTION
## Summary

- enable the D500 motion module on macOS
- use the existing RSUSB interrupt-transfer path for HID reports
- remove the separate macOS HIDAPI implementation
- stream accelerometer and gyroscope data without changing non-macOS behavior

## Scope

This branch is based on `development` after #15550. The diff is limited to D500 motion discovery and streaming on macOS.

## Validation

Tested on Apple Silicon with a D555 connected directly over USB-C at 5 Gbps.

The final branch was tested with Homebrew libusb 1.0.30 in two consecutive Viewer sessions without reconnecting the camera. Depth, color, accelerometer, and gyroscope ran together in both sessions. The following checks passed:

- 2D depth, color, accelerometer, and gyroscope streams
- 3D point cloud
- Custom to High Density profile change while streaming
- stream stop followed by normal Viewer shutdown
- final UVC ownership restored to 5/5

The latest session received 532 depth, 553 color, 1,828 accelerometer, and 3,659 gyroscope callbacks.

This PR remains a draft while the new CI run completes.
