### PR TITLE
Map D500 external-sync XU selector (0x1A) on GMSL

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -519,14 +519,24 @@ namespace librealsense
             {
                 if( _fw_version >= firmware_version( "7.58.40929.13516" ) )
                 {
-                    std::map< float, std::string > description_per_value = { { 2.f, "Internal" },
-                                                                             { 3.f, "External" } };
+                    // GMSL: d4xx kernel driver exposes the D457-style range 0..2 (0:Internal, 1:Master, 2:External);
+                    // USB: FW register 0x2C uses the D500-native 2:Internal, 3:External. Different range → different
+                    // labels are needed for the viewer to render this as an enum combo rather than a slider.
+                    std::map< float, std::string > description_per_value = _is_mipi_device
+                        ? std::map< float, std::string >{ { 0.f, "Internal" },
+                                                          { 1.f, "Master" },
+                                                          { 2.f, "External" } }
+                        : std::map< float, std::string >{ { 2.f, "Internal" },
+                                                          { 3.f, "External" } };
+                    const char * desc = _is_mipi_device
+                        ? "Inter-camera synchronization mode: 0:Internal, 1:Master, 2:External"
+                        : "Inter-camera synchronization mode: 2:Internal, 3:External";
                     depth_sensor.register_option( RS2_OPTION_INTER_CAM_SYNC_MODE,
                                                   std::make_shared< uvc_xu_option< uint16_t > >(
                                                       raw_depth_sensor,
                                                       depth_xu,
                                                       d500_xu_id::EXTERNAL_SYNC_MODE,
-                                                      "Inter-camera synchronization mode: 2:Internal, 3:External",
+                                                      desc,
                                                       description_per_value,
                                                       false /* allow_set_while_streaming */ ) );
                 }

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -73,6 +73,7 @@ namespace librealsense
             static constexpr uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
             static constexpr uint8_t RS_EXTERNAL_SYNC                   = 0x12;
             static constexpr uint8_t RS_READOUT_SHAPING                 = 0x13;
+            static constexpr uint8_t RS_EXTERNAL_SYNC_D500              = 0x1A; // d500_xu_id::EXTERNAL_SYNC_MODE
             static constexpr uint8_t RS_PVT_TEMPERATURE                 = 0x15;
             static constexpr uint8_t RS_PROJECTOR_TEMPERATURE           = 0x16;
             static constexpr uint8_t RS_OHM_TEMPERATURE                 = 0x17;
@@ -309,7 +310,8 @@ namespace librealsense
                     case RS_HARDWARE_PRESET : return RS_CAMERA_CID_PRESET;
                     case RS_EMITTER_FREQUENCY : return RS_CAMERA_CID_EMITTER_FREQUENCY;
                     case RS_DEPTH_AUTO_EXPOSURE_MODE : return RS_CAMERA_CID_AE_MODE;
-                    case RS_EXTERNAL_SYNC : return RS_CAMERA_CID_SYNC_MODE;
+                    case RS_EXTERNAL_SYNC :
+                    case RS_EXTERNAL_SYNC_D500 : return RS_CAMERA_CID_SYNC_MODE;
                     case RS_READOUT_SHAPING : return RS_CAMERA_CID_READOUT_SHAPING;
                     case RS_PVT_TEMPERATURE : return RS_CAMERA_CID_SOC_PVT_TEMPERATURE;
                     case RS_OHM_TEMPERATURE : return RS_CAMERA_CID_OHM_TEMPERATURE;

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -73,10 +73,10 @@ namespace librealsense
             static constexpr uint8_t RS_DEPTH_AUTO_EXPOSURE_MODE        = 0x11;
             static constexpr uint8_t RS_EXTERNAL_SYNC                   = 0x12;
             static constexpr uint8_t RS_READOUT_SHAPING                 = 0x13;
-            static constexpr uint8_t RS_EXTERNAL_SYNC_D500              = 0x1A; // d500_xu_id::EXTERNAL_SYNC_MODE
             static constexpr uint8_t RS_PVT_TEMPERATURE                 = 0x15;
             static constexpr uint8_t RS_PROJECTOR_TEMPERATURE           = 0x16;
             static constexpr uint8_t RS_OHM_TEMPERATURE                 = 0x17;
+            static constexpr uint8_t RS_EXTERNAL_SYNC_D500              = 0x1A; // d500_xu_id::EXTERNAL_SYNC_MODE
 
             bool is_auto_exposure_control( uint8_t control )
             {
@@ -294,7 +294,7 @@ namespace librealsense
                 }
             }
 
-            // D457 controls map - temporal solution to bypass backend interface with actual codes
+            // MIPI controls map - temporal solution to bypass backend interface with actual codes
             uint32_t xu_to_cid( const extension_unit & xu, uint8_t control )
             {
                 if( 0 == xu.subdevice )


### PR DESCRIPTION
**Overview:** Make `Inter Cam Sync Mode` work end-to-end on D585 over GMSL — unblock the XU→CID lookup on the MIPI backend and label the option's values so the viewer renders a combo box (Internal / Master / External) instead of a slider.

Tracked on [RSDEV-9254]

## Why
Two issues stacked on the D585 GMSL sync-mode path:

1. **Backend threw on any get/set of `RS2_OPTION_INTER_CAM_SYNC_MODE`.** The GMSL/MIPI XU→V4L2 CID map in `xu_to_cid()` only knew the D400 external-sync selector `0x12`. D500 uses selector `0x1A` (`d500_xu_id::EXTERNAL_SYNC_MODE`) for the same option, so the depth XU option registration threw `linux_backend_exception("no v4l2 mipi cid for XU depth control 26")`. That in turn broke triggered calibration, which touches the sync mode during setup.

2. **Viewer rendered the option as a slider on GMSL.** The `description_per_value` map was keyed on `{2:"Internal", 3:"External"}` — matching the D500 USB FW register semantics — but on GMSL the d4xx kernel driver advertises the D457-style range `0..2` (`0:Internal, 1:Master, 2:External`). `option_model::is_enum()` walks `range.min..range.max` and requires a description for every value; the map didn't cover `0` and `1`, so it fell back to `draw_slider`.

## Summary
- `src/linux/v4l-mipi-logic.cpp` — add `RS_EXTERNAL_SYNC_D500 = 0x1A`; route both `RS_EXTERNAL_SYNC` (D400) and `RS_EXTERNAL_SYNC_D500` (D500) to the existing `RS_CAMERA_CID_SYNC_MODE`. Comment on the map generalized from "D457" to "MIPI".
- `src/ds/d500/d500-device.cpp` — when the device is MIPI, register `RS2_OPTION_INTER_CAM_SYNC_MODE` with the GMSL-native description map `{0:"Internal", 1:"Master", 2:"External"}` and matching description string; USB path (`{2:"Internal", 3:"External"}`) unchanged.

## Test plan
- [x] Linux GMSL build — open D585 in `realsense-viewer`: no `no v4l2 mipi cid for XU depth control 26` throw.
- [x] `Inter Cam Sync Mode` renders as a **combo box** (Internal / Master / External), not a slider.
- [x] Select each value; option round-trips through the driver.

---
🤖 Generated by AI