### PR TITLE
dispatcher: add a name and use it in logs

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -161,7 +161,7 @@ namespace rs2
         // Queue capacity is generous: even rapid slider drags coalesce into at most one
         // queued job per option (see option_model::set_option_async), so realistically
         // depth ≪ 16.
-        _set_dispatcher( std::make_shared< dispatcher >( 64u ) )
+        _set_dispatcher( std::make_shared< dispatcher >( 64u, "subdevice-set-option" ) )
     {
         // dispatcher's worker thread starts in _was_stopped=true; invoke() is a
         // silent no-op until start() is called. (The header comment claiming it

--- a/src/core/notification.cpp
+++ b/src/core/notification.cpp
@@ -24,7 +24,7 @@ notification::notification( rs2_notification_category category,
 
 
 notifications_processor::notifications_processor()
-    : _dispatcher( 10 )
+    : _dispatcher( 10, "notifications" )
 {
 }
 

--- a/src/ds/ds-thermal-monitor.cpp
+++ b/src/ds/ds-thermal-monitor.cpp
@@ -12,7 +12,7 @@ namespace librealsense
         _monitor([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            }),
+            }, "thermal-monitor"),
         _poll_intervals_ms(2000), // Temperature check routine to be invoked every 2 sec
         _thermal_threshold_deg(2.f),
         _temp_base(0.f),

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -22,7 +22,7 @@ namespace librealsense
         _decoder(std::move(decoder))
     {
         _active_object = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
-            {  polling(cancellable_timer);  });
+            {  polling(cancellable_timer);  }, "error-polling");
     }
 
     polling_error_handler::~polling_error_handler()

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -280,7 +280,7 @@ namespace librealsense
         _active_object([this](dispatcher::cancellable_timer cancellable_timer)
             {
                 polling(cancellable_timer);
-            })
+            }, "time-diff-keeper")
     {
         //LOG_DEBUG("start new time_diff_keeper ");
     }

--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -57,7 +57,7 @@ namespace librealsense
 
         rs_hid_device::rs_hid_device(rs_usb_device usb_device)
             : _usb_device(usb_device),
-              _action_dispatcher(10)
+              _action_dispatcher(10, "hid-device")
         {
             _id_to_sensor[REPORT_ID_GYROMETER_3D] = gyro;
             _id_to_sensor[REPORT_ID_ACCELEROMETER_3D] = accel;
@@ -150,7 +150,7 @@ namespace librealsense
                 _handle_interrupts_thread = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
                 {
                     handle_interrupt();
-                });
+                }, "hid-interrupts");
 
                 _handle_interrupts_thread->start();
 

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -463,7 +463,7 @@ namespace librealsense
               _sampling_frequency_name(""),
               _callback(nullptr),
               _is_capturing(false),
-              _pm_dispatcher(16)    // queue for async power management commands
+              _pm_dispatcher(16, "hid-power-mgmt")    // queue for async power management commands
         {
             init(frequency, sensitivity);
         }

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -145,7 +145,7 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
             }
             _changed = false;
         }
-    } )
+    }, "udev-device-watcher" )
 {
     _udev_ctx = udev_new();
     if( ! _udev_ctx )

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -37,7 +37,7 @@ std::shared_ptr< device_interface > playback_device_info::create_device()
 
 playback_device::playback_device( std::shared_ptr< const device_info > const & dev_info,
                                   std::shared_ptr< device_serializer::reader > const & serializer )
-    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max() ); } )
+    : m_read_thread( []() { return std::make_shared< dispatcher >( std::numeric_limits< unsigned int >::max(), "playback-read" ); } )
     , m_device_info( dev_info )
     , m_is_started( false )
     , m_is_paused( false )

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -96,7 +96,9 @@ void playback_sensor::open(const stream_profiles& requests)
 
         m_dispatchers.emplace( std::make_pair(
             profile->get_unique_id(),
-            std::make_shared< dispatcher >( _default_queue_size, on_drop_callback ) ) );
+            std::make_shared< dispatcher >( _default_queue_size,
+                                            rsutils::string::from() << "playback-" << profile_to_string( profile ),
+                                            on_drop_callback ) ) );
 
         m_dispatchers[profile->get_unique_id()]->start();
 

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -13,7 +13,7 @@ using namespace librealsense;
 
 librealsense::record_device::record_device(std::shared_ptr<librealsense::device_interface> device,
                                       std::shared_ptr<librealsense::device_serializer::writer> serializer):
-    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max());}),
+    m_write_thread([](){return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max(), "record-write");}),
     m_is_recording(true),
     m_record_total_pause_duration(0)
 {

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -21,7 +21,7 @@ namespace librealsense
     {
         pipeline::pipeline(std::shared_ptr<librealsense::context> ctx) :
             _ctx(ctx),
-            _dispatcher(10),
+            _dispatcher(10, "pipeline"),
             _hub( device_hub::make( ctx, RS2_PRODUCT_LINE_ANY_INTEL )),
             _synced_streams({ RS2_STREAM_COLOR, RS2_STREAM_DEPTH, RS2_STREAM_INFRARED, RS2_STREAM_FISHEYE })
         {}

--- a/src/polling-device-watcher.h
+++ b/src/polling-device-watcher.h
@@ -19,7 +19,8 @@ class polling_device_watcher : public librealsense::platform::device_watcher
 public:
     polling_device_watcher( const platform::backend * backend_ref )
         : _backend( backend_ref )
-        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); } )
+        , _active_object( [this]( dispatcher::cancellable_timer cancellable_timer ) { polling( cancellable_timer ); },
+                          "polling-device-watcher" )
         , _devices_data()
     {
         _devices_data = { _backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices() };

--- a/src/usbhost/device-usbhost.cpp
+++ b/src/usbhost/device-usbhost.cpp
@@ -9,6 +9,8 @@
 #include "usbhost.h"
 #include "../types.h"
 
+#include <rsutils/string/from.h>
+
 #include <string>
 #include <regex>
 #include <sstream>
@@ -100,13 +102,13 @@ namespace librealsense
                     auto type = e->get_type();
                     if(type == RS2_USB_ENDPOINT_INTERRUPT || type == RS2_USB_ENDPOINT_BULK)
                     {
-                        _dispatchers[e->get_address()] = std::make_shared<dispatcher>(10);
+                        _dispatchers[e->get_address()] = std::make_shared<dispatcher>(10, rsutils::string::from() << "usbhost-ep-" << (int)e->get_address());
                         auto d = _dispatchers.at(e->get_address());
                         d->start();
                     }
                 }
             }
-            _dispatcher = std::make_shared<dispatcher>(10);
+            _dispatcher = std::make_shared<dispatcher>(10, "usbhost-device");
             _dispatcher->start();
         }
 

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -82,7 +82,7 @@ namespace librealsense
         rs_uvc_device::rs_uvc_device(const rs_usb_device& usb_device, const uvc_device_info &info, uint8_t usb_request_count) :
                 _usb_device(usb_device),
                 _info(info),
-                _action_dispatcher(10),
+                _action_dispatcher(10, "uvc-device"),
                 _usb_request_count(usb_request_count)
         {
             _parser = std::make_shared<uvc_parser>(usb_device, info);

--- a/src/uvc/uvc-streamer.cpp
+++ b/src/uvc/uvc-streamer.cpp
@@ -16,7 +16,7 @@ namespace librealsense
     namespace platform
     {
         uvc_streamer::uvc_streamer(uvc_streamer_context context) :
-            _context(context), _action_dispatcher(10)
+            _context(context), _action_dispatcher(10, "uvc-streamer")
         {
             auto inf = context.usb_device->get_interface(context.control->bInterfaceNumber);
             if (inf == nullptr)
@@ -100,7 +100,7 @@ namespace librealsense
                     if(_publish_frames && running())
                         _context.user_cb(_context.profile, fp->fo, []() mutable {});
                 }
-            });
+            }, "uvc-publish-frame");
 
             _watchdog = std::make_shared<watchdog>([this]()
              {

--- a/src/winusb/messenger-winusb.cpp
+++ b/src/winusb/messenger-winusb.cpp
@@ -10,6 +10,8 @@
 #include "usb/usb-enumerator.h"
 #include "types.h"
 
+#include <rsutils/string/from.h>
+
 #include <Windows.h>
 #include <Sddl.h>
 #include <string>
@@ -176,7 +178,7 @@ namespace librealsense
             std::lock_guard<std::mutex> lk(_mutex);
             if (_dispatchers.find(endpoint) == _dispatchers.end())
             {
-                _dispatchers[endpoint] = std::make_shared<dispatcher>(10);
+                _dispatchers[endpoint] = std::make_shared<dispatcher>(10, rsutils::string::from() << "winusb-ep-" << (int)endpoint);
                 _dispatchers[endpoint]->start();
             }
             return _dispatchers.at(endpoint);

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -39,7 +39,7 @@ dds_device_server::dds_device_server( std::shared_ptr< dds_participant > const &
     : _publisher( std::make_shared< dds_publisher >( participant ) )
     , _subscriber( std::make_shared< dds_subscriber >( participant ) )
     , _topic_root( topic_root )
-    , _control_dispatcher( QUEUE_MAX_SIZE )
+    , _control_dispatcher( QUEUE_MAX_SIZE, rsutils::string::from() << "dds-control-" << debug_name() )
 {
     LOG_DEBUG( "[" << debug_name() << "] device server created" );
     _control_dispatcher.start();

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -19,6 +19,7 @@
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 
 #include <rsutils/json.h>
+#include <rsutils/string/from.h>
 
 
 using namespace eprosima::fastdds::dds;
@@ -61,7 +62,8 @@ dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher
                       _new_instant_notification = false;
                   }
               }
-          } )
+          },
+          rsutils::string::from() << "dds-notify-" << topic_name )
 {
     auto topic = topics::flexible_msg::create_topic( publisher->get_participant(), topic_name.c_str() );
     _writer = std::make_shared< dds_topic_writer >( topic, publisher );

--- a/third-party/rsutils/include/rsutils/concurrency/concurrency.h
+++ b/third-party/rsutils/include/rsutils/concurrency/concurrency.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <cassert>
 #include <exception>
+#include <string>
 
 const int QUEUE_MAX_SIZE = 10;
 // Simplest implementation of a blocking concurrent queue for thread messaging
@@ -397,10 +398,15 @@ public:
     // and we're non-blocking. The on_drop_callback allows caputring of these instances, if we
     // want...
     //
+    // The name is logged alongside our address, which distinguishes the many same-named instances.
+    //
     dispatcher( unsigned int queue_capacity,
+                std::string name,
                 std::function< void( action ) > on_drop_callback = nullptr );
 
     ~dispatcher();
+
+    std::string const & name() const { return _name; }
 
     bool empty() const { return _queue.empty(); }
 
@@ -465,6 +471,7 @@ private:
 
     friend cancellable_timer;
 
+    std::string const _name;
     single_consumer_queue<std::function<void(cancellable_timer)>> _queue;
     std::thread _thread;
 
@@ -481,8 +488,8 @@ template<class T = std::function<void(dispatcher::cancellable_timer)>>
 class active_object
 {
 public:
-    active_object(T operation)
-        : _operation(std::move(operation)), _dispatcher(1), _stopped(true)
+    active_object( T operation, std::string name )
+        : _operation(std::move(operation)), _dispatcher(1, std::move(name)), _stopped(true)
     {
     }
 
@@ -544,7 +551,7 @@ public:
                 std::lock_guard<std::mutex> lk(_m);
                 _kicked = false;
             }
-        });
+        }, "watchdog" );
     }
 
     ~watchdog()

--- a/third-party/rsutils/src/dispatcher.cpp
+++ b/third-party/rsutils/src/dispatcher.cpp
@@ -49,8 +49,9 @@ dispatcher::dispatcher( unsigned int cap, std::string name, std::function< void(
 
 dispatcher::~dispatcher()
 {
-    // Logged before the join, so a thread that hangs on exit leaves this as its last trace
-    LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] destroying" );
+    // The teardown path is deliberately unlogged: a dispatcher can be destroyed during static
+    // destruction -- e.g. by an app holding an rs2::device in a global -- when the logger is
+    // already gone, calling LOG_DEBUG will issue a segmentation fault.
 
     // Don't get into any more dispatches
     _is_alive = false;
@@ -101,16 +102,13 @@ void dispatcher::stop()
         assert(_queue.empty());
     }
     // Signal we've stopped so any sleeping dispatched will wake up immediately
-    bool was_started;
     {
         std::lock_guard< std::mutex > lock( _was_stopped_mutex );
-        was_started = ! _was_stopped.exchange( true );
+        _was_stopped = true;
     }
     _was_stopped_cv.notify_all();
 
-    // Only the actual transition: stop() is called more than once (see above)
-    if( was_started )
-        LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] stopped" );
+    // Stopping not logged: stop() is also reached from the destructor -- see the note there
 }
 
 

--- a/third-party/rsutils/src/dispatcher.cpp
+++ b/third-party/rsutils/src/dispatcher.cpp
@@ -5,11 +5,14 @@
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/time/waiting-on.h>
 
-dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_drop_callback )
-    : _queue( cap, on_drop_callback )
+dispatcher::dispatcher( unsigned int cap, std::string name, std::function< void( action ) > on_drop_callback )
+    : _name( std::move( name ) )
+    , _queue( cap, on_drop_callback )
     , _was_stopped( true )
     , _is_alive( true )
 {
+    LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] created" );
+
     // We keep a running thread that takes stuff off our queue and dispatches them
     _thread = std::thread([&]()
     {
@@ -31,11 +34,11 @@ dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_dro
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_ERROR("Dispatcher [" << this << "] exception caught: " << e.what());
+                        LOG_ERROR( "Dispatcher [" << _name << " @ " << this << "] exception caught: " << e.what() );
                     }
                     catch (...)
                     {
-                        LOG_ERROR("Dispatcher [" << this << "] unknown exception caught!");
+                        LOG_ERROR( "Dispatcher [" << _name << " @ " << this << "] unknown exception caught!" );
                     }
                 }
             }
@@ -46,6 +49,9 @@ dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_dro
 
 dispatcher::~dispatcher()
 {
+    // Logged before the join, so a thread that hangs on exit leaves this as its last trace
+    LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] destroying" );
+
     // Don't get into any more dispatches
     _is_alive = false;
 
@@ -60,14 +66,18 @@ dispatcher::~dispatcher()
 
 void dispatcher::start()
 {
+    bool was_stopped;
     {
         std::lock_guard< std::mutex > lock(_was_stopped_mutex);
-        _was_stopped = false;
+        was_stopped = _was_stopped.exchange( false );
     }
     _queue.start();
     // Wake up all threads that wait for the dispatcher to start
     _was_stopped_cv.notify_all();
 
+    // Only the actual transition, so repeated calls don't fill the log
+    if( was_stopped )
+        LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] started" );
 }
 
 
@@ -91,11 +101,16 @@ void dispatcher::stop()
         assert(_queue.empty());
     }
     // Signal we've stopped so any sleeping dispatched will wake up immediately
+    bool was_started;
     {
         std::lock_guard< std::mutex > lock( _was_stopped_mutex );
-        _was_stopped = true;
+        was_started = ! _was_stopped.exchange( true );
     }
     _was_stopped_cv.notify_all();
+
+    // Only the actual transition: stop() is called more than once (see above)
+    if( was_started )
+        LOG_DEBUG( "Dispatcher [" << _name << " @ " << this << "] stopped" );
 }
 
 

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -638,7 +638,7 @@ lrs_device_controller::frame_to_streaming_server( rs2::frame const & f, rs2::str
 lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< realdds::dds_device_server > dds_device_server )
     : _rs_dev( dev )
     , _dds_device_server( dds_device_server )
-    , _control_dispatcher( QUEUE_MAX_SIZE )
+    , _control_dispatcher( QUEUE_MAX_SIZE, "lrs-device-control" )
 {
     if( ! _dds_device_server )
         throw std::runtime_error( "Empty dds_device_server" );

--- a/unit-tests/rsutils/concurrency/test-dispatcher.cpp
+++ b/unit-tests/rsutils/concurrency/test-dispatcher.cpp
@@ -22,7 +22,7 @@ int fibo( int num )
 
 TEST_CASE( "dispatcher main flow" )
 {
-    dispatcher d(3);
+    dispatcher d( 3, "test" );
     std::atomic_bool run = { false };
     auto func = [&](dispatcher::cancellable_timer c) 
     {
@@ -45,7 +45,7 @@ TEST_CASE( "dispatcher main flow" )
 
 TEST_CASE( "invoke and wait" )
 {
-    dispatcher d(2);
+    dispatcher d( 2, "test" );
 
     std::atomic_bool run = { false };
     auto func = [&](dispatcher::cancellable_timer c)
@@ -68,7 +68,7 @@ TEST_CASE( "invoke and wait is blocking by default" )
     std::atomic_bool queued_action_dropped{ false };
     std::atomic_bool invocation_started{ false };
     std::atomic_bool invoked_action_ran{ false };
-    dispatcher d( 1, [&]( dispatcher::action const & ) { queued_action_dropped = true; } );
+    dispatcher d( 1, "test", [&]( dispatcher::action const & ) { queued_action_dropped = true; } );
     d.start();
 
     d.invoke( [&]( dispatcher::cancellable_timer ) {
@@ -100,7 +100,7 @@ TEST_CASE( "invoke and wait is blocking by default" )
 
 TEST_CASE( "invoke and wait propagates action errors" )
 {
-    dispatcher d( 1 );
+    dispatcher d( 1, "test" );
     d.start();
 
 #if defined( _WIN32 )
@@ -128,7 +128,7 @@ TEST_CASE("verify stop() not consuming high CPU usage")
 
     for (int i = 0 ; i < 32; ++i)
     {
-        dispatchers.push_back(std::make_shared<dispatcher>(10));
+        dispatchers.push_back(std::make_shared<dispatcher>( 10, "test" ));
     }
 
     for (auto &&dispatcher : dispatchers)
@@ -160,7 +160,7 @@ TEST_CASE("stop() notify flush to finish")
 {
     // On this test we check that if during a flush() another thread call stop(),
     // than the flush CV will be triggered to exit and not wait a full timeout
-    dispatcher dispatcher( 10 );
+    dispatcher dispatcher( 10, "test" );
     dispatcher.start();
 
     stopwatch sw;
@@ -190,4 +190,9 @@ TEST_CASE("stop() notify flush to finish")
     //std::cout << "Flushing is done" << std::endl;
     CHECK( sw.get_elapsed() < timeout );
     stop_thread.join();
+}
+
+TEST_CASE( "dispatcher name" )
+{
+    CHECK( dispatcher( 10, "my-dispatcher" ).name() == "my-dispatcher" );
 }

--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -126,7 +126,7 @@ PYBIND11_MODULE(NAME, m) {
     class py_async_log_callback : public rs2_log_callback
     {
         py::function _fn;
-        dispatcher _dispatcher{ 4096 };  // bounded; oldest dropped on overflow
+        dispatcher _dispatcher{ 4096, "py-log-callback" };  // bounded; oldest dropped on overflow
 
     public:
         explicit py_async_log_callback( py::function fn )


### PR DESCRIPTION
**Overview:** Every dispatcher now carries a name and logs under it, so log lines say which
dispatcher they came from instead of showing a raw pointer.

Tracked on [RSDSO-21820]

## Why

The SDK runs ~25 dispatcher / active_object instances. They were indistinguishable in logs — the
only handle was `this`, and only on the exception path.

## Summary

- `dispatcher` takes a name as its **second, non-defaulted** parameter; `active_object` and
  `watchdog` forward one.
- Name and address are logged together. Most names have several live instances at once — a single
  D455 has three `notifications` dispatchers, one per sensor — so the name alone doesn't identify
  an instance.
- Added `created` and `started` at DEBUG. `start()` logs only the real state transition, since it
  can be called repeatedly.
- **The teardown path is deliberately silent.** A dispatcher can be destroyed during static
  destruction — e.g. by an app holding an `rs2::device` in a global — when the logger is already
  gone. `LIBRS_LOG_` calls `el::Loggers::getLogger()` *before* it tests the level, so a
  `LOG_DEBUG` in `~dispatcher()` or `stop()` segfaults there even with debug logging off. See the
  comment in `~dispatcher()`.
- Named all 25 construction sites. Where an instance discriminator was already in hand the name
  carries it: `winusb-ep-<n>`, `usbhost-ep-<n>`, `playback-<profile>`, `dds-control-<device>`,
  `dds-notify-<topic>`.

### Deviation from the ticket

RSDSO-21820 asks for the name to be optional/defaulted with no API break. This makes it
**mandatory**, so no dispatcher can ever be anonymous. The break is a loud compile error — a
`std::function` won't convert to `std::string`. `dispatcher` is not bound in pyrsutils and rsutils
installs no headers, so the blast radius is out-of-tree C++ built against the source tree. The
ticket AC is being updated to match.

Out of scope per the ticket: OS-level thread naming, thread-start callback.

## Test plan

- [x] Windows (VS2022): realsense2, realsense-viewer, pyrealsense2, realdds, rs-dds-adapter — clean
- [x] Linux (Ubuntu 24.04, gcc): full `make -j8` — clean; covers `backend-hid.cpp` and
      `udev-device-watcher.cpp`, which the Windows build never compiles
- [x] `test-rsutils-concurrency-dispatcher` and `test-rsutils-concurrency-scq` pass on both platforms
- [x] Log output verified against the built library: name + address on both catch paths, and
      repeated `start()` correctly emitting nothing
- [x] Static-linkage teardown verified: a global holding a dispatcher past `main()` exits 0
      (it segfaulted with the teardown logging in place)
- [x] Nightly CI 17745 green on all six platforms. Jetson JP5 213/213, including
      `pytest-fw-update` taking the same-version reflash path — the case that caught this
- [ ] `src/usbhost/device-usbhost.cpp` not compile-verified — Android NDK only

## Follow-up (not in this PR)

`rs-fw-update` holds `rs2::device` / `rs2::update_device` at file scope, so a device handle
outlives `main()` and is released during static destruction. That is fragile independently of this
change; this PR only stops it being fatal. Worth a separate ticket.

---
🤖 Generated by AI