### PR TITLE
Read all advanced-mode controls in one bulk operation

### DIFF
--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -210,27 +210,24 @@ inline void draw_advanced_mode_controls(rs400::advanced_mode& advanced,
 {
     if (get_curr_advanced_controls)
     {
+        // Get Current Algo Control Values
+        auto all = advanced.get_all_controls();
         for (int k = 0; k < 3; ++k)
         {
-            // Get Current Algo Control Values
-            amc.depth_controls.vals[k] = advanced.get_depth_control(k);
-            amc.rsm.vals[k] = advanced.get_rsm(k);
-            amc.rsvc.vals[k] = advanced.get_rau_support_vector_control(k);
-            amc.color_control.vals[k] = advanced.get_color_control(k);
-            amc.rctc.vals[k] = advanced.get_rau_thresholds_control(k);
-            amc.sctc.vals[k] = advanced.get_slo_color_thresholds_control(k);
-            amc.spc.vals[k] = advanced.get_slo_penalty_control(k);
-            amc.cc.vals[k] = advanced.get_color_correction(k);
-            amc.depth_table.vals[k] = advanced.get_depth_table(k);
-            amc.census.vals[k] = advanced.get_census(k);
-            amc.amp_factor.vals[k] = advanced.get_amp_factor(k);
+            amc.depth_controls.vals[k] = all.depth_control[k];
+            amc.rsm.vals[k] = all.rsm[k];
+            amc.rsvc.vals[k] = all.rsvc[k];
+            amc.color_control.vals[k] = all.color_control[k];
+            amc.rctc.vals[k] = all.rctc[k];
+            amc.sctc.vals[k] = all.sctc[k];
+            amc.spc.vals[k] = all.spc[k];
+            amc.cc.vals[k] = all.cc[k];
+            amc.depth_table.vals[k] = all.depth_table[k];
+            amc.census.vals[k] = all.census[k];
+            amc.amp_factor.vals[k] = all.amp_factor[k];
+            amc.hdad.vals[k] = all.hdad[k];
+            amc.ae.vals[k] = all.ae[k];
         }
-        amc.hdad.vals[0] = advanced.get_hdad();
-        amc.hdad.vals[1] = amc.hdad.vals[0]; //setting min/max to the same value
-        amc.hdad.vals[2] = amc.hdad.vals[0]; //setting min/max to the same value
-        amc.ae.vals[0] = advanced.get_ae_control();
-        amc.ae.vals[1] = amc.ae.vals[0]; //setting min/max to the same value
-        amc.ae.vals[2] = amc.ae.vals[0]; //setting min/max to the same value
         get_curr_advanced_controls = false;
     }
 

--- a/include/librealsense2/h/rs_advanced_mode_command.h
+++ b/include/librealsense2/h/rs_advanced_mode_command.h
@@ -127,6 +127,26 @@ typedef struct
     float   amplitude;
 }STAFactor;
 
+/* Every control group, with an entry per mode: [0] the value, [1] the minimum, [2] the maximum */
+#define RS2_ADVANCED_MODE_MODES 3
+
+typedef struct
+{
+    STDepthControlGroup          depth_control[RS2_ADVANCED_MODE_MODES];
+    STRsm                        rsm[RS2_ADVANCED_MODE_MODES];
+    STRauSupportVectorControl    rsvc[RS2_ADVANCED_MODE_MODES];
+    STColorControl               color_control[RS2_ADVANCED_MODE_MODES];
+    STRauColorThresholdsControl  rctc[RS2_ADVANCED_MODE_MODES];
+    STSloColorThresholdsControl  sctc[RS2_ADVANCED_MODE_MODES];
+    STSloPenaltyControl          spc[RS2_ADVANCED_MODE_MODES];
+    STHdad                       hdad[RS2_ADVANCED_MODE_MODES];
+    STColorCorrection            cc[RS2_ADVANCED_MODE_MODES];
+    STDepthTableControl          depth_table[RS2_ADVANCED_MODE_MODES];
+    STAEControl                  ae[RS2_ADVANCED_MODE_MODES];
+    STCensusRadius               census[RS2_ADVANCED_MODE_MODES];
+    STAFactor                    amp_factor[RS2_ADVANCED_MODE_MODES];
+}STAdvancedModeControls;
+
 #ifdef __cplusplus
 extern "C"{
 #endif

--- a/include/librealsense2/rs_advanced_mode.h
+++ b/include/librealsense2/rs_advanced_mode.h
@@ -90,6 +90,9 @@ void rs2_set_amp_factor(rs2_device* dev, const  STAFactor* group, rs2_error** er
 /* Gets new values for STAFactor, returns 0 if success */
 void rs2_get_amp_factor(rs2_device* dev, STAFactor* group, int mode, rs2_error** error);
 
+/* Gets every control group and mode in one call; see STAdvancedModeControls */
+void rs2_get_all_advanced_controls(rs2_device* dev, STAdvancedModeControls* controls, rs2_error** error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/librealsense2/rs_advanced_mode.hpp
+++ b/include/librealsense2/rs_advanced_mode.hpp
@@ -262,6 +262,17 @@ namespace rs400
 
             return group;
         }
+
+        /** Reads every control group and mode in one call; see STAdvancedModeControls */
+        STAdvancedModeControls get_all_controls() const
+        {
+            rs2_error* e = nullptr;
+            STAdvancedModeControls controls{};
+            rs2_get_all_advanced_controls(_dev.get(), &controls, &e);
+            rs2::error::handle(e);
+
+            return controls;
+        }
     };
 }
 

--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -77,6 +77,9 @@ namespace librealsense
         virtual void get_census_radius(STCensusRadius* ptr, int mode = 0) const = 0;
         virtual void get_amp_factor(STAFactor* ptr, int mode = 0) const = 0;
 
+        // Reads every group, for every mode, under a single bulk operation
+        virtual void get_all_controls( STAdvancedModeControls * ptr ) const = 0;
+
         virtual void set_depth_control_group(const STDepthControlGroup& val) = 0;
         virtual void set_rsm(const STRsm& val) = 0;
         virtual void set_rau_support_vector_control(const STRauSupportVectorControl& val) = 0;
@@ -122,6 +125,8 @@ namespace librealsense
         void get_ae_control(STAEControl* ptr, int mode = 0) const override;
         void get_census_radius(STCensusRadius* ptr, int mode = 0) const override;
         void get_amp_factor(STAFactor* ptr, int mode = 0) const override;
+
+        void get_all_controls( STAdvancedModeControls * ptr ) const override;
 
         void set_depth_control_group(const STDepthControlGroup& val) override;
         void set_rsm(const STRsm& val) override;

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -318,6 +318,47 @@ namespace librealsense
             []() { STAFactor af; af.amplitude = 0.f; return af; }();
     }
 
+    void ds_advanced_mode_base::get_all_controls( STAdvancedModeControls * ptr ) const
+    {
+        // Every group and mode is read here, under one bulk operation, and not by a query per group:
+        // each standalone GET_ADV powers the depth sensor up and back down again
+        rsutils::deferred depth_bulk = _depth_sensor->bulk_operation();
+
+        // A group whose min/max FW does not report (hdad, and ae on some devices) fails the query;
+        // it gets the value in all three, which is what callers showed for such a group anyway.
+        // Only the FW rejection is caught - a transport failure must not pass as a min/max.
+        auto read = [this]( auto getter, auto * dst )
+        {
+            for( int mode = 0; mode < RS2_ADVANCED_MODE_MODES; ++mode )
+            {
+                try
+                {
+                    ( this->*getter )( &dst[mode], mode );
+                }
+                catch( std::runtime_error const & )
+                {
+                    if( ! mode )
+                        throw;
+                    dst[mode] = dst[0];
+                }
+            }
+        };
+
+        read( &ds_advanced_mode_base::get_depth_control_group, ptr->depth_control );
+        read( &ds_advanced_mode_base::get_rsm, ptr->rsm );
+        read( &ds_advanced_mode_base::get_rau_support_vector_control, ptr->rsvc );
+        read( &ds_advanced_mode_base::get_color_control, ptr->color_control );
+        read( &ds_advanced_mode_base::get_rau_color_thresholds_control, ptr->rctc );
+        read( &ds_advanced_mode_base::get_slo_color_thresholds_control, ptr->sctc );
+        read( &ds_advanced_mode_base::get_slo_penalty_control, ptr->spc );
+        read( &ds_advanced_mode_base::get_hdad, ptr->hdad );
+        read( &ds_advanced_mode_base::get_color_correction, ptr->cc );
+        read( &ds_advanced_mode_base::get_depth_table_control, ptr->depth_table );
+        read( &ds_advanced_mode_base::get_ae_control, ptr->ae );
+        read( &ds_advanced_mode_base::get_census_radius, ptr->census );
+        read( &ds_advanced_mode_base::get_amp_factor, ptr->amp_factor );
+    }
+
     bool ds_advanced_mode_base::supports_option( const sensor_base * sensor, rs2_option opt ) const
     {
         if( ! sensor )

--- a/src/ds/advanced_mode/rs_advanced_mode.cpp
+++ b/src/ds/advanced_mode/rs_advanced_mode.cpp
@@ -295,6 +295,12 @@ void rs2_get_amp_factor(rs2_device* dev, STAFactor* group, int mode, rs2_error**
     advanced_mode->get_amp_factor(group, mode);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
-void rs2_set_amp_factor(rs2_device* dev, const  STAFactor* group, rs2_error** error);
 
-void rs2_get_amp_factor(rs2_device* dev, STAFactor* group, int mode, rs2_error** error);
+void rs2_get_all_advanced_controls(rs2_device* dev, STAdvancedModeControls* controls, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(dev);
+    VALIDATE_NOT_NULL(controls);
+    auto advanced_mode = VALIDATE_INTERFACE(dev->device, librealsense::ds_advanced_mode_interface);
+    advanced_mode->get_all_controls(controls);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, dev, controls)

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -271,6 +271,7 @@ EXPORTS
     rs2_get_census
     rs2_get_amp_factor
     rs2_set_amp_factor
+    rs2_get_all_advanced_controls
     rs2_rs400_visual_preset_to_string
     rs2_l500_visual_preset_to_string
     rs2_sensor_mode_to_string

--- a/unit-tests/live/options/pytest-advanced-mode.py
+++ b/unit-tests/live/options/pytest-advanced-mode.py
@@ -303,6 +303,43 @@ def test_set_amp_factor(test_device_wrapped):
     assert new_af.a_factor == pytest.approx(0.12, abs=0.005)
 
 
+# (attribute on advanced_controls, the getter that reads the same group by itself)
+_ALL_CONTROLS_GROUPS = [
+    ('depth_control', 'get_depth_control'),
+    ('rsm', 'get_rsm'),
+    ('rsvc', 'get_rau_support_vector_control'),
+    ('color_control', 'get_color_control'),
+    ('rctc', 'get_rau_thresholds_control'),
+    ('sctc', 'get_slo_color_thresholds_control'),
+    ('spc', 'get_slo_penalty_control'),
+    ('hdad', 'get_hdad'),
+    ('cc', 'get_color_correction'),
+    ('depth_table', 'get_depth_table'),
+    ('ae', 'get_ae_control'),
+    ('census', 'get_census'),
+    ('amp_factor', 'get_amp_factor'),
+]
+
+
+def test_get_all_controls_matches_individual_getters(test_device_wrapped):
+    """get_all_controls reads every group and mode in one bulk operation - the values must be the ones
+    the per-group getters return. A group whose min/max FW does not report gives its value instead."""
+    if not _module_state.get('preset_ok'):
+        pytest.skip("prerequisite test_visual_preset_support failed")
+    dev, ctx = test_device_wrapped
+    am_dev = get_am_dev(dev)
+    all_controls = am_dev.get_all_controls()
+    for attr, getter in _ALL_CONTROLS_GROUPS:
+        per_mode = getattr(all_controls, attr)
+        assert len(per_mode) == 3, f"{attr}: expected a value, a minimum and a maximum"
+        for mode in (0, 1, 2):
+            try:
+                expected = getattr(am_dev, getter)(mode)
+            except RuntimeError:  # FW has no min/max for this group, so the value is expected
+                expected = getattr(am_dev, getter)(0)
+            assert repr(per_mode[mode]) == repr(expected), f"{getter} mode {mode}"
+
+
 def test_return_to_default_visual_preset(test_device_wrapped):
     if not _module_state.get('preset_ok'):
         pytest.skip("prerequisite test_visual_preset_support failed")

--- a/wrappers/python/pyrs_advanced_mode.cpp
+++ b/wrappers/python/pyrs_advanced_mode.cpp
@@ -5,6 +5,13 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include <librealsense2/rs_advanced_mode.hpp>
 #include <librealsense2/hpp/rs_serializable_device.hpp>
 
+// Each control group in STAdvancedModeControls is an array, which python sees as a list
+template< typename T, size_t N >
+static std::vector< T > to_list( T const ( & a )[N] )
+{
+    return std::vector< T >( a, a + N );
+}
+
 void init_advanced_mode(py::module &m) {
     /** RS400 Advanced Mode commands **/
     py::class_<STDepthControlGroup> _STDepthControlGroup(m, "STDepthControlGroup");
@@ -221,6 +228,22 @@ void init_advanced_mode(py::module &m) {
             return ss.str();
     });
 
+    // Each group holds 3 entries - [0] value, [1] min, [2] max - exposed as a list
+    py::class_< STAdvancedModeControls > advanced_controls( m, "STAdvancedModeControls" );
+    advanced_controls.def_property_readonly( "depth_control", []( STAdvancedModeControls const & self ) { return to_list( self.depth_control ); } );
+    advanced_controls.def_property_readonly( "rsm", []( STAdvancedModeControls const & self ) { return to_list( self.rsm ); } );
+    advanced_controls.def_property_readonly( "rsvc", []( STAdvancedModeControls const & self ) { return to_list( self.rsvc ); } );
+    advanced_controls.def_property_readonly( "color_control", []( STAdvancedModeControls const & self ) { return to_list( self.color_control ); } );
+    advanced_controls.def_property_readonly( "rctc", []( STAdvancedModeControls const & self ) { return to_list( self.rctc ); } );
+    advanced_controls.def_property_readonly( "sctc", []( STAdvancedModeControls const & self ) { return to_list( self.sctc ); } );
+    advanced_controls.def_property_readonly( "spc", []( STAdvancedModeControls const & self ) { return to_list( self.spc ); } );
+    advanced_controls.def_property_readonly( "hdad", []( STAdvancedModeControls const & self ) { return to_list( self.hdad ); } );
+    advanced_controls.def_property_readonly( "cc", []( STAdvancedModeControls const & self ) { return to_list( self.cc ); } );
+    advanced_controls.def_property_readonly( "depth_table", []( STAdvancedModeControls const & self ) { return to_list( self.depth_table ); } );
+    advanced_controls.def_property_readonly( "ae", []( STAdvancedModeControls const & self ) { return to_list( self.ae ); } );
+    advanced_controls.def_property_readonly( "census", []( STAdvancedModeControls const & self ) { return to_list( self.census ); } );
+    advanced_controls.def_property_readonly( "amp_factor", []( STAdvancedModeControls const & self ) { return to_list( self.amp_factor ); } );
+
     py::class_<rs400::advanced_mode> rs400_advanced_mode(m, "rs400_advanced_mode");
     rs400_advanced_mode.def(py::init<rs2::device>(), "device"_a)
         .def("toggle_advanced_mode", &rs400::advanced_mode::toggle_advanced_mode, "enable"_a)
@@ -251,6 +274,8 @@ void init_advanced_mode(py::module &m) {
         .def("get_census", &rs400::advanced_mode::get_census, "mode"_a = 0) //STCensusRadius
         .def("set_amp_factor", &rs400::advanced_mode::set_amp_factor, "group"_a)    //STAFactor
         .def("get_amp_factor", &rs400::advanced_mode::get_amp_factor, "mode"_a = 0) //STAFactor
+        .def("get_all_controls", &rs400::advanced_mode::get_all_controls,
+             "Read every control group and mode at once, in a single bulk operation")
         .def("serialize_json", &rs400::advanced_mode::serialize_json)
         .def("load_json", &rs400::advanced_mode::load_json, "json_content"_a);
 }


### PR DESCRIPTION
Tracked on: [RSDSO-21876]

### Preparation for the global controls search

RSDSO-21876 moves the viewer's controls search box up a level, so that one search covers the advanced controls, the embedded filters and the post-processing blocks - not just the sensor controls it filters today.

Searching the advanced controls means reading them, and reading them was the problem: the panel read its 13 control groups one at a time for each of the 3 modes (value, min, max) - 35 separate GET_ADV commands, seconds of stalled UI. Today that cost is paid only when someone expands the Advanced Controls panel. Once the search reaches into those groups, it lands wherever the search box lives, which is everywhere.

So this PR is the preparation: it makes reading the advanced controls cheap enough that the search can touch them. The search box move itself follows in a separate PR on the same ticket, keeping the SDK change and the viewer/UX change reviewable apart.

### The change

`rs2_get_all_advanced_controls` reads every group and mode under a single `bulk_operation()`, the same way `get_all()` already did for its mode-0 sweep. On a UVC sensor each standalone query powers the depth sensor up and back down again, and that power-up dominates - so all three modes go in one call rather than one call per mode.

| device | before (35 queries) | after (1 call) | |
|---|---|---|---|
| D455 | 5167 ms | 171 ms | 30x |
| D435I | 5541 ms | 198 ms | 28x |

Values from the bulk read are identical to the per-group getters for all 13 groups across all 3 modes, on every device tested - 33 comparisons each, 0 mismatches, asserted by `pytest-advanced-mode.py`.

Firmware does not report a min/max for every group (`hdad` on both D400 and D500, `ae` on D400) and asking fails the command. Such a group reports its value for all three modes, which is what the viewer displayed for it anyway. Only the firmware rejection is caught, so a transport failure cannot pass as a min/max.

### API

One new exported function, additive:

```c
void rs2_get_all_advanced_controls(rs2_device* dev, STAdvancedModeControls* controls, rs2_error** error);
```

`STAdvancedModeControls` sits in `h/rs_advanced_mode_command.h` next to the 13 `ST*` types it is built from, so one definition serves the C API, the internal interface and the C++ wrapper. `rs400::advanced_mode::get_all_controls()` returns it; Python exposes each group as a 3-element list. The per-group getters are untouched.
