### PR TITLE
[RSDEV-13202][D585][gmsl] Render RGB calibration in RealSense Viewer

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -389,6 +389,7 @@ namespace rs2
         GLuint texture;
         rs2::frame_queue last_queue[2];
         mutable rs2::frame last[2];
+        std::vector<uint8_t> raw16_rgb;
     public:
         std::shared_ptr<colorizer> colorize;
         std::shared_ptr<yuy_decoder> yuy2rgb;
@@ -398,6 +399,7 @@ namespace rs2
         bool zoom_preview = false;
         rect curr_preview_rect{};
         int texture_id = 0;
+        bool raw16_grbg10 = false;
 
         // Own the GL texture properly. Each Stop/Start cycle gc_streams destroys
         // and recreates this object, so without a destructor the GL texture (and
@@ -678,6 +680,40 @@ namespace rs2
                 case RS2_FORMAT_Y10BPACK:
                     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
                     break;
+                case RS2_FORMAT_RAW16:
+                {
+                    if( ! raw16_grbg10 )
+                    {
+                        memset( (void *)data, 0, height * width );
+                        glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data );
+                        break;
+                    }
+
+                    int const output_width = width / 2;
+                    int const output_height = height / 2;
+                    raw16_rgb.resize( static_cast< size_t >( output_width ) * output_height * 3 );
+                    auto out = raw16_rgb.data();
+                    auto bytes = static_cast< const uint8_t * >( data );
+                    for( int y = 0; y < height - 1; y += 2 )
+                    {
+                        auto row0 = reinterpret_cast< const uint16_t * >( bytes + y * stride );
+                        auto row1 = reinterpret_cast< const uint16_t * >( bytes + ( y + 1 ) * stride );
+                        for( int x = 0; x < width - 1; x += 2 )
+                        {
+                            auto const green = ( ( row0[x] & 0x03ffu ) + ( row1[x + 1] & 0x03ffu ) ) / 2;
+                            *out++ = static_cast< uint8_t >( ( row0[x + 1] & 0x03ffu ) >> 2 );
+                            *out++ = static_cast< uint8_t >( green >> 2 );
+                            *out++ = static_cast< uint8_t >( ( row1[x] & 0x03ffu ) >> 2 );
+                        }
+                    }
+
+                    GLint unpack_alignment;
+                    glGetIntegerv( GL_UNPACK_ALIGNMENT, &unpack_alignment );
+                    glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
+                    glTexImage2D( GL_TEXTURE_2D, 0, GL_RGB, output_width, output_height, 0, GL_RGB, GL_UNSIGNED_BYTE, raw16_rgb.data() );
+                    glPixelStorei( GL_UNPACK_ALIGNMENT, unpack_alignment );
+                    break;
+                }
                 case RS2_FORMAT_RAW8:
                 case RS2_FORMAT_MOTION_RAW:
                 case RS2_FORMAT_GPIO_RAW:

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -219,6 +219,10 @@ namespace rs2
         texture->m420_to_rgb = d->m420_to_rgb;
         texture->nv12_to_rgb = d->nv12_to_rgb;
         texture->y411 = d->y411;
+        texture->raw16_grbg10 = p.stream_type() == RS2_STREAM_COLOR && p.format() == RS2_FORMAT_RAW16
+            && d->dev.supports( RS2_CAMERA_INFO_PRODUCT_LINE )
+            && std::string( d->dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE ) ) == "D500"
+            && d->dev.supports( RS2_CAMERA_INFO_MIPI_DRIVER_VERSION );
 
         if (auto vd = p.as<video_stream_profile>())
         {

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -428,6 +428,9 @@ namespace rs2
             std::map<int, rs2_format> def_format{ {0, RS2_FORMAT_ANY} };
             auto default_resolution = std::make_pair(1280, 720);
             auto default_fps = 30;
+            auto const use_rw16_label = dev.supports( RS2_CAMERA_INFO_PRODUCT_LINE )
+                && std::string( dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE ) ) == "D500"
+                && dev.supports( RS2_CAMERA_INFO_MIPI_DRIVER_VERSION );
             std::map<int, int> def_fps_per_stream;   // per-stream default-profile FPS (by unique_id)
             for (auto&& profile : sensor_profiles)
             {
@@ -473,6 +476,9 @@ namespace rs2
 
                 std::string format = rs2_format_to_string(profile.format());
 
+                // D500 MIPI exposes the RAW16 SDK format through the RW16 V4L2 fourcc.
+                if( use_rw16_label && profile.format() == RS2_FORMAT_RAW16 )
+                    format = "RW16";
                 push_back_if_not_exists(formats[profile.unique_id()], format);
                 push_back_if_not_exists(format_values[profile.unique_id()], profile.format());
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2072,7 +2072,9 @@ namespace rs2
             stream_mv.show_stream_footer(font1, stream_rect, active_mouse, streams, *this);
 
 
-            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG }))
+            auto const format = stream_mv.profile.format();
+            if( val_in_range( format, { RS2_FORMAT_RAW10, RS2_FORMAT_MJPEG } )
+                || ( format == RS2_FORMAT_RAW16 && ! stream_mv.texture->raw16_grbg10 ) )
             {
                 show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w),
                     static_cast<int>(stream_rect.h), stream_mv.profile.format());

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -145,6 +145,13 @@ namespace librealsense
         switch( _native_format )
         {
         case RS2_FORMAT_YUYV:
+            // Register NV12 first so MIPI RGB targets prefer it while YUYV remains a fallback.
+            if( _is_mipi_device )
+                color_ep.register_processing_block( processing_block_factory::create_pbf_vector< nv12_converter >(
+                    RS2_FORMAT_NV12,
+                    map_supported_color_formats( RS2_FORMAT_NV12 ),
+                    RS2_STREAM_COLOR ) );
+
             color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
                 RS2_FORMAT_YUYV,
                 map_supported_color_formats( RS2_FORMAT_YUYV ),

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -336,7 +336,14 @@ void uvc_sensor::open( const stream_profiles & requests )
                         auto && video = dynamic_cast< video_frame * >( fh.frame );
                         if( video )
                         {
-                            video->assign( width, height, width * bpp / 8, bpp );
+                            auto stride = width * bpp / 8;
+                            // NV12 and M420 are 12-bpp semi-planar formats. Their average bits per
+                            // pixel includes the chroma plane, while each plane's row stride remains
+                            // one byte per pixel.
+                            if( req_profile_base->get_format() == RS2_FORMAT_NV12
+                                || req_profile_base->get_format() == RS2_FORMAT_M420 )
+                                stride = width;
+                            video->assign( width, height, stride, bpp );
                         }
 
                         fh->set_timestamp_domain( timestamp_domain );

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -52,6 +52,19 @@ void init_frame(py::module &m) {
                     { static_cast<size_t>(vf.get_height()), static_cast<size_t>(vf.get_width()), 4 },
                     { static_cast<size_t>(vf.get_stride_in_bytes()), static_cast<size_t>(vf.get_bytes_per_pixel()), 1 });
                 break;
+            case RS2_FORMAT_NV12: case RS2_FORMAT_M420:
+            {
+                auto const data_size = static_cast<size_t>( self.get_data_size() );
+                auto const stride = static_cast<size_t>( vf.get_stride_in_bytes() );
+                if( stride && data_size % stride == 0 )
+                    return BufData( const_cast<void *>( vf.get_data() ), 1, std::string( "@B" ), 2,
+                                    { data_size / stride, stride },
+                                    { stride, 1 } );
+                return BufData( const_cast<void *>( vf.get_data() ),
+                                1,
+                                std::string( "@B" ),
+                                data_size );
+            }
             default:
                 return BufData(const_cast<void*>(vf.get_data()), static_cast<size_t>(vf.get_bytes_per_pixel()), bytes_per_pixel_to_format[vf.get_bytes_per_pixel()], 2,
                     { static_cast<size_t>(vf.get_height()), static_cast<size_t>(vf.get_width()) },


### PR DESCRIPTION
**Overview:** Adds a color preview for D500 GMSL RW16 calibration streams in RealSense Viewer while preserving the existing unsupported behavior for unrelated RAW16 streams.

Tracked on [RSDEV-13202]

Depends on #15565

## Why
D500 GMSL exposes the RGB calibration surface as RAW16 through the RW16 V4L2 format. RealSense Viewer treated every RAW16 stream as unsupported and cleared its preview, so the calibration profile appeared as a black stream.

## Summary
- Identify D500 MIPI color RAW16 profiles as RW16 GRBG10 calibration surfaces.
- Label those profiles as RW16 in the Viewer profile selector.
- Convert each 2x2 GRBG10 Bayer block into an RGB preview without changing RAW16 behavior for other devices.
- Keep the RGB calibration commit stacked on the NV12 branch from #15565.

## Test plan
- [x] The original calibration change passed a Jetson ARM64 Viewer/full build and rendered RW16 at 1600x1300@25 before the PR split.
- [ ] Re-run the stacked head build and live Viewer check on Jetson67 when the shared bench is available.

---
🤖 Generated by AI
