### PR TITLE
Refactor matchers, also supporting multiple depth streams

### DIFF
--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -233,20 +233,17 @@ typedef enum rs2_matchers
    RS2_MATCHER_DI,      //compare depth and ir based on frame number
 
    RS2_MATCHER_DI_C,    //compare depth and ir based on frame number,
-                        //compare the pair of corresponding depth and ir with color based on closest timestamp,
+                        //compare the pair of corresponding depth and ir with color based on closest timestamp
 
    RS2_MATCHER_DLR_C,   //compare depth, left and right ir based on frame number,
-                        //compare the set of corresponding depth, left and right with color based on closest timestamp,
-                        //commonly used by RS415, RS435
+                        //compare the set of corresponding depth, left and right with color based on closest timestamp
 
-   RS2_MATCHER_DLR,     //compare depth, left and right ir based on frame number,
-                        //commonly used by RS400, RS405, RS410, RS420, RS430
+   RS2_MATCHER_DLR,     //compare depth, left and right ir based on frame number
 
-   RS2_MATCHER_DIC,     //compare depth, ir and confidence based on frame number used by RS500
+   RS2_MATCHER_DIC,     //compare depth, ir and confidence based on frame number
 
    RS2_MATCHER_DIC_C,    //compare depth, ir and confidence based on frame number,
                          //compare the set of corresponding depth, ir and confidence with color based on closest timestamp,
-                         //commonly used by RS515
 
    RS2_MATCHER_DEFAULT, //the default matcher compare all the streams based on closest timestamp
 

--- a/src/core/matcher-factory.cpp
+++ b/src/core/matcher-factory.cpp
@@ -6,172 +6,152 @@
 #include "stream-interface.h"
 
 #include <src/sync.h>
+#include <algorithm>
 #include <stdexcept>
 
 
 namespace librealsense {
 
 
+// A frame number only means something within the sensor that produced it. Depth and the IRs come off one
+// sensor and share a counter, so they can be matched exactly; color comes off another with a counter of its
+// own, and the only thing the two have in common is time. Every matcher here is therefore built the same way:
+//
+//     timestamp( frame_number( depth, ir1, ir2 ),      <- one sensor, matched exactly
+//                frame_number( color, ... ) )          <- another sensor, matched exactly
+//                                                         the two related only by time
+//
+// rs2_matchers names which streams a device emits together, since a stream_interface does not say which
+// sensor produced it. Perception streams are not produced per depth frame at all and are never matched.
+
+
+// The profiles named by 'group'. Returns none unless every selector found a stream: a group is a set that
+// must be complete, not a filter - two streams of three have no common frame to match on.
+std::vector< stream_interface * > matcher_factory::select_group( std::vector< match_group > const & group,
+                                                                 std::vector< stream_interface * > const & profiles )
+{
+    std::vector< stream_interface * > selected;
+    for( auto & selector : group )
+    {
+        auto const before = selected.size();
+        for( auto & profile : profiles )
+            if( profile->get_stream_type() == selector.stream
+                && ( selector.index < 0 || profile->get_stream_index() == selector.index ) )
+                selected.push_back( profile );
+
+        if( selected.size() == before )
+            return {};
+    }
+
+    return selected;
+}
+
+
+// Relates the given profiles to one another: one matcher per stream, composed by frame number, by timestamp,
+// or - for streams that are matched to nothing - not at all, each passing through on its own.
+std::shared_ptr< matcher > matcher_factory::relate( std::vector< stream_interface * > const & profiles, sync_by sync )
+{
+    std::vector< std::shared_ptr< matcher > > matchers;
+    for( auto & p : profiles )
+        matchers.push_back( create_identity_matcher( p ) );
+
+    switch( sync )
+    {
+    case sync_by::frame_number:
+        return create_frame_number_composite_matcher( matchers );
+    case sync_by::timestamp:
+        return create_timestamp_composite_matcher( matchers );
+    default:
+        return create_composite_identity_matcher( matchers );
+    }
+}
+
+
+// One sensor's streams, related to each other. An incomplete group leaves nothing to match on, so every
+// stream falls back to being related by timestamp.
+std::shared_ptr< matcher > matcher_factory::match_sensor_profiles( std::vector< match_group > const & group,
+                                                                   sync_by sync,
+                                                                   std::vector< stream_interface * > const & profiles )
+{
+    auto const selected = select_group( group, profiles );
+    if( selected.empty() )
+    {
+        LOG_DEBUG( "Created default matcher" );
+        return relate( profiles, sync_by::timestamp );
+    }
+
+    return relate( selected, sync );
+}
+
+
+// Two sensors: the group, and color. Each is related within itself, and the two to each other by timestamp.
+// Without color there is no second sensor, so everything falls back to being related by timestamp.
+std::shared_ptr< matcher >
+matcher_factory::match_sensor_profiles_with_color( std::vector< match_group > const & group,
+                                                   sync_by sync,
+                                                   std::vector< stream_interface * > const & profiles )
+{
+    // A stream belongs to one matcher only
+    std::vector< stream_interface * > rest;
+    auto const color = separate_color( profiles, rest );
+    if( color.empty() )
+    {
+        LOG_DEBUG( "Created default matcher" );
+        return relate( profiles, sync_by::timestamp );
+    }
+
+    return create_timestamp_composite_matcher( { match_sensor_profiles( group, sync, rest ),
+                                                 relate( color, sync_by::frame_number ) } );
+}
+
+
 std::shared_ptr< matcher > matcher_factory::create( rs2_matchers matcher,
                                                     std::vector< stream_interface * > const & profiles )
 {
+    // Depth is selected without an index: a device may expose more than one depth stream - raw next to
+    // device-aligned - and they are produced from the same frame, so they carry its frame number.
+    static const std::vector< match_group > di = { { RS2_STREAM_DEPTH, -1 }, { RS2_STREAM_INFRARED, 1 } };
+    static const std::vector< match_group > dlr = { { RS2_STREAM_DEPTH, -1 },
+                                                    { RS2_STREAM_INFRARED, 1 },
+                                                    { RS2_STREAM_INFRARED, 2 } };
+    static const std::vector< match_group > dic = { { RS2_STREAM_DEPTH, -1 },
+                                                    { RS2_STREAM_INFRARED, -1 },
+                                                    { RS2_STREAM_CONFIDENCE, -1 } };
+
     switch( matcher )
     {
-    case RS2_MATCHER_DI:
-        return create_DI_matcher( profiles );
-    case RS2_MATCHER_DI_C:
-        return create_DI_C_matcher( profiles );
-    case RS2_MATCHER_DLR_C:
-        return create_DLR_C_matcher( profiles );
-    case RS2_MATCHER_DLR:
-        return create_DLR_matcher( profiles );
-    case RS2_MATCHER_DIC:
-        return create_DIC_matcher( profiles );
-    case RS2_MATCHER_DIC_C:
-        return create_DIC_C_matcher( profiles );
+        case RS2_MATCHER_DI:    return match_sensor_profiles( di, sync_by::frame_number, profiles );
+        case RS2_MATCHER_DLR:   return match_sensor_profiles( dlr, sync_by::frame_number, profiles );
+        // Confidence does not share the depth frame counter, so this group is related by timestamp
+        case RS2_MATCHER_DIC:   return match_sensor_profiles( dic, sync_by::timestamp, profiles );
 
-    case RS2_MATCHER_DEFAULT:
-    default:
-        return create_timestamp_matcher( profiles );
+        case RS2_MATCHER_DI_C:  return match_sensor_profiles_with_color( di, sync_by::frame_number, profiles );
+        case RS2_MATCHER_DIC_C: return match_sensor_profiles_with_color( dic, sync_by::timestamp, profiles );
+
+        case RS2_MATCHER_DLR_C:
+        {
+            std::vector< stream_interface * > rest;
+            auto const perception = separate_perception( profiles, rest );
+            auto const matched = match_sensor_profiles_with_color( dlr, sync_by::frame_number, rest );
+            if( perception.empty() )
+                return matched;
+
+            return create_composite_identity_matcher( { matched, relate( perception, sync_by::nothing ) } );
+        }
+
+        case RS2_MATCHER_DEFAULT:
+        default:
+        {
+            // No group at all: whatever is streaming, related by timestamp
+            std::vector< stream_interface * > rest;
+            auto const perception = separate_perception( profiles, rest );
+            auto const matched = relate( rest, sync_by::timestamp );
+            if( perception.empty() )
+                return matched;
+
+            return create_composite_identity_matcher( { matched, relate( perception, sync_by::nothing ) } );
+        }
     }
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DLR_C_matcher( std::vector< stream_interface * > const & profiles )
-{
-    auto infer = get_perception_profiles( profiles );
-
-    std::vector< stream_interface * > synchronized_profiles;
-    synchronized_profiles.reserve( profiles.size() );
-    for( auto & profile : profiles )
-    {
-        if( profile->get_stream_type() != RS2_STREAM_OBJECT_DETECTION )
-            synchronized_profiles.push_back( profile );
-    }
-
-    auto color = get_color_profiles( synchronized_profiles );
-    if( color.empty() )
-    {
-        LOG_DEBUG( "Created default matcher" );
-        auto sync_matcher = create_timestamp_matcher( synchronized_profiles );
-        if( infer.empty() )
-            return sync_matcher;
-
-        std::vector< std::shared_ptr< matcher > > matchers;
-        if( ! synchronized_profiles.empty() )
-            matchers.push_back( sync_matcher );
-        for( auto & profile : infer )
-            matchers.push_back( create_identity_matcher( profile ) );
-
-        return std::make_shared< composite_identity_matcher >( matchers );
-    }
-
-    auto sync_matcher = create_timestamp_composite_matcher(
-        { create_DLR_matcher( synchronized_profiles ), create_color_composite_matcher( color ) } );
-    if( infer.empty() )
-        return sync_matcher;
-
-    std::vector< std::shared_ptr< matcher > > matchers = { sync_matcher };
-    for( auto & profile : infer )
-        matchers.push_back( create_identity_matcher( profile ) );
-
-    return std::make_shared< composite_identity_matcher >( matchers );
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DI_C_matcher( std::vector< stream_interface * > const & profiles )
-{
-    auto color = get_color_profiles( profiles );
-    if( color.empty() )
-    {
-        LOG_DEBUG( "Created default matcher" );
-        return create_timestamp_matcher( profiles );
-    }
-
-    return create_timestamp_composite_matcher( { create_DI_matcher( profiles ), create_color_composite_matcher( color ) } );
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DLR_matcher( std::vector< stream_interface * > const & profiles )
-{
-    auto depth = find_profile( RS2_STREAM_DEPTH, 0, profiles );
-    auto left = find_profile( RS2_STREAM_INFRARED, 1, profiles );
-    auto right = find_profile( RS2_STREAM_INFRARED, 2, profiles );
-
-    if( ! depth || ! left || ! right )
-    {
-        LOG_DEBUG( "Created default matcher" );
-        return create_timestamp_matcher( profiles );
-    }
-    return create_frame_number_matcher( { depth, left, right } );
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DI_matcher( std::vector< stream_interface * > const & profiles )
-{
-    auto depth = find_profile( RS2_STREAM_DEPTH, 0, profiles );
-    auto ir = find_profile( RS2_STREAM_INFRARED, 1, profiles );
-
-    if( ! depth || ! ir )
-    {
-        LOG_DEBUG( "Created default matcher" );
-        return create_timestamp_matcher( profiles );
-    }
-    return create_frame_number_matcher( { depth, ir } );
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DIC_matcher( std::vector< stream_interface * > const & profiles )
-{
-    std::vector< std::shared_ptr< matcher > > matchers;
-    if( auto depth = find_profile( RS2_STREAM_DEPTH, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( depth ) );
-    if( auto ir = find_profile( RS2_STREAM_INFRARED, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( ir ) );
-    if( auto confidence = find_profile( RS2_STREAM_CONFIDENCE, -1, profiles ) )
-        matchers.push_back( create_identity_matcher( confidence ) );
-
-    if( matchers.empty() )
-    {
-        LOG_ERROR( "no depth, ir, or confidence streams found for matcher" );
-        for( auto && p : profiles )
-            LOG_DEBUG( p->get_stream_type() << '/' << p->get_unique_id() );
-        throw std::runtime_error( "no depth, ir, or confidence streams found for matcher" );
-    }
-
-    return create_timestamp_composite_matcher( matchers );
-}
-
-
-std::shared_ptr< matcher > matcher_factory::create_DIC_C_matcher( std::vector< stream_interface * > const & profiles )
-{
-    auto color = get_color_profiles( profiles );
-    if( color.empty() )
-        throw std::runtime_error( "no color stream found for matcher" );
-
-    return create_timestamp_composite_matcher( { create_DIC_matcher( profiles ), create_color_composite_matcher( color ) } );
-}
-
-
-std::shared_ptr< matcher >
-matcher_factory::create_frame_number_matcher( std::vector< stream_interface * > const & profiles )
-{
-    std::vector< std::shared_ptr< matcher > > matchers;
-    for( auto & p : profiles )
-        matchers.push_back( std::make_shared< identity_matcher >( p->get_unique_id(), p->get_stream_type() ) );
-
-    return create_frame_number_composite_matcher( matchers );
-}
-
-
-std::shared_ptr< matcher >
-matcher_factory::create_timestamp_matcher( std::vector< stream_interface * > const & profiles )
-{
-    std::vector< std::shared_ptr< matcher > > matchers;
-    for( auto & p : profiles )
-        matchers.push_back( std::make_shared< identity_matcher >( p->get_unique_id(), p->get_stream_type() ) );
-
-    return create_timestamp_composite_matcher( matchers );
 }
 
 
@@ -179,6 +159,14 @@ std::shared_ptr< matcher > matcher_factory::create_identity_matcher( stream_inte
 {
     return std::make_shared< identity_matcher >( profile->get_unique_id(), profile->get_stream_type() );
 }
+
+
+std::shared_ptr< matcher >
+matcher_factory::create_composite_identity_matcher( std::vector< std::shared_ptr< matcher > > const & matchers )
+{
+    return std::make_shared< composite_identity_matcher >( matchers );
+}
+
 
 std::shared_ptr< matcher >
 matcher_factory::create_frame_number_composite_matcher( std::vector< std::shared_ptr< matcher > > const & matchers )
@@ -194,8 +182,8 @@ matcher_factory::create_timestamp_composite_matcher( std::vector< std::shared_pt
 }
 
 
-std::vector< stream_interface * >
-matcher_factory::get_color_profiles( std::vector< stream_interface * > const & profiles )
+std::vector< stream_interface * > matcher_factory::separate_color( std::vector< stream_interface * > const & profiles,
+                                                                   std::vector< stream_interface * > & rest )
 {
     // We need one profile per stream - matcher use only UID and type
     std::map< int, stream_interface * > color_profiles;
@@ -203,35 +191,30 @@ matcher_factory::get_color_profiles( std::vector< stream_interface * > const & p
         if( profile->get_stream_type() == RS2_STREAM_COLOR )
             color_profiles[profile->get_stream_index()] = profile;
 
-    std::vector< stream_interface * > ret;
+    std::vector< stream_interface * > color;
     for( auto & profile : color_profiles )
-        ret.push_back( profile.second );
+        color.push_back( profile.second );
 
-    return ret;
+    for( auto & profile : profiles )
+        if( std::find( color.begin(), color.end(), profile ) == color.end() )
+            rest.push_back( profile );
+
+    return color;
 }
 
 
 std::vector< stream_interface * >
-matcher_factory::get_perception_profiles( std::vector< stream_interface * > const & profiles )
+matcher_factory::separate_perception( std::vector< stream_interface * > const & profiles,
+                                      std::vector< stream_interface * > & rest )
 {
-    std::vector< stream_interface * > ret;
+    std::vector< stream_interface * > perception;
     for( auto & profile : profiles )
-        if( profile->get_stream_type() == RS2_STREAM_OBJECT_DETECTION)
-            ret.push_back( profile );
+        if( profile->get_stream_type() == RS2_STREAM_OBJECT_DETECTION )
+            perception.push_back( profile );
+        else
+            rest.push_back( profile );
 
-    return ret;
-}
-
-
-std::shared_ptr< matcher >
-matcher_factory::create_color_composite_matcher( std::vector< stream_interface * > const & profiles )
-{
-    std::vector< std::shared_ptr< matcher > > color_matchers;
-    for( auto & profile : profiles )
-        color_matchers.push_back( std::make_shared< identity_matcher >( profile->get_unique_id(),
-                                                                        profile->get_stream_type() ) );
-
-    return create_frame_number_composite_matcher( color_matchers );
+    return perception;
 }
 
 

--- a/src/core/matcher-factory.cpp
+++ b/src/core/matcher-factory.cpp
@@ -6,7 +6,6 @@
 #include "stream-interface.h"
 
 #include <src/sync.h>
-#include <algorithm>
 #include <stdexcept>
 
 
@@ -185,27 +184,19 @@ matcher_factory::create_timestamp_composite_matcher( std::vector< std::shared_pt
 std::vector< stream_interface * > matcher_factory::separate_color( std::vector< stream_interface * > const & profiles,
                                                                    std::vector< stream_interface * > & rest )
 {
-    // We need one profile per stream - matcher use only UID and type
-    std::map< int, stream_interface * > color_profiles;
+    std::vector< stream_interface * > color;
     for( auto & profile : profiles )
         if( profile->get_stream_type() == RS2_STREAM_COLOR )
-            color_profiles[profile->get_stream_index()] = profile;
-
-    std::vector< stream_interface * > color;
-    for( auto & profile : color_profiles )
-        color.push_back( profile.second );
-
-    for( auto & profile : profiles )
-        if( std::find( color.begin(), color.end(), profile ) == color.end() )
+            color.push_back( profile );
+        else
             rest.push_back( profile );
 
     return color;
 }
 
 
-std::vector< stream_interface * >
-matcher_factory::separate_perception( std::vector< stream_interface * > const & profiles,
-                                      std::vector< stream_interface * > & rest )
+std::vector< stream_interface * > matcher_factory::separate_perception( std::vector< stream_interface * > const & profiles,
+                                                                        std::vector< stream_interface * > & rest )
 {
     std::vector< stream_interface * > perception;
     for( auto & profile : profiles )

--- a/src/core/matcher-factory.h
+++ b/src/core/matcher-factory.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <librealsense2/h/rs_types.h>
+#include <librealsense2/h/rs_sensor.h>
 
 #include <vector>
 #include <memory>
@@ -16,6 +17,10 @@ class stream_interface;
 class matcher;
 
 
+// Builds the matcher a syncer uses to group frames from different streams into a frameset.
+//
+// Frames of streams produced within one sensor usually carry a common frame number and are matched exactly.
+// Frames from different sensors share only a timestamp. Matching by timestamp is also the RS2_MATCHER_DEFAULT behaviour.
 class matcher_factory
 {
 public:
@@ -23,25 +28,43 @@ public:
                                               std::vector< stream_interface * > const & profiles );
 
 private:
-    static std::shared_ptr< matcher > create_DLR_C_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_DLR_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_DI_C_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_DI_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_DIC_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_DIC_C_matcher( std::vector< stream_interface * > const & profiles );
+    // A stream taking part in a matcher's group; a negative index means every stream of that type
+    struct match_group
+    {
+        rs2_stream stream;
+        int index;
+    };
 
+    // How frames are related: by the exact frame number, by the time they were taken, or not at all -
+    // for streams that are never matched to anything and simply pass through
+    enum class sync_by
+    {
+        frame_number,
+        timestamp,
+        nothing
+    };
+
+    static std::vector< stream_interface * > select_group( std::vector< match_group > const & group,
+                                                           std::vector< stream_interface * > const & profiles );
+    static std::shared_ptr< matcher > relate( std::vector< stream_interface * > const & profiles, sync_by );
+    static std::shared_ptr< matcher > match_sensor_profiles( std::vector< match_group > const & group,
+                                                      sync_by,
+                                                      std::vector< stream_interface * > const & profiles );
+    static std::shared_ptr< matcher > match_sensor_profiles_with_color( std::vector< match_group > const & group,
+                                                                 sync_by,
+                                                                 std::vector< stream_interface * > const & profiles );
     static std::shared_ptr< matcher > create_identity_matcher( stream_interface * profiles );
-    static std::shared_ptr< matcher > create_frame_number_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher > create_timestamp_matcher( std::vector< stream_interface * > const & profiles );
-
-    static std::vector< stream_interface * > get_color_profiles( std::vector< stream_interface * > const & profiles );
-    static std::vector< stream_interface * > get_perception_profiles( std::vector< stream_interface * > const & profiles );
     static std::shared_ptr< matcher >
-        create_color_composite_matcher( std::vector< stream_interface * > const & profiles );
-    static std::shared_ptr< matcher >
-        create_timestamp_composite_matcher( std::vector< std::shared_ptr< matcher > > const & matchers );
+        create_composite_identity_matcher( std::vector< std::shared_ptr< matcher > > const & matchers );
     static std::shared_ptr< matcher >
         create_frame_number_composite_matcher( std::vector< std::shared_ptr< matcher > > const & matchers );
+    static std::shared_ptr< matcher >
+        create_timestamp_composite_matcher( std::vector< std::shared_ptr< matcher > > const & matchers );
+    // Take the streams of one kind out of 'profiles', leaving every other stream in 'rest'
+    static std::vector< stream_interface * > separate_color( std::vector< stream_interface * > const & profiles,
+                                                             std::vector< stream_interface * > & rest );
+    static std::vector< stream_interface * > separate_perception( std::vector< stream_interface * > const & profiles,
+                                                                  std::vector< stream_interface * > & rest );
 };
 
 

--- a/unit-tests/syncer/pytest-matcher-groups.py
+++ b/unit-tests/syncer/pytest-matcher-groups.py
@@ -1,0 +1,239 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Frame-number matchers group a fixed set of streams: depth with one or two IRs, and optionally
+# confidence. A software device lets us drive them with known frame numbers and no hardware.
+
+import logging
+import pyrealsense2 as rs
+
+log = logging.getLogger(__name__)
+
+W = 640
+H = 480
+BPP = 2
+FPS = 60
+DOMAIN = rs.timestamp_domain.hardware_clock
+
+PIXELS = bytearray(b'\x00' * (W * H * BPP))
+
+
+def video_stream(uid, stream, index, fmt=rs.format.z16):
+    s = rs.video_stream()
+    s.type = stream
+    s.index = index
+    s.uid = uid
+    s.width = W
+    s.height = H
+    s.fps = FPS
+    s.bpp = BPP
+    s.fmt = fmt
+    return s
+
+
+class sw_device:
+    """A software device whose streams are driven frame by frame through a syncer."""
+
+    def __init__(self, streams, matcher):
+        self.device = rs.software_device()
+        self.device.create_matcher(matcher)
+        self.sensor = self.device.add_sensor("sensor")
+        for uid, (stream, index, fmt) in enumerate(streams):
+            self.sensor.add_video_stream(video_stream(uid, stream, index, fmt))
+        self.profiles = self.sensor.get_stream_profiles()
+        self.syncer = rs.syncer(100)
+        self.sensor.open(self.profiles)
+        self.sensor.start(self.syncer)
+
+    def close(self):
+        self.sensor.stop()
+        self.sensor.close()
+
+    def push(self, frame_number, timestamp):
+        """One frame on every stream, all sharing a frame number, as a device produces them."""
+        for profile in self.profiles:
+            frame = rs.software_video_frame()
+            frame.pixels = PIXELS
+            frame.stride = W * BPP
+            frame.bpp = BPP
+            frame.timestamp = timestamp
+            frame.domain = DOMAIN
+            frame.frame_number = frame_number
+            frame.profile = profile.as_video_stream_profile()
+            self.sensor.on_video_frame(frame)
+
+    def collect(self, pushes=6):
+        """Push a few sets of frames and return the largest frameset the syncer produced."""
+        best = []
+        for n in range(pushes):
+            self.push(frame_number=n, timestamp=n * (1000 / FPS))
+            while True:
+                frames = self.syncer.poll_for_frames()
+                if not frames:
+                    break
+                got = sorted((str(f.profile.stream_type()), f.profile.stream_index()) for f in frames)
+                log.debug("frameset: %s", got)
+                if len(got) > len(best):
+                    best = got
+        return best
+
+
+DEPTH0 = (rs.stream.depth, 0, rs.format.z16)
+DEPTH1 = (rs.stream.depth, 1, rs.format.z16)
+IR1 = (rs.stream.infrared, 1, rs.format.y8)
+IR2 = (rs.stream.infrared, 2, rs.format.y8)
+COLOR = (rs.stream.color, 0, rs.format.rgb8)
+CONFIDENCE = (rs.stream.confidence, 0, rs.format.raw8)
+DETECTION = (rs.stream.object_detection, 0, rs.format.y8)
+
+
+def expected(*streams):
+    return sorted((str(s[0]), s[1]) for s in streams)
+
+
+#############################################################################################
+def test_dlr_matches_depth_and_both_irs():
+    """The established DLR grouping still matches all three streams together."""
+    dev = sw_device([DEPTH0, IR1, IR2], rs.matchers.dlr)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, IR2)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_dlr_matches_two_depth_streams():
+    """A device may expose raw and device-aligned depth; both share the source frame number and so
+    belong in the same group. Selecting only depth index 0 would leave the second one unmatched."""
+    dev = sw_device([DEPTH0, DEPTH1, IR1, IR2], rs.matchers.dlr)
+    try:
+        assert dev.collect() == expected(DEPTH0, DEPTH1, IR1, IR2)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_dlr_c_matches_two_depth_streams_with_color():
+    """With color present the group is frame-number matched and then timestamp matched to color -
+    the path a DDS device takes."""
+    dev = sw_device([DEPTH0, DEPTH1, IR1, IR2, COLOR], rs.matchers.dlr_c)
+    try:
+        assert dev.collect() == expected(DEPTH0, DEPTH1, IR1, IR2, COLOR)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_di_matches_two_depth_streams():
+    """DI groups depth with a single IR, and must not drop a second depth stream either."""
+    dev = sw_device([DEPTH0, DEPTH1, IR1], rs.matchers.di)
+    try:
+        assert dev.collect() == expected(DEPTH0, DEPTH1, IR1)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_incomplete_group_falls_back_to_timestamp():
+    """DLR needs both IRs. Without IR2 the group cannot be frame-number matched, so every stream is
+    matched by timestamp instead - which still yields a full frameset."""
+    dev = sw_device([DEPTH0, IR1], rs.matchers.dlr)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_timestamp_matcher_takes_every_stream():
+    """The default matcher groups nothing - it matches whatever is streaming by timestamp, so extra
+    depth streams need no special handling there."""
+    dev = sw_device([DEPTH0, DEPTH1, IR1, IR2, COLOR], rs.matchers.default)
+    try:
+        assert dev.collect() == expected(DEPTH0, DEPTH1, IR1, IR2, COLOR)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_dic_matches_depth_ir_and_confidence():
+    """DIC is timestamp matched, not frame-number matched, whatever rs2_matchers says."""
+    dev = sw_device([DEPTH0, IR1, CONFIDENCE], rs.matchers.dic)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, CONFIDENCE)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_di_c_matches_group_against_color():
+    """A grouped matcher and color, composed by timestamp."""
+    dev = sw_device([DEPTH0, DEPTH1, IR1, COLOR], rs.matchers.di_c)
+    try:
+        assert dev.collect() == expected(DEPTH0, DEPTH1, IR1, COLOR)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_group_matcher_carries_streams_outside_its_group():
+    """Streams the group does not name - here motion-less extras like a second color - must still
+    reach the caller rather than being dropped for having no matcher."""
+    color1 = (rs.stream.color, 1, rs.format.rgb8)
+    dev = sw_device([DEPTH0, IR1, IR2, COLOR, color1], rs.matchers.dlr_c)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, IR2, COLOR, color1)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_incomplete_group_with_color_does_not_double_claim_color():
+    """When the group cannot be matched it falls back to relating everything it was given. Color is
+    matched separately, so it must not be handed to the group as well or it lands in two matchers."""
+    dev = sw_device([DEPTH0, IR1, COLOR], rs.matchers.dlr_c)   # dlr needs IR2, so the group is incomplete
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, COLOR)
+    finally:
+        dev.close()
+
+
+def all_streams_seen(dev, pushes=6):
+    """Every (stream, index) the syncer delivered, and the largest frameset it grouped."""
+    seen, best = set(), []
+    for n in range(pushes):
+        dev.push(frame_number=n, timestamp=n * (1000 / FPS))
+        while True:
+            frames = dev.syncer.poll_for_frames()
+            if not frames:
+                break
+            got = sorted((str(f.profile.stream_type()), f.profile.stream_index()) for f in frames)
+            seen.update(got)
+            if len(got) > len(best):
+                best = got
+    return seen, best
+
+
+#############################################################################################
+def test_perception_is_carried_by_the_default_matcher():
+    """Perception frames are not produced per depth frame, so the default matcher must carry them
+    alongside rather than timestamp match them into the frameset."""
+    dev = sw_device([DEPTH0, COLOR, DETECTION], rs.matchers.default)
+    try:
+        seen, best = all_streams_seen(dev)
+        assert seen == set(expected(DEPTH0, COLOR, DETECTION)), "a stream was dropped"
+        assert best == expected(DEPTH0, COLOR), "perception was matched into the frameset"
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_perception_is_carried_by_dlr_c():
+    """Same for DLR_C, which is where perception streams reach the syncer over DDS."""
+    dev = sw_device([DEPTH0, IR1, IR2, COLOR, DETECTION], rs.matchers.dlr_c)
+    try:
+        seen, best = all_streams_seen(dev)
+        assert seen == set(expected(DEPTH0, IR1, IR2, COLOR, DETECTION)), "a stream was dropped"
+        assert best == expected(DEPTH0, IR1, IR2, COLOR), "perception was matched into the frameset"
+    finally:
+        dev.close()

--- a/unit-tests/syncer/pytest-matcher-groups.py
+++ b/unit-tests/syncer/pytest-matcher-groups.py
@@ -237,3 +237,26 @@ def test_perception_is_carried_by_dlr_c():
         assert best == expected(DEPTH0, IR1, IR2, COLOR), "perception was matched into the frameset"
     finally:
         dev.close()
+
+
+#############################################################################################
+def test_dic_matches_every_infrared_stream():
+    """DIC names infrared without an index, so both IRs join the group. The old code took only the
+    first, leaving the second with no matcher at all."""
+    dev = sw_device([DEPTH0, IR1, IR2, CONFIDENCE], rs.matchers.dic)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, IR2, CONFIDENCE)
+    finally:
+        dev.close()
+
+
+#############################################################################################
+def test_two_color_streams_are_matched_together():
+    """Color streams are told apart by index, so both reach the color matcher and neither leaks into
+    the group - the case the de-duplicating map used to guard."""
+    color1 = (rs.stream.color, 1, rs.format.rgb8)
+    dev = sw_device([DEPTH0, IR1, IR2, COLOR, color1], rs.matchers.dlr_c)
+    try:
+        assert dev.collect() == expected(DEPTH0, IR1, IR2, COLOR, color1)
+    finally:
+        dev.close()


### PR DESCRIPTION
**Overview:** The six frame matchers were near-copies of each other, and none coped with a device
exposing more than one depth stream - that case crashed. This merges them into one implementation
driven by a small table.

Tracked on [RSDEV-9405]

## Why
Devices can now expose two depth streams (raw alongside device-aligned). Every frame-number matcher
hard-coded depth index 0, so the second stream got no matcher at all; under DLR the syncer then
recursed until the stack overflowed. Fixing that in place would have meant the same edit in three
functions, since DI, DLR and DIC each carried their own copy of the selection-and-fallback logic.

## Summary
- Merged the six `create_*_matcher` factories into a group table plus `relate`, `match_sensor_profiles`
  and `match_sensor_profiles_with_color`.
- Depth is selected without an index, so every depth stream joins the group.
- `RS2_MATCHER_DEFAULT` now carries object-detection streams instead of timestamp-matching them into
  the frameset. Reachable on D500 over USB.
- A stream can no longer be claimed by two matchers - colour and perception are separated out before
  the rest is matched.
- Removed stale device references from the `rs2_matchers` comments. No enum values changed.

Deliberately unchanged: DIC stays timestamp-matched (its comment claimed frame number, the code never
did), and the `*_C` matchers still fall back to plain timestamp matching when no colour is streaming.

## Test plan
- [ ] `unit-tests/syncer/pytest-matcher-groups.py` - 12 new software-device tests: each matcher, two
      depth streams, incomplete groups, perception carriage. 17/17 including the existing syncer tests.
- [ ] Confirmed the new tests fail on the pre-refactor code: the two-depth-stream case crashes with a
      stack overflow, and DEFAULT matches perception into the frameset.
- [ ] D435I over USB: 168 complete depth/IR1/IR2/colour framesets, zero unmatched-frame errors.

---
🤖 Generated by AI