### PR TITLE
rs-fw-update: return recovery result and fix reconnect wait match

### DIFF
--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -210,7 +210,7 @@ int update_recovery_device(rs2::context& ctx, rs2::cli::value<std::string>& file
     }
     try
     {
-        auto update_serial_number = recovery_device.get_info(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID);
+        std::string update_serial_number = recovery_device.get_info(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID);
         bool d457_recovery_device = rs2::fw_update::is_mipi_recovery_device(recovery_device);
         volatile bool recovery_device_found = false;
         ctx.set_devices_changed_callback([&](rs2::event_information& info) {
@@ -414,9 +414,7 @@ try
 
     // Recovery
     if (recover_arg.isSet())
-    {
-        update_recovery_device(ctx, file_arg);
-    }
+        return update_recovery_device(ctx, file_arg);
 
     // Update device
     ctx.set_devices_changed_callback([&](rs2::event_information& info)


### PR DESCRIPTION
Tracked by: RSDEV-12551

**Overview:** Fix two defects in `rs-fw-update -r` that together produced the reported "timeout then second flash": the recovery result was discarded so execution fell through into the runtime update loop, and the reconnect-wait callback was doing a pointer compare instead of a string compare and never matched.

## Why
Both regressions were introduced by commit `e9c2afd40` ("Mipi fixing fw update") when the inline Recovery branch was extracted into `update_recovery_device()`:

1. `main()` lost the `return`, so `update_recovery_device()`'s `EXIT_SUCCESS/EXIT_FAILURE` was ignored and `main()` fell through to the normal runtime-device update loop — producing a second flash of the same image.
2. `update_serial_number` used to be a `std::string` declared in `main()`. In the extracted function it was rewritten as `auto update_serial_number = recovery_device.get_info(...)`, deducing `const char*`. The devices-changed callback compares `recovery_sn == update_serial_number` — that became a pointer compare and never matched, so the recovery reconnect always timed out. In the pre-fix flow the timeout was masked because the fall-through re-queried the device immediately; with fix (1) alone, `-r` would still exit `EXIT_FAILURE` on a successful flash.

## Summary
- `tools/fw-update/rs-fw-update.cpp`:
  - `if (recover_arg.isSet()) return update_recovery_device(ctx, file_arg);` — stop fall-through.
  - `std::string update_serial_number = recovery_device.get_info(...);` — restore string comparison in the reconnect callback.

## Test plan
- [x] D415 (reproducer from RSDEV-12551 comments): `rs-fw-update -r -f <image>` — one recovery pass, `Recovery done`, exit success. No timeout, no second flash.
- [ ] D585: `rs-fw-update -r -f rvp-flash-dfu.img` — one recovery pass, exit success.
- [x] Recovery reconnect timeout still propagates as `EXIT_FAILURE` when the device genuinely fails to re-enumerate (yank cable before reconnect).
- [ ] D457 MIPI recovery: prints the MIPI recovery message and exits success (no runtime update pass).

---
🤖 Generated by AI