### PR TITLE
Stop FW error polling when the device is disconnected, not only destroyed

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -38,8 +38,8 @@ librealsense::find_profile( rs2_stream stream, int index, std::vector< stream_in
 
 device::device( std::shared_ptr< const device_info > const & dev_info,
                 bool device_changed_notifications )
-    : _dev_info( dev_info )
-    , _is_alive( std::make_shared< std::atomic< bool > >( true ) )
+    : _is_alive( std::make_shared< std::atomic< bool > >( true ) )
+    , _dev_info( dev_info )
     , _profiles_tags( [this]() { return get_profiles_tags(); } )
     , _format_conversion(
           [this]

--- a/src/device.h
+++ b/src/device.h
@@ -108,10 +108,14 @@ protected:
 
     std::map<int, std::pair<uint32_t, std::shared_ptr<const stream_interface>>> _extrinsics;
 
+    // Cleared when the device is disconnected; a derived destructor also clears it so
+    // its background loops stop before they are joined. Shared so those loops can hold
+    // a weak_ptr and survive any destruction order.
+    std::shared_ptr< std::atomic< bool > > _is_alive;
+
 private:
     std::vector<std::shared_ptr<sensor_interface>> _sensors;
     std::shared_ptr< const device_info > _dev_info;
-    std::shared_ptr< std::atomic< bool > > _is_alive;
     rsutils::subscription _device_change_subscription;
     rsutils::lazy< std::vector< tagged_profile > > _profiles_tags;
     rsutils::lazy< format_conversion > _format_conversion;

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -630,7 +630,7 @@ namespace librealsense
     {
         // Signal background loops (polling_error_handler) so they exit cleanly on the
         // next tick instead of firing one more failing FW query before being joined.
-        _device_alive->store( false );
+        _is_alive->store( false );
     }
 
     void d400_device::init(std::shared_ptr<context> ctx,
@@ -837,7 +837,7 @@ namespace librealsense
 
                     _polling_error_handler = std::make_shared<polling_error_handler>(1000,
                         error_control,
-                        std::weak_ptr<std::atomic<bool>>( _device_alive ),
+                        std::weak_ptr<std::atomic<bool>>( _is_alive ),
                         raw_depth_sensor->get_notifications_processor(),
                         std::make_shared< ds_notification_decoder >( d400_fw_error_report ) );
 

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -155,12 +155,6 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
-        // MUST be declared before _polling_error_handler — destruction order matters:
-        // members destruct in reverse declaration order, so _polling_error_handler's
-        // worker thread joins (and dereferences this weak_ptr) while _device_alive is
-        // still alive.
-        std::shared_ptr<std::atomic<bool>> _device_alive
-            = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;
         std::shared_ptr<ds_thermal_monitor> _thermal_monitor;
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _left_right_extrinsics;

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -398,7 +398,7 @@ namespace librealsense
     {
         // Signal background loops (polling_error_handler) so they exit cleanly on the
         // next tick instead of firing one more failing FW query before being joined.
-        _device_alive->store( false );
+        _is_alive->store( false );
     }
 
     void d500_device::init(std::shared_ptr<context> ctx,
@@ -617,7 +617,7 @@ namespace librealsense
             _polling_error_handler = std::make_shared< polling_error_handler >(
                 1000,
                 error_control,
-                std::weak_ptr<std::atomic<bool>>( _device_alive ),
+                std::weak_ptr<std::atomic<bool>>( _is_alive ),
                 raw_depth_sensor->get_notifications_processor(),
                 std::make_shared< ds_notification_decoder >( d500_fw_error_report ) );
 

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -163,12 +163,6 @@ namespace librealsense
         rsutils::lazy< std::vector< uint8_t > > _coefficients_table_raw;
         rsutils::lazy< std::vector< uint8_t > > _new_calib_table_raw;
 
-        // MUST be declared before _polling_error_handler — destruction order matters:
-        // members destruct in reverse declaration order, so _polling_error_handler's
-        // worker thread joins (and dereferences this weak_ptr) while _device_alive is
-        // still alive.
-        std::shared_ptr<std::atomic<bool>> _device_alive
-            = std::make_shared<std::atomic<bool>>(true);
         std::shared_ptr<polling_error_handler> _polling_error_handler;
         std::shared_ptr<ds_thermal_monitor> _thermal_monitor;
         std::shared_ptr< rsutils::lazy< rs2_extrinsics > > _left_right_extrinsics;

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -34,6 +34,9 @@ namespace librealsense
     {
         if( poll_intervals_ms )
             _poll_intervals_ms = poll_intervals_ms;
+        // An explicit re-enable is a request to try again, even if a previous run gave up
+        _silenced = false;
+        _consecutive_failures = 0;
         _active_object->start();
     }
     void polling_error_handler::stop()
@@ -47,11 +50,10 @@ namespace librealsense
         {
             if( ! _silenced )
             {
-                // The owning device sets *_device_alive = false in its destructor body,
-                // before any of its members destruct. That's our signal to exit cleanly
-                // without firing another (failing) FW query. An expired weak_ptr is
-                // treated the same as a false flag for robustness against destruction
-                // ordering changes.
+                // Cleared both when the device is disconnected and when the owning
+                // device destructs, so we exit without firing another (failing) FW
+                // query. An expired weak_ptr is treated the same as a false flag for
+                // robustness against destruction ordering changes.
                 auto alive = _device_alive.lock();
                 if( ! alive || ! alive->load() )
                 {
@@ -62,6 +64,7 @@ namespace librealsense
                 try
                 {
                     auto val = static_cast< uint8_t >( _option->query() );
+                    _consecutive_failures = 0;
 
                     if( val != 0 )
                     {
@@ -101,17 +104,36 @@ namespace librealsense
                 }
                 catch( const std::exception & ex )
                 {
-                    LOG_ERROR( "Error during polling error handler: " << ex.what() );
+                    on_query_failure( ex.what() );
                 }
                 catch( ... )
                 {
-                    LOG_ERROR( "Unknown error during polling error handler!" );
+                    on_query_failure( "unknown error" );
                 }
             }
         }
         else
         {
             LOG_DEBUG( "Notification polling loop is being shut-down" );
+        }
+    }
+
+    // Repeated failures mean the camera stopped answering - typically it was
+    // unplugged while the application still holds it. Report the first one, then
+    // give up instead of logging the same error on every tick, forever.
+    void polling_error_handler::on_query_failure( std::string const & what )
+    {
+        ++_consecutive_failures;
+        if( _consecutive_failures == 1 )
+            LOG_ERROR( "Error during polling error handler: " << what );
+        else
+            LOG_DEBUG( "Error during polling error handler (" << _consecutive_failures << " in a row): " << what );
+
+        if( _consecutive_failures >= MAX_CONSECUTIVE_FAILURES )
+        {
+            LOG_WARNING( "FW error polling failed " << _consecutive_failures
+                                                    << " times in a row; shutting down error polling loop" );
+            _silenced = true;
         }
     }
 

--- a/src/error-handling.h
+++ b/src/error-handling.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string>
 
 
 namespace librealsense
@@ -33,9 +34,15 @@ namespace librealsense
 
     private:
         void polling(dispatcher::cancellable_timer cancellable_timer);
+        void on_query_failure( std::string const & what );
+
+        // Consecutive query failures after which the loop gives up. A disconnected
+        // camera fails every tick forever, and there is nobody left to recover from.
+        static const unsigned int MAX_CONSECUTIVE_FAILURES = 3;
 
         unsigned int _poll_intervals_ms;
         bool _silenced = false;
+        unsigned int _consecutive_failures = 0;
         std::shared_ptr<option> _option;
         std::weak_ptr<std::atomic<bool>> _device_alive;
         std::shared_ptr < active_object<> > _active_object;


### PR DESCRIPTION
**Overview:** FW error polling no longer logs an error every second after a camera is unplugged while the application still holds the device.

Tracked on [RSDSO-21927]

## Why
`polling_error_handler` queries the FW error register once a second. When the camera is disconnected but the application still holds the device, every query fails and logs at ERROR level, forever:

```
ERROR (error-handling.cpp:104) Error during polling error handler: MFCreateDeviceSource(_device_attrs, &_source) returned: HResult 0x80070003: "The system cannot find the path specified."
```

PR #15056 stopped the loop on device *destruction* by adding a private `_device_alive` flag to `d400_device`/`d500_device`, cleared in the destructor. Disconnection never clears it, so that path was still unbounded.

The base class already tracks disconnection: `device::_is_alive` is cleared by the context device-changed subscription when the device is removed. The polling handler was wired to the duplicate flag instead of that one.

## Summary
- Wire `polling_error_handler` to `device::_is_alive`, so both disconnection and destruction stop the loop. Removes the duplicate `_device_alive` member from both device classes.
- Moved `_is_alive` to `protected` so derived destructors can signal their background loops. Base members outlive derived ones, so the handler's worker thread is joined while the flag is still alive.
- Cap consecutive query failures at 3: log the first at ERROR, repeats at DEBUG, then one WARNING and stop the loop. Guards against any other failure mode spamming the log.
- Re-enabling `RS2_OPTION_ERROR_POLLING_ENABLED` clears the silenced state, so an explicit re-enable retries.

## Test plan
- [x] D585 Prototype (FW 7.58.40947.13653) on Windows 11, device held by the app, port powered off: was 1 ERROR/sec unbounded, now 1 ERROR + 2 DEBUG + 1 WARNING and silence.
- [x] Same scenario with polling re-enabled after the removal event: loop exits on the `_is_alive` flag ("Device marked dead; shutting down polling loop") without issuing a query.
- [x] Windows Release build of `realsense2`, `pyrealsense2`, `rs-fw-update`.
- [ ] LibCI

---
🤖 Generated by AI
