### PR TITLE
Cherry-pick #15586: dual rgb ISP mode

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -806,6 +806,9 @@ namespace rs2
                 {
                     auto tmp = stream_enabled;
                     label = rsutils::string::from() << stream_display_names[f.first] << "##" << f.first;
+                    // Grey out streams invalid in the current D401 GMSL mode (see is_stream_mode_locked).
+                    const bool mode_locked = is_stream_mode_locked(f.first);
+                    if (mode_locked) ImGui::BeginDisabled();
                     if (ImGui::Checkbox(label.c_str(), &stream_enabled[f.first]))
                     {
                         prev_stream_enabled = tmp;
@@ -813,8 +816,7 @@ namespace rs2
 
                         if (stream_enabled[f.first])
                         {
-                            // The two imagers stream mono IR (Y8) OR Bayer color (BA81), not both,
-                            // so enabling a color stream disables IR and vice versa (depth is free).
+                            // D401 GMSL streams one mode at a time; reconcile the other streams.
                             if( is_dual_color_subdevice() )
                                 enforce_dual_color_ir_exclusion(f.first);
 
@@ -846,6 +848,7 @@ namespace rs2
                             }
                         }
                     }
+                    if (mode_locked) ImGui::EndDisabled();
                 }
             }
 
@@ -877,8 +880,13 @@ namespace rs2
                 {
                     ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 25); // Set the width for the combo box itself with a 25 buffer 
                     ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, { 1,1,1,1 });
-                    RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
-                        static_cast<int>(formats_chars.size()));
+                    if (RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
+                        static_cast<int>(formats_chars.size())))
+                    {
+                        // Color format can flip raw (RGB8) <-> ISP mode; reconcile the other streams.
+                        if (is_dual_color_subdevice() && stream_enabled.count(f.first) && stream_enabled.at(f.first))
+                            enforce_dual_color_ir_exclusion(f.first);
+                    }
                     ImGui::PopStyleColor();
                     ImGui::PopItemWidth();
                 }
@@ -1045,10 +1053,15 @@ namespace rs2
                     res = true;
                     auto tmp = stream_enabled;
                     label = rsutils::string::from() << stream_display_names[f.first] << "##" << f.first;
+                    const bool mode_locked = is_stream_mode_locked(f.first);
+                    if (mode_locked) ImGui::BeginDisabled();
                     if (ImGui::Checkbox(label.c_str(), &stream_enabled[f.first]))
                     {
                         prev_stream_enabled = tmp;
+                        if (is_dual_color_subdevice() && stream_enabled.count(f.first) && stream_enabled.at(f.first))
+                            enforce_dual_color_ir_exclusion(f.first);
                     }
+                    if (mode_locked) ImGui::EndDisabled();
                 }
             }
 
@@ -1080,8 +1093,13 @@ namespace rs2
                 {
                     ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 25); // Set the width for the combo box itself with a 25 buffer 
                     ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, { 1,1,1,1 });
-                    RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
-                        static_cast<int>(formats_chars.size()));
+                    if (RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
+                        static_cast<int>(formats_chars.size())))
+                    {
+                        // Color format can flip raw (RGB8) <-> ISP mode; reconcile the other streams.
+                        if (is_dual_color_subdevice() && stream_enabled.count(f.first) && stream_enabled.at(f.first))
+                            enforce_dual_color_ir_exclusion(f.first);
+                    }
                     ImGui::PopStyleColor();
                     ImGui::PopItemWidth();
                 }
@@ -1586,36 +1604,114 @@ namespace rs2
         return color_streams >= 2 && has_stereo;
     }
 
-    void subdevice_model::enforce_dual_color_ir_exclusion(int just_enabled_unique_id)
+    bool subdevice_model::color_uid_is_raw(int unique_id) const
     {
-        // Caller gates this on is_dual_color_subdevice().
-        auto stream_type_of = [this](int unique_id) -> rs2_stream
+        // Raw/dual-RGB color surfaces as RGB8 (BA81->rggb); ISP color is YUYV/BGR8/RGBA8/BGRA8.
+        bool is_color = false;
+        for (auto&& p : profiles)
+            if (p.unique_id() == unique_id) { is_color = ( p.stream_type() == RS2_STREAM_COLOR ); break; }
+        if (!is_color)
+            return false;
+        auto fit = format_values.find(unique_id);
+        auto sit = ui.selected_format_id.find(unique_id);
+        if (fit == format_values.end() || sit == ui.selected_format_id.end())
+            return false;
+        int idx = sit->second;
+        if (idx < 0 || idx >= (int)fit->second.size())
+            return false;
+        return fit->second[idx] == RS2_FORMAT_RGB8;
+    }
+
+    rs2_stream subdevice_model::stream_type_of(int unique_id) const
+    {
+        for (auto&& p : profiles) if (p.unique_id() == unique_id) return p.stream_type();
+        return RS2_STREAM_ANY;
+    }
+
+    int subdevice_model::stream_index_of(int unique_id) const
+    {
+        for (auto&& p : profiles) if (p.unique_id() == unique_id) return p.stream_index();
+        return 0;
+    }
+
+    void subdevice_model::enforce_dual_color_ir_exclusion(int changed_unique_id)
+    {
+        // Caller gates this on is_dual_color_subdevice(). Reconciles the single-mode invariant.
+        auto set_format = [this](int uid, rs2_format tgt)
         {
-            for (auto&& p : profiles)
-                if (p.unique_id() == unique_id)
-                    return p.stream_type();
-            return RS2_STREAM_ANY;
+            auto fit = format_values.find(uid);
+            if (fit == format_values.end()) return;
+            for (int i = 0; i < (int)fit->second.size(); ++i)
+                if (fit->second[i] == tgt) { ui.selected_format_id[uid] = i; return; }
         };
+        auto is_color = [this](int uid) { return stream_type_of(uid) == RS2_STREAM_COLOR; };
+        auto is_ir    = [this](int uid) { return stream_type_of(uid) == RS2_STREAM_INFRARED; };
 
-        auto is_color = [](rs2_stream st) { return st == RS2_STREAM_COLOR; };
-        auto is_ir    = [](rs2_stream st) { return st == RS2_STREAM_INFRARED; };
+        rs2_stream ct = stream_type_of(changed_unique_id);
+        if (ct != RS2_STREAM_COLOR && ct != RS2_STREAM_INFRARED)
+            return;   // depth etc. - no mode effect
 
-        rs2_stream enabled_type = stream_type_of(just_enabled_unique_id);
-        // Only color<->IR conflict (the two imagers stream mono IR OR Bayer color, not both). Depth
-        // is a separate node - enabling it clears nothing, and it survives enabling color or IR.
-        if (!is_color(enabled_type) && !is_ir(enabled_type))
-            return;
+        bool changed_on = stream_enabled.count(changed_unique_id) && stream_enabled[changed_unique_id];
+        if (!changed_on)
+            return;   // disabling a stream never forces another off
 
-        for (auto& other : stream_enabled)
+        if (is_color(changed_unique_id) && color_uid_is_raw(changed_unique_id))
         {
-            if (other.first == just_enabled_unique_id || !other.second)
-                continue;
-
-            rs2_stream other_type = stream_type_of(other.first);
-            if ((is_color(enabled_type) && is_ir(other_type)) ||
-                (is_ir(enabled_type) && is_color(other_type)))
-                other.second = false;   // color and IR share the imagers -> mutually exclusive
+            // Raw mode: drop mono IR; couple the other color to RGB8 (no ISP+raw imager mix).
+            for (auto& o : stream_enabled)
+            {
+                if (o.first == changed_unique_id || !o.second) continue;
+                if (is_ir(o.first))         o.second = false;
+                else if (is_color(o.first)) set_format(o.first, RS2_FORMAT_RGB8);
+            }
         }
+        else if (is_ir(changed_unique_id))
+        {
+            // Enabling IR -> ISP/stereo mode: drop any raw color (RGB8 Color 0 and the raw-only Color 1).
+            for (auto& o : stream_enabled)
+            {
+                if (o.first == changed_unique_id || !o.second) continue;
+                if (is_color(o.first) && ( color_uid_is_raw(o.first) || stream_index_of(o.first) >= 1 ))
+                    o.second = false;
+            }
+        }
+        else if (is_color(changed_unique_id))
+        {
+            // Enabling / selecting an ISP color -> drop the raw-only Color 1 (no ISP + raw mix).
+            for (auto& o : stream_enabled)
+            {
+                if (o.first == changed_unique_id || !o.second) continue;
+                if (is_color(o.first) && stream_index_of(o.first) >= 1)
+                    o.second = false;
+            }
+        }
+    }
+
+    bool subdevice_model::is_stream_mode_locked(int unique_id) const
+    {
+        if (!is_dual_color_subdevice())
+            return false;
+
+        bool raw_active = false, ir_active = false, isp_color_active = false;
+        for (auto&& kv : stream_enabled)
+        {
+            if (!kv.second) continue;
+            rs2_stream t = stream_type_of(kv.first);
+            if (t == RS2_STREAM_COLOR)
+            {
+                if (color_uid_is_raw(kv.first)) raw_active = true;
+                else                            isp_color_active = true;
+            }
+            else if (t == RS2_STREAM_INFRARED)
+                ir_active = true;
+        }
+
+        rs2_stream t = stream_type_of(unique_id);
+        if (t == RS2_STREAM_INFRARED)
+            return raw_active;                              // IR unavailable while raw color streams
+        if (t == RS2_STREAM_COLOR && stream_index_of(unique_id) >= 1)
+            return ir_active || isp_color_active;           // Color 1 is raw-only
+        return false;                                       // depth and Color 0 (mode chooser) never lock
     }
 
     bool subdevice_model::is_depth_calibration_profile() const

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -273,10 +273,22 @@ namespace rs2
         // color (BA81) - not both - so color and infrared are mutually exclusive on the imager nodes;
         // depth is a separate node and coexists with either group.
         bool is_dual_color_subdevice() const;
-        // Enforce the color/IR mutual exclusion on the dual-RGB subdevice: enabling a color stream
-        // disables the infrared streams and vice versa. Depth is left untouched (it can coexist with
-        // either dual-RGB or stereo-IR).
-        void enforce_dual_color_ir_exclusion(int just_enabled_unique_id);
+        // The D401 GMSL streams in exactly ONE mode at a time, selected by the color format:
+        //   RAW / dual-RGB : a color stream in RS2_FORMAT_RGB8 (BA81 -> rggb). Both imagers are
+        //                    Bayer, so mono IR is unavailable and the raw-only 2nd color pin (Color 1)
+        //                    is available.
+        //   ISP / stereo   : color in YUYV/BGR8/RGBA8/BGRA8 (FW-processed). Coexists with IR1/IR2;
+        //                    the raw-only Color 1 is unavailable.
+        // Depth is a separate node and coexists with either mode.
+        rs2_stream stream_type_of(int unique_id) const;   // profile stream type for a unique id (ANY if not found)
+        int        stream_index_of(int unique_id) const;  // profile stream index for a unique id (0 if not found)
+        bool color_uid_is_raw(int unique_id) const;   // color stream currently in the raw RGB8 format
+        // Reconcile the single-mode invariant after `changed_unique_id` toggled or changed format:
+        // uncheck streams that can't coexist with it and couple the two color pins to the same format.
+        void enforce_dual_color_ir_exclusion(int changed_unique_id);
+        // True when `unique_id`'s checkbox should be greyed out given the current mode (IR while a raw
+        // color is active; the raw-only Color 1 while an ISP color or IR is active).
+        bool is_stream_mode_locked(int unique_id) const;
         void set_extrinsics_from_depth_if_needed();
         bool is_post_processing_enabled_in_config_file() const;
         void avoid_streaming_on_embedded_filters_not_matching_configuration() const;

--- a/src/proc/rggb-converter.cpp
+++ b/src/proc/rggb-converter.cpp
@@ -100,11 +100,9 @@ namespace librealsense
             return;
         }
 
-        // White-patch auto white balance: balance the brightest *unclipped* surfaces (the white/
-        // light objects) to neutral, so white reads as white. Gray-world (scene average) leaves a
-        // cast on white objects that are cooler than the average; white-patch targets them directly.
-        // Two sparse passes over the packed source: (1) find the brightest unclipped green, (2)
-        // average R/G/B over the top brightness band. EMA-smoothed; feeds CPU + CUDA debayer.
+        // Hybrid auto white balance: white-patch (balance the brightest unclipped surfaces to neutral),
+        // falling back to gray-world when the bright band is a tiny fraction of the frame - i.e. isolated
+        // light sources, where white-patch would balance the whole scene to the lamp colour. EMA-smoothed.
         {
             const int bl = _isp.black_level;
             auto bval = [&]( int x, int y ) -> int {
@@ -121,8 +119,8 @@ namespace librealsense
                     if( g < hi && g > gmax ) gmax = g;
                 }
             const int gthr = ( gmax * 3 ) / 5;   // top ~40% brightness band = light/white surfaces
-            double sR = 0, sG = 0, sB = 0;
-            long n = 0;
+            double sR = 0, sG = 0, sB = 0;   long n = 0;    // white-patch (bright band)
+            double wR = 0, wG = 0, wB = 0;   long wn = 0;   // gray-world (all unclipped samples)
             for( int y = 0; y + 1 < height; y += step )
                 for( int x = 0; x + 1 < real_width; x += step )   // x,y even -> land on R sites
                 {
@@ -130,17 +128,30 @@ namespace librealsense
                     const int gg2 = ( bval( x + 1, y ) + bval( x, y + 1 ) ) >> 1;  // (Gr + Gb) / 2
                     int bb  = bval( x + 1, y + 1 );                        // B site (BGGR: this is R)
                     if( _isp.swap_rb ) { int t = rr; rr = bb; bb = t; }    // BGGR: real R/B are swapped
+                    if( rr < hi && gg2 < hi && bb < hi ) { wR += rr; wG += gg2; wB += bb; ++wn; }  // gray-world
                     if( gg2 < gthr )         continue;                     // not a bright surface
                     if( rr >= hi || gg2 >= hi || bb >= hi ) continue;      // any channel clipped
                     sR += rr;  sG += gg2;  sB += bb;  ++n;
                 }
-            if( n > 20 && sR > 1.0 && sB > 1.0 )   // enough bright-surface samples to trust it
+            auto clampg = []( float g ) { return g < 0.5f ? 0.5f : ( g > 4.f ? 4.f : g ); };
+            // Bright band under 10% of the sampled pixels => isolated light sources, not a white surface,
+            // so use gray-world; otherwise white-patch (a white surface or a colour-dominated scene).
+            const bool bright_isolated = ( wn > 20 ) && ( (double)n / (double)wn < 0.10 );
+            float tR = -1.f, tB = -1.f;
+            if( bright_isolated )                          // isolated light source -> gray-world
             {
-                const double mR = sR / n, mG = sG / n, mB = sB / n;
-                auto clampg = []( float g ) { return g < 0.5f ? 0.5f : ( g > 4.f ? 4.f : g ); };
-                // No warm bias: validated against the captured raw, the unbiased white-patch gains
-                // (gR~2.15, gB~1.72) land the bright surfaces neutral. A bias only re-introduces a tint.
-                const float tR = clampg( float( mG / mR ) ), tB = clampg( float( mG / mB ) );
+                if( wR > 1.0 && wB > 1.0 ) { tR = clampg( float( wG / wR ) ); tB = clampg( float( wG / wB ) ); }
+            }
+            else if( n > 20 && sR > 1.0 && sB > 1.0 )      // real bright/white surface -> white-patch
+            {
+                tR = clampg( float( sG / sR ) ); tB = clampg( float( sG / sB ) );
+            }
+            else if( wn > 20 && wR > 1.0 && wB > 1.0 )     // no trustworthy bright band -> gray-world
+            {
+                tR = clampg( float( wG / wR ) ); tB = clampg( float( wG / wB ) );
+            }
+            if( tR > 0.f )
+            {
                 const float a = 0.1f;                              // EMA: converges in ~30 frames
                 _awb_gain_r += a * ( tR - _awb_gain_r );
                 _awb_gain_b += a * ( tB - _awb_gain_b );


### PR DESCRIPTION
**Overview:** Cherry-pick of #15586 to `r/2.58.4` — D401 GMSL dual-RGB color fixes: viewer stream selection now reflects the camera's two color modes, and the raw dual-RGB auto white balance no longer casts warm-lit scenes yellow.

## Why
Both fixes are wanted in the 2.58.4 release. Original PR merged to `development` as `018ff3e8`.

## Summary
- `common/subdevice-model.cpp/.h`: format-aware stream selection for the D401 GMSL (PID 0xABCC). ISP color formats coexist with IR and Depth; RGB8 (raw Bayer) color clears IR, since the imagers are consumed by Bayer color. Unstreamable streams are greyed out instead of silently unchecked, and the two color pins stay coupled. All gated on `is_dual_color_subdevice()`.
- `src/proc/rggb-converter.cpp`: hybrid AWB — white-patch normally, gray-world fallback when the bright band is a tiny isolated fraction of the frame (a light source, not a white surface).
- No changes outside the D401 GMSL dual-RGB color path.

## Test plan
- [x] Cherry-pick applies cleanly; diff content identical to `018ff3e8` (line offsets only).
- [ ] LibCI on the cherry-pick branch.
- [ ] Original PR was validated on a D401 GMSL + Jetson Orin: ISP color + IR1 + IR2 + Depth stream together, RGB8 greys out IR, warm-LED scene goes from B/G ~0.44 to ~1.0.

---
🤖 Generated by AI
