### PR TITLE
Examples: wait for asynchronous device discovery

### DIFF
--- a/examples/C/color/rs-color.c
+++ b/examples/C/color/rs-color.c
@@ -33,21 +33,14 @@ int main()
     rs2_context* ctx = rs2_create_context(RS2_API_VERSION, &e);
     check_error(e);
 
-    /* Get a list of all the connected devices. */
-    // The returned object should be released with rs2_delete_device_list(...)
-    rs2_device_list* device_list = rs2_query_devices(ctx, &e);
+    rs2_device* dev = wait_for_device(ctx, &e);
     check_error(e);
-
-    int dev_count = rs2_get_device_count(device_list, &e);
-    check_error(e);
-    printf("There are %d connected RealSense devices.\n", dev_count);
-    if (0 == dev_count)
+    if (!dev)
+    {
+        fprintf(stderr, "No RealSense device found before discovery timeout.\n");
+        rs2_delete_context(ctx);
         return EXIT_FAILURE;
-
-    // Get the first connected device
-    // The returned object should be released with rs2_delete_device(...)
-    rs2_device* dev = rs2_create_device(device_list, 0, &e);
-    check_error(e);
+    }
 
     print_device_info(dev);
 

--- a/examples/C/depth/rs-depth.c
+++ b/examples/C/depth/rs-depth.c
@@ -79,21 +79,14 @@ int main()
     rs2_context* ctx = rs2_create_context(RS2_API_VERSION, &e);
     check_error(e);
 
-    /* Get a list of all the connected devices. */
-    // The returned object should be released with rs2_delete_device_list(...)
-    rs2_device_list* device_list = rs2_query_devices(ctx, &e);
+    rs2_device* dev = wait_for_device(ctx, &e);
     check_error(e);
-
-    int dev_count = rs2_get_device_count(device_list, &e);
-    check_error(e);
-    printf("There are %d connected RealSense devices.\n", dev_count);
-    if (0 == dev_count)
+    if (!dev)
+    {
+        fprintf(stderr, "No RealSense device found before discovery timeout.\n");
+        rs2_delete_context(ctx);
         return EXIT_FAILURE;
-
-    // Get the first connected device
-    // The returned object should be released with rs2_delete_device(...)
-    rs2_device* dev = rs2_create_device(device_list, 0, &e);
-    check_error(e);
+    }
 
     print_device_info(dev);
 

--- a/examples/C/distance/rs-distance.c
+++ b/examples/C/distance/rs-distance.c
@@ -34,21 +34,14 @@ int main()
     rs2_context* ctx = rs2_create_context(RS2_API_VERSION, &e);
     check_error(e);
 
-    /* Get a list of all the connected devices. */
-    // The returned object should be released with rs2_delete_device_list(...)
-    rs2_device_list* device_list = rs2_query_devices(ctx, &e);
+    rs2_device* dev = wait_for_device(ctx, &e);
     check_error(e);
-
-    int dev_count = rs2_get_device_count(device_list, &e);
-    check_error(e);
-    printf("There are %d connected RealSense devices.\n", dev_count);
-    if (0 == dev_count)
+    if (!dev)
+    {
+        fprintf(stderr, "No RealSense device found before discovery timeout.\n");
+        rs2_delete_context(ctx);
         return EXIT_FAILURE;
-
-    // Get the first connected device
-    // The returned object should be released with rs2_delete_device(...)
-    rs2_device* dev = rs2_create_device(device_list, 0, &e);
-    check_error(e);
+    }
 
     print_device_info(dev);
 

--- a/examples/C/example.h
+++ b/examples/C/example.h
@@ -43,7 +43,13 @@ static rs2_device* wait_for_device(rs2_context* ctx, rs2_error** e)
     {
         rs2_device_list* list = rs2_query_devices_ex(
             ctx, RS2_PRODUCT_LINE_ANY | RS2_PRODUCT_LINE_SW_ONLY, e);
-        if ((e && *e) || !list)
+        if (e && *e)
+        {
+            if (list)
+                rs2_delete_device_list(list);
+            return NULL;
+        }
+        if (!list)
             return NULL;
 
         int count = rs2_get_device_count(list, e);

--- a/examples/C/example.h
+++ b/examples/C/example.h
@@ -5,6 +5,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 /* Function calls to librealsense may raise errors of type rs_error*/
 void check_error(rs2_error* e)
 {
@@ -25,4 +31,42 @@ void print_device_info(rs2_device* dev)
     check_error(e);
     printf("    Firmware version: %s\n\n", rs2_get_device_info(dev, RS2_CAMERA_INFO_FIRMWARE_VERSION, &e));
     check_error(e);
+}
+
+/* Wait up to 30 seconds for USB or asynchronous Ethernet/DDS discovery. */
+static rs2_device* wait_for_device(rs2_context* ctx, rs2_error** e)
+{
+    int waited_sec = 0;
+    printf("Waiting for a RealSense device (USB or Ethernet/DDS, up to 30s)...\n");
+
+    while (waited_sec < 30)
+    {
+        rs2_device_list* list = rs2_query_devices_ex(
+            ctx, RS2_PRODUCT_LINE_ANY | RS2_PRODUCT_LINE_SW_ONLY, e);
+        if ((e && *e) || !list)
+            return NULL;
+
+        int count = rs2_get_device_count(list, e);
+        if (e && *e)
+        {
+            rs2_delete_device_list(list);
+            return NULL;
+        }
+
+        if (count > 0)
+        {
+            rs2_device* dev = rs2_create_device(list, 0, e);
+            rs2_delete_device_list(list);
+            return dev;
+        }
+
+        rs2_delete_device_list(list);
+#ifdef _WIN32
+        Sleep(1000);
+#else
+        sleep(1);
+#endif
+        ++waited_sec;
+    }
+    return NULL;
 }

--- a/examples/C/infrared/rs-infrared.c
+++ b/examples/C/infrared/rs-infrared.c
@@ -50,21 +50,14 @@ int main(void)
     rs2_context* ctx = rs2_create_context(RS2_API_VERSION, &e);
     check_error(e);
 
-    /* Get a list of all the connected devices. */
-    // The returned object should be released with rs2_delete_device_list(...)
-    rs2_device_list* device_list = rs2_query_devices(ctx, &e);
+    rs2_device* dev = wait_for_device(ctx, &e);
     check_error(e);
-
-    int dev_count = rs2_get_device_count(device_list, &e);
-    check_error(e);
-    printf("There are %d connected RealSense devices.\n", dev_count);
-    if (0 == dev_count)
+    if (!dev)
+    {
+        fprintf(stderr, "No RealSense device found before discovery timeout.\n");
+        rs2_delete_context(ctx);
         return EXIT_FAILURE;
-
-    // Get the first connected device
-    // The returned object should be released with rs2_delete_device(...)
-    rs2_device* dev = rs2_create_device(device_list, 0, &e);
-    check_error(e);
+    }
 
     print_device_info(dev);
 
@@ -272,7 +265,6 @@ int main(void)
     rs2_delete_pipeline(pipeline);
     rs2_delete_pipeline_profile(pipeline_profile);
     rs2_delete_device(dev);
-    rs2_delete_device_list(device_list);
     rs2_delete_context(ctx);
     
     return EXIT_SUCCESS;

--- a/examples/callback/rs-callback.cpp
+++ b/examples/callback/rs-callback.cpp
@@ -4,6 +4,7 @@
 #include <librealsense2/rs.hpp> // Include RealSense Cross Platform API
 
 #include <common/cli.h>
+#include "../example-utils.hpp"
 
 #include <iostream>
 #include <map>
@@ -40,8 +41,11 @@ int main(int argc, char * argv[]) try
         }
     };
 
+    rs2::context ctx( settings.dump() );
+    wait_for_devices( ctx );
+
     // Declare RealSense pipeline, encapsulating the actual device and sensors.
-    rs2::pipeline pipe( settings.dump() );
+    rs2::pipeline pipe( ctx );
 
     // Start streaming through the callback with default recommended configuration
     // The default video configuration contains Depth and Color streams

--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -17,8 +17,11 @@ int main(int argc, char * argv[]) try
     // Declare rates printer for showing streaming rates of the enabled streams.
     rs2::rates_printer printer;
 
+    rs2::context ctx;
+    wait_for_devices( ctx );
+
     // Declare RealSense pipeline, encapsulating the actual device and sensors
-    rs2::pipeline pipe;
+    rs2::pipeline pipe( ctx );
     rs2::config cfg;
 
     // Enable all camera streams

--- a/examples/example-utils.hpp
+++ b/examples/example-utils.hpp
@@ -7,15 +7,41 @@
 #include <map>
 #include <librealsense2/rs.hpp>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 //////////////////////////////
 // Demos Helpers            //
 //////////////////////////////
 
+// USB devices are normally visible immediately, while Ethernet/DDS discovery is
+// asynchronous. Keep the wait bounded so examples still fail predictably when no
+// camera is connected.
+inline rs2::device_list wait_for_devices( rs2::context & ctx, int timeout_seconds = 30 )
+{
+    constexpr int device_mask = RS2_PRODUCT_LINE_ANY | RS2_PRODUCT_LINE_SW_ONLY;
+    for( int waited = 0; waited < timeout_seconds; ++waited )
+    {
+        auto devices = ctx.query_devices( device_mask );
+        if( devices.size() )
+            return devices;
+
+        if( waited == 0 )
+            std::cout << "Waiting for RealSense device (USB instant; Ethernet/DDS discovery up to "
+                      << timeout_seconds << "s)..." << std::endl;
+        std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+    }
+
+    auto devices = ctx.query_devices( device_mask );
+    if( ! devices.size() )
+        throw std::runtime_error( "No RealSense device found before discovery timeout" );
+    return devices;
+}
+
 // Find devices with specified streams
 bool device_with_streams( rs2::context & ctx, std::vector< rs2_stream > stream_requests, std::string & out_serial )
 {
-    auto devs = ctx.query_devices();
+    auto devs = wait_for_devices( ctx );
     std::vector <rs2_stream> unavailable_streams = stream_requests;
     for (auto dev : devs)
     {

--- a/examples/example-utils.hpp
+++ b/examples/example-utils.hpp
@@ -41,7 +41,16 @@ inline rs2::device_list wait_for_devices( rs2::context & ctx, int timeout_second
 // Find devices with specified streams
 bool device_with_streams( rs2::context & ctx, std::vector< rs2_stream > stream_requests, std::string & out_serial )
 {
-    auto devs = wait_for_devices( ctx );
+    rs2::device_list devs;
+    try
+    {
+        devs = wait_for_devices( ctx );
+    }
+    catch( std::runtime_error const & error )
+    {
+        std::cerr << error.what() << std::endl;
+        return false;
+    }
     std::vector <rs2_stream> unavailable_streams = stream_requests;
     for (auto dev : devs)
     {

--- a/examples/hdr/rs-hdr.cpp
+++ b/examples/hdr/rs-hdr.cpp
@@ -3,6 +3,7 @@
 
 #include <librealsense2/rs.hpp> // Include RealSense Cross Platform API
 #include "example-imgui.hpp"    // Include short list of convenience functions for rendering
+#include "../example-utils.hpp"
 #include <iostream>
 
 #include "imgui_impl_glfw.h"
@@ -14,7 +15,7 @@ int main() try
 {
 
     rs2::context ctx;
-    rs2::device_list devices_list = ctx.query_devices();
+    rs2::device_list devices_list = wait_for_devices( ctx );
     size_t device_count = devices_list.size();
     if (!device_count)
     {

--- a/examples/hello-realsense/rs-hello-realsense.cpp
+++ b/examples/hello-realsense/rs-hello-realsense.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include <common/cli.h>
+#include "../example-utils.hpp"
 
 // Hello RealSense example demonstrates the basics of connecting to a RealSense device
 // and taking advantage of depth data
@@ -13,8 +14,11 @@ int main(int argc, char * argv[]) try
     auto settings = rs2::cli( "hello-realsense example" )
         .process( argc, argv );
 
+    rs2::context ctx( settings.dump() );
+    wait_for_devices( ctx );
+
     // Create a Pipeline - this serves as a top-level API for streaming and processing frames
-    rs2::pipeline p( settings.dump() );
+    rs2::pipeline p( ctx );
 
     // Configure and start the pipeline
     p.start();

--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -23,8 +23,11 @@ int main(int argc, char * argv[]) try
     // We want the points object to be persistent so we can display the last cloud when a frame drops
     rs2::points points;
 
+    rs2::context ctx;
+    wait_for_devices( ctx );
+
     // Declare RealSense pipeline, encapsulating the actual device and sensors
-    rs2::pipeline pipe;
+    rs2::pipeline pipe( ctx );
     // Start streaming with default recommended configuration
     pipe.start();
 

--- a/examples/post-processing/rs-post-processing.cpp
+++ b/examples/post-processing/rs-post-processing.cpp
@@ -71,7 +71,9 @@ int main(int argc, char * argv[]) try
     rs2::pointcloud filtered_pc;
 
     // Declare RealSense pipeline, encapsulating the actual device and sensors
-    rs2::pipeline pipe;
+    rs2::context ctx;
+    wait_for_devices( ctx );
+    rs2::pipeline pipe( ctx );
     rs2::config cfg;
     // Use a configuration object to request only depth from the pipeline
     cfg.enable_stream(RS2_STREAM_DEPTH, 640, 0, RS2_FORMAT_Z16, 30);

--- a/examples/save-to-disk/rs-save-to-disk.cpp
+++ b/examples/save-to-disk/rs-save-to-disk.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2015-2017 RealSense, Inc. All Rights Reserved.
 
 #include <librealsense2/rs.hpp> // Include RealSense Cross Platform API
+#include "../example-utils.hpp"
 
 #include <fstream>              // File IO
 #include <iostream>             // Terminal IO
@@ -21,8 +22,11 @@ int main(int argc, char * argv[]) try
     // Declare depth colorizer for pretty visualization of depth data
     rs2::colorizer color_map;
 
+    rs2::context ctx;
+    wait_for_devices( ctx );
+
     // Declare RealSense pipeline, encapsulating the actual device and sensors
-    rs2::pipeline pipe;
+    rs2::pipeline pipe( ctx );
     // Start streaming with default recommended configuration
     pipe.start();
 


### PR DESCRIPTION
## Summary

RealSense Ethernet devices are discovered asynchronously through DDS. Several basic examples currently query once at startup and exit before a network device has had time to appear.

This change gives the C and C++ examples a bounded 30-second discovery wait. The same context is then reused by the pipeline, preserving the participant that discovered the device.

USB behavior is unchanged in practice because locally connected devices are returned by the first query.

## Validation

- Apple Silicon Release build with examples and graphical examples: PASS
- GitHub CI: PASS
- physical D555 Ethernet test with the #15551 DDS build: PASS twice
- `rs-save-to-disk` discovered the D555 and wrote non-empty depth and color images in both runs
- clean shutdown and rediscovery after the runs: PASS

The current `development` branch has an unrelated C++14 build failure when DDS is enabled. The focused macOS DDS build update is tracked in #15551. This PR remains a draft until that dependency is merged.

Supersedes the example discovery portion of #15398.
