### PR TITLE
Bound FW tool child processes with a timeout and fix rs-fw-update reconnect deadlock

### DIFF
--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -156,9 +156,6 @@ void waiting_for_device_to_reconnect(rs2::context& ctx, rs2::cli::value<std::str
         cv.wait_for(lk, std::chrono::seconds(WAIT_FOR_DEVICE_TIMEOUT), [&] { return !done || new_device; });
     }
 
-    // Release `mutex` before querying: the devices-changed callback takes it too, and a device
-    // re-enumerating on several interfaces raises more than one event -- one landing here would
-    // block the watcher thread against this query and hang the tool past its wait timeout.
     if (done)
     {
         auto devs = ctx.query_devices();

--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -151,9 +151,14 @@ void list_devices(rs2::context ctx)
 void waiting_for_device_to_reconnect(rs2::context& ctx, rs2::cli::value<std::string>& serial_number_arg)
 {
     std::cout << std::endl << "Waiting for device to reconnect..." << std::endl;
-    std::unique_lock<std::mutex> lk(mutex);
-    cv.wait_for(lk, std::chrono::seconds(WAIT_FOR_DEVICE_TIMEOUT), [&] { return !done || new_device; });
+    {
+        std::unique_lock<std::mutex> lk(mutex);
+        cv.wait_for(lk, std::chrono::seconds(WAIT_FOR_DEVICE_TIMEOUT), [&] { return !done || new_device; });
+    }
 
+    // Release `mutex` before querying: the devices-changed callback takes it too, and a device
+    // re-enumerating on several interfaces raises more than one event -- one landing here would
+    // block the watcher thread against this query and hang the tool past its wait timeout.
     if (done)
     {
         auto devs = ctx.query_devices();

--- a/unit-tests/pytest-fw-update.py
+++ b/unit-tests/pytest-fw-update.py
@@ -26,14 +26,22 @@ pytestmark = [
     pytest.mark.device_each("D585"),
     pytest.mark.device_exclude("D585S"),
     pytest.mark.priority(1),
-    pytest.mark.timeout(500),
+    pytest.mark.timeout(750),
     pytest.mark.skipif(bool(os.environ.get('GITHUB_ACTIONS')), reason="not runnable on GHA"),
 ]
 
 
 # A FW tool that never returns blocks the whole pytest session, and if pytest is then killed the
 # tool survives as an orphan whose CWD pins the workspace directory (undeletable on Windows).
-FW_TOOL_TIMEOUT = 300  # seconds; a real flash + device reboot is well under 100s
+FW_TOOL_TIMEOUT = 150  # seconds; a real flash + device reboot is well under 100s
+
+
+def abs_fw_path( path ):
+    """
+    Resolve a FW image path against the current working directory, so it stays valid for a tool
+    that we run from elsewhere. Returns `path` unchanged when it is empty.
+    """
+    return os.path.abspath( path ) if path else path
 
 
 def run_fw_tool( cmd, timeout = FW_TOOL_TIMEOUT ):
@@ -239,9 +247,11 @@ def test_fw_update( request, module_device_setup, test_context_var ):
     if not fw_updater_exe:
         pytest.fail( "Could not find the update tool file (rs-fw-update.exe)" )
 
-    custom_fw_d400 = request.config.getoption( '--custom-fw-d400' )
-    custom_fw_d555 = request.config.getoption( '--custom-fw-d555' )
-    custom_fw_d585 = request.config.getoption( '--custom-fw-d585' )
+    # Absolutize here, in the parent: run_fw_tool runs the tool from its own directory, so a
+    # relative --custom-fw-* path would no longer resolve for the child.
+    custom_fw_d400 = abs_fw_path( request.config.getoption( '--custom-fw-d400' ) )
+    custom_fw_d555 = abs_fw_path( request.config.getoption( '--custom-fw-d555' ) )
+    custom_fw_d585 = abs_fw_path( request.config.getoption( '--custom-fw-d585' ) )
 
     # FW-compat pre-flash gate (was harness-side, in run-unit-tests.py): refuse to flash a
     # below-min image, or substitute the per-device fallback image registered in

--- a/unit-tests/pytest-fw-update.py
+++ b/unit-tests/pytest-fw-update.py
@@ -5,6 +5,7 @@ import sys
 import os
 import subprocess
 import tempfile
+import shutil
 import re
 import pytest
 from pytest_check import check
@@ -43,12 +44,14 @@ def run_fw_tool( cmd, timeout = FW_TOOL_TIMEOUT ):
     """
     log.debug( f'running: {cmd}' )
     sys.stdout.flush()
-    with tempfile.TemporaryDirectory() as tool_cwd:
-        try:
-            return subprocess.run( cmd, cwd=tool_cwd, timeout=timeout )
-        except subprocess.TimeoutExpired:
-            log.error( f'{cmd[0]} did not exit within {timeout} seconds; killed it' )
-            return subprocess.CompletedProcess( cmd, returncode=-1 )
+    tool_cwd = tempfile.mkdtemp()
+    try:
+        return subprocess.run( cmd, cwd=tool_cwd, timeout=timeout )
+    except subprocess.TimeoutExpired:
+        log.error( f'{cmd[0]} did not exit within {timeout} seconds; killed it' )
+        return subprocess.CompletedProcess( cmd, returncode=-1 )
+    finally:
+        shutil.rmtree( tool_cwd, ignore_errors=True )
 
 
 def wait_for_reboot( same_version ):

--- a/unit-tests/pytest-fw-update.py
+++ b/unit-tests/pytest-fw-update.py
@@ -4,6 +4,7 @@
 import sys
 import os
 import subprocess
+import tempfile
 import re
 import pytest
 from pytest_check import check
@@ -27,6 +28,27 @@ pytestmark = [
     pytest.mark.timeout(500),
     pytest.mark.skipif(bool(os.environ.get('GITHUB_ACTIONS')), reason="not runnable on GHA"),
 ]
+
+
+# A FW tool that never returns blocks the whole pytest session, and if pytest is then killed the
+# tool survives as an orphan whose CWD pins the workspace directory (undeletable on Windows).
+FW_TOOL_TIMEOUT = 300  # seconds; a real flash + device reboot is well under 100s
+
+
+def run_fw_tool( cmd, timeout = FW_TOOL_TIMEOUT ):
+    """
+    Run a FW tool (rs-fw-update / rs-dds-config) bounded by `timeout`, from a CWD outside the
+    repo so a surviving process cannot pin the workspace. On timeout the child is killed and a
+    non-zero result is returned, so callers keep their normal reboot-wait and failure flow.
+    """
+    log.debug( f'running: {cmd}' )
+    sys.stdout.flush()
+    with tempfile.TemporaryDirectory() as tool_cwd:
+        try:
+            return subprocess.run( cmd, cwd=tool_cwd, timeout=timeout )
+        except subprocess.TimeoutExpired:
+            log.error( f'{cmd[0]} did not exit within {timeout} seconds; killed it' )
+            return subprocess.CompletedProcess( cmd, returncode=-1 )
 
 
 def wait_for_reboot( same_version ):
@@ -182,8 +204,7 @@ def recover_dds_device_on_golden_domain( serial, context, fw_updater_exe ):
         pytest.fail( f"Could not download gold recovery FW for {rec_name} ({serial}); cannot recover DFU device" )
     # 1) gold-flash on domain 0 (where a bricked DDS device lives)
     cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', serial, '--domain-id', '0']
-    log.debug( f'running: {cmd}' )
-    result = subprocess.run( cmd )
+    result = run_fw_tool( cmd )
     if result.returncode != 0:
         pytest.fail( f"Gold-flash failed for {serial} (rc={result.returncode}); device may still be in DFU" )
     wait_for_reboot( same_version=False )
@@ -199,8 +220,7 @@ def recover_dds_device_on_golden_domain( serial, context, fw_updater_exe ):
         # its DDS domain to the rig's configured value.
         cmd = [dds_config_exe, '--serial-number', serial,
                '--transient-sdk-domain-id', '0', '--domain-id', str( config_domain )]
-        log.debug( f'running: {cmd}' )
-        result = subprocess.run( cmd )
+        result = run_fw_tool( cmd )
         if result.returncode != 0:
             log.warning( f"rs-dds-config returned rc={result.returncode}; camera may not be on DDS domain {config_domain}" )
         wait_for_reboot( same_version=False )
@@ -276,8 +296,7 @@ def test_fw_update( request, module_device_setup, test_context_var ):
             pytest.fail( f"Could not download gold recovery FW for {product_name}; cannot recover DFU device" )
         cmd = [fw_updater_exe, '-r', '-f', gold_fw, '-s', serial]
         del device, ctx
-        log.debug( f'running: {cmd}' )
-        subprocess.run( cmd )
+        run_fw_tool( cmd )
         recovered = True
         fw_compat.reload_d4xx_driver_on_jetson( context )
         # The device's identity changed: in DFU it exposed firmware_update_id only,
@@ -351,9 +370,7 @@ def test_fw_update( request, module_device_setup, test_context_var ):
 
     # for DDS devices we need to close device and context to detect it back after FW update
     del device, ctx
-    log.debug( f'running: {cmd}' )
-    sys.stdout.flush()
-    result = subprocess.run( cmd )   # may throw
+    result = run_fw_tool( cmd )
 
     # Wait for the camera to finish rebooting before doing anything else, REGARDLESS of
     # rs-fw-update's exit code. A non-zero exit doesn't necessarily mean no flash started:


### PR DESCRIPTION
**Overview:** A firmware-update test can no longer hang indefinitely: the `rs-fw-update` / `rs-dds-config` child processes now run under a timeout, and a deadlock that could hang `rs-fw-update` after a successful flash is fixed.

## Why

On a Windows CI run, `test_fw_update` wedged for over three hours. `rs-fw-update` finished the flash, printed `Waiting for device to reconnect...` and never exited; `subprocess.run()` had no timeout, so the test blocked with it. When pytest-timeout finally killed the Python process, the child survived as an orphan whose current directory was the workspace root — which on Windows makes the directory undeletable, so the next builds on that node failed workspace cleanup until the machine was rebooted.

Two independent defects:

1. `waiting_for_device_to_reconnect()` calls `ctx.query_devices()` while still holding `mutex`. The devices-changed callback takes the same `mutex`, and a device re-enumerating on several interfaces raises more than one event. An event arriving during the query blocks the watcher thread on `mutex` while the query waits on backend state that thread must advance — the tool hangs past its own 15s wait timeout.
2. No call site bounded the FW tools, so any hang in them became a hang of the whole pytest session.

## Summary

- `rs-fw-update.cpp`: scope `mutex` to the `cv.wait_for` only, releasing it before `ctx.query_devices()`.
- `pytest-fw-update.py`: new `run_fw_tool()` helper replaces all four raw `subprocess.run()` calls. It bounds the child at `FW_TOOL_TIMEOUT` (150s; a real flash plus reboot is well under 100s), kills it on expiry and returns a non-zero result, so existing call sites keep their reboot-wait and failure handling instead of blocking. On the main flash path this matters: `wait_for_reboot()` must still run before the test fails, so a device mid-reboot doesn't lose USB power.
- `run_fw_tool()` also runs the child from a temporary directory outside the repo, so a surviving process can never pin the workspace directory. The `--custom-fw-*` options are absolutized where they are read, so a relative image path still resolves for a tool started from elsewhere.

The module's `pytest.mark.timeout` goes from 500s to 750s so the bounded steps fit inside it. Worst case is the DDS recovery path (two tool runs plus two 60s reboot waits) followed by the main flash: `3 * 150 + 180 = 630s`, leaving room for the gold-FW download and device discovery, which are not bounded here. A hung tool now yields a normal test failure instead of pytest-timeout terminating the session.

## Test plan

- [x] `rs-fw-update` builds clean on Windows (VS 2022, x64, `BUILD_WITH_DDS=ON`); `rs-fw-update -l` runs
- [ ] LibCI Windows + Linux: `pytest-fw-update.py` passes on D400 / D555 (flash path, unchanged timing)
- [ ] Recovery paths exercised: D400 USB DFU gold-flash, D555 domain-0 recovery + `rs-dds-config` domain restore

The deadlock fix is by inspection — it is a race that needs a second device-change event to land inside the query window, so it is not reproducible on demand. The child-process timeout is the change that actually keeps a future hang from taking a CI node out.

---
🤖 Generated by AI


