### PR TITLE
Fix two auto-exposure warmup issues in the basic-color image-quality test

### DIFF
--- a/unit-tests/live/image-quality/iq_helper.py
+++ b/unit-tests/live/image-quality/iq_helper.py
@@ -246,6 +246,8 @@ def make_depth_filter_chain():
 #        hue is undefined and HSV S is dominated by sensor noise.
 TOLERANCE = {'hue': 10, 'sat': 70, 'val': 70, 'rgb': 70}
 ACHROMATIC_S = 40       # expected S below this → treat as gray/white/black
+ACHROMATIC_V = 50       # hue is meaningless this dark: at V=30 a 6-count channel spread
+                        # reads S=51, so compare dark patches per-channel instead
 
 
 def is_color_close(actual, expected):
@@ -254,7 +256,7 @@ def is_color_close(actual, expected):
         cv2.cvtColor(np.uint8([[[expected[2], expected[1], expected[0]]]]), cv2.COLOR_BGR2HSV)[0, 0])
 
     # Gray/black/white have no real hue, so compare RGB directly instead of HSV.
-    if expected_s < ACHROMATIC_S:
+    if expected_s < ACHROMATIC_S or expected_v < ACHROMATIC_V:
         r_diff = abs(actual[0] - expected[0])
         g_diff = abs(actual[1] - expected[1])
         b_diff = abs(actual[2] - expected[2])

--- a/unit-tests/live/image-quality/iq_helper.py
+++ b/unit-tests/live/image-quality/iq_helper.py
@@ -246,8 +246,7 @@ def make_depth_filter_chain():
 #        hue is undefined and HSV S is dominated by sensor noise.
 TOLERANCE = {'hue': 10, 'sat': 70, 'val': 70, 'rgb': 70}
 ACHROMATIC_S = 40       # expected S below this → treat as gray/white/black
-ACHROMATIC_V = 50       # hue is meaningless this dark: at V=30 a 6-count channel spread
-                        # reads S=51, so compare dark patches per-channel instead
+ACHROMATIC_V = 50       # too dark for hue to mean anything - compare per-channel instead
 
 
 def is_color_close(actual, expected):

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -25,6 +25,10 @@ FRAMES_PASS_THRESHOLD =0.8 # Percentage of frames that needs to pass
 # Idle between configurations so the RGB ISP powers down and each configuration starts from a
 # cold sensor. Without it a fast restart reuses the still-powered ISP and inherits its exposure.
 CONFIG_SETTLE_SEC = 3
+# Auto-exposure needs wall-clock time, not a frame count: 60 frames is 1s at 60fps but 12s at
+# 5fps. Wait for both a minimum frame count and a minimum duration.
+WARMUP_SEC = 2.0
+WARMUP_MIN_FRAMES = 30
 DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)
@@ -99,8 +103,12 @@ def run_test(dev, ctx, resolution, fps):
         log.info(f"Configuration {resolution[0]}x{resolution[1]}@{fps}fps is not supported by the device")
         return
     pipeline_profile = pipeline.start(cfg)
-    for i in range(60):  # skip initial frames
+    # let auto-exposure settle before sampling
+    warmup_start = time.time()
+    warmup_frames = 0
+    while warmup_frames < WARMUP_MIN_FRAMES or time.time() - warmup_start < WARMUP_SEC:
         pipeline.wait_for_frames()
+        warmup_frames += 1
     last_frame_bgr = None
     last_roi = None
     try:

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -30,17 +30,16 @@ DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)
 expected_colors = {
-    # Means measured on the image-quality bench across D435 and D455, 158 fully-passing
-    # configurations. Re-measure if the bench lighting or the colour chart changes.
-    "red":   (126, 50, 50),
-    "green": (39, 84, 59),
-    "blue":  (13, 67, 97),
-    "black": (30, 30, 24),
-    "white": (132, 131, 132),
-    "gray":  (84, 88, 88),
-    "purple": (45, 49, 71),
-    "orange": (130, 60, 48),
-    "yellow": (144, 126, 51),
+    # All expected values are empirical means across 10 camera instances
+    "red":   (175, 77, 82),
+    "green": (64, 123, 95),
+    "blue":  (26, 104, 146),
+    "black": (50, 50, 46),
+    "white": (183, 184, 186),
+    "gray":  (121, 129, 130),
+    "purple": (69, 77, 109),
+    "orange": (182, 94, 83),
+    "yellow": (199, 178, 85),
 }
 # list of color names in insertion order -> used left->right, top->bottom
 color_names = list(expected_colors.keys())

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -102,15 +102,16 @@ def run_test(dev, ctx, resolution, fps):
         log.info(f"Configuration {resolution[0]}x{resolution[1]}@{fps}fps is not supported by the device")
         return
     pipeline_profile = pipeline.start(cfg)
-    # let auto-exposure settle before sampling
-    warmup_start = time.time()
-    warmup_frames = 0
-    while warmup_frames < WARMUP_MIN_FRAMES or time.time() - warmup_start < WARMUP_SEC:
-        pipeline.wait_for_frames()
-        warmup_frames += 1
     last_frame_bgr = None
     last_roi = None
     try:
+        # let auto-exposure settle before sampling
+        warmup_start = time.time()
+        warmup_frames = 0
+        while warmup_frames < WARMUP_MIN_FRAMES or time.time() - warmup_start < WARMUP_SEC:
+            pipeline.wait_for_frames()
+            warmup_frames += 1
+
         # find region of interest (page) and get the transformation matrix
         find_roi_location(pipeline, (0, 1, 2, 3), DEBUG_MODE) # markers in the lab are 0,1,2,3
 

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -22,10 +22,10 @@ pytestmark = [
 
 NUM_FRAMES = 100 # Number of frames to check
 FRAMES_PASS_THRESHOLD =0.8 # Percentage of frames that needs to pass
-# Auto-exposure needs wall-clock time, not a frame count: 60 frames is 1s at 60fps but 12s at
-# 5fps. Wait for both a minimum frame count and a minimum duration.
-WARMUP_SEC = 2.0
-WARMUP_MIN_FRAMES = 30
+# Auto-exposure settles in a few frames, but a frame count alone scales badly: 60 frames is 1s
+# at 60fps and 12s at 5fps. Gate on both a frame count and a duration.
+WARMUP_SEC = 1.0
+WARMUP_MIN_FRAMES = 15
 DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -33,16 +33,18 @@ DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)
 expected_colors = {
-    # All expected values are empirical means across 10 camera instances
-    "red":   (175, 77, 82),
-    "green": (64, 123, 95),
-    "blue":  (26, 104, 146),
-    "black": (50, 50, 46),
-    "white": (183, 184, 186),
-    "gray":  (121, 129, 130),
-    "purple": (69, 77, 109),
-    "orange": (182, 94, 83),
-    "yellow": (199, 178, 85),
+    # Means measured on the image-quality bench (D435 + D455) over 17 firmware-clean nightly runs,
+    # 158 fully-passing configurations. The previous values were ~50 counts brighter than this
+    # bench reads, which spent most of the tolerance budget before any real deviation.
+    "red":   (126, 50, 50),
+    "green": (39, 84, 59),
+    "blue":  (13, 67, 97),
+    "black": (30, 30, 24),
+    "white": (132, 131, 132),
+    "gray":  (84, 88, 88),
+    "purple": (45, 49, 71),
+    "orange": (130, 60, 48),
+    "yellow": (144, 126, 51),
 }
 # list of color names in insertion order -> used left->right, top->bottom
 color_names = list(expected_colors.keys())

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -30,9 +30,8 @@ DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)
 expected_colors = {
-    # Means measured on the image-quality bench (D435 + D455) over 17 firmware-clean nightly runs,
-    # 158 fully-passing configurations. The previous values were ~50 counts brighter than this
-    # bench reads, which spent most of the tolerance budget before any real deviation.
+    # Means measured on the image-quality bench across D435 and D455, 158 fully-passing
+    # configurations. Re-measure if the bench lighting or the colour chart changes.
     "red":   (126, 50, 50),
     "green": (39, 84, 59),
     "blue":  (13, 67, 97),

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -22,9 +22,6 @@ pytestmark = [
 
 NUM_FRAMES = 100 # Number of frames to check
 FRAMES_PASS_THRESHOLD =0.8 # Percentage of frames that needs to pass
-# Idle between configurations so the RGB ISP powers down and each configuration starts from a
-# cold sensor. Without it a fast restart reuses the still-powered ISP and inherits its exposure.
-CONFIG_SETTLE_SEC = 3
 # Auto-exposure needs wall-clock time, not a frame count: 60 frames is 1s at 60fps but 12s at
 # 5fps. Wait for both a minimum frame count and a minimum duration.
 WARMUP_SEC = 2.0
@@ -188,7 +185,5 @@ def test_basic_color(test_device, test_context_var):
             log.warning(f"D436 FW color-stream bug: skipping color configs fps>30: {skipped}")
         configurations = [c for c in configurations if c[1] <= 30]
 
-    for i, (resolution, fps) in enumerate(configurations):
-        if i:
-            time.sleep(CONFIG_SETTLE_SEC)
+    for resolution, fps in configurations:
         run_test(dev, ctx, resolution, fps)

--- a/unit-tests/live/image-quality/pytest-basic-color.py
+++ b/unit-tests/live/image-quality/pytest-basic-color.py
@@ -8,6 +8,7 @@ import numpy as np
 import cv2
 import logging
 import re
+import time
 from iq_helper import (find_roi_location, get_roi_from_frame, is_color_close, save_failure_snapshot,
                        WIDTH, HEIGHT, DEFAULT_CONFIGURATIONS, NIGHTLY_CONFIGURATIONS)
 
@@ -21,6 +22,9 @@ pytestmark = [
 
 NUM_FRAMES = 100 # Number of frames to check
 FRAMES_PASS_THRESHOLD =0.8 # Percentage of frames that needs to pass
+# Idle between configurations so the RGB ISP powers down and each configuration starts from a
+# cold sensor. Without it a fast restart reuses the still-powered ISP and inherits its exposure.
+CONFIG_SETTLE_SEC = 3
 DEBUG_MODE = False
 
 # expected colors (insertion order -> mapped row-major to 3x3 grid)
@@ -174,5 +178,7 @@ def test_basic_color(test_device, test_context_var):
             log.warning(f"D436 FW color-stream bug: skipping color configs fps>30: {skipped}")
         configurations = [c for c in configurations if c[1] <= 30]
 
-    for resolution, fps in configurations:
+    for i, (resolution, fps) in enumerate(configurations):
+        if i:
+            time.sleep(CONFIG_SETTLE_SEC)
         run_test(dev, ctx, resolution, fps)


### PR DESCRIPTION
**Overview:** `pytest-basic-color.py` was failing on the image-quality bench roughly 80% of the time whenever a D400 nightly firmware was under test. The cause turned out to be a firmware regression (RSDSO-21896), now reverted in FW 5.17.4.19. Chasing it surfaced two genuine test bugs, which is all that remains here.

Related: RSDSO-21896 — FW 5.17.4.18 deferred the RGB ISP power-down behind a 2s grace timer (side effect of RSDSO-19670), so a stream restart inside that window reused the still-powered ISP and auto-exposure never re-converged. Alon reverted it in `2e44ada7`; 5.17.4.19 powers the ISP down inline again.

### Changes

1. **Warmup gated on duration, not just a frame count.** `for i in range(60)` was 1s at 60fps and 12s at 5fps. Now `WARMUP_SEC = 1.0` with a `WARMUP_MIN_FRAMES = 15` floor: identical to the old behaviour at 60fps, 3s instead of 12s at 5fps. Auto-exposure settles in a few frames, so this is already generous.
2. **Warmup moved inside the `try`.** It previously ran before it, so a `wait_for_frames()` timeout would skip `finally` and leave the pipeline open for the next configuration to inherit. Pre-existing; caught in review.
3. **`ACHROMATIC_V = 50` in `iq_helper.py`.** `is_color_close()` picks its comparison path from the *expected* colour — desaturated colours compare per-channel in RGB, everything else in HSV. Saturation is a ratio, so a near-black patch can read as highly saturated off a couple of counts of noise and fall onto the hue path, where hue is meaningless at that luminance. Guarding on value as well as saturation prevents that. With the current expected values this is defensive only — black already qualifies as achromatic on saturation alone — so say the word if you would rather not carry it.

### Two things that were in earlier revisions and are not here any more

**A 3s idle between stream configurations.** It worked around the firmware bug above by letting the ISP fully power down between configurations. With the firmware reverted it has no reason to exist, and a test that idles to hide a firmware defect is worse than one that reports it. Removed.

**A re-baseline of `expected_colors`.** The image-quality bench reads about 50 counts darker than the current expected values, which consumed most of the tolerance budget before any real deviation, so I replaced them with means measured on that bench. That was wrong: the Jetson bench is lit much more brightly, and the D457 there reads white (196,195,198) and yellow (215,192,105) — close to the *original* values. The re-baselined table failed that bench (orange 10/100, yellow 43/100, build 18829). The original numbers are not wrong, they simply match a differently lit bench, and re-baselining just moved the table from one bench's lighting to the other's. Reverted; `expected_colors` is untouched by this PR.

That leaves a real open problem which does not belong in this PR: a single absolute colour table cannot serve two differently lit benches. Either the image-quality bench lighting is brought in line with the reference the original values came from, or the comparison is normalised against the white patch so illumination cancels out. Worth its own discussion.

### Validation

Full nightly context (`nightly image-quality linux dds`, 12 tests, all 10 stream configurations per camera) on the image-quality bench:

- Build 16001 — on the bad firmware 5.17.4.18: 12 passed, no reruns.
- Build 16023 — on the fixed firmware 5.17.4.19 with the idle removed: 12 passed, no reruns, inter-configuration gaps back to 0.0-0.9s.
- Builds 16027 / 16028 — PR gating on golden 5.17.3.10: passed.
- Build 18829 (Jetson) — failed on the re-baselined colours, which is why that commit is gone. A re-run on this revision is needed to confirm it is green again.

---
🤖 Generated by AI
