### PR TITLE
D457 MIPI: drop motion packets not addressed to the subscribed profile

### DIFF
--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -205,13 +205,29 @@ void uvc_sensor::open( const stream_profiles & requests )
                     if( msp )
                     {
                         expected_size = 64;  // 32; // D457 - WORKAROUND - SHOULD BE REMOVED AFTER CORRECTION IN DRIVER
-                        //Motion stream on uvc is used only for mipi. Stream frame number counts gyro and accel together.
-                        //We override it using 2 seperate counters.
-                        auto stream_type = ((uint8_t *)f.pixels)[0];
-                        if( stream_type == 1 ) // 1 == Accel
+                        // MIPI motion node interleaves accel/gyro packets on one V4L2 stream, tagged by
+                        // the first payload byte (matches the demux in motion_to_accel_gyro in
+                        // motion-transform.cpp). Drop packets not addressed to this profile - still
+                        // call continuation() on drop so the backend buffer is re-queued (VIDIOC_QBUF).
+                        constexpr uint8_t mipi_payload_accel = 1;
+                        constexpr uint8_t mipi_payload_gyro = 2;
+                        const auto stream_type = ((uint8_t *)f.pixels)[0];
+                        const auto requested_stream_type = req_profile_base->get_stream_type();
+                        if( stream_type == mipi_payload_accel )
+                        {
+                            if( requested_stream_type != RS2_STREAM_ACCEL ) { continuation(); return; }
                             fr->additional_data.frame_number = ++_accel_counter;
-                        else if( stream_type == 2 ) // 2 == Gyro
+                        }
+                        else if( stream_type == mipi_payload_gyro )
+                        {
+                            if( requested_stream_type != RS2_STREAM_GYRO ) { continuation(); return; }
                             fr->additional_data.frame_number = ++_gyro_counter;
+                        }
+                        else
+                        {
+                            continuation();
+                            return;
+                        }
                         frame_counter = fr->additional_data.frame_number;
                     }
 


### PR DESCRIPTION
Tracked by: RSDSO-20605

## Overview

On D457 MIPI, requesting Gyro at 50 Hz in the viewer yields a hardware FPS reading of 100 Hz. Root cause: on MIPI the IMU delivers accel and gyro packets interleaved on a single V4L2 node, tagged by the first payload byte. `uvc-sensor.cpp` used that byte only to pick which frame counter to advance (`_accel_counter` vs `_gyro_counter`) and then forwarded every packet to the subscribed motion profile regardless of packet type. A gyro-only subscription therefore received accel packets (~100 Hz) alongside gyro packets (~50 Hz) on the same output stream. Because accel packets are twice as frequent, the accel counter dominates the sequence downstream reads for hardware FPS, so the viewer displays 100 Hz.

Log evidence (7.36 s capture, gyro-only): 1041 `FrameAccepted,Gyro,...` lines split cleanly into two independent monotonic counter series — Series A at ~10 ms period reaching counter 699 (~95 Hz, accel packets forwarded as Gyro) and Series B at ~20 ms period reaching counter 342 (~46 Hz, the real gyro packets). Every Series B frame triggers `Frame counter reset` because its `_gyro_counter` value lags behind the last-seen `_accel_counter`. 699 + 342 = 1041, matches the total.

## Fix

`src/uvc-sensor.cpp` — check the in-band packet type byte against `req_profile_base->get_stream_type()` and return early when they don't match. Accel-only subscribers drop gyro packets; gyro-only subscribers drop accel packets. When both are subscribed each profile still keeps only its own packets — behavior is unchanged.

## Test plan

- [x] Build on Jetson (D457 MIPI, primary target).
- [ ] Viewer: subscribe Gyro only at 50 Hz; confirm hardware FPS reads 50 Hz and `Frame counter reset` no longer fires.
- [ ] Viewer: subscribe Accel only at 100 Hz; confirm hardware FPS reads 100 Hz and no `Frame counter reset`.
- [ ] Viewer: subscribe Accel + Gyro simultaneously; confirm each reads its requested rate.
- [ ] USB path (D400 HID): non-MIPI motion streaming unaffected (this code path is guarded by `motion_stream_profile` and only fires on the MIPI shared node).