### PR TITLE
Fix out-of-bounds read of HID samples in the RSUSB backend

### DIFF
--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -264,7 +264,9 @@ namespace librealsense
 
             data.fo.pixels = &(hid.x);
             data.fo.metadata = &(report.timeStamp);
-            data.fo.frame_size = sizeof(REALSENSE_HID_REPORT);
+            // pixels points at hid, which is 12 bytes; REALSENSE_HID_REPORT is
+            // 38. hid_sensor::start copies frame_size bytes from pixels.
+            data.fo.frame_size = sizeof(hid);
             data.fo.metadata_size = sizeof(report.timeStamp);
 
             _callback(data);
@@ -287,7 +289,8 @@ namespace librealsense
 
                     data.fo.pixels = &(hid.x);
                     data.fo.metadata = &(report.timeStamp);
-                    data.fo.frame_size = sizeof(REALSENSE_HID_REPORT);
+                    // See above: pixels is a hid_data, not a whole report.
+                    data.fo.frame_size = sizeof(hid);
                     data.fo.metadata_size = sizeof(report.timeStamp);
 
                     _callback(data);


### PR DESCRIPTION
(filed automatically from claude opus 5) 

**TL;DR:** The RSUSB HID path copies 38 bytes out of a 12-byte stack object for every accelerometer and gyroscope sample; this makes the size match the buffer.

## Summary
- `rs_hid_device::handle_interrupt` sets `data.fo.pixels = &hid.x` (a `hid_data`, three `int32_t`, 12 bytes) but `data.fo.frame_size = sizeof(REALSENSE_HID_REPORT)` (packed, 38 bytes).
- `hid_sensor::start`'s callback then does `memcpy(frame->get_frame_data(), sensor_data.fo.pixels, sensor_data.fo.frame_size)`, reading 26 bytes past the end of `hid`.
- Both occurrences in that function are corrected to `sizeof(hid)`. `mf-hid.cpp` already pairs the two consistently (`d.fo.pixels = &data; d.fo.frame_size = sizeof(data);`), so this brings the RSUSB backend in line with the Media Foundation one.

## Why
AddressSanitizer flags it on every IMU sample on Linux with `FORCE_RSUSB_BACKEND=ON`:

```
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 38 at 0x7b896032017c thread T87
    #1 librealsense::hid_sensor::start(...)::$_0::operator()(...) src/hid-sensor.cpp:260
    #6 librealsense::platform::rs_hid_device::handle_interrupt() src/hid/hid-device.cpp:293
```

The 26 bytes read past `hid` are whatever the stack happens to hold, and they are copied into the motion frame. Since `alloc_frame` is also given `frame_size`, the allocation shrinks to 12 bytes with this change and the frame now contains exactly the x/y/z that were meant to be in it.

## Test plan
- [x] D435i on Linux, `FORCE_RSUSB_BACKEND=ON`, accel + gyro enabled: ASan reports no stack-buffer-overflow, where it fired on every sample before.
- [x] Motion frames still stream at their native rates (63 Hz accel, 200 Hz gyro) and read one gravity at rest (|a| = 9.90 m/s²).
- [ ] Windows/MF backend unaffected — that path was already correct and is untouched.
