### PR TITLE
Cherry-pick #15600: dual RGB firmware guard

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -883,7 +883,7 @@ namespace rs2
                     if (RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
                         static_cast<int>(formats_chars.size())))
                     {
-                        // Color format can flip raw (RGB8) <-> ISP mode; reconcile the other streams.
+                        // Setting Color 0 to an ISP format (non-RGB8) can't pair with raw Color 1; reconcile.
                         if (is_dual_color_subdevice() && stream_enabled.count(f.first) && stream_enabled.at(f.first))
                             enforce_dual_color_ir_exclusion(f.first);
                     }
@@ -1096,7 +1096,7 @@ namespace rs2
                     if (RsImGui::CustomComboBox(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
                         static_cast<int>(formats_chars.size())))
                     {
-                        // Color format can flip raw (RGB8) <-> ISP mode; reconcile the other streams.
+                        // Setting Color 0 to an ISP format (non-RGB8) can't pair with raw Color 1; reconcile.
                         if (is_dual_color_subdevice() && stream_enabled.count(f.first) && stream_enabled.at(f.first))
                             enforce_dual_color_ir_exclusion(f.first);
                     }
@@ -1590,23 +1590,31 @@ namespace rs2
             || std::string(dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID)) != "ABCC")   // RS401_GMSL_PID
             return false;
 
-        // Structural sanity: this subdevice actually exposes the dual-RGB config (two color streams
-        // alongside the stereo streams) rather than, say, the plain depth sensor of the same device.
-        int color_streams = 0;
-        bool has_stereo = false;
+        // Treat this as a dual-RGB subdevice only when it actually exposes a second color stream
+        // (Color 1) alongside the stereo streams. This mirrors exactly what the device registers:
+        // raw dual-RGB - and therefore Color 1 - is exposed only on firmware that supports it, so on
+        // older firmware there is a single color stream and this returns false (no Color 1, no raw
+        // color format, no color<->IR gating). Distinct color stream indices, not profile count, are
+        // what separate a real second color stream from the many format/resolution profiles of a
+        // single ISP color stream.
+        bool has_color0 = false, has_second_color = false, has_stereo = false;
         for (auto&& p : profiles)
         {
             if (p.stream_type() == RS2_STREAM_COLOR)
-                ++color_streams;
+            {
+                if (p.stream_index() == 0) has_color0 = true;
+                else                       has_second_color = true;
+            }
             else if (p.stream_type() == RS2_STREAM_INFRARED || p.stream_type() == RS2_STREAM_DEPTH)
                 has_stereo = true;
         }
-        return color_streams >= 2 && has_stereo;
+        return has_color0 && has_second_color && has_stereo;
     }
 
     bool subdevice_model::color_uid_is_raw(int unique_id) const
     {
-        // Raw/dual-RGB color surfaces as RGB8 (BA81->rggb); ISP color is YUYV/BGR8/RGBA8/BGRA8.
+        // Pure format check: is this color stream currently set to RGB8. NOTE this alone does NOT mean
+        // "raw mode" - a lone Color 0 RGB8 is ISP color. Raw dual-RGB is decided by dual_rgb_active().
         bool is_color = false;
         for (auto&& p : profiles)
             if (p.unique_id() == unique_id) { is_color = ( p.stream_type() == RS2_STREAM_COLOR ); break; }
@@ -1634,6 +1642,15 @@ namespace rs2
         return 0;
     }
 
+    bool subdevice_model::dual_rgb_active() const
+    {
+        // Raw dual-RGB is active iff Color 1 (index >= 1) is enabled; a lone Color 0 (even RGB8) is ISP.
+        for (auto&& kv : stream_enabled)
+            if (kv.second && stream_type_of(kv.first) == RS2_STREAM_COLOR && stream_index_of(kv.first) >= 1)
+                return true;
+        return false;
+    }
+
     void subdevice_model::enforce_dual_color_ir_exclusion(int changed_unique_id)
     {
         // Caller gates this on is_dual_color_subdevice(). Reconciles the single-mode invariant.
@@ -1655,29 +1672,32 @@ namespace rs2
         if (!changed_on)
             return;   // disabling a stream never forces another off
 
-        if (is_color(changed_unique_id) && color_uid_is_raw(changed_unique_id))
+        const bool changed_is_color = is_color(changed_unique_id);
+        const int  changed_index    = stream_index_of(changed_unique_id);
+
+        if (changed_is_color && changed_index >= 1)
         {
-            // Raw mode: drop mono IR; couple the other color to RGB8 (no ISP+raw imager mix).
+            // Enabling Color 1 -> raw dual-RGB: drop IR and force Color 0 to RGB8 (both pins must be raw).
             for (auto& o : stream_enabled)
             {
                 if (o.first == changed_unique_id || !o.second) continue;
-                if (is_ir(o.first))         o.second = false;
-                else if (is_color(o.first)) set_format(o.first, RS2_FORMAT_RGB8);
+                if (is_ir(o.first))                                          o.second = false;
+                else if (is_color(o.first) && stream_index_of(o.first) == 0) set_format(o.first, RS2_FORMAT_RGB8);
             }
         }
         else if (is_ir(changed_unique_id))
         {
-            // Enabling IR -> ISP/stereo mode: drop any raw color (RGB8 Color 0 and the raw-only Color 1).
+            // Enabling IR -> ISP/stereo: drop the raw-only Color 1 (Color 0 stays; RGB8 there is now ISP).
             for (auto& o : stream_enabled)
             {
                 if (o.first == changed_unique_id || !o.second) continue;
-                if (is_color(o.first) && ( color_uid_is_raw(o.first) || stream_index_of(o.first) >= 1 ))
+                if (is_color(o.first) && stream_index_of(o.first) >= 1)
                     o.second = false;
             }
         }
-        else if (is_color(changed_unique_id))
+        else if (changed_is_color && changed_index == 0 && !color_uid_is_raw(changed_unique_id))
         {
-            // Enabling / selecting an ISP color -> drop the raw-only Color 1 (no ISP + raw mix).
+            // Color 0 on an ISP format can't pair with raw Color 1: drop Color 1.
             for (auto& o : stream_enabled)
             {
                 if (o.first == changed_unique_id || !o.second) continue;
@@ -1692,26 +1712,19 @@ namespace rs2
         if (!is_dual_color_subdevice())
             return false;
 
-        bool raw_active = false, ir_active = false, isp_color_active = false;
+        const bool raw_active = dual_rgb_active();          // Color 1 enabled => raw dual-RGB
+        bool ir_active = false;
         for (auto&& kv : stream_enabled)
         {
-            if (!kv.second) continue;
-            rs2_stream t = stream_type_of(kv.first);
-            if (t == RS2_STREAM_COLOR)
-            {
-                if (color_uid_is_raw(kv.first)) raw_active = true;
-                else                            isp_color_active = true;
-            }
-            else if (t == RS2_STREAM_INFRARED)
-                ir_active = true;
+            if (kv.second && stream_type_of(kv.first) == RS2_STREAM_INFRARED) { ir_active = true; break; }
         }
 
         rs2_stream t = stream_type_of(unique_id);
         if (t == RS2_STREAM_INFRARED)
-            return raw_active;                              // IR unavailable while raw color streams
+            return raw_active;                              // IR unavailable while raw dual-RGB (Color 1) streams
         if (t == RS2_STREAM_COLOR && stream_index_of(unique_id) >= 1)
-            return ir_active || isp_color_active;           // Color 1 is raw-only
-        return false;                                       // depth and Color 0 (mode chooser) never lock
+            return ir_active;                              // Color 1 (raw) unavailable while IR streams
+        return false;                                       // depth and Color 0 work in both modes - never lock
     }
 
     bool subdevice_model::is_depth_calibration_profile() const

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -282,12 +282,15 @@ namespace rs2
         // Depth is a separate node and coexists with either mode.
         rs2_stream stream_type_of(int unique_id) const;   // profile stream type for a unique id (ANY if not found)
         int        stream_index_of(int unique_id) const;  // profile stream index for a unique id (0 if not found)
-        bool color_uid_is_raw(int unique_id) const;   // color stream currently in the raw RGB8 format
+        bool color_uid_is_raw(int unique_id) const;   // this color uid's selected format is RGB8
+        // Raw dual-RGB mode is active iff the second color stream (Color 1, index >= 1) is enabled. A lone
+        // Color 0 (any format, including RGB8) is ISP color and coexists with infrared.
+        bool dual_rgb_active() const;
         // Reconcile the single-mode invariant after `changed_unique_id` toggled or changed format:
         // uncheck streams that can't coexist with it and couple the two color pins to the same format.
         void enforce_dual_color_ir_exclusion(int changed_unique_id);
-        // True when `unique_id`'s checkbox should be greyed out given the current mode (IR while a raw
-        // color is active; the raw-only Color 1 while an ISP color or IR is active).
+        // True when `unique_id`'s checkbox should be greyed out given the current mode (IR while raw
+        // dual-RGB is active; the raw-only Color 1 while IR is active).
         bool is_stream_mode_locked(int unique_id) const;
         void set_extrinsics_from_depth_if_needed();
         bool is_post_processing_enabled_in_config_file() const;

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -30,6 +30,7 @@
 * Device specific topics:
   * [D400 at realsense.intel.com/](https://realsenseai.com/stereo-depth-cameras/) - Camera specifications
   * [D400 Advanced Mode](rs400/rs400_advanced_mode.md) - Overview of the Advanced Mode APIs
+  * [D401 GMSL Dual-RGB and ISP color](rs400/d401_dual_rgb_gmsl.md) - Using the D401 GMSL raw dual-RGB and legacy ISP color modes (SDK and Viewer)
   * [D400 cameras with Raspberry Pi](./RaspberryPi3.md) - Example of low-end system without USB3 interface
   * [D400 cameras on **rooted** Android devices](./android.md) - Instructions of how to build the RealSense SDK for Android OS.
   * [D435i depth camera with IMU](./d435i.md) - An introduction to the D435i depth camera and it's IMU

--- a/doc/rs400/d401_dual_rgb_gmsl.md
+++ b/doc/rs400/d401_dual_rgb_gmsl.md
@@ -1,0 +1,112 @@
+# D401 GMSL — Dual‑RGB (raw) and ISP color modes
+
+## Overview
+
+The **D401 GMSL** builds its color image from its **two OV9782 global‑shutter stereo imagers**, which are shared between **depth** and **color**. Each imager can, at any given moment, produce **either** a mono infrared image **or** a Bayer color image — never both at once. Because of this, there are two ways to obtain color from the D401 GMSL:
+
+| Mode | Where color is produced | Color streams | Runs together with infrared? |
+|------|-------------------------|---------------|------------------------------|
+| **ISP color** (legacy) | Firmware ISP (`YUYV`, converted on the host) | one `Color` | **Yes** — with `Infrared 1`, `Infrared 2`, `Depth` |
+| **Raw dual‑RGB** | Host‑side debayer of raw Bayer (`RAW8`/`BA81`) | `Color` **+** `Color 1` | **No** — both imagers are producing Bayer |
+
+> **Firmware requirement.** Raw dual‑RGB is available only on firmware **5.17.4.13 or newer**. On older firmware the camera exposes the **ISP color** path only; requesting dual‑RGB (a second color stream) will fail to resolve, and the Viewer shows a single ISP color stream.
+
+## The two modes
+
+### ISP color (legacy)
+
+The firmware ISP produces a single processed color stream (`YUYV`), which the SDK converts to the standard color formats. This is the original D401 GMSL color behavior and it coexists with `Depth`, `Infrared 1`, and `Infrared 2`. Use ISP color when you want color **alongside** infrared.
+
+<p align="center">
+  <img src="https://librealsense.realsenseai.com/readme-media/d401_isp_color_viewer.png" width="820" alt="ISP color mode in the Viewer: Depth, Infrared 1, Infrared 2 and a YUYV Color stream"/>
+</p>
+<p align="center"><em>ISP color mode — <code>Depth</code> + <code>Infrared 1</code> + <code>Infrared 2</code> + <code>Color</code> (<code>YUYV</code>) all streaming together.</em></p>
+
+### Raw dual‑RGB
+
+Both imagers stream **raw Bayer** (`RAW8`, fourcc `BA81`). The SDK debayers and color‑processes each imager on the host and exposes **two** color streams: `Color` (index 0, left imager) and `Color 1` (index 1, right imager). Because both imagers are producing Bayer color, **infrared is not available** in this mode. The Viewer additionally offers a stereo‑rectification filter (on by default) that aligns the two color streams.
+
+<p align="center">
+  <img src="https://librealsense.realsenseai.com/readme-media/d401_dual_rgb_viewer.png" width="820" alt="Raw dual-RGB mode in the Viewer: Depth, Color and Color 1 both RGB8"/>
+</p>
+<p align="center"><em>Raw dual‑RGB mode — <code>Depth</code> + <code>Color</code> + <code>Color 1</code> (both <code>RGB8</code>); infrared is unavailable while both imagers produce Bayer.</em></p>
+
+## Streams and formats
+
+| Stream | Formats | Notes |
+|--------|---------|-------|
+| `Depth` | `Z16` | Independent — always available |
+| `Infrared 1` | `Y8`, `Y16` | Left imager (mono) |
+| `Infrared 2` | `Y8`, `Y16` | Right imager (mono) |
+| `Color` (index 0) | `RGB8`, `BGR8`, `RGBA8`, `BGRA8`, `YUYV` | Left imager — ISP color on its own; switches to raw when `Color 1` is also enabled |
+| `Color 1` (index 1) | `RGB8` | Right imager — raw dual‑RGB only |
+
+The **second color stream (`Color 1`) selects the mode**: enable `Color 1` for raw dual‑RGB. A single `Color` stream — in **any** format, including `RGB8` — is ISP color and coexists with infrared.
+
+Resolutions (shared across depth, infrared, and color): `1280x720`, `848x480`, `640x480`, `640x360`, `480x270`, `424x240`.
+
+## Valid stream combinations
+
+Because the imagers are shared, only certain combinations can stream together. Infrared can run with a single (ISP) `Color` stream in **any** format; raw dual‑RGB (`Color` + `Color 1`) consumes both imagers, so infrared is not available there. Depth is independent and can be added to any row.
+
+| Use case | Depth | Infrared 1 | Infrared 2 | Color | Color 1 |
+|----------|:-----:|:----------:|:----------:|:-----:|:-------:|
+| Depth + stereo IR | `Z16` | `Y8/Y16` | `Y8/Y16` | — | — |
+| Depth + IR + **ISP** color | `Z16` | `Y8/Y16` | `Y8/Y16` | `RGB8/BGR8/YUYV/RGBA8/BGRA8` | — |
+| **ISP** color only (any format) | `Z16` (opt) | — | — | `RGB8/BGR8/YUYV/RGBA8/BGRA8` | — |
+| **Raw** dual‑RGB (+ optional depth) | `Z16` (opt) | — | — | `RGB8` | `RGB8` |
+| Infrared only | — | `Y8/Y16` | `Y8/Y16` | — | — |
+
+## Using it in the SDK
+
+**Raw dual‑RGB — both color streams:**
+
+```cpp
+rs2::config cfg;
+cfg.enable_stream(RS2_STREAM_COLOR, 0, 848, 480, RS2_FORMAT_RGB8, 30); // Color   (left imager)
+cfg.enable_stream(RS2_STREAM_COLOR, 1, 848, 480, RS2_FORMAT_RGB8, 30); // Color 1 (right imager)
+// Depth may be added; infrared cannot run in this mode.
+
+rs2::pipeline pipe;
+pipe.start(cfg);
+```
+
+**ISP color together with depth and infrared:**
+
+```cpp
+rs2::config cfg;
+cfg.enable_stream(RS2_STREAM_DEPTH,       848, 480, RS2_FORMAT_Z16,  30);
+cfg.enable_stream(RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8,   30);
+cfg.enable_stream(RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8,   30);
+cfg.enable_stream(RS2_STREAM_COLOR,       848, 480, RS2_FORMAT_BGR8, 30); // ISP color
+
+rs2::pipeline pipe;
+pipe.start(cfg);
+```
+
+> A single `Color` stream is ISP regardless of format — `RGB8` on its own is ISP color and runs with infrared. Raw dual‑RGB is selected by also enabling `Color 1`.
+>
+> On firmware older than 5.17.4.13, enabling `Color 1` throws `Couldn't resolve requests`, since raw dual‑RGB is not exposed. ISP color (a single `Color` stream) continues to work.
+
+## Using it in the Viewer
+
+In **Stereo Module → Available Streams** you will see `Depth`, `Infrared 1`, `Infrared 2`, `Color`, and (on supported firmware) `Color 1`. The **`Color 1` checkbox chooses the mode**:
+
+- Leave **`Color 1` off** → **ISP** color. `Color` streams in any format (including `RGB8`) alongside `Infrared 1/2`.
+- Tick **`Color 1`** → **raw** dual‑RGB. `Infrared 1/2` grey out and `Color` switches to `RGB8`.
+
+The Viewer greys out any stream that cannot run in the currently selected mode, so it is not possible to pick an unstreamable combination. See the two mode screenshots above.
+
+## Controls
+
+On the D401 GMSL all controls are exposed on a single **Stereo Module** sensor (depth, infrared, and color are folded into it). Which controls affect the image depends on the mode:
+
+- **Depth / infrared:** exposure, gain, auto‑exposure and the depth controls behave as on any D400 stereo module.
+- **ISP color:** the firmware ISP applies exposure, gain, white balance, saturation, and sharpness to the color image.
+- **Raw dual‑RGB color:** white balance is performed automatically on the host, so the hardware `White Balance` / `Auto White Balance` controls do not apply. When streaming color only (depth off), color exposure may be high; streaming depth alongside color lets the depth exposure govern the shared imager.
+
+## Limitations
+
+- **Color and infrared cannot run together in raw mode** — both imagers are producing Bayer, and `Color 1` uses the infrared imager. Keep to a single `Color` stream (do not enable `Color 1`) if you need color and infrared together.
+- **Colored infrared** is not available on GMSL (infrared is delivered as `Y8`/`Y16` only).
+- Raw dual‑RGB requires firmware **5.17.4.13+**; older firmware provides ISP color only.

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -362,6 +362,45 @@ namespace librealsense
                 color_ep.register_processing_block(processing_block_factory::create_pbf_vector<yuy2_converter>(RS2_FORMAT_YUYV, map_supported_color_formats(RS2_FORMAT_YUYV), RS2_STREAM_COLOR));
             }
         }
+
+        // D401 GMSL raw dual-RGB: register the RAW8->RGB8 debayer AFTER the ISP blocks above so ISP wins
+        // ties. formats_converter::find_pbf_matching_most_profiles picks the block satisfying the most
+        // REQUESTED targets; find_satisfied_requests counts only requested profiles, so the raw block's
+        // extra Color 1 output is NOT counted when Color 1 is not requested. A lone Color 0 RGB8 is thus a
+        // tie (both blocks satisfy 1, equal source size) and the first-registered block - ISP - wins, so it
+        // stays ISP and coexists with IR. Requesting Color 1 too makes only the raw block satisfy both
+        // (count 2), so raw wins for both imagers (which excludes IR). Verified on HW: Color 0 RGB8 + IR
+        // stream together. Per-pin routing is set in d400_device::init().
+        if( _is_mipi_device && _pid == ds::RS401_GMSL_PID && _fw_version >= firmware_version( "5.17.4.13" ) )
+        {
+            // Native color is 1288x808 (after cropping 1612 transport padding); other resolutions are
+            // center-crop + bilinear scale. resolution_transform is a captureless fn ptr, one per output.
+            static const int NATIVE_W = 1288;
+            struct color_res { int w, h; void ( *xf )( uint32_t &, uint32_t & ); };
+            static const color_res color_resolutions[] = {
+                { 1280, 720, []( uint32_t & w, uint32_t & h ) { w = 1280; h = 720; } },
+                {  848, 480, []( uint32_t & w, uint32_t & h ) { w =  848; h = 480; } },
+                {  640, 480, []( uint32_t & w, uint32_t & h ) { w =  640; h = 480; } },
+                {  640, 360, []( uint32_t & w, uint32_t & h ) { w =  640; h = 360; } },
+                {  480, 270, []( uint32_t & w, uint32_t & h ) { w =  480; h = 270; } },
+                {  424, 240, []( uint32_t & w, uint32_t & h ) { w =  424; h = 240; } },
+            };
+            for( auto & r : color_resolutions )
+            {
+                const int rw = r.w, rh = r.h;
+                color_ep.register_processing_block(
+                    { { RS2_FORMAT_RAW8, RS2_STREAM_COLOR } },
+                    { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 0, 0, 0, 0, r.xf },
+                      { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 1, 0, 0, 0, r.xf } },
+                    [rw, rh]() {
+                        rggb::isp_params isp;
+                        isp.swap_rb = true;   // OV9782 is BGGR (driver declares SBGGR8); base demosaic is
+                                              // RGGB-pattern, so swap R<->B to correct it
+                        return std::make_shared< rggb_converter >( RS2_FORMAT_RGB8, NATIVE_W, rw, rh, isp );
+                    }
+                );
+            }
+        }
     }
 
     void d400_color::register_metadata_mipi(const synthetic_sensor &color_ep) const

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -770,59 +770,18 @@ namespace librealsense
                 );
 
                 // D401 GMSL dual-RGB: the two OV9782 imagers stream 8-bit RGGB Bayer via the FW RAW8
-                // CSI passthrough. Expose each as a color stream - crop the transport padding
-                // (1612 -> 1288 px) and demosaic RGGB -> RGB8. The per-imager stream index (0/1) is
-                // carried through from the source profile, mirroring the IR1/IR2 split.
-                if( _pid == RS401_GMSL_PID )
+                // CSI passthrough, routed to Color 0 / Color 1. Only firmware with that passthrough
+                // supports it; older firmware exposes the ISP color path only. Keep this guard identical
+                // to the block registration guard in d400_color::register_processing_blocks() - the
+                // resolver armed here and the RAW8->RGB8 blocks there must be enabled together.
+                if( _is_mipi_device && _pid == RS401_GMSL_PID && _fw_version >= firmware_version( "5.17.4.13" ) )
                 {
                     // Route the two identical BGGR color pins to Color 0 / Color 1 (ascending pin order).
                     raw_depth_sensor->set_stream_id_resolver( resolve_d401_color_stream );
-
-                    // Both imagers share one hardware frame counter; without a per-stream counter the
-                    // reported color FPS reads 2x.
+                    // Both imagers share one HW frame counter; without a per-stream counter FPS reads 2x.
                     raw_depth_sensor->enable_software_color_frame_numbers();
-
-                    // The camera always delivers one native color resolution (1288x808 after the
-                    // 1612 transport crop). For the user we expose the standard resolutions too: each
-                    // is produced by demosaicing to native then center-cropping to that aspect ratio
-                    // and bilinear-scaling (crop-to-aspect + scale, no stretch; see rggb_converter /
-                    // cuda-rggb). We mirror the depth resolution set so the viewer offers one shared
-                    // resolution across depth + Color 0/1 (no per-stream resolution UI needed).
-                    //
-                    // resolution_transform is a plain function pointer (no captures), so each output
-                    // resolution needs its own captureless transform; the converter factory (a
-                    // std::function) captures the target size. Index 0 = left imager, 1 = right; the
-                    // resolver tags the two RGGB sources 0/1 and formats-converter matches by index.
-                    static const int NATIVE_W = 1288;
-                    struct color_res { int w, h; void ( *xf )( uint32_t &, uint32_t & ); };
-                    // Mirror the depth resolution set exactly (top out at 1280x720, not the native
-                    // 1288x808) so color shares every resolution with depth/IR. That keeps the viewer
-                    // on a single shared Resolution dropdown and lets depth + IR + Color 0/1 always be
-                    // selected together (depth has no 1288x808 mode). The native 1288x808 is still the
-                    // internal capture/demosaic size; 1280x720 is its center-cropped 16:9 output.
-                    static const color_res color_resolutions[] = {
-                        { 1280, 720, []( uint32_t & w, uint32_t & h ) { w = 1280; h = 720; } },
-                        {  848, 480, []( uint32_t & w, uint32_t & h ) { w =  848; h = 480; } },
-                        {  640, 480, []( uint32_t & w, uint32_t & h ) { w =  640; h = 480; } },
-                        {  640, 360, []( uint32_t & w, uint32_t & h ) { w =  640; h = 360; } },
-                        {  480, 270, []( uint32_t & w, uint32_t & h ) { w =  480; h = 270; } },
-                        {  424, 240, []( uint32_t & w, uint32_t & h ) { w =  424; h = 240; } },
-                    };
-                    for( auto & r : color_resolutions )
-                    {
-                        const int rw = r.w, rh = r.h;
-                        depth_sensor.register_processing_block(
-                            { { RS2_FORMAT_RAW8, RS2_STREAM_COLOR } },
-                            { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 0, 0, 0, 0, r.xf },
-                              { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 1, 0, 0, 0, r.xf } },
-                            [rw, rh]() {
-                                rggb::isp_params isp;
-                                isp.swap_rb = true;   // OV9782 is BGGR (driver declares SBGGR8); the base
-                                                      // demosaic is RGGB-pattern, so swap R<->B to correct it
-                                return std::make_shared< rggb_converter >( RS2_FORMAT_RGB8, NATIVE_W, rw, rh, isp );
-                            }
-                        );
-                    }
+                    // The RAW8->RGB8 blocks are registered in d400_color::register_processing_blocks(),
+                    // after the ISP blocks, so a lone Color 0 RGB8 stays ISP and only Color 1 forces raw.
                 }
             }
 


### PR DESCRIPTION
**Overview:** Cherry-pick of #15600 to `r/2.58.4` — D401 GMSL raw dual-RGB (`Color` + `Color 1`) is exposed only on firmware 5.17.4.13 and newer; older firmware offers the ISP color path only.

## Why
Raw dual-RGB on the D401 GMSL requires firmware 5.17.4.13+. Without the gate, older firmware advertises color streams that never resolve. Wanted in the 2.58.4 release. Original PR merged to `development` as `dafe93cc`.

## Summary
- `src/ds/d400/d400-device.cpp`, `src/ds/d400/d400-color.cpp`: register the raw dual-RGB color streams only when `_fw_version >= 5.17.4.13`.
- `common/subdevice-model.cpp/.h`: `is_dual_color_subdevice()` returns `false` below 5.17.4.13, so the Viewer shows a single ISP color stream (no `Color 1`).
- Docs: add `doc/rs400/d401_dual_rgb_gmsl.md`, linked from `doc/readme.md`.
- Gated on the D401 GMSL product id; no other model is affected.

## Test plan
- [x] Cherry-pick applies cleanly (`git cherry-pick -m 1 dafe93cc`); diff content identical to the original merge (hunk offsets only).
- [x] `realsense2` builds on Windows (MSVC, Release) on the cherry-pick branch.
- [ ] LibCI on the cherry-pick branch.

---
🤖 Generated by AI
