### PR TITLE
[RSDEV-13298] Expose MJPEG colour profiles on D500 USB

### DIFF
--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -179,6 +179,14 @@ namespace librealsense
         }
         color_ep.register_processing_block(  // Color Raw (Bayer 10-bit embedded in 16-bit) for calibration
             processing_block_factory::create_id_pbf( RS2_FORMAT_RAW16, RS2_STREAM_COLOR ) );
+
+        // MJPG is advertised on USB only. Decode to RGB8 for display, and also
+        // expose the compressed stream passthrough for consumers that want it.
+        color_ep.register_processing_block( { { RS2_FORMAT_MJPEG } },
+                                            { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR } },
+                                            []() { return std::make_shared< mjpeg_converter >( RS2_FORMAT_RGB8 ); } );
+        color_ep.register_processing_block(
+            processing_block_factory::create_id_pbf( RS2_FORMAT_MJPEG, RS2_STREAM_COLOR ) );
     }
 
     void d500_color::register_options()


### PR DESCRIPTION
## What

`src/ds/d500/d500-color.cpp` maps the `MJPG` fourcc to `RS2_FORMAT_MJPEG` but never registers
a processing block for it. librealsense only surfaces formats that have one, so the profile is
**dropped entirely**: a D555/D585 that advertises MJPG over UVC shows no MJPEG profile in
`rs-enumerate-devices`, and the stream cannot be opened from the Viewer or the pipeline API.

This registers the same pair that `src/platform-camera.cpp` already uses for generic UVC
cameras:

- an `mjpeg_converter` → `RGB8`, so the stream is displayable
- an identity passthrough (`create_id_pbf`) for `RS2_FORMAT_MJPEG`, so consumers that want the
  compressed frames can take them as-is

## Why now

D500-family firmware is gaining MJPG on the colour stream (RSDEV-13303). Without this, the
firmware side is complete and the format is still invisible to every librealsense client —
including RealSense Viewer — on **both** D555 and D585.

## Verification

On a **D585 Prototype, s/n 416422320106**, running firmware with MJPG enabled:

- before: `rs-enumerate-devices` lists no MJPEG profile for Color (only RGB8 / NV12 / BGRA8 /
  RGBA8 / BGR8 / YUYV / RAW16)
- after: **7 MJPEG colour profiles** appear, matching the 7 resolutions the firmware advertises
- `rs-data-collect` with `COLOR,640,480,30,MJPEG,0` captures 40/40 frames
- saved frames decode as `JPEG image data, JFIF standard 1.02, baseline, precision 8, 640x480,
  components 3`, with embedded Huffman tables, sizes varying 11–19 KB with scene content

Built and installed from `development` on an AGX Orin (JP7.2); no other profile or device
affected.

## Note

`src/image.cpp` already accounts `RS2_FORMAT_MJPEG` at 8 bits per pixel, which matches the
firmware-side frame-size bound of width × height used for the UVC descriptors — so the two
sides agree on the bound without further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
