### PR TITLE
fw-logger: reject unsupported devices

### DIFF
--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -99,6 +99,13 @@ int main(int argc, char* argv[]) try
 
             setvbuf(stdout, NULL, _IONBF, 0); // unbuffering stdout
 
+            if (!dev.is<rs2::firmware_logger>())
+            {
+                cerr << "\nDevice " << serial
+                     << " does not support firmware logging (RS2_EXTENSION_FW_LOGGER)." << endl;
+                return EXIT_FAILURE;
+            }
+
             auto fw_log_device = dev.as<rs2::firmware_logger>();
 
             bool using_parser = false;


### PR DESCRIPTION
## Summary

`rs-fw-logger` currently casts the selected device to `rs2::firmware_logger` without checking whether the extension is available. Unsupported devices therefore fail later with an unclear error.

This change checks `RS2_EXTENSION_FW_LOGGER` first and exits with a direct message that includes the selected serial number.

## Validation

- Apple Silicon Release build of `rs-fw-logger`: PASS
- GitHub Actions: PASS
- RealSense LibCI pipeline #17638: PASS
  - Image Quality: 12/12
  - Jetson JP6: 43/43
  - Linux: 209/209
  - Jetson JP5: 117/117
  - Windows: 212/212, no compilation warnings
- no merge conflicts

Supersedes the firmware logger guard from #15398.
