### PR TITLE
v4l2: make USERPTR capture buffers GPU-visible for zero-copy

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -354,7 +354,14 @@ namespace librealsense
             else
             {
                 //_length += (V4L2_BUF_TYPE_VIDEO_CAPTURE==type) ? MAX_META_DATA_SIZE : 0;
+#ifdef RS2_USE_CUDA_ZEROCOPY
+                // USERPTR path: allocate the capture buffer in GPU-visible (CUDA host-mapped)
+                // memory so a zero-copy frame aliasing it stays GPU-resident, matching the MMAP
+                // path (rs_v4l2_zc_register) and the RSUSB path (frame_data_allocator).
+                _start = static_cast<uint8_t*>(rs_frame_zc_alloc( _length ));
+#else
                 _start = static_cast<uint8_t*>(malloc( _length));
+#endif
                 if (!_start) throw linux_backend_exception("User_p allocation failed!");
                 memset(_start, 0, _length);
             }
@@ -395,7 +402,11 @@ namespace librealsense
             }
             else
             {
+#ifdef RS2_USE_CUDA_ZEROCOPY
+               rs_frame_zc_free( _start );
+#else
                free(_start);
+#endif
             }
         }
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -357,10 +357,11 @@ namespace librealsense
 #ifdef RS2_USE_CUDA_ZEROCOPY
                 // USERPTR: GPU-visible buffer so a zero-copy frame aliasing it stays GPU-resident (as MMAP/RSUSB do).
                 _start = static_cast<uint8_t*>(rs_frame_zc_alloc( _length ));
+                if (!_start) throw linux_backend_exception("rs_frame_zc_alloc for USERPTR buffer failed!");
 #else
                 _start = static_cast<uint8_t*>(malloc( _length));
-#endif
                 if (!_start) throw linux_backend_exception("User_p allocation failed!");
+#endif
                 memset(_start, 0, _length);
             }
         }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -355,9 +355,7 @@ namespace librealsense
             {
                 //_length += (V4L2_BUF_TYPE_VIDEO_CAPTURE==type) ? MAX_META_DATA_SIZE : 0;
 #ifdef RS2_USE_CUDA_ZEROCOPY
-                // USERPTR path: allocate the capture buffer in GPU-visible (CUDA host-mapped)
-                // memory so a zero-copy frame aliasing it stays GPU-resident, matching the MMAP
-                // path (rs_v4l2_zc_register) and the RSUSB path (frame_data_allocator).
+                // USERPTR: GPU-visible buffer so a zero-copy frame aliasing it stays GPU-resident (as MMAP/RSUSB do).
                 _start = static_cast<uint8_t*>(rs_frame_zc_alloc( _length ));
 #else
                 _start = static_cast<uint8_t*>(malloc( _length));


### PR DESCRIPTION
## v4l2: make USERPTR capture buffers GPU-visible for zero-copy

### 🐞 Problem
`test_capture_zero_copy_covers_depth` was flaky on the **JP5** Jetson leg. On a **USB camera (D436)** depth came back **uploaded** (host→device copy) while color was zero-copy, so the GPU path paid a per-frame copy for depth.

### 🔍 Root cause
The V4L2 backend chooses its buffer mode **per device class**, and only two of the three modes were wired for zero-copy:

| Device class | Cameras | V4L2 mode | GPU-visible? |
|---|---|---|---|
| `v4l_mipi_device` | D457, D401 (GMSL) | `MMAP` | ✅ via `rs_v4l2_zc_register` |
| `v4l_uvc_device` | **D436, D455 (USB)** | `USERPTR` | ❌ plain `malloc`, never registered |

Depth is passed through verbatim, so it **aliases the capture buffer**. On the USERPTR path that buffer isn't GPU-visible → depth can't be zero-copy.

The CI "flakiness" was this bug surfacing through **device selection**: `pytest.mark.device("D400*")` runs on the *first enumerated* D400, so JP5 (which has both a D436 and a D457) **passed when it landed on the GMSL camera** and **failed when it landed on the USB one**.

### 🔧 Fix
Allocate the USERPTR capture buffer with `rs_frame_zc_alloc` (free with `rs_frame_zc_free`), matching the MMAP and RSUSB paths. Only the USERPTR branch changes; non-zero-copy and discrete-GPU builds fall back to `malloc` unchanged.

### ✅ Verification
- **Real JP5 runner** (D436, CUDA 11.4, static build matching CI): depth zero-copy **0% → 100%**, test assertion passes.
- **D455** (Orin, CUDA 12.6): both zero-copy tests pass, **200/200** frames zero-copy.
- **GMSL path (D457/D401): unchanged.**
