### PR TITLE
Fix pytest-emitter-d500 stability for D585

### DIFF
--- a/unit-tests/live/d500/pytest-emitter-d500.py
+++ b/unit-tests/live/d500/pytest-emitter-d500.py
@@ -94,6 +94,7 @@ def test_emitter_on_off_blocked_while_always_on(test_device):
         pipe.wait_for_frames()
 
         depth_sensor.set_option(rs.option.emitter_on_off, 0)
+        time.sleep(0.1)  # laser/emitter is physical: let it settle before the next read/set
         depth_sensor.set_option(rs.option.emitter_always_on, 1)
         time.sleep(0.1)  # laser/emitter is physical: let it settle before the next read/set
 
@@ -103,6 +104,7 @@ def test_emitter_on_off_blocked_while_always_on(test_device):
 
         # with always on back off, the same set goes through
         depth_sensor.set_option(rs.option.emitter_always_on, 0)
+        time.sleep(0.1)  # laser/emitter is physical: let it settle before the next read/set
         depth_sensor.set_option(rs.option.emitter_on_off, 1)
         time.sleep(0.1)  # laser/emitter is physical: let it settle before the next read/set
         check.equal(depth_sensor.get_option(rs.option.emitter_on_off), 1.0)


### PR DESCRIPTION
**Overview:** Add a 100 ms settle after clearing Emitter Always On in `test_emitter_on_off_blocked_while_always_on`, fixing the D585 nightly regression.

**Why:** Without it, the following `emitter_on_off` set is silently discarded by `gated_option::set`, whose live query of Emitter Always On still returns 1 while the projector is still actuating — so the read-back is 0 instead of 1.

**Test plan:** Verified on vtglnx163 with D585 Prototype 541522320025 (FW 7.58.41128.14352): 3/3 failed before, 5/5 passed after, and the SDK log drops from two `Emitter ON/OFF cannot be set while Emitter always ON is enabled` warnings to the single intended one.
