### PR TITLE
D401 GMSL dual-RGB: support the SBGGR10P (pBAA) raw color format

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -28,7 +28,8 @@ namespace librealsense
          {rs_fourcc('M','J','P','G'), RS2_FORMAT_MJPEG},
          {rs_fourcc('R','W','1','6'), RS2_FORMAT_RAW16},
          {rs_fourcc('B','Y','R','2'), RS2_FORMAT_RAW16},
-         {rs_fourcc('B','A','8','1'), RS2_FORMAT_RAW8}    // D401 GMSL dual-RGB: SBGGR8 (driver PR #459), RAW10 in disguise
+         {rs_fourcc('B','A','8','1'), RS2_FORMAT_RAW8},   // D401 GMSL dual-RGB: SBGGR8 (older MIPI driver)
+         {rs_fourcc('p','B','A','A'), RS2_FORMAT_RAW10}   // D401 GMSL dual-RGB: SBGGR10P (MIPI driver 1.0.6.10+)
     };
     std::map<rs_fourcc::value_type, rs2_stream> d400_color_fourcc_to_rs2_stream = {
         {rs_fourcc('Y','U','Y','2'), RS2_STREAM_COLOR},
@@ -37,7 +38,8 @@ namespace librealsense
         {rs_fourcc('R','W','1','6'), RS2_STREAM_COLOR},
         {rs_fourcc('B','Y','R','2'), RS2_STREAM_COLOR},
         {rs_fourcc('M','J','P','G'), RS2_STREAM_COLOR},
-        {rs_fourcc('B','A','8','1'), RS2_STREAM_COLOR}   // D401 GMSL dual-RGB: SBGGR8 (driver PR #459)
+        {rs_fourcc('B','A','8','1'), RS2_STREAM_COLOR},  // D401 GMSL dual-RGB: SBGGR8 (older MIPI driver)
+        {rs_fourcc('p','B','A','A'), RS2_STREAM_COLOR}   // D401 GMSL dual-RGB: SBGGR10P (MIPI driver 1.0.6.10+)
     };
 
     d400_color::d400_color( std::shared_ptr< const d400_info > const & dev_info )
@@ -381,18 +383,14 @@ namespace librealsense
             }
         }
 
-        // D401 GMSL raw dual-RGB: register the RAW8->RGB8 debayer AFTER the ISP blocks above so ISP wins
-        // ties. formats_converter::find_pbf_matching_most_profiles picks the block satisfying the most
-        // REQUESTED targets; find_satisfied_requests counts only requested profiles, so the raw block's
-        // extra Color 1 output is NOT counted when Color 1 is not requested. A lone Color 0 RGB8 is thus a
-        // tie (both blocks satisfy 1, equal source size) and the first-registered block - ISP - wins, so it
-        // stays ISP and coexists with IR. Requesting Color 1 too makes only the raw block satisfy both
-        // (count 2), so raw wins for both imagers (which excludes IR). Verified on HW: Color 0 RGB8 + IR
-        // stream together. Per-pin routing is set in d400_device::init().
+        // D401 GMSL raw dual-RGB: register the raw->RGB8 debayer AFTER the ISP blocks so ISP wins the tie
+        // for a lone Color 0 RGB8 (registration order breaks ties in find_pbf_matching_most_profiles); raw
+        // wins only when Color 1 is also requested. Per-pin routing is set in d400_device::init().
         if( _is_mipi_device && _pid == ds::RS401_GMSL_PID && _fw_version >= firmware_version( "5.17.4.13" ) )
         {
-            // Native color is 1288x808 (after cropping 1612 transport padding); other resolutions are
-            // center-crop + bilinear scale. resolution_transform is a captureless fn ptr, one per output.
+            // Native color 1288x808; raw payload is packed MIPI RAW10 (SBGGR10P/pBAA on 1.0.6.10+, or the
+            // older BA81 padded to 1612). The converter recovers the true stride from the frame size, so
+            // both are handled. Other resolutions are center-crop + scale (one captureless xf per output).
             static const int NATIVE_W = 1288;
             struct color_res { int w, h; void ( *xf )( uint32_t &, uint32_t & ); };
             static const color_res color_resolutions[] = {
@@ -403,20 +401,27 @@ namespace librealsense
                 {  480, 270, []( uint32_t & w, uint32_t & h ) { w =  480; h = 270; } },
                 {  424, 240, []( uint32_t & w, uint32_t & h ) { w =  424; h = 240; } },
             };
+            // One SINGLE-source block per (resolution, format): a multi-format source list trips the
+            // formats-converter many-to-one guard and drops the RGB8 targets. BA81->RAW8, pBAA->RAW10;
+            // only the format the driver advertises has matching raw pins.
+            static const rs2_format raw_src_formats[] = { RS2_FORMAT_RAW8, RS2_FORMAT_RAW10 };
             for( auto & r : color_resolutions )
             {
                 const int rw = r.w, rh = r.h;
-                color_ep.register_processing_block(
-                    { { RS2_FORMAT_RAW8, RS2_STREAM_COLOR } },
-                    { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 0, 0, 0, 0, r.xf },
-                      { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 1, 0, 0, 0, r.xf } },
-                    [rw, rh]() {
-                        rggb::isp_params isp;
-                        isp.swap_rb = true;   // OV9782 is BGGR (driver declares SBGGR8); base demosaic is
-                                              // RGGB-pattern, so swap R<->B to correct it
-                        return std::make_shared< rggb_converter >( RS2_FORMAT_RGB8, NATIVE_W, rw, rh, isp );
-                    }
-                );
+                for( auto src_fmt : raw_src_formats )
+                {
+                    color_ep.register_processing_block(
+                        { { src_fmt, RS2_STREAM_COLOR } },
+                        { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 0, 0, 0, 0, r.xf },
+                          { RS2_FORMAT_RGB8, RS2_STREAM_COLOR, 1, 0, 0, 0, r.xf } },
+                        [rw, rh]() {
+                            rggb::isp_params isp;
+                            isp.swap_rb = true;   // OV9782 is BGGR (driver declares SBGGR8 / SBGGR10P); base
+                                                  // demosaic is RGGB-pattern, so swap R<->B to correct it
+                            return std::make_shared< rggb_converter >( RS2_FORMAT_RGB8, NATIVE_W, rw, rh, isp );
+                        }
+                    );
+                }
             }
         }
     }

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -66,8 +66,8 @@ namespace librealsense
         {fourcc('R','G','B','2'), RS2_FORMAT_BGR8},
         {fourcc('M','J','P','G'), RS2_FORMAT_MJPEG},
         {fourcc('B','Y','R','2'), RS2_FORMAT_RAW16},
-        {fourcc('B','A','8','1'), RS2_FORMAT_RAW8}   // D401 GMSL dual-RGB: SBGGR8 8-bit Bayer (RAW8 CSI passthrough, driver PR #459)
-
+        {fourcc('B','A','8','1'), RS2_FORMAT_RAW8},   // D401 GMSL dual-RGB: SBGGR8 (older MIPI driver)
+        {fourcc('p','B','A','A'), RS2_FORMAT_RAW10}   // D401 GMSL dual-RGB: SBGGR10P (MIPI driver 1.0.6.10+)
     };
     std::map<fourcc::value_type, rs2_stream> d400_depth_fourcc_to_rs2_stream = {
         {fourcc('Y','U','Y','2'), RS2_STREAM_COLOR},
@@ -83,23 +83,25 @@ namespace librealsense
         {fourcc('Z','1','6','H'), RS2_STREAM_DEPTH},
         {fourcc('B','Y','R','2'), RS2_STREAM_COLOR},
         {fourcc('M','J','P','G'), RS2_STREAM_COLOR},
-        {fourcc('B','A','8','1'), RS2_STREAM_COLOR}   // D401 GMSL dual-RGB: SBGGR8, expose each OV9782 imager as color
+        {fourcc('B','A','8','1'), RS2_STREAM_COLOR},   // D401 GMSL dual-RGB: SBGGR8 (older MIPI driver)
+        {fourcc('p','B','A','A'), RS2_STREAM_COLOR}    // D401 GMSL dual-RGB: SBGGR10P (MIPI driver 1.0.6.10+)
     };
 
-    // D401 GMSL dual-RGB stream-id resolver. The two OV9782 imagers each arrive on a separate backend pin,
-    // both advertising identical SBGGR8 (fourcc BA81). Rank the BA81 color pins by ascending pin_index and
-    // route them to Color 0 / Color 1 (distinct streams), mirroring the IR1/IR2 split. Uses the upstream
-    // per-pin _stream_id_resolver mechanism (cf. d500_dual_rgb::resolve_color_stream).
+    // D401 GMSL dual-RGB stream-id resolver: the two imagers arrive on separate backend pins with the same
+    // raw Bayer fourcc (SBGGR8/BA81 on older drivers, SBGGR10P/pBAA on 1.0.6.10+). Rank those pins by
+    // ascending pin_index -> Color 0 / Color 1 (cf. d500_dual_rgb::resolve_color_stream).
     static void resolve_d401_color_stream( const std::vector< platform::stream_profile > & all,
                                            const platform::stream_profile & p, rs2_stream & type, int & index )
     {
-        const auto ba81 = fourcc( 'B', 'A', '8', '1' );
-        if( p.format != ba81 )
+        const auto ba81 = fourcc( 'B', 'A', '8', '1' );   // SBGGR8  (older MIPI driver)
+        const auto pbaa = fourcc( 'p', 'B', 'A', 'A' );   // SBGGR10P (MIPI driver 1.0.6.10+)
+        auto is_raw_color = [&]( uint32_t f ) { return f == ba81 || f == pbaa; };
+        if( ! is_raw_color( p.format ) )
             return;  // not a D401 color pin - leave type/index as resolved by the fourcc map
 
         std::set< uint32_t > color_pins;
         for( auto & q : all )
-            if( q.format == ba81 )
+            if( is_raw_color( q.format ) )
                 color_pins.insert( q.pin_index );
 
         int rank = 0;
@@ -777,11 +779,9 @@ namespace librealsense
                     []() {return std::make_shared<y12i_to_y16y16_mipi>(); }
                 );
 
-                // D401 GMSL dual-RGB: the two OV9782 imagers stream 8-bit RGGB Bayer via the FW RAW8
-                // CSI passthrough, routed to Color 0 / Color 1. Only firmware with that passthrough
-                // supports it; older firmware exposes the ISP color path only. Keep this guard identical
-                // to the block registration guard in d400_color::register_processing_blocks() - the
-                // resolver armed here and the RAW8->RGB8 blocks there must be enabled together.
+                // D401 GMSL dual-RGB: arm the raw-Bayer -> Color 0 / Color 1 routing (raw payload supported
+                // only on firmware with the RAW8/RAW10 CSI passthrough). Keep this guard identical to the
+                // block-registration guard in d400_color::register_processing_blocks().
                 if( _is_mipi_device && _pid == RS401_GMSL_PID && _fw_version >= firmware_version( "5.17.4.13" ) )
                 {
                     // Route the two identical BGGR color pins to Color 0 / Color 1 (ascending pin order).

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -259,9 +259,11 @@ void uvc_sensor::open( const stream_profiles & requests )
                     if( val_in_range( req_profile_base->get_format(), { RS2_FORMAT_MJPEG } ) || is_perception )
                         expected_size = f.frame_size;
 
-                    // D401 GMSL dual-RGB color is packed MIPI RAW10 (pBAA) but sized at 16 bpp (unpacked)
-                    // here, so copy the packed payload verbatim; the rggb converter unpacks it downstream.
-                    if( req_profile_base->get_format() == RS2_FORMAT_RAW10
+                    // D401 GMSL dual-RGB (per_stream_color_fn, set only for that path) color is packed MIPI
+                    // RAW10 (pBAA) but sized at 16 bpp (unpacked) here; copy the packed payload verbatim,
+                    // the rggb converter unpacks it downstream.
+                    if( per_stream_color_fn
+                        && req_profile_base->get_format() == RS2_FORMAT_RAW10
                         && req_profile_base->get_stream_type() == RS2_STREAM_COLOR )
                         expected_size = f.frame_size;
 

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -259,6 +259,12 @@ void uvc_sensor::open( const stream_profiles & requests )
                     if( val_in_range( req_profile_base->get_format(), { RS2_FORMAT_MJPEG } ) || is_perception )
                         expected_size = f.frame_size;
 
+                    // D401 GMSL dual-RGB color is packed MIPI RAW10 (pBAA) but sized at 16 bpp (unpacked)
+                    // here, so copy the packed payload verbatim; the rggb converter unpacks it downstream.
+                    if( req_profile_base->get_format() == RS2_FORMAT_RAW10
+                        && req_profile_base->get_stream_type() == RS2_STREAM_COLOR )
+                        expected_size = f.frame_size;
+
                     // The MIPI 64-byte width realignment path must copy (it rewrites the pixel
                     // layout into a tightly-packed buffer), so it is never eligible for zero-copy.
                     const bool align64 = ( ( width * bpp >> 3 ) % 64 != 0 && f.frame_size > expected_size );


### PR DESCRIPTION
## D401 GMSL dual-RGB: support the SBGGR10P (pBAA) raw color format

MIPI driver 1.0.6.10 changes how the D401 GMSL advertises its raw dual-RGB color pins:
the fourcc goes from SBGGR8 (BA81) at 1612x808 to SBGGR10P (pBAA) at the real 1288x808.
The payload is the same packed MIPI RAW10; only the advertised fourcc and width changed.
This adds SDK support for the new format while keeping the old one working.

### Changes
- `src/ds/d400/d400-device.cpp`: map pBAA to `RS2_FORMAT_RAW10` (and `RS2_STREAM_COLOR`)
  in the color fourcc maps; the dual-RGB stream resolver now accepts BA81 or pBAA.
- `src/ds/d400/d400-color.cpp`: register the raw debayer as one single-source block per
  format (RAW8, RAW10). A multi-format source list trips the formats-converter
  many-to-one guard and silently drops the RGB8 targets (so Color 1 never appears).
- `src/uvc-sensor.cpp`: copy the packed RAW10 color payload verbatim. `RS2_FORMAT_RAW10`
  is sized at 16 bpp (unpacked), larger than the packed frame, which overran the copy
  buffer and crashed on Color 1; the rggb converter unpacks the packed data downstream.

### Applies to
This is valid only for **MIPI driver 1.0.6.10 or newer** (which advertises pBAA), on a
D401 GMSL with firmware 5.17.4.13+. Older drivers that advertise SBGGR8/BA81 keep working
unchanged, so this does not regress existing setups.

### Testing
Verified on a D401 GMSL (driver 1.0.6.10, FW 5.17.4.19): dual-RGB is exposed
(Color 0 + Color 1) and both stream at 848x480; ISP color still works; no crash.
