### PR TITLE
Support dual color AE mode

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -120,7 +120,7 @@ extern "C" {
         RS2_OPTION_AUTO_EXPOSURE_LIMIT_TOGGLE, /**< Enable / disable color image auto-exposure*/
         RS2_OPTION_AUTO_GAIN_LIMIT_TOGGLE, /**< Enable / disable color image auto-gain*/
         RS2_OPTION_EMITTER_FREQUENCY, /**< Select emitter (laser projector) frequency, see rs2_emitter_frequency for values */
-        RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE, /**< Select depth sensor auto exposure mode see rs2_depth_auto_exposure_mode for values  */
+        RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE, /**< Select depth sensor auto exposure mode, see rs2_depth_auto_exposure_mode for values - or rs2_colored_ir_auto_exposure_mode on colored-IR devices */
         RS2_OPTION_OHM_TEMPERATURE, /**< Temperature of the Optical Head Sensor */
         RS2_OPTION_SOC_PVT_TEMPERATURE, /**< Temperature of PVT SOC */
         RS2_OPTION_GYRO_SENSITIVITY,/**< Control of the gyro sensitivity level, see rs2_gyro_sensitivity for values */ 
@@ -317,6 +317,18 @@ extern "C" {
         RS2_DEPTH_AUTO_EXPOSURE_COUNT        /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_depth_auto_exposure_mode;
     const char* rs2_depth_auto_exposure_mode_to_string( rs2_depth_auto_exposure_mode mode );
+
+    /** \brief values for RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE option on colored-IR devices, where the same imagers
+        feed both the color and the depth pipeline so auto exposure has to be arbitrated between them. */
+    typedef enum rs2_colored_ir_auto_exposure_mode
+    {
+        RS2_COLORED_IR_AUTO_EXPOSURE_AUTO = 0,  /**< Let the firmware choose the policy */
+        RS2_COLORED_IR_AUTO_EXPOSURE_DEPTH_PRIORITY = 1,  /**< Favor the depth pipeline */
+        RS2_COLORED_IR_AUTO_EXPOSURE_COLOR_PRIORITY = 2,  /**< Favor the color pipeline */
+        RS2_COLORED_IR_AUTO_EXPOSURE_HYBRID = 3,  /**< Combine color and depth pipelines for best results on both */
+        RS2_COLORED_IR_AUTO_EXPOSURE_COUNT        /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
+    } rs2_colored_ir_auto_exposure_mode;
+    const char* rs2_colored_ir_auto_exposure_mode_to_string( rs2_colored_ir_auto_exposure_mode mode );
 
     /** \brief values for RS2_OPTION_SAFETY_MODE option. */
     typedef enum rs2_safety_mode

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -79,6 +79,7 @@ RS2_ENUM_HELPERS_CUSTOMIZED( rs2_digital_gain, RS2_DIGITAL_GAIN_HIGH, RS2_DIGITA
 RS2_ENUM_HELPERS( rs2_host_perf_mode, HOST_PERF )
 RS2_ENUM_HELPERS( rs2_emitter_frequency_mode, EMITTER_FREQUENCY )
 RS2_ENUM_HELPERS( rs2_depth_auto_exposure_mode, DEPTH_AUTO_EXPOSURE )
+RS2_ENUM_HELPERS( rs2_colored_ir_auto_exposure_mode, COLORED_IR_AUTO_EXPOSURE )
 RS2_ENUM_HELPERS( rs2_safety_mode, SAFETY_MODE )
 RS2_ENUM_HELPERS( rs2_d500_intercam_sync_mode, D500_INTERCAM_SYNC )
 RS2_ENUM_HELPERS( rs2_point_cloud_label, POINT_CLOUD_LABEL )

--- a/src/ds/d500/d500-dual-color.cpp
+++ b/src/ds/d500/d500-dual-color.cpp
@@ -8,6 +8,7 @@
 #include "proc/color-formats-converter.h"  // m420_converter, nv12_converter
 #include <src/proc/identity-processing-block.h>
 #include <src/uvc-sensor.h>
+#include <src/platform/uvc-option.h>
 #include <src/metadata-parser.h>
 #include <src/ds/ds-color-common.h>
 
@@ -69,6 +70,24 @@ namespace librealsense
 
         register_color_extrinsics();
         register_color_metadata();
+        register_ae_policy_option();
+    }
+    void d500_dual_color::register_ae_policy_option()
+    {
+
+        // IR imagers feed both RGB and depth at once, so AE has to be arbitrated between the IPU (color priority) and the SDP (depth priority).
+        auto options_map = std::map< float, std::string >{ { static_cast< float >( RS2_COLORED_IR_AUTO_EXPOSURE_AUTO ), "Auto" },
+                                                           { static_cast< float >( RS2_COLORED_IR_AUTO_EXPOSURE_DEPTH_PRIORITY ), "Depth Priority" },
+                                                           { static_cast< float >( RS2_COLORED_IR_AUTO_EXPOSURE_COLOR_PRIORITY ), "Color Priority" },
+                                                           { static_cast< float >( RS2_COLORED_IR_AUTO_EXPOSURE_HYBRID ), "Hybrid" } };
+        get_depth_sensor().register_option( RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE,
+                                            std::make_shared< uvc_xu_option< uint8_t > >( get_raw_depth_sensor(),
+                                                                                          ds::depth_xu,
+                                                                                          ds::d500_xu_id::COLORED_IR_AE_POLICY,
+                                                                                          "Auto exposure policy for sensor with both color and depth streams",
+                                                                                          options_map,
+                                                                                          false ) ); // Not settable while streaming
+                                                
     }
 
     void d500_dual_color::register_color_metadata()

--- a/src/ds/d500/d500-dual-color.h
+++ b/src/ds/d500/d500-dual-color.h
@@ -26,6 +26,7 @@ namespace librealsense
     private:
         void register_color_extrinsics();
         void register_color_metadata();
+        void register_ae_policy_option();
 
         // Stream-id resolver: route color pins (NV12/M420/YUY2) to Color 1 / Color 2 streams
         static void resolve_color_stream( const std::vector< platform::stream_profile > & all,

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -40,6 +40,7 @@ namespace librealsense
             PVT_TEMPERATURE       = 0x15,
             PROJECTOR_TEMPERATURE = 0x16,
             OHM_TEMPERATURE       = 0x17,
+            COLORED_IR_AE_POLICY  = 0x19,
             EXTERNAL_SYNC_MODE    = 0x1A
         };
 

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -281,6 +281,7 @@ EXPORTS
     rs2_serialize_json
     rs2_emitter_frequency_mode_to_string
     rs2_depth_auto_exposure_mode_to_string
+    rs2_colored_ir_auto_exposure_mode_to_string
     rs2_gyro_sensitivity_to_string
 
     rs2_create_record_device

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -243,6 +243,22 @@ const char * get_string( rs2_depth_auto_exposure_mode mode )
 #undef CASE
 }
 
+const char * get_string( rs2_colored_ir_auto_exposure_mode mode )
+{
+#define CASE( X ) STRCASE( COLORED_IR_AUTO_EXPOSURE, X )
+    switch( mode )
+    {
+    CASE( AUTO )
+    CASE( DEPTH_PRIORITY )
+    CASE( COLOR_PRIORITY )
+    CASE( HYBRID )
+    default:
+        assert( ! is_valid( mode ) );
+        return UNKNOWN_VALUE;
+    }
+#undef CASE
+}
+
 const char * get_string( rs2_safety_mode mode )
 {
 #define CASE( X ) STRCASE( SAFETY_MODE, X )
@@ -1037,6 +1053,7 @@ const char * rs2_calibration_status_to_string( rs2_calibration_status status ) {
 const char * rs2_host_perf_mode_to_string( rs2_host_perf_mode mode ) { return librealsense::get_string( mode ); }
 const char * rs2_emitter_frequency_mode_to_string( rs2_emitter_frequency_mode mode ) { return librealsense::get_string( mode ); }
 const char * rs2_depth_auto_exposure_mode_to_string( rs2_depth_auto_exposure_mode mode ) { return librealsense::get_string( mode ); }
+const char * rs2_colored_ir_auto_exposure_mode_to_string( rs2_colored_ir_auto_exposure_mode mode ) { return librealsense::get_string( mode ); }
 const char * rs2_safety_mode_to_string( rs2_safety_mode mode ) { return librealsense::get_string( mode ); }
 const char * rs2_d500_intercam_sync_mode_to_string( rs2_d500_intercam_sync_mode mode ) { return librealsense::get_string( mode ); }
 const char * rs2_point_cloud_label_to_string(rs2_point_cloud_label label) { return librealsense::get_string(label); }

--- a/unit-tests/live/d500/pytest-rgb-ae-policy.py
+++ b/unit-tests/live/d500/pytest-rgb-ae-policy.py
@@ -79,6 +79,8 @@ def test_ae_policy_rejected_while_streaming(test_device):
         depth_sensor.close()
 
     # ... and settable again once streaming stopped
-    depth_sensor.set_option(AE_MODE, target)
-    assert depth_sensor.get_option(AE_MODE) == target
-    depth_sensor.set_option(AE_MODE, original)
+    try:
+        depth_sensor.set_option(AE_MODE, target)
+        assert depth_sensor.get_option(AE_MODE) == target
+    finally:
+        depth_sensor.set_option(AE_MODE, original)

--- a/unit-tests/live/d500/pytest-rgb-ae-policy.py
+++ b/unit-tests/live/d500/pytest-rgb-ae-policy.py
@@ -1,0 +1,84 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Auto-exposure policy arbitration between the color (IPU / 3A) and depth (SDP / 2A) pipelines, exposed
+# on D585 dual-RGB SKUs as depth_auto_exposure_mode over the depth XU. Other D585 variants do not register it.
+
+import pytest
+import pyrealsense2 as rs
+import logging
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.device_each("D585"),
+    pytest.mark.skip(reason="No D585 dual-RGB camera in CI"), # Verified locally against a D585 Proto Dual RGB (PID 0x0C07)
+]
+
+# RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE: python names come from rs2_option_to_string, not the C identifier
+AE_MODE = rs.option.auto_exposure_mode
+POLICIES = rs.colored_ir_auto_exposure_mode
+
+
+def get_depth_sensor(dev):
+    depth_sensor = dev.first_depth_sensor()
+    if not depth_sensor.supports(AE_MODE):
+        pytest.skip("auto exposure policy not exposed on this device")
+    return depth_sensor
+
+
+def test_ae_policy_range(test_device):
+    dev, _ = test_device
+    depth_sensor = get_depth_sensor(dev)
+
+    r = depth_sensor.get_option_range(AE_MODE)
+    assert r.min == POLICIES.auto
+    assert r.max == POLICIES.hybrid
+    assert r.step == 1
+
+
+def test_ae_policy_set_get(test_device):
+    dev, _ = test_device
+    depth_sensor = get_depth_sensor(dev)
+
+    original = depth_sensor.get_option(AE_MODE)
+    try:
+        for policy in (POLICIES.auto, POLICIES.color_priority, POLICIES.depth_priority, POLICIES.hybrid):
+            depth_sensor.set_option(AE_MODE, policy)
+            assert depth_sensor.get_option(AE_MODE) == policy
+    finally:
+        depth_sensor.set_option(AE_MODE, original)
+
+
+def test_ae_policy_rejects_out_of_range(test_device):
+    dev, _ = test_device
+    depth_sensor = get_depth_sensor(dev)
+
+    for bad in (int(POLICIES.hybrid) + 1, 10, 255):
+        with pytest.raises(Exception):
+            depth_sensor.set_option(AE_MODE, bad)
+
+
+def test_ae_policy_rejected_while_streaming(test_device):
+    # The firmware applies the policy at stream start, so the option is not settable while streaming.
+    dev, _ = test_device
+    depth_sensor = get_depth_sensor(dev)
+
+    original = depth_sensor.get_option(AE_MODE)
+    target = POLICIES.color_priority if original != POLICIES.color_priority else POLICIES.depth_priority
+
+    depth_profile = next(p for p in depth_sensor.profiles
+                         if p.stream_type() == rs.stream.depth and p.format() == rs.format.z16)
+    depth_sensor.open(depth_profile)
+    depth_sensor.start(lambda frame: None)
+    try:
+        with pytest.raises(Exception):
+            depth_sensor.set_option(AE_MODE, target)
+        assert depth_sensor.get_option(AE_MODE) == original
+    finally:
+        depth_sensor.stop()
+        depth_sensor.close()
+
+    # ... and settable again once streaming stopped
+    depth_sensor.set_option(AE_MODE, target)
+    assert depth_sensor.get_option(AE_MODE) == target
+    depth_sensor.set_option(AE_MODE, original)

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -65,6 +65,7 @@ void init_c_files(py::module &m) {
     BIND_ENUM(m, rs2_calibration_type, RS2_CALIBRATION_TYPE_COUNT, "Calibration type for use in device_calibration")
     BIND_ENUM_CUSTOM(m, rs2_calibration_status, RS2_CALIBRATION_STATUS_FIRST, RS2_CALIBRATION_STATUS_LAST, "Calibration callback status for use in device_calibration.trigger_device_calibration")
     BIND_ENUM(m, rs2_d500_intercam_sync_mode, RS2_D500_INTERCAM_SYNC_COUNT, "For D500: intercamera synchronization mode")
+    BIND_ENUM(m, rs2_colored_ir_auto_exposure_mode, RS2_COLORED_IR_AUTO_EXPOSURE_COUNT, "For colored-IR devices: how auto exposure is arbitrated between the color and depth pipelines")
 
     /** rs_types.h **/
     py::class_<rs2_intrinsics> intrinsics(m, "intrinsics", "Video stream intrinsics.");


### PR DESCRIPTION
**Overview:** D585 dual-RGB cameras can now choose how auto exposure is shared between the color and depth pipelines.

Tracked on [RSDEV-13974]

## Why
On dual-RGB SKUs the same imagers feed both pipelines, so auto exposure must be arbitrated between color (IPU / 3A) and depth (SDP / 2A). Firmware exposes this on a new depth XU selector; the SDK had no way to reach it.

## Summary
- Depth XU selector 0x19 registered as `RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE` on dual-RGB devices — reuses the existing option id rather than adding one.
- New `rs2_colored_ir_auto_exposure_mode` enum for the values, since they differ from the D400 meanings of that option. Values follow firmware/driver numbering.
- Added to-string, the `.def` export, and the pyrealsense2 binding (`rs.colored_ir_auto_exposure_mode`).
- Registered from `d500_dual_color` only, and not settable while streaming — firmware applies the policy at stream start.
- Tested USB only for now. Dual color GMSL support is still WIP.

## Test plan
- [ ] `live/d500/pytest-rgb-ae-policy.py` — 4 tests: range, set/get across all values, out-of-range rejection, and rejection while streaming
- [ ] Passed locally against a D585 Proto Dual RGB (PID 0x0C07); camera restored to its original policy afterwards
- [ ] Marked `pytest.mark.skip` — CI has no D585 dual-RGB (2C) camera yet; remove the mark once the lab has one

---
🤖 Generated by AI

