### PR TITLE
Accept H264 as camera published format

### DIFF
--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -103,6 +103,7 @@ typedef enum rs2_format
     RS2_FORMAT_M420            , /**< YUV 4:2:0: y for each pixel, and u,v data for every four pixels - packed as 2 lines of y, 1 line of u,v. 12 bits per pixel on average. */
     RS2_FORMAT_COMBINED_MOTION , /**< Combined motion data, as in the combined_motion structure */
     RS2_FORMAT_NV12            , /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
+    RS2_FORMAT_H264            , /**< H.264 compressed video bitstream; each frame is an access unit of variable length. */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -45,6 +45,7 @@ namespace librealsense
         case RS2_FORMAT_MOTION_XYZ32F: return 1;
         case RS2_FORMAT_6DOF: return 1;
         case RS2_FORMAT_MJPEG: return 8;
+        case RS2_FORMAT_H264: return 8;
         case RS2_FORMAT_Y8I: return 16;
         case RS2_FORMAT_Y12I: return 32;  // bpp for Y12i format was 24, but since D457 GMSL SerDes required 32, it had been increased to 32 for both
         case RS2_FORMAT_INZI: return 32;

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -701,6 +701,7 @@ const char * get_string( rs2_format value )
     CASE( Y16I )
     CASE( M420 )
     CASE( NV12 )
+    CASE( H264 )
     default:
         assert( ! is_valid( value ) );
         return UNKNOWN_VALUE;

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -71,6 +71,7 @@ enum rs2_format  // copy from rs2_sensor.h
     RS2_FORMAT_M420,  /**< YUV 4:2:0: y for each pixel, and u,v for every four pixels - packed as 2 lines of y, 1 line of u,v. 12 bits per pixel on average. */
     RS2_FORMAT_COMBINED_MOTION, /**< Combined motion data, as in the combined_motion structure */
     RS2_FORMAT_NV12,  /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
+    RS2_FORMAT_H264,  /**< H.264 compressed video bitstream; each frame is an access unit of variable length. */
     RS2_FORMAT_COUNT  /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 };
 
@@ -98,6 +99,7 @@ int dds_video_encoding::to_rs2() const
         { "Y10B", RS2_FORMAT_Y10BPACK },
         { "M420", RS2_FORMAT_M420 },  // Used by D500 color streams
         { "NV12", RS2_FORMAT_NV12 },
+        { "h264", RS2_FORMAT_H264 },  // ROS2-compatible for compressed video
     };
 
     std::string s = to_string();
@@ -133,6 +135,7 @@ dds_video_encoding dds_video_encoding::from_rs2( int rs2_format )
     case RS2_FORMAT_Y10BPACK: encoding = "Y10B"; break;
     case RS2_FORMAT_M420: encoding = "M420"; break;  // Used by D500 color streams
     case RS2_FORMAT_NV12: encoding = "NV12"; break;
+    case RS2_FORMAT_H264: encoding = "h264"; break;
     default:
         DDS_THROW( runtime_error, "cannot translate rs2_format " + std::to_string( rs2_format ) + " to any known dds_video_encoding" );
     };
@@ -209,7 +212,8 @@ dds_video_stream_profile::dds_video_stream_profile( rsutils::json const & j, int
 
 bool dds_video_stream_profile::is_compressed_encoding() const
 {
-    return _encoding.to_rs2() == RS2_FORMAT_MJPEG;
+    int const format = _encoding.to_rs2();
+    return format == RS2_FORMAT_MJPEG || format == RS2_FORMAT_H264;
 }
 
 

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamFormat.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamFormat.java
@@ -34,7 +34,9 @@ public enum StreamFormat {
     Y411(30),
     Y16I(31),
     M420(32),
-    COMBINED_MOTION(33);
+    COMBINED_MOTION(33),
+    NV12(34),
+    H264(35);
     private final int mValue;
 
     private StreamFormat(int value) { mValue = value; }


### PR DESCRIPTION
D555 publishes H264 as ROS native (without SDK), but also started publishing to the SDK that such profiles exist.
This is a first stage in SDK supporting H264 formats, currently just not throwing an exception when such profiles are met.

Note - the device will be ready but won't forward these formats as available to the user.