### PR TITLE
[D585][gmsl][RSDEV-13159] Enable NV12 color in RealSense Viewer

### DIFF
--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -141,16 +141,19 @@ namespace librealsense
     void d500_color::register_color_processing_blocks()
     {
         auto & color_ep = get_color_sensor();
+        auto register_nv12 = [&]() {
+            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< nv12_converter >(
+                RS2_FORMAT_NV12,
+                map_supported_color_formats( RS2_FORMAT_NV12 ),
+                RS2_STREAM_COLOR ) );
+        };
 
         switch( _native_format )
         {
         case RS2_FORMAT_YUYV:
             // Register NV12 first so MIPI RGB targets prefer it while YUYV remains a fallback.
             if( _is_mipi_device )
-                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< nv12_converter >(
-                    RS2_FORMAT_NV12,
-                    map_supported_color_formats( RS2_FORMAT_NV12 ),
-                    RS2_STREAM_COLOR ) );
+                register_nv12();
 
             color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
                 RS2_FORMAT_YUYV,
@@ -161,10 +164,7 @@ namespace librealsense
         case RS2_FORMAT_NV12:
             // NV12 registered before M420 so RGB targets resolve to NV12 when present, and to M420 when it is not
             // (converter breaks ties by registration order). YUY2 is exposed passthrough-only.
-            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< nv12_converter >(
-                RS2_FORMAT_NV12,
-                map_supported_color_formats( RS2_FORMAT_NV12 ),
-                RS2_STREAM_COLOR ) );
+            register_nv12();
             color_ep.register_processing_block( processing_block_factory::create_pbf_vector< m420_converter >(
                 RS2_FORMAT_M420,
                 map_supported_color_formats( RS2_FORMAT_M420 ),

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -145,6 +145,13 @@ namespace librealsense
         switch( _native_format )
         {
         case RS2_FORMAT_YUYV:
+            // Register NV12 first so MIPI RGB targets prefer it while YUYV remains a fallback.
+            if( _is_mipi_device )
+                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< nv12_converter >(
+                    RS2_FORMAT_NV12,
+                    map_supported_color_formats( RS2_FORMAT_NV12 ),
+                    RS2_STREAM_COLOR ) );
+
             color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
                 RS2_FORMAT_YUYV,
                 map_supported_color_formats( RS2_FORMAT_YUYV ),

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -336,7 +336,14 @@ void uvc_sensor::open( const stream_profiles & requests )
                         auto && video = dynamic_cast< video_frame * >( fh.frame );
                         if( video )
                         {
-                            video->assign( width, height, width * bpp / 8, bpp );
+                            auto stride = width * bpp / 8;
+                            // NV12 and M420 are 12-bpp semi-planar formats. Their average bits per
+                            // pixel includes the chroma plane, while each plane's row stride remains
+                            // one byte per pixel.
+                            if( req_profile_base->get_format() == RS2_FORMAT_NV12
+                                || req_profile_base->get_format() == RS2_FORMAT_M420 )
+                                stride = width;
+                            video->assign( width, height, stride, bpp );
                         }
 
                         fh->set_timestamp_domain( timestamp_domain );

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -52,6 +52,19 @@ void init_frame(py::module &m) {
                     { static_cast<size_t>(vf.get_height()), static_cast<size_t>(vf.get_width()), 4 },
                     { static_cast<size_t>(vf.get_stride_in_bytes()), static_cast<size_t>(vf.get_bytes_per_pixel()), 1 });
                 break;
+            case RS2_FORMAT_NV12: case RS2_FORMAT_M420:
+            {
+                auto const data_size = static_cast<size_t>( self.get_data_size() );
+                auto const stride = static_cast<size_t>( vf.get_stride_in_bytes() );
+                if( stride && data_size % stride == 0 )
+                    return BufData( const_cast<void *>( vf.get_data() ), 1, std::string( "@B" ), 2,
+                                    { data_size / stride, stride },
+                                    { stride, 1 } );
+                return BufData( const_cast<void *>( vf.get_data() ),
+                                1,
+                                std::string( "@B" ),
+                                data_size );
+            }
             default:
                 return BufData(const_cast<void*>(vf.get_data()), static_cast<size_t>(vf.get_bytes_per_pixel()), bytes_per_pixel_to_format[vf.get_bytes_per_pixel()], 2,
                     { static_cast<size_t>(vf.get_height()), static_cast<size_t>(vf.get_width()) },

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -7,6 +7,7 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include <cstdint>
 #include <rsutils/string/from.h>
 #include <src/image.cpp>  // bad idea? for get_image_bpp
+#include <src/log.h>
 
 
 namespace {
@@ -56,9 +57,16 @@ void init_frame(py::module &m) {
             {
                 auto const data_size = static_cast<size_t>( self.get_data_size() );
                 auto const stride = static_cast<size_t>( vf.get_stride_in_bytes() );
-                if( stride && data_size % stride == 0 )
+                if( data_size && stride && data_size % stride == 0 )
                     return BufData( const_cast<void *>( vf.get_data() ), 1, std::string( "@B" ), 2,
                                     { data_size / stride, stride },
+                                    { stride, 1 } );
+                LOG_WARNING( "Invalid NV12/M420 buffer layout: data size " << data_size << ", row stride " << stride
+                            << "; using a compatibility buffer view" );
+                if( ! data_size && stride )
+                    return BufData( const_cast<void *>( vf.get_data() ), 1, std::string( "@B" ), 2,
+                                    { static_cast< size_t >( vf.get_height() ),
+                                      static_cast< size_t >( vf.get_width() ) },
                                     { stride, 1 } );
                 return BufData( const_cast<void *>( vf.get_data() ),
                                 1,


### PR DESCRIPTION
**Overview:** Enables native NV12 color profiles for D500 GMSL devices so RealSense Viewer and SDK clients can enumerate and render NV12 streams with the correct frame layout.

Tracked on [RSDEV-13159](https://rsjira.realsenseai.com/browse/RSDEV-13159)

## Why
D500 GMSL exposes native NV12 profiles, but the D500 color processing graph registered only YUYV. NV12 was therefore filtered from the SDK profile set, and semi-planar frames used an incorrect row stride and incomplete Python buffer shape.

## Summary
- Register NV12 conversion and identity paths for D500 MIPI while retaining YUYV fallback.
- Use byte-row stride for NV12 and M420 semi-planar frames.
- Expose the complete contiguous NV12/M420 buffer through the Python buffer protocol when payload size is reported.
- Warn and retain the legacy HxW view for software/sink frames that do not report payload size.

## Test plan
- [x] Complete Jetson ARM64 RelWithDebInfo build with graphical examples and Python bindings.
- [x] Run RealSense Viewer and Python import smoke checks from the build outputs.
- [x] Enumerate D585 NV12 profiles from the build outputs.
- [x] Capture 30 D585 NV12 frames at 1280x960@60 with zero frame-number gaps, 60.68 FPS, shape 1440x1280, stride 1280 bytes, and 1,843,200-byte buffers.
- [x] Rebuild `realsense2` and `pyrealsense2` in a workstation-local output directory and smoke-import the local Python module without installation.
- [x] Validate owned-payload shape (12 bytes, stride 4 -> 3x4) and software-sink no-size compatibility shape (2x4).

