### PR TITLE
macOS: enable D555 Ethernet DDS on Apple Silicon

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -17,6 +17,14 @@ function(get_fastdds)
         get_filename_component(_FASTDDS_MACOS_REUSEPORT_PATCH
             "${CMAKE_SOURCE_DIR}/CMake/patches/fastdds-v2.10.4-macos-reuseport.patch"
             ABSOLUTE)
+        get_filename_component(_FASTDDS_MACOS_PATCH_SCRIPT
+            "${CMAKE_SOURCE_DIR}/CMake/patches/apply-fastdds-macos-patch.cmake"
+            ABSOLUTE)
+        set(_FASTDDS_PATCH_COMMAND
+            PATCH_COMMAND ${CMAKE_COMMAND}
+                -DFASTDDS_SOURCE_DIR=<SOURCE_DIR>
+                -DFASTDDS_PATCH=${_FASTDDS_MACOS_REUSEPORT_PATCH}
+                -P ${_FASTDDS_MACOS_PATCH_SCRIPT})
     endif()
 
     FetchContent_Declare(
@@ -30,6 +38,7 @@ function(get_fastdds)
       GIT_SUBMODULES ""     # Submodules will be cloned as part of the FastDDS cmake configure stage
       GIT_SHALLOW ON        # No history needed
       SOURCE_DIR ${CMAKE_BINARY_DIR}/third-party/fastdds
+      ${_FASTDDS_PATCH_COMMAND}
     )
 
     # Set FastDDS internal variables
@@ -59,62 +68,7 @@ function(get_fastdds)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
     set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
 
-    # Populate first so the Apple transport patch is applied before FastDDS is
-    # configured or compiled.
-    FetchContent_GetProperties(fastdds)
-    if(NOT fastdds_POPULATED)
-        FetchContent_Populate(fastdds)
-    endif()
-
-    if(APPLE)
-        if(NOT EXISTS "${_FASTDDS_MACOS_REUSEPORT_PATCH}")
-            message(FATAL_ERROR "FastDDS macOS SO_REUSEPORT patch is missing: ${_FASTDDS_MACOS_REUSEPORT_PATCH}")
-        endif()
-        if(NOT EXISTS "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp")
-            message(FATAL_ERROR "FastDDS source tree is incomplete: ${fastdds_SOURCE_DIR}")
-        endif()
-
-        # BSD patch can auto-detect a reversed patch even with -R --dry-run,
-        # producing a false "already applied" result on clean sources. Check
-        # the semantic marker in both transport files instead.
-        set(_fastdds_udp4 "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp")
-        set(_fastdds_udp6 "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv6Transport.cpp")
-        file(READ "${_fastdds_udp4}" _fastdds_udp4_contents)
-        file(READ "${_fastdds_udp6}" _fastdds_udp6_contents)
-        string(FIND "${_fastdds_udp4_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp4_marker)
-        string(FIND "${_fastdds_udp6_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp6_marker)
-        if(NOT _fastdds_udp4_marker EQUAL -1 AND NOT _fastdds_udp6_marker EQUAL -1)
-            message(STATUS "FastDDS macOS SO_REUSEPORT patch already applied")
-        else()
-            execute_process(
-                COMMAND patch -p1 --forward --dry-run -i "${_FASTDDS_MACOS_REUSEPORT_PATCH}"
-                WORKING_DIRECTORY "${fastdds_SOURCE_DIR}"
-                RESULT_VARIABLE _fastdds_patch_dry_run_rc
-                OUTPUT_VARIABLE _fastdds_patch_dry_run_out
-                ERROR_VARIABLE _fastdds_patch_dry_run_err)
-            if(NOT _fastdds_patch_dry_run_rc EQUAL 0)
-                message(FATAL_ERROR
-                    "FastDDS macOS SO_REUSEPORT patch dry-run failed (rc=${_fastdds_patch_dry_run_rc}): "
-                    "${_fastdds_patch_dry_run_err}${_fastdds_patch_dry_run_out}")
-            endif()
-            execute_process(
-                COMMAND patch -p1 --forward -i "${_FASTDDS_MACOS_REUSEPORT_PATCH}"
-                WORKING_DIRECTORY "${fastdds_SOURCE_DIR}"
-                RESULT_VARIABLE _fastdds_patch_rc
-                OUTPUT_VARIABLE _fastdds_patch_out
-                ERROR_VARIABLE _fastdds_patch_err)
-            if(NOT _fastdds_patch_rc EQUAL 0)
-                message(FATAL_ERROR
-                    "FastDDS macOS SO_REUSEPORT patch failed (rc=${_fastdds_patch_rc}): "
-                    "${_fastdds_patch_err}${_fastdds_patch_out}")
-            endif()
-            message(STATUS "FastDDS macOS SO_REUSEPORT patch applied")
-        endif()
-    endif()
-
-    if(NOT TARGET fastrtps)
-        add_subdirectory(${fastdds_SOURCE_DIR} ${fastdds_BINARY_DIR})
-    endif()
+    FetchContent_MakeAvailable(fastdds)
 
     # GCC 14 / libstdc++-15 (Ubuntu 26.04 "resolute") removed transitive <cstdint>
     # includes from many std headers. FastDDS 2.10.4 uses uint8_t (e.g. in

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -13,6 +13,12 @@ function(get_fastdds)
     message(CHECK_START  "Fetching fastdds...")
     list(APPEND CMAKE_MESSAGE_INDENT "  ")  # Indent outputs
 
+    if(APPLE)
+        get_filename_component(_FASTDDS_MACOS_REUSEPORT_PATCH
+            "${CMAKE_SOURCE_DIR}/CMake/patches/fastdds-v2.10.4-macos-reuseport.patch"
+            ABSOLUTE)
+    endif()
+
     FetchContent_Declare(
       fastdds
       GIT_REPOSITORY https://github.com/eProsima/Fast-DDS.git
@@ -40,13 +46,75 @@ function(get_fastdds)
     # Enforce NO_TLS to disable SSL: if OpenSSL is found, it will be linked to, and we don't want it!
     set(NO_TLS ON CACHE INTERNAL "" FORCE)
 
-    # Set special values for FastDDS sub directory
-    set(BUILD_SHARED_LIBS OFF)
+    # Set special values for FastDDS sub directory. This function scope keeps
+    # BUILD_SHARED_LIBS from leaking back into librealsense. On Apple, FastDDS
+    # must be shared: linking its static archives into librealsense2.dylib
+    # crashes in DomainParticipantFactory::create_participant at runtime.
+    if(APPLE)
+        set(BUILD_SHARED_LIBS ON)
+        message(STATUS "FastDDS: shared libraries (required for macOS librealsense2.dylib + DDS)")
+    else()
+        set(BUILD_SHARED_LIBS OFF)
+    endif()
     set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
     set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/fastdds/fastdds_install)
 
-    # Get fastdds
-    FetchContent_MakeAvailable(fastdds)
+    # Populate first so the Apple transport patch is applied before FastDDS is
+    # configured or compiled.
+    FetchContent_GetProperties(fastdds)
+    if(NOT fastdds_POPULATED)
+        FetchContent_Populate(fastdds)
+    endif()
+
+    if(APPLE)
+        if(NOT EXISTS "${_FASTDDS_MACOS_REUSEPORT_PATCH}")
+            message(FATAL_ERROR "FastDDS macOS SO_REUSEPORT patch is missing: ${_FASTDDS_MACOS_REUSEPORT_PATCH}")
+        endif()
+        if(NOT EXISTS "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp")
+            message(FATAL_ERROR "FastDDS source tree is incomplete: ${fastdds_SOURCE_DIR}")
+        endif()
+
+        # BSD patch can auto-detect a reversed patch even with -R --dry-run,
+        # producing a false "already applied" result on clean sources. Check
+        # the semantic marker in both transport files instead.
+        set(_fastdds_udp4 "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp")
+        set(_fastdds_udp6 "${fastdds_SOURCE_DIR}/src/cpp/rtps/transport/UDPv6Transport.cpp")
+        file(READ "${_fastdds_udp4}" _fastdds_udp4_contents)
+        file(READ "${_fastdds_udp6}" _fastdds_udp6_contents)
+        string(FIND "${_fastdds_udp4_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp4_marker)
+        string(FIND "${_fastdds_udp6_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp6_marker)
+        if(NOT _fastdds_udp4_marker EQUAL -1 AND NOT _fastdds_udp6_marker EQUAL -1)
+            message(STATUS "FastDDS macOS SO_REUSEPORT patch already applied")
+        else()
+            execute_process(
+                COMMAND patch -p1 --forward --dry-run -i "${_FASTDDS_MACOS_REUSEPORT_PATCH}"
+                WORKING_DIRECTORY "${fastdds_SOURCE_DIR}"
+                RESULT_VARIABLE _fastdds_patch_dry_run_rc
+                OUTPUT_VARIABLE _fastdds_patch_dry_run_out
+                ERROR_VARIABLE _fastdds_patch_dry_run_err)
+            if(NOT _fastdds_patch_dry_run_rc EQUAL 0)
+                message(FATAL_ERROR
+                    "FastDDS macOS SO_REUSEPORT patch dry-run failed (rc=${_fastdds_patch_dry_run_rc}): "
+                    "${_fastdds_patch_dry_run_err}${_fastdds_patch_dry_run_out}")
+            endif()
+            execute_process(
+                COMMAND patch -p1 --forward -i "${_FASTDDS_MACOS_REUSEPORT_PATCH}"
+                WORKING_DIRECTORY "${fastdds_SOURCE_DIR}"
+                RESULT_VARIABLE _fastdds_patch_rc
+                OUTPUT_VARIABLE _fastdds_patch_out
+                ERROR_VARIABLE _fastdds_patch_err)
+            if(NOT _fastdds_patch_rc EQUAL 0)
+                message(FATAL_ERROR
+                    "FastDDS macOS SO_REUSEPORT patch failed (rc=${_fastdds_patch_rc}): "
+                    "${_fastdds_patch_err}${_fastdds_patch_out}")
+            endif()
+            message(STATUS "FastDDS macOS SO_REUSEPORT patch applied")
+        endif()
+    endif()
+
+    if(NOT TARGET fastrtps)
+        add_subdirectory(${fastdds_SOURCE_DIR} ${fastdds_BINARY_DIR})
+    endif()
 
     # GCC 14 / libstdc++-15 (Ubuntu 26.04 "resolute") removed transitive <cstdint>
     # includes from many std headers. FastDDS 2.10.4 uses uint8_t (e.g. in
@@ -83,11 +151,29 @@ function(get_fastdds)
 
     add_definitions(-DBUILD_WITH_DDS)
 
-    install(TARGETS dds fastrtps eProsima_atomic EXPORT realsense2Targets)
+    if(APPLE)
+        # foonathan_memory remains a static vendor archive in the observed
+        # FastDDS build; only fastrtps and fastcdr need dylib RPATH metadata.
+        foreach(_dds_tgt fastrtps fastcdr)
+            if(TARGET ${_dds_tgt})
+                set_target_properties(${_dds_tgt} PROPERTIES
+                    BUILD_RPATH "@loader_path"
+                    INSTALL_RPATH "@loader_path"
+                    MACOSX_RPATH ON
+                    INSTALL_NAME_DIR "@rpath")
+            endif()
+        endforeach()
+    endif()
+
+    install(TARGETS dds fastrtps eProsima_atomic EXPORT realsense2Targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     
     # fastcdr is installed separately because it cannot be exported to realsense2Targets - it is already exported in fastdds
-    # install in order to set ARCHIVE DESTINATION - to put libfastcdr.a into the x86_64 folder
-    install(TARGETS fastcdr 
+    install(TARGETS fastcdr
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     message(CHECK_PASS "Done")
 endfunction()

--- a/CMake/external_pybind11.cmake
+++ b/CMake/external_pybind11.cmake
@@ -72,7 +72,19 @@ function(get_pybind11)
       set( PYTHON_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
     else()
       find_package(Python REQUIRED COMPONENTS Interpreter Development)
-      set( PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+      # Keep Apple DDS installs prefix-local so the extension and all shared
+      # libraries can be relocated together without DYLD_LIBRARY_PATH.
+      if(APPLE AND BUILD_WITH_DDS)
+        if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+          include(GNUInstallDirs)
+        endif()
+        set( _pyrealsense2_default_install_dir
+             "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/pyrealsense2" )
+      else()
+        set( _pyrealsense2_default_install_dir "${Python_SITEARCH}/pyrealsense2" )
+      endif()
+      set( PYTHON_INSTALL_DIR "${_pyrealsense2_default_install_dir}"
+           CACHE PATH "Installation directory for Python bindings")
     endif()
 
     message( STATUS #CHECK_PASS

--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -110,6 +110,14 @@ macro(global_target_config)
             PRIVATE ${USB_INCLUDE_DIRS}
     )
 
+    # Apple DDS builds link shared FastDDS dylibs. Keep this target relocatable
+    # without changing the RPATH policy of non-DDS Apple builds.
+    if(APPLE AND BUILD_WITH_DDS)
+        set_target_properties(${LRS_TARGET} PROPERTIES
+            MACOSX_RPATH ON
+            BUILD_RPATH "@loader_path"
+            INSTALL_RPATH "@loader_path"
+            INSTALL_NAME_DIR "@rpath")
+    endif()
 
 endmacro()
-

--- a/CMake/patches/apply-fastdds-macos-patch.cmake
+++ b/CMake/patches/apply-fastdds-macos-patch.cmake
@@ -1,0 +1,43 @@
+if(NOT EXISTS "${FASTDDS_PATCH}")
+    message(FATAL_ERROR "FastDDS macOS SO_REUSEPORT patch is missing: ${FASTDDS_PATCH}")
+endif()
+
+set(_fastdds_udp4 "${FASTDDS_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp")
+set(_fastdds_udp6 "${FASTDDS_SOURCE_DIR}/src/cpp/rtps/transport/UDPv6Transport.cpp")
+if(NOT EXISTS "${_fastdds_udp4}" OR NOT EXISTS "${_fastdds_udp6}")
+    message(FATAL_ERROR "FastDDS source tree is incomplete: ${FASTDDS_SOURCE_DIR}")
+endif()
+
+file(READ "${_fastdds_udp4}" _fastdds_udp4_contents)
+file(READ "${_fastdds_udp6}" _fastdds_udp6_contents)
+string(FIND "${_fastdds_udp4_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp4_marker)
+string(FIND "${_fastdds_udp6_contents}" "defined(__QNX__) || defined(__APPLE__)" _fastdds_udp6_marker)
+if(NOT _fastdds_udp4_marker EQUAL -1 AND NOT _fastdds_udp6_marker EQUAL -1)
+    message(STATUS "FastDDS macOS SO_REUSEPORT patch already applied")
+    return()
+endif()
+
+execute_process(
+    COMMAND patch -p1 --forward --dry-run -i "${FASTDDS_PATCH}"
+    WORKING_DIRECTORY "${FASTDDS_SOURCE_DIR}"
+    RESULT_VARIABLE _fastdds_patch_dry_run_rc
+    OUTPUT_VARIABLE _fastdds_patch_dry_run_out
+    ERROR_VARIABLE _fastdds_patch_dry_run_err)
+if(NOT _fastdds_patch_dry_run_rc EQUAL 0)
+    message(FATAL_ERROR
+        "FastDDS macOS SO_REUSEPORT patch dry-run failed (rc=${_fastdds_patch_dry_run_rc}): "
+        "${_fastdds_patch_dry_run_err}${_fastdds_patch_dry_run_out}")
+endif()
+
+execute_process(
+    COMMAND patch -p1 --forward -i "${FASTDDS_PATCH}"
+    WORKING_DIRECTORY "${FASTDDS_SOURCE_DIR}"
+    RESULT_VARIABLE _fastdds_patch_rc
+    OUTPUT_VARIABLE _fastdds_patch_out
+    ERROR_VARIABLE _fastdds_patch_err)
+if(NOT _fastdds_patch_rc EQUAL 0)
+    message(FATAL_ERROR
+        "FastDDS macOS SO_REUSEPORT patch failed (rc=${_fastdds_patch_rc}): "
+        "${_fastdds_patch_err}${_fastdds_patch_out}")
+endif()
+message(STATUS "FastDDS macOS SO_REUSEPORT patch applied")

--- a/CMake/patches/fastdds-v2.10.4-macos-reuseport.patch
+++ b/CMake/patches/fastdds-v2.10.4-macos-reuseport.patch
@@ -1,0 +1,46 @@
+diff --git a/src/cpp/rtps/transport/UDPv4Transport.cpp b/src/cpp/rtps/transport/UDPv4Transport.cpp
+index bb1960cc5..04e4fd514 100644
+--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
++++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
+@@ -314,10 +314,16 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
+     if (is_multicast)
+     {
+         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
+-#if defined(__QNX__)
++        // QNX and Apple require SO_REUSEPORT so multiple processes can all
++        // receive the same multicast datagrams (SPDP 239.255.0.1:7400).
++        // SO_REUSEADDR alone allows the second bind on some platforms but
++        // on macOS concurrent FastDDS participants that start together then
++        // miss discovery entirely. Linux deliberately omitted: SO_REUSEPORT
++        // load-balances and would deliver each packet to only one socket.
++#if defined(__QNX__) || defined(__APPLE__)
+         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
+                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+-#endif // if defined(__QNX__)
++#endif // if defined(__QNX__) || defined(__APPLE__)
+     }
+     else
+     {
+diff --git a/src/cpp/rtps/transport/UDPv6Transport.cpp b/src/cpp/rtps/transport/UDPv6Transport.cpp
+index 4064af9cf..68a63bf82 100644
+--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
++++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
+@@ -318,10 +318,16 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
+     if (is_multicast)
+     {
+         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
+-#if defined(__QNX__)
++        // QNX and Apple require SO_REUSEPORT so multiple processes can all
++        // receive the same multicast datagrams (SPDP 239.255.0.1:7400).
++        // SO_REUSEADDR alone allows the second bind on some platforms but
++        // on macOS concurrent FastDDS participants that start together then
++        // miss discovery entirely. Linux deliberately omitted: SO_REUSEPORT
++        // load-balances and would deliver each packet to only one socket.
++#if defined(__QNX__) || defined(__APPLE__)
+         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
+                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
+-#endif // if defined(__QNX__)
++#endif // if defined(__QNX__) || defined(__APPLE__)
+     }
+     else
+     {

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -117,4 +117,14 @@ macro(os_set_flags)
 endmacro()
 
 macro(os_target_config)
+    # Shared FastDDS libraries live next to librealsense2 in the build tree
+    # and under ../lib from installed tools. Apply these defaults before the
+    # wrapper, example, and tool targets are created.
+    if(APPLE AND BUILD_WITH_DDS)
+        set(CMAKE_BUILD_RPATH "@loader_path")
+        set(CMAKE_INSTALL_RPATH "@loader_path;@loader_path/../lib")
+        set(CMAKE_MACOSX_RPATH ON)
+        set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif()
 endmacro()

--- a/src/dds/rs-dds-embedded-close-range-filter.cpp
+++ b/src/dds/rs-dds-embedded-close-range-filter.cpp
@@ -12,6 +12,12 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14 static constexpr data members are not implicitly inline.
+    constexpr const char * rs_dds_embedded_close_range_filter::ENABLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::DOWNSCALE_RATIO_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::DISPARITY_SHIFT_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_close_range_filter::THRESHOLD_OPTION_NAME;
+
     rs_dds_embedded_close_range_filter::rs_dds_embedded_close_range_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/src/dds/rs-dds-embedded-decimation-filter.cpp
+++ b/src/dds/rs-dds-embedded-decimation-filter.cpp
@@ -15,6 +15,11 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14 static constexpr data members are not implicitly inline.
+    constexpr const char * rs_dds_embedded_decimation_filter::TOGGLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_decimation_filter::MAGNITUDE_OPTION_NAME;
+    constexpr int32_t rs_dds_embedded_decimation_filter::DECIMATION_MAGNITUDE;
+
     rs_dds_embedded_decimation_filter::rs_dds_embedded_decimation_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/src/dds/rs-dds-embedded-temporal-filter.cpp
+++ b/src/dds/rs-dds-embedded-temporal-filter.cpp
@@ -15,6 +15,13 @@ using rsutils::json;
 
 namespace librealsense {
 
+    // C++14 static constexpr data members are not implicitly inline.
+    constexpr const char * rs_dds_embedded_temporal_filter::TOGGLE_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::ALPHA_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::DELTA_OPTION_NAME;
+    constexpr const char * rs_dds_embedded_temporal_filter::PERSISTENCY_OPTION_NAME;
+    constexpr int32_t rs_dds_embedded_temporal_filter::PERSISTENCY_MAX_LEN;
+
     rs_dds_embedded_temporal_filter::rs_dds_embedded_temporal_filter(const std::shared_ptr< realdds::dds_embedded_filter >& dds_embedded_filter,
         set_embedded_filter_callback set_embedded_filter_cb,
         query_embedded_filter_callback query_embedded_filter_cb)

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -685,6 +685,18 @@ void dds_device::impl::write_control_message( json const & j, json * reply )
     }
 }
 
+std::shared_ptr< dds_device::impl > dds_device::impl::shared_from_this_if_owned()
+{
+    try
+    {
+        return shared_from_this();
+    }
+    catch( std::bad_weak_ptr const & )
+    {
+        return {};
+    }
+}
+
 void dds_device::impl::create_notifications_reader()
 {
     if( _notifications_reader )
@@ -711,12 +723,7 @@ void dds_device::impl::create_notifications_reader()
             // weak_from_this() requires C++17. This reader is created from the
             // constructor, so shared ownership may not exist yet; preserve the
             // old empty-weak-pointer behavior in that window.
-            std::shared_ptr< impl > self;
-            try
-            {
-                self = shared_from_this();
-            }
-            catch( std::bad_weak_ptr const & ) {}
+            auto self = shared_from_this_if_owned();
             if( ! self )
                 return;
             topics::flexible_msg notification;
@@ -753,12 +760,7 @@ void dds_device::impl::create_metadata_reader()
         {
             // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
             // if a metadata handler drops the device's last reference.
-            std::shared_ptr< impl > self;
-            try
-            {
-                self = shared_from_this();
-            }
-            catch( std::bad_weak_ptr const & ) {}
+            auto self = shared_from_this_if_owned();
             if( ! self )
                 return;
             topics::flexible_msg message;

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -708,7 +708,15 @@ void dds_device::impl::create_notifications_reader()
         {
             // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
             // if a notification handler drops the device's last reference.
-            auto self = weak_from_this().lock();
+            // weak_from_this() requires C++17. This reader is created from the
+            // constructor, so shared ownership may not exist yet; preserve the
+            // old empty-weak-pointer behavior in that window.
+            std::shared_ptr< impl > self;
+            try
+            {
+                self = shared_from_this();
+            }
+            catch( std::bad_weak_ptr const & ) {}
             if( ! self )
                 return;
             topics::flexible_msg notification;
@@ -745,7 +753,12 @@ void dds_device::impl::create_metadata_reader()
         {
             // Keep the impl alive for the duration of the dispatch, so it can't be freed mid-loop
             // if a metadata handler drops the device's last reference.
-            auto self = weak_from_this().lock();
+            std::shared_ptr< impl > self;
+            try
+            {
+                self = shared_from_this();
+            }
+            catch( std::bad_weak_ptr const & ) {}
             if( ! self )
                 return;
             topics::flexible_msg message;

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -128,6 +128,7 @@ public:
     }
 
 private:
+    std::shared_ptr< impl > shared_from_this_if_owned();
     void create_notifications_reader();
     void create_metadata_reader();
     void create_control_writer();

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -22,6 +22,16 @@
 #include <map>
 #include <mutex>
 
+#if defined( __APPLE__ )
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <thread>
+#include <unistd.h>
+#endif
+
 using namespace eprosima::fastdds::dds;
 using namespace realdds;
 
@@ -32,6 +42,67 @@ namespace {
     participant_id last_participants_id = 0;
 
     std::map< std::string, dds_guid_prefix > participant_by_name;
+
+#if defined( __APPLE__ )
+    // FastDDS 2.10.4 participant creation has a narrow cross-process race on
+    // macOS. Serialize only this critical window. The lock is best-effort and
+    // bounded so a stale or hostile holder cannot wedge discovery indefinitely.
+    class apple_participant_create_guard
+    {
+    public:
+        apple_participant_create_guard()
+        {
+            auto const * tmpdir = std::getenv( "TMPDIR" );
+            std::string const lock_path
+                = std::string( tmpdir && *tmpdir ? tmpdir : "/tmp" )
+                + "/realdds-dds-participant-create.lock";
+            _fd = ::open( lock_path.c_str(), O_CREAT | O_RDWR | O_NOFOLLOW | O_CLOEXEC, 0600 );
+            if( _fd < 0 )
+                return;
+
+            for( int attempt = 0; attempt < 40; ++attempt )
+            {
+                if( ::flock( _fd, LOCK_EX | LOCK_NB ) == 0 )
+                    return;
+                if( errno != EWOULDBLOCK && errno != EAGAIN )
+                    break;
+                if( attempt != 39 )
+                    std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+            }
+
+            ::close( _fd );
+            _fd = -1;
+        }
+
+        ~apple_participant_create_guard() { release(); }
+
+        bool owns_lock() const { return _fd >= 0; }
+
+        void settle_and_release()
+        {
+            if( _fd >= 0 )
+            {
+                // Participant creation succeeded; keep peers out of the
+                // empirically observed race window before releasing the lock.
+                std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+                release();
+            }
+        }
+
+    private:
+        void release()
+        {
+            if( _fd >= 0 )
+            {
+                ::flock( _fd, LOCK_UN );
+                ::close( _fd );
+                _fd = -1;
+            }
+        }
+
+        int _fd = -1;
+    };
+#endif
 
     struct participant_info
     {
@@ -245,11 +316,22 @@ void dds_participant::init( dds_domain_id domain_id, qos & pqos, rsutils::json c
     // We need none of the standard callbacks at this level: these can be enabled on a per-reader/-writer basis!
     StatusMask const par_mask = StatusMask::none();
     _participant_factory = DomainParticipantFactory::get_shared_instance();
+
+#if defined( __APPLE__ )
+    apple_participant_create_guard apple_create_guard;
+    if( ! apple_create_guard.owns_lock() )
+        LOG_WARNING( "macOS DDS participant create lock unavailable after bounded wait; proceeding unlocked" );
+#endif
+
     _participant
         = DDS_API_CALL( _participant_factory->create_participant( domain_id, pqos, _domain_listener.get(), par_mask ) );
 
     if( ! _participant )
         DDS_THROW( runtime_error, "failed creating participant " << pqos.name() << " on domain id " << domain_id );
+
+#if defined( __APPLE__ )
+    apple_create_guard.settle_and_release();
+#endif
 
     if( settings.is_object() )
         _settings = settings;

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -25,9 +25,9 @@
 #if defined( __APPLE__ )
 #include <cerrno>
 #include <chrono>
-#include <cstdlib>
 #include <fcntl.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <thread>
 #include <unistd.h>
 #endif
@@ -52,13 +52,11 @@ namespace {
     public:
         apple_participant_create_guard()
         {
-            auto const * tmpdir = std::getenv( "TMPDIR" );
-            std::string const lock_path
-                = std::string( tmpdir && *tmpdir ? tmpdir : "/tmp" )
-                + "/realdds-dds-participant-create.lock";
-            _fd = ::open( lock_path.c_str(), O_CREAT | O_RDWR | O_NOFOLLOW | O_CLOEXEC, 0600 );
+            char const * const lock_path = "/tmp/realdds-dds-participant-create.lock";
+            _fd = ::open( lock_path, O_CREAT | O_RDWR | O_NOFOLLOW | O_CLOEXEC, 0666 );
             if( _fd < 0 )
                 return;
+            ::fchmod( _fd, 0666 );
 
             for( int attempt = 0; attempt < 40; ++attempt )
             {

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -39,10 +39,16 @@ void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, size_
                    "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
                        + std::to_string( profiles.size() ) + " stream profiles" );
 
-    // weak_from_this() requires C++17; realdds targets C++14. Streams are
-    // always shared-owned before profile initialization, so shared_from_this()
-    // throwing here correctly exposes an ownership bug.
-    auto self = std::weak_ptr< dds_stream_base >( shared_from_this() );
+    // weak_from_this() requires C++17; preserve its empty-result behavior when
+    // the stream is not yet owned by a shared_ptr.
+    std::weak_ptr< dds_stream_base > self;
+    try
+    {
+        self = shared_from_this();
+    }
+    catch( std::bad_weak_ptr const & )
+    {
+    }
     for( auto const & profile : profiles )
     {
         check_profile( profile );

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -39,7 +39,10 @@ void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, size_
                    "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
                        + std::to_string( profiles.size() ) + " stream profiles" );
 
-    auto self = weak_from_this();
+    // weak_from_this() requires C++17; realdds targets C++14. Streams are
+    // always shared-owned before profile initialization, so shared_from_this()
+    // throwing here correctly exposes an ownership bug.
+    auto self = std::weak_ptr< dds_stream_base >( shared_from_this() );
     for( auto const & profile : profiles )
     {
         check_profile( profile );

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -34,6 +34,16 @@ set_target_properties( pyrealsense2
         FOLDER Library/Python
     )
 
+if(APPLE AND BUILD_WITH_DDS)
+    # Build tree: librealsense2 and FastDDS are not co-located with the Python
+    # extension. Install tree: climb from
+    # lib/pythonX.Y/site-packages/pyrealsense2 to the prefix lib directory.
+    set_target_properties(pyrealsense2 PROPERTIES
+        BUILD_RPATH "@loader_path;${CMAKE_BINARY_DIR};${CMAKE_BINARY_DIR}/fastdds/fastdds_install/lib"
+        INSTALL_RPATH "@loader_path;@loader_path/../../.."
+        MACOSX_RPATH ON)
+endif()
+
 set(RAW_RS
     pybackend.cpp
     pybackend_extras.h


### PR DESCRIPTION
## Summary

Enable D555 Ethernet/DDS builds on Apple Silicon without changing the non-Apple FastDDS path.

- build FastDDS as shared libraries on macOS
- apply the FastDDS 2.10.4 `SO_REUSEPORT` fix to IPv4 and IPv6 transports
- keep librealsense, FastDDS, tools, and Python bindings relocatable after installation
- preserve the C++14 contract used by realdds
- serialize the short macOS participant-creation window to avoid concurrent discovery loss

This replaces #15390 and is based on the current `development` branch.

## Validation

Build and packaging checks on Apple Silicon:

- clean Release configure and build with `BUILD_WITH_DDS=ON`
- tools and Python bindings build
- install into a clean prefix
- installed `rs-enumerate-devices --version`
- installed `pyrealsense2` import
- installed tool and dylib RPATH inspection
- GitHub CI: PASS

Physical D555 Ethernet validation on Apple Silicon completed twice using the PR head (`db7d5744a7f1344e214e0c3102c9e5e10ca93348`):

- depth + color: PASS in both runs
- depth + color + combined motion: PASS in both runs
- run 1: 235 depth, 234 color, and 1576 valid motion frames
- run 2: 235 depth, 234 color, and 1576 valid motion frames
- clean shutdown and rediscovery: PASS

The host used `192.168.11.70/24`, MTU 9000, and DDS domain 0. The D555 was connected only through PoE/Ethernet at `192.168.11.55`.
