### PR TITLE
Remove pipeline use from react viewer and fix selected AI model

### DIFF
--- a/wrappers/rest-api/tools/react-viewer/src/api/chat.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/chat.ts
@@ -16,7 +16,7 @@ interface ProviderConfig {
 const PROVIDERS: Record<Provider, ProviderConfig> = {
   groq: {
     url: 'https://api.groq.com/openai/v1/chat/completions',
-    model: 'llama-3.3-70b-versatile', // Fast and capable, free tier
+    model: 'openai/gpt-oss-120b', // Groq retires models; check /models if this 404s
     modelsEndpoint: 'https://api.groq.com/openai/v1/models',
   },
   openai: {

--- a/wrappers/rest-api/tools/react-viewer/src/api/client.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/client.ts
@@ -4,8 +4,6 @@ import type {
   DeviceInfo,
   SensorInfo,
   OptionInfo,
-  StreamStartRequest,
-  StreamStatus,
   WebRTCOffer,
   WebRTCSession,
   ICECandidate,
@@ -154,22 +152,6 @@ class ApiClient {
       `/devices/${deviceId}/sensors/${sensorId}/options/${optionId}/`,
       { value }
     )
-    return response.data
-  }
-
-  // ============ Streams ============
-
-  async startStreaming(deviceId: string, request: StreamStartRequest): Promise<void> {
-    await this.client.post(`/devices/${deviceId}/stream/start/`, request)
-  }
-
-  async stopStreaming(deviceId: string): Promise<StreamStatus> {
-    const response = await this.client.post<StreamStatus>(`/devices/${deviceId}/stream/stop/`)
-    return response.data
-  }
-
-  async getStreamStatus(deviceId: string): Promise<StreamStatus> {
-    const response = await this.client.get<StreamStatus>(`/devices/${deviceId}/stream/status/`)
     return response.data
   }
 

--- a/wrappers/rest-api/tools/react-viewer/src/api/types.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/api/types.ts
@@ -75,20 +75,6 @@ export interface StreamConfig {
   enable: boolean
 }
 
-export interface StreamStartRequest {
-  configs: StreamConfig[]
-  align_to?: string
-  apply_filters: boolean
-  reuse_cache?: boolean
-}
-
-export interface StreamStatus {
-  device_id?: string
-  is_streaming: boolean
-  active_streams: string[]
-  stopping?: boolean
-}
-
 export interface WebRTCOffer {
   device_id: string
   stream_types: string[]
@@ -174,12 +160,10 @@ export interface DeviceState {
   streamConfigs: StreamConfig[]
   sensorConfigs: Record<string, SensorConfig> // Per-sensor resolution/FPS, keyed by sensor_id
   isStreaming: boolean
-  isStopping?: boolean
   isActive: boolean // whether this device is shown in viewer
   isLoading: boolean // loading sensors/options
   streamMetadata: Record<string, StreamMetadata> // keyed by stream_type
   // Per-sensor streaming state (sensor API)
-  streamingMode: 'idle' | 'pipeline' | 'sensor' // which API is being used
   sensorStreamingStatus: Record<string, SensorStreamStatus> // keyed by sensor_id
 }
 

--- a/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/DevicePanel.tsx
@@ -407,7 +407,6 @@ function DeviceCard({
   const options = deviceState?.options || {}
   const streamConfigs = deviceState?.streamConfigs || []
   const sensorConfigs = deviceState?.sensorConfigs || {}
-  const streamingMode = deviceState?.streamingMode || 'idle'
   const sensorStreamingStatus = deviceState?.sensorStreamingStatus || {}
 
   // Group stream configs by sensor
@@ -594,27 +593,12 @@ function DeviceCard({
         <div className="border-t border-gray-700">
           {/* Stream Configuration */}
           <div className="p-3">
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-2">
-                <h4 className="text-sm font-medium text-gray-300">Streams</h4>
-                {/* Streaming mode indicator */}
-                {streamingMode !== 'idle' && (
-                  <span className={`text-xs px-1.5 py-0.5 rounded ${
-                    streamingMode === 'pipeline' 
-                      ? 'bg-blue-900 text-blue-300' 
-                      : 'bg-purple-900 text-purple-300'
-                  }`}>
-                    {streamingMode === 'pipeline' ? 'All' : 'Per-sensor'}
-                  </span>
-                )}
-              </div>
-            </div>
+            <h4 className="text-sm font-medium text-gray-300 mb-2">Streams</h4>
             
             {/* Stream configs grouped by sensor */}
             <SensorStreamControls
               sensors={sensors}
               streamsBySensor={streamsBySensor}
-              streamingMode={streamingMode}
               sensorStreamingStatus={sensorStreamingStatus}
               sensorConfigs={sensorConfigs}
               onUpdateStreamConfig={onUpdateStreamConfig}
@@ -675,7 +659,6 @@ function DeviceCard({
 interface SensorStreamControlsProps {
   sensors: SensorInfo[]
   streamsBySensor: Record<string, StreamConfig[]>
-  streamingMode: string
   sensorStreamingStatus: Record<string, { is_streaming: boolean; pendingOp?: string | null; error?: string | null }>
   sensorConfigs: Record<string, SensorConfig>
   onUpdateStreamConfig: (config: StreamConfig) => void
@@ -687,7 +670,6 @@ interface SensorStreamControlsProps {
 function SensorStreamControls({
   sensors,
   streamsBySensor,
-  streamingMode,
   sensorStreamingStatus,
   sensorConfigs,
   onUpdateStreamConfig,
@@ -716,7 +698,7 @@ function SensorStreamControls({
         const hasEnabledSensorStreams = sensorStreamConfigs.some(c => c.enable)
         const sensorConfig = sensorConfigs[sensor.sensor_id]
 
-        const canStartSensor = hasEnabledSensorStreams && streamingMode !== 'pipeline'
+        const canStartSensor = hasEnabledSensorStreams
         const isExpanded = expandedSensors.has(sensor.sensor_id)
 
         const computeCommonOptions = () => {
@@ -770,7 +752,7 @@ function SensorStreamControls({
                 }
                 disabled={isSensorPending || (!canStartSensor && !isSensorStreaming)}
                 data-testid={isSensorStreaming ? "stop-streaming" : "start-streaming"}
-                title={streamingMode === 'pipeline' ? 'Stop all streams first' : isSensorPending ? 'Stopping...' : isSensorStreaming ? 'Stop' : 'Start'}
+                title={isSensorPending ? 'Stopping...' : isSensorStreaming ? 'Stop' : 'Start'}
                 className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
                   isSensorPending
                     ? 'bg-yellow-600 text-white cursor-wait'
@@ -803,7 +785,7 @@ function SensorStreamControls({
                       const [width, height] = e.target.value.split('x').map(Number)
                       onUpdateSensorConfig(sensor.sensor_id, { resolution: { width, height } })
                     }}
-                    disabled={streamingMode === 'pipeline' || isSensorStreaming}
+                    disabled={isSensorStreaming}
                     className="bg-gray-700 text-white rounded px-1 py-0.5 text-xs"
                   >
                     {availableResolutions.map(([w, h]) => (
@@ -818,7 +800,7 @@ function SensorStreamControls({
                   <select
                     value={sensorConfig.framerate}
                     onChange={(e) => onUpdateSensorConfig(sensor.sensor_id, { framerate: Number(e.target.value) })}
-                    disabled={streamingMode === 'pipeline' || isSensorStreaming}
+                    disabled={isSensorStreaming}
                     className="bg-gray-700 text-white rounded px-1 py-0.5 text-xs"
                   >
                     {availableFps.map((fps) => (
@@ -838,7 +820,7 @@ function SensorStreamControls({
                   config={config}
                   sensors={sensors}
                   onUpdate={onUpdateStreamConfig}
-                  disabled={streamingMode === 'pipeline' || isSensorStreaming}
+                  disabled={isSensorStreaming}
                   isMotionSensor={sensorConfig?.isMotionSensor ?? false}
                 />
               ))}

--- a/wrappers/rest-api/tools/react-viewer/src/components/StreamViewer.tsx
+++ b/wrappers/rest-api/tools/react-viewer/src/components/StreamViewer.tsx
@@ -25,20 +25,13 @@ export function StreamViewer() {
       if (!ds.isActive) return
       
       ds.streamConfigs.filter(c => c.enable).forEach(config => {
-        // Determine if this specific stream is actually streaming
-        let streamIsActive = false
-        if (ds.streamingMode === 'pipeline') {
-          // Pipeline mode: all enabled streams are active when isStreaming=true
-          streamIsActive = ds.isStreaming
-        } else if (ds.streamingMode === 'sensor') {
-          // Sensor mode: check if this specific stream type is running on its sensor
-          const sensorStatus = ds.sensorStreamingStatus?.[config.sensor_id]
-          // Check if stream type is in the list of active streams (new) or matches single stream (backward compat)
-          const activeTypes = sensorStatus?.stream_types || (sensorStatus?.stream_type ? [sensorStatus.stream_type] : [])
-          streamIsActive = sensorStatus?.is_streaming === true && 
-                          activeTypes.some(st => st.toLowerCase() === config.stream_type.toLowerCase())
-        }
-        
+        // Is this specific stream running on its sensor?
+        const sensorStatus = ds.sensorStreamingStatus?.[config.sensor_id]
+        // stream_types is the current shape; stream_type is the older single-stream one
+        const activeTypes = sensorStatus?.stream_types || (sensorStatus?.stream_type ? [sensorStatus.stream_type] : [])
+        const streamIsActive = sensorStatus?.is_streaming === true &&
+                        activeTypes.some(st => st.toLowerCase() === config.stream_type.toLowerCase())
+
         if (!streamIsActive) return
 
         streams.push({

--- a/wrappers/rest-api/tools/react-viewer/src/store/index.ts
+++ b/wrappers/rest-api/tools/react-viewer/src/store/index.ts
@@ -156,10 +156,6 @@ interface AppState {
   updateStreamConfig: (deviceId: string, config: StreamConfig) => void
   updateSensorConfig: (deviceId: string, sensorId: string, config: Partial<SensorConfig>) => void
 
-  // Per-device streaming
-  startDeviceStreaming: (deviceId: string) => Promise<void>
-  stopDeviceStreaming: (deviceId: string) => Promise<void>
-
   // Per-sensor streaming (sensor API)
   startSensorStreaming: (deviceId: string, sensorId: string) => Promise<void>
   stopSensorStreaming: (deviceId: string, sensorId: string) => Promise<void>
@@ -316,8 +312,8 @@ export const useAppStore = create<AppState>()((set, get) => ({
     
     if (existing?.isActive) {
       // Deactivate: stop streaming if active, then remove
-      if (existing.isStreaming) {
-        await get().stopDeviceStreaming(device.device_id)
+      for (const [sensorId, status] of Object.entries(existing.sensorStreamingStatus)) {
+        if (status.is_streaming) await get().stopSensorStreaming(device.device_id, sensorId)
       }
       set((s) => {
         const newStates = { ...s.deviceStates }
@@ -334,11 +330,9 @@ export const useAppStore = create<AppState>()((set, get) => ({
         streamConfigs: [],
         sensorConfigs: {},
         isStreaming: false,
-        isStopping: false,
         isActive: true,
         isLoading: true,
         streamMetadata: {},
-        streamingMode: 'idle',
         sensorStreamingStatus: {},
       }
       set((s) => ({
@@ -503,129 +497,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
     })
   },
 
-  // Per-device streaming
-  startDeviceStreaming: async (deviceId) => {
-    const state = get()
-    const deviceState = state.deviceStates[deviceId]
-    if (!deviceState) return
-
-    // If a stop is still in progress, wait briefly until it finishes
-    if (deviceState.isStopping) {
-      for (let i = 0; i < 20; i++) {
-        try {
-          const status = await apiClient.getStreamStatus(deviceId)
-          if (!status.stopping) break
-        } catch (e) {
-          // ignore and retry
-        }
-        await new Promise((resolve) => setTimeout(resolve, 150))
-      }
-    }
-
-    const enabledStreamConfigs = deviceState.streamConfigs.filter((c) => c.enable)
-    if (enabledStreamConfigs.length === 0) {
-      set({ error: 'Please enable at least one stream' })
-      return
-    }
-
-    // Apply sensor-level resolution/FPS to each enabled stream config
-    const configsWithSensorSettings = enabledStreamConfigs.map(c => {
-      const sensorConfig = deviceState.sensorConfigs[c.sensor_id]
-      if (sensorConfig) {
-        return {
-          ...c,
-          resolution: sensorConfig.resolution,
-          framerate: sensorConfig.framerate,
-        }
-      }
-      return c
-    })
-
-    try {
-      await apiClient.startStreaming(deviceId, {
-        configs: configsWithSensorSettings,
-        apply_filters: false,
-        reuse_cache: true,
-      })
-      set((s) => ({
-        deviceStates: {
-          ...s.deviceStates,
-          [deviceId]: {
-            ...s.deviceStates[deviceId],
-            isStreaming: true,
-            isStopping: false,
-            streamingMode: 'pipeline',
-          },
-        },
-        error: null,
-      }))
-    } catch (error) {
-      // Extract error message - axios errors have response.data.detail
-      let errorMessage = 'Unknown error'
-      if (error && typeof error === 'object') {
-        const axiosError = error as { response?: { data?: { detail?: string } }; message?: string }
-        if (axiosError.response?.data?.detail) {
-          errorMessage = axiosError.response.data.detail
-        } else if (axiosError.message) {
-          errorMessage = axiosError.message
-        }
-      }
-      set({
-        error: `Failed to start streaming: ${errorMessage}`,
-      })
-    }
-  },
-
-  stopDeviceStreaming: async (deviceId) => {
-    // Optimistically mark stopping and hide stream immediately. Also drop the
-    // last point cloud so the 3D canvas doesn't show a frozen last frame after
-    // stop. If another device is still streaming its next frame will repopulate.
-    set((state) => ({
-      pointCloudVertices: null,
-      pointCloudColors: null,
-      deviceStates: {
-        ...state.deviceStates,
-        [deviceId]: {
-          ...state.deviceStates[deviceId],
-          isStopping: true,
-          isStreaming: false,
-          streamMetadata: {},
-        },
-      },
-    }))
-
-    try {
-      const status = await apiClient.stopStreaming(deviceId)
-      set((state) => ({
-        deviceStates: {
-          ...state.deviceStates,
-          [deviceId]: {
-            ...state.deviceStates[deviceId],
-            isStopping: !!status?.stopping,
-            isStreaming: status?.is_streaming ?? false,
-            streamingMode: 'idle',
-            sensorStreamingStatus: {},
-            streamMetadata: status?.stopping ? state.deviceStates[deviceId].streamMetadata : {},
-          },
-        },
-      }))
-    } catch (error) {
-      set({
-        error: `Failed to stop streaming: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      })
-      // Roll back stopping flag on error
-      set((state) => ({
-        deviceStates: {
-          ...state.deviceStates,
-          [deviceId]: {
-            ...state.deviceStates[deviceId],
-            isStopping: false,
-          },
-        },
-      }))
-    }
-  },
-
   // Per-sensor streaming (sensor API)
   startSensorStreaming: async (deviceId, sensorId) => {
     // Wait for any pending stop operation to complete before starting
@@ -638,12 +509,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
     const state = get()
     const deviceState = state.deviceStates[deviceId]
     if (!deviceState) return
-
-    // Check mode - can't use sensor API if pipeline is active
-    if (deviceState.streamingMode === 'pipeline') {
-      set({ error: 'Stop all streams before using per-sensor control' })
-      return
-    }
 
     // Find ALL enabled stream configs for this sensor (not just first)
     const enabledStreamConfigs = deviceState.streamConfigs.filter(
@@ -678,7 +543,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
           ...s.deviceStates,
           [deviceId]: {
             ...s.deviceStates[deviceId],
-            streamingMode: 'sensor',
             isStreaming: true,
             sensorStreamingStatus: {
               ...s.deviceStates[deviceId].sensorStreamingStatus,
@@ -758,7 +622,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
           ...s.deviceStates,
           [deviceId]: {
             ...deviceState,
-            streamingMode: anyStreaming ? 'sensor' : 'idle',
             isStreaming: anyStreaming,
             sensorStreamingStatus: newSensorStatus,
           },
@@ -789,7 +652,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
               ...s.deviceStates,
               [deviceId]: {
                 ...deviceState,
-                streamingMode: anyStreaming ? 'sensor' : 'idle',
                 isStreaming: anyStreaming,
                 sensorStreamingStatus: newSensorStatus,
               },
@@ -810,7 +672,6 @@ export const useAppStore = create<AppState>()((set, get) => ({
               ...s.deviceStates,
               [deviceId]: {
                 ...deviceState,
-                streamingMode: 'sensor',
                 isStreaming: true,
                 sensorStreamingStatus: {
                   ...deviceState.sensorStreamingStatus,
@@ -1047,7 +908,7 @@ export const useAppStore = create<AppState>()((set, get) => ({
                 enable: proposedConfig.enable,
               }
             }
-            return existingConfig
+            return { ...existingConfig, enable: false }
           })
           
           return {
@@ -1087,9 +948,14 @@ export const useAppStore = create<AppState>()((set, get) => ({
         if (enabledConfigs.length === 0) {
           throw new Error('No streams enabled. Please configure at least one stream before starting.')
         }
-        await get().startDeviceStreaming(deviceId)
+        for (const sensorId of new Set(enabledConfigs.map(c => c.sensor_id))) {
+          await get().startSensorStreaming(deviceId, sensorId)
+        }
       } else if (settings.streamAction === 'stop') {
-        await get().stopDeviceStreaming(deviceId)
+        const status = get().deviceStates[deviceId]?.sensorStreamingStatus || {}
+        for (const [sensorId, ss] of Object.entries(status)) {
+          if (ss.is_streaming) await get().stopSensorStreaming(deviceId, sensorId)
+        }
       }
       
       // Clear pending settings

--- a/wrappers/rest-api/tools/react-viewer/tests/e2e/fixtures.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/e2e/fixtures.ts
@@ -43,12 +43,6 @@ export interface TestFixtures {
   
   /** Check if a specific device is connected */
   isDeviceConnected: (serial_number?: string) => Promise<boolean>
-  
-  /** Start streaming for a device */
-  startStreaming: (page: Page, deviceId?: string) => Promise<void>
-  
-  /** Stop streaming for a device */
-  stopStreaming: (page: Page, deviceId?: string) => Promise<void>
 }
 
 /**
@@ -153,29 +147,6 @@ export const test = base.extend<TestFixtures>({
       }
     }
     await use(checkFn)
-  },
-
-  startStreaming: async ({ page }, use) => {
-    const startFn = async (p: Page, deviceId?: string) => {
-      // Click the start streaming button for the device
-      const streamButton = p.locator('[data-testid="start-streaming-button"], button:has-text("Start")').first()
-      await streamButton.click()
-      
-      // Wait for streaming to start
-      await p.waitForSelector('video, [data-testid="stream-tile"]', { timeout: 10000 })
-    }
-    await use(startFn)
-  },
-
-  stopStreaming: async ({ page }, use) => {
-    const stopFn = async (p: Page, deviceId?: string) => {
-      // Click the stop streaming button
-      const stopButton = p.locator('[data-testid="stop-streaming-button"], button:has-text("Stop")').first()
-      if (await stopButton.isVisible()) {
-        await stopButton.click()
-      }
-    }
-    await use(stopFn)
   },
 })
 

--- a/wrappers/rest-api/tools/react-viewer/tests/mocks/api-handlers.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/mocks/api-handlers.ts
@@ -55,42 +55,6 @@ export const handlers = [
     return HttpResponse.json({ success: true, value: body.value })
   }),
 
-  // Start streaming (pipeline mode)
-  http.post(`${API_BASE}/devices/:deviceId/stream/start`, () => {
-    return HttpResponse.json({
-      is_streaming: true,
-      active_streams: ['depth'],
-      timings: {
-        refresh_devices: 0.0,
-        device_lookup: 0.001,
-        pipeline_config_init: 0.2,
-        stream_enable: 0.001,
-        pipeline_start: 0.5,
-        post_start_setup: 0.001,
-        thread_start: 0.001,
-        total: 0.7,
-      },
-    })
-  }),
-
-  // Stop streaming (pipeline mode)
-  http.post(`${API_BASE}/devices/:deviceId/stream/stop`, () => {
-    return HttpResponse.json({
-      is_streaming: false,
-      active_streams: [],
-      stopping: false,
-    })
-  }),
-
-  // Get stream status
-  http.get(`${API_BASE}/devices/:deviceId/stream/status`, () => {
-    return HttpResponse.json({
-      is_streaming: false,
-      active_streams: [],
-      stopping: false,
-    })
-  }),
-
   // Get depth range
   http.get(`${API_BASE}/devices/:deviceId/stream/depth-range`, () => {
     return HttpResponse.json({

--- a/wrappers/rest-api/tools/react-viewer/tests/mocks/fixtures/devices.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/mocks/fixtures/devices.ts
@@ -99,11 +99,9 @@ export const mockDeviceState: DeviceState = {
   streamConfigs: mockStreamConfigs,
   sensorConfigs: mockSensorConfigs,
   isStreaming: false,
-  isStopping: false,
   isActive: true,
   isLoading: false,
   streamMetadata: {},
-  streamingMode: 'idle',
   sensorStreamingStatus: {},
 }
 
@@ -115,7 +113,6 @@ export const mockDeviceStateInactive: DeviceState = {
 export const mockDeviceStateStreaming: DeviceState = {
   ...mockDeviceState,
   isStreaming: true,
-  streamingMode: 'pipeline',
   streamMetadata: {
     depth: {
       stream_type: 'depth',

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/api/client.test.ts
@@ -125,31 +125,6 @@ describe('API Client', () => {
     })
   })
 
-  describe('startStreaming', () => {
-    it('starts streaming for a device', async () => {
-      await expect(apiClient.startStreaming(mockDevice.device_id, {
-        streams: [{ stream_type: 'depth', width: 640, height: 480, format: 'Z16', fps: 30 }],
-      })).resolves.not.toThrow()
-    })
-  })
-
-  describe('stopStreaming', () => {
-    it('stops streaming for a device', async () => {
-      const status = await apiClient.stopStreaming(mockDevice.device_id)
-      
-      expect(status.is_streaming).toBe(false)
-      expect(status.active_streams).toEqual([])
-    })
-  })
-
-  describe('getStreamStatus', () => {
-    it('returns stream status', async () => {
-      const status = await apiClient.getStreamStatus(mockDevice.device_id)
-      
-      expect(status).toHaveProperty('is_streaming')
-      expect(status).toHaveProperty('active_streams')
-    })
-  })
 
   describe('getDepthRange', () => {
     it('returns depth range for a device', async () => {

--- a/wrappers/rest-api/tools/react-viewer/tests/unit/components/StreamViewer.test.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/unit/components/StreamViewer.test.tsx
@@ -56,7 +56,9 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [depthConfig],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       
       render(<StreamViewer />, {
@@ -84,7 +86,9 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [depthConfig, colorConfig],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color'] },
+        },
       })
       
       render(<StreamViewer />, {
@@ -111,13 +115,17 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [config1],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       const state2 = createMockDeviceState(device2, {
         isActive: true,
         streamConfigs: [config2],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       
       render(<StreamViewer />, {
@@ -140,13 +148,17 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [createMockStreamConfig({ enable: true })],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       const inactiveState = createMockDeviceState(inactiveDevice, {
         isActive: false,
         streamConfigs: [createMockStreamConfig({ enable: true })],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       
       render(<StreamViewer />, {
@@ -170,7 +182,6 @@ describe('StreamViewer', () => {
       const notStreamingState = createMockDeviceState(device, {
         isActive: true,
         isStreaming: false,
-        streamingMode: 'idle',
         streamConfigs: [config],
       })
 
@@ -186,26 +197,7 @@ describe('StreamViewer', () => {
   })
 
   describe('Tile hiding until streaming', () => {
-    it('hides tile when stream is enabled but not actively streaming', () => {
-      const device = createMockDevice()
-      const config = createMockStreamConfig({ stream_type: 'depth', enable: true })
-      const deviceState = createMockDeviceState(device, {
-        isActive: true,
-        isStreaming: false,
-        streamingMode: 'pipeline',
-        streamConfigs: [config],
-      })
-
-      render(<StreamViewer />, {
-        initialStoreState: {
-          deviceStates: { [device.device_id]: deviceState },
-        },
-      })
-
-      expect(screen.getByText('Nothing is streaming!')).toBeInTheDocument()
-    })
-
-    it('sensor mode: renders tile when stream_type is in active list (case-insensitive)', () => {
+    it('renders tile when stream_type is in the active list (case-insensitive)', () => {
       const device = createMockDevice()
       const config = createMockStreamConfig({
         stream_type: 'INFRARED-1',
@@ -214,7 +206,6 @@ describe('StreamViewer', () => {
       })
       const deviceState = createMockDeviceState(device, {
         isActive: true,
-        streamingMode: 'sensor',
         streamConfigs: [config],
         sensorStreamingStatus: {
           'sensor-0': {
@@ -235,7 +226,7 @@ describe('StreamViewer', () => {
       expect(document.querySelectorAll('video.stream-video')).toHaveLength(1)
     })
 
-    it('sensor mode: hides tile when stream_type is not in active list', () => {
+    it('hides tile when stream_type is not in the active list', () => {
       const device = createMockDevice()
       const config = createMockStreamConfig({
         stream_type: 'color',
@@ -244,7 +235,6 @@ describe('StreamViewer', () => {
       })
       const deviceState = createMockDeviceState(device, {
         isActive: true,
-        streamingMode: 'sensor',
         streamConfigs: [config],
         sensorStreamingStatus: {
           'sensor-0': {
@@ -268,26 +258,6 @@ describe('StreamViewer', () => {
   })
 
   describe('Stream Types', () => {
-    it('handles depth stream type', () => {
-      const device = createMockDevice()
-      const config = createMockStreamConfig({ stream_type: 'depth', enable: true })
-      const deviceState = createMockDeviceState(device, {
-        isActive: true,
-        streamConfigs: [config],
-        isStreaming: true,
-        streamingMode: 'pipeline',
-      })
-      
-      render(<StreamViewer />, {
-        initialStoreState: {
-          deviceStates: { [device.device_id]: deviceState },
-        },
-      })
-      
-      expect(screen.getByText('DEPTH')).toBeInTheDocument()
-      expect(document.querySelectorAll('video.stream-video')).toHaveLength(1)
-    })
-
     it('handles color stream type', () => {
       const device = createMockDevice()
       const config = createMockStreamConfig({ stream_type: 'color', format: 'RGB8', enable: true })
@@ -295,7 +265,9 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [config],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       
       render(<StreamViewer />, {
@@ -315,7 +287,9 @@ describe('StreamViewer', () => {
         isActive: true,
         streamConfigs: [config],
         isStreaming: true,
-        streamingMode: 'pipeline',
+        sensorStreamingStatus: {
+          'test-device-1-sensor-0': { sensor_id: 'test-device-1-sensor-0', name: '', is_streaming: true, stream_types: ['depth', 'color', 'infrared'] },
+        },
       })
       
       render(<StreamViewer />, {

--- a/wrappers/rest-api/tools/react-viewer/tests/utils/test-utils.tsx
+++ b/wrappers/rest-api/tools/react-viewer/tests/utils/test-utils.tsx
@@ -51,7 +51,6 @@ export function createMockDeviceState(device: DeviceInfo, overrides: Partial<Dev
     sensorConfigs: {},
     isActive: false,
     isStreaming: false,
-    streamingMode: 'idle',
     sensorStreamingStatus: {},
     isPointCloudEnabled: false,
     pointCloudVertices: null,


### PR DESCRIPTION
**Overview:** The viewer only ever starts streams per sensor, so this removes the parallel device-wide "pipeline" streaming path and the state that existed to tell the two apart.

No ticket — cleanup found while tracing an unrelated chat bug.

## Why
Two streaming APIs were live at once: device-wide (pipeline) and per-sensor. Nothing in the UI called the pipeline one — the only reachable caller was the AI chat's Apply button, which meant "start depth" from chat behaved differently from the Start button sitting next to it. `DeviceState.streamingMode` existed solely to distinguish the two, and `DevicePanel` carried an "All / Per-sensor" badge plus five disabled-guards for a state the UI could not actually produce.

## Summary
- `applyProposedSettings` starts and stops per sensor, the same path the device panel uses
- Dropped `startDeviceStreaming`, `stopDeviceStreaming`, `startAllStreaming`, `stopAllStreaming` and the `startStreaming` / `stopStreaming` aliases — none had callers
- Dropped `apiClient.startStreaming`, `stopStreaming`, `getStreamStatus`; the last existed only for a 20×150ms poll loop inside `startDeviceStreaming`
- Dropped `DeviceState.streamingMode`, which collapsed to `isStreaming ? 'sensor' : 'idle'` once pipeline was gone, along with the badge and guards it fed
- A chat proposal that lists streams now disables the ones it doesn't list, so "start depth" starts only depth. This also switches off streams the user enabled by hand.
- Pointed the Groq provider at a current model: `llama-3.3-70b-versatile` is decommissioned and 404s on any current key, leaving the chat feature dead

Net −257 lines.

## Test plan
- [ ] `vitest run` — 131 pass; StreamViewer fixtures moved to the per-sensor shape, two tests that had become duplicates removed
- [ ] `tsc --noEmit` clean; eslint count unchanged from base
- [ ] Live D555: per-sensor Start streams depth; chat "start only the depth stream" → Apply starts exactly one stream (previously two); chat stop clears it

---
🤖 Generated by AI

