### PR TITLE
Align High-Accuracy sloRauDiffThresh to the FW register step

### DIFF
--- a/src/ds/advanced_mode/presets.cpp
+++ b/src/ds/advanced_mode/presets.cpp
@@ -664,7 +664,7 @@ namespace librealsense
         p.rsm.diffThresh = 1.65625f;
         p.rsm.removeThresh = 136;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.78125f;
+        p.rsm.sloRauDiffThresh = 0.78125f; // was 0.785714, off the register's 1/32 step - FW quantized to this anyway
         p.rsvc.minEast = 6;
         p.rsvc.minNorth = 3;
         p.rsvc.minNSsum = 7;

--- a/src/ds/advanced_mode/presets.cpp
+++ b/src/ds/advanced_mode/presets.cpp
@@ -664,7 +664,7 @@ namespace librealsense
         p.rsm.diffThresh = 1.65625f;
         p.rsm.removeThresh = 136;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.785714f;
+        p.rsm.sloRauDiffThresh = 0.78125f;
         p.rsvc.minEast = 6;
         p.rsvc.minNorth = 3;
         p.rsvc.minNSsum = 7;


### PR DESCRIPTION
**Overview:** Sets the High-Accuracy preset value for `sloRauDiffThresh` to the value the hardware actually programs, so the camera reports back the same number the SDK asked for.

Tracked on [RSDEV-12554]

## Why
The RSM `sloRauDiffThresh` register field is 7-bit fixed point 2.5, giving a step of 1/32 and a range of 0 to 3.96875. The preset value `0.785714` (11/14) is not on that grid, so it can never be stored exactly — FW quantizes it to 25/32 on write.

D400 FW reads the register back on get, so it has always returned `0.78125`, and the viewer has always shown `0.781`. QA raised the value as a defect after seeing `0.786` reported on D585 3C/2C, which echoes the written value instead of the register content.

## Summary
- `high_accuracy()` preset: `sloRauDiffThresh` 0.785714f -> 0.78125f, matching the value the register holds.

This is a host-side alignment only. The reason D585 3C/2C and D585 GMSL report different values for the same written bytes is a separate FW issue, tracked on RSDEV-12554.

## Test plan
- [x] D455 over USB, FW 5.17.3.10 — apply High-Accuracy, read back `sloRauDiffThresh`: `0.78125` (register code 25) both before and after this change.
- [x] D457 over GMSL, FW 5.17.3.10 — identical results, confirming the change is a no-op on D400 across both transports.
- [x] Direct write probes on both: `0.785714` and `0.78125` both read back as `0.78125`; off-grid control `0.80` reads back as `0.8125` (code 26), matching the FW round-half-up conversion.
- [ ] D585 verification once a unit is available.

---
🤖 Generated by AI
