### PR TITLE
v4l2: keep variable-size frames the kernel reports as compressed

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1258,12 +1258,16 @@ namespace librealsense
                 v4l2_fmtdesc pixel_format = {};
                 pixel_format.type = _dev.buf_type;
 
+                _variable_frame_size = false;
                 while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
                 {
                     v4l2_frmsizeenum frame_size = {};
                     frame_size.pixel_format = pixel_format.pixelformat;
 
                     uint32_t fourcc = (const big_endian<int> &)pixel_format.pixelformat;
+
+                    if (fourcc == profile.format)
+                        _variable_frame_size = (pixel_format.flags & V4L2_FMT_FLAG_COMPRESSED) != 0;
 
                     if (pixel_format.pixelformat == 0)
                     {
@@ -1543,7 +1547,7 @@ namespace librealsense
                         }
 
                         // Relax the required frame size for compressed formats, i.e. MJPG, Z16H
-                        bool compressed_format = val_in_range(_profile.format, { 0x4d4a5047U , 0x5a313648U});
+                        bool compressed_format = _variable_frame_size || val_in_range(_profile.format, { 0x4d4a5047U , 0x5a313648U});
 
                         // METADATA STREAM
                         // Read metadata. Metadata node performs a blocking call to ensure video and metadata sync

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -448,6 +448,8 @@ namespace librealsense
 
             std::vector<std::shared_ptr<buffer>> _buffers;
             stream_profile _profile;
+            // Kernel reports the format as compressed: frames may be shorter than the buffer
+            bool _variable_frame_size = false;
             frame_callback _callback;
             std::atomic<bool> _is_capturing;
             std::atomic<bool> _is_alive;


### PR DESCRIPTION
**Overview:** Object detection frames are no longer dropped on Linux. The V4L2 backend now treats a frame as complete when the kernel reports the format as variable-size, instead of requiring every frame to fill the buffer.

Tracked on [RSDSO-21859]

## Why

Object detection travels over a `1067x1` GREY envelope, but its packets are variable-length: `43 + 16 * detections` bytes, so 43 bytes when nothing is detected. The V4L2 backend rejects any frame shorter than the buffer:

```cpp
bool partial_frame = (!compressed_format && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE));
```

With `1322 - 255 = 1067`, every packet below a full 64 detections is discarded as incomplete. The `compressed_format` escape hatch was a hardcoded `{MJPG, Z16H}` list that `GREY` is not in.

This surfaced when firmware stopped zero-padding ODET packets to 1067 bytes. The padding had been satisfying the size check by exact equality; without it the stream goes silent — the sensor opens and starts normally and no frame ever arrives. Windows is unaffected: the Media Foundation backend has no equivalent size check.

The firmware behavior is per contract. The D500 person-detection integration guide states that `bytesused` is authoritative and that the SDK must not treat buffer capacity or zero padding as part of the frame.

The check itself dates to `7ffeb61c7`, a heuristic for kernels before 4.16 that appended metadata to the video payload. It assumes every stream is a fixed-size image.

## Summary

- Record `V4L2_FMT_FLAG_COMPRESSED` for the streamed format in `probe_and_commit`, which already enumerates formats and discarded `flags`. No new ioctl or call path.
- Skip the partial-frame check when that flag is set. The existing MJPG/Z16H list is kept, since `Z16H` requires a kernel patch to enumerate and may not be flagged.
- Reset the flag before each enumeration so a profile switch cannot inherit the previous stream's value.

Only formats the kernel marks compressed are affected. Verified on the D585 descriptor: `GREY 1067x1` is flagged; `Z16`, `UYVY`, `Y8I`, `Y16I`, `YUYV`, `NV12` and `pRAA` are not and keep the size check unchanged.

## Test plan

- [x] Jetson (aarch64, kernel 5.15), object detection: 0 frames before, 172 after on variable-size FW; 117 before / 177 after on padded FW
- [x] x86 (Ubuntu 24.04, kernel 7.0), object detection: 174 frames on padded FW, 172 on variable-size FW, CRC valid on every frame
- [x] Both firmware layouts on two separate D585 units, confirming backward compatibility — the fix can ship ahead of firmware
- [x] Depth + IR and color streaming unaffected on both platforms
- [x] Format sweep across all video nodes confirming only the object-detection format carries the compressed flag
- [ ] A live regression test asserting frames arrive is drafted but not included: the existing perception test starts the stream with a no-op callback and never checks for a frame, which is why this went unnoticed. Tracked separately.

---
🤖 Generated by AI
