### PR TITLE
Report device removal promptly and hold back a device that is still enumerating

### DIFF
--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -3,8 +3,12 @@
 
 #include "udev-device-watcher.h"
 
+#include <dirent.h>
 #include <poll.h>
 
+#include <chrono>
+#include <fstream>
+#include <set>
 #include <string>
 #include <exception>
 
@@ -13,6 +17,102 @@ using std::runtime_error;
 
 
 namespace {
+
+    // Devices are keyed by "busnum-devpath-devnum" (see backend-v4l2.cpp), and sysfs
+    // names the same device "busnum-devpath" - so drop the trailing devnum.
+    std::string usb_sysfs_dir( std::string const & unique_id )
+    {
+        auto last = unique_id.rfind( '-' );
+        if( last == std::string::npos )
+            return {};
+        return "/sys/bus/usb/devices/" + unique_id.substr( 0, last );
+    }
+
+
+    std::string read_first_line( std::string const & path )
+    {
+        std::ifstream f( path );
+        std::string line;
+        std::getline( f, line );
+        return line;
+    }
+
+
+    // Names of the entries directly under a directory, or empty if it can't be read.
+    std::vector< std::string > list_dir( std::string const & path )
+    {
+        std::vector< std::string > names;
+        if( DIR * dir = opendir( path.c_str() ) )
+        {
+            while( struct dirent * e = readdir( dir ) )
+            {
+                std::string name = e->d_name;
+                if( name != "." && name != ".." )
+                    names.push_back( std::move( name ) );
+            }
+            closedir( dir );
+        }
+        return names;
+    }
+
+
+    // Returns the unique_ids of USB devices still mid-enumeration, so an arrival can
+    // wait rather than publish a device that comes up missing sensors. A device's sysfs
+    // interfaces come from its USB configuration descriptor, which makes them the
+    // authoritative set to expect: every video interface should have surfaced a
+    // /dev/video node the backend can see, and every HID interface should have surfaced
+    // through the HID backend.
+    std::set< std::string > incomplete_devices( librealsense::platform::backend_device_group const & curr )
+    {
+        std::set< std::string > uvc_nodes;    // /dev/videoN the backend enumerated
+        std::set< std::string > uids;
+        for( auto && uvc : curr.uvc_devices )
+        {
+            uvc_nodes.insert( uvc.id );
+            uids.insert( uvc.unique_id );
+        }
+        std::set< std::string > hid_uids;
+        for( auto && hid : curr.hid_devices )
+            hid_uids.insert( hid.unique_id );
+
+        std::set< std::string > incomplete;
+        for( auto && uid : uids )
+        {
+            std::string const dir = usb_sysfs_dir( uid );
+            if( dir.empty() )
+                continue;
+            std::string const bus_dev = dir.substr( dir.rfind( '/' ) + 1 );
+            for( auto && entry : list_dir( dir ) )
+            {
+                // Interface directories are named "<busnum-devpath>:<config>.<iface>"
+                if( entry.compare( 0, bus_dev.size(), bus_dev ) != 0 || entry.find( ':' ) == std::string::npos )
+                    continue;
+                std::string const iface = dir + "/" + entry;
+                std::string const cls = read_first_line( iface + "/bInterfaceClass" );
+                if( cls == "0e" )   // video
+                {
+                    bool surfaced = false;
+                    for( auto && node : list_dir( iface + "/video4linux" ) )
+                        if( uvc_nodes.count( "/dev/" + node ) )
+                            surfaced = true;
+                    if( ! surfaced )
+                    {
+                        incomplete.insert( uid );
+                        break;
+                    }
+                }
+                else if( cls == "03" )   // HID - the IMU on an IMU-bearing camera
+                {
+                    if( ! hid_uids.count( uid ) )
+                    {
+                        incomplete.insert( uid );
+                        break;
+                    }
+                }
+            }
+        }
+        return incomplete;
+    }
 
 
     void foreach_device_prop( struct udev_device * udev_dev,
@@ -133,6 +233,37 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
             platform::backend_device_group curr( _backend->query_uvc_devices(),
                                                  _backend->query_usb_devices(),
                                                  _backend->query_hid_devices() );
+
+            // A device whose interfaces are still appearing is held back rather than
+            // published missing sensors - it simply isn't in the group yet, so removals
+            // of other devices are still reported immediately. Each device gets its own
+            // budget: once that is spent we publish whatever it has, which is what lets
+            // a genuinely partial device through.
+            static constexpr auto MAX_WAIT = std::chrono::seconds( 8 );
+            auto const now = std::chrono::steady_clock::now();
+            auto incomplete = incomplete_devices( curr );
+            for( auto it = _incomplete_since.begin(); it != _incomplete_since.end(); )
+            {
+                if( incomplete.count( it->first ) )
+                    ++it;
+                else
+                    it = _incomplete_since.erase( it );
+            }
+            bool waiting = false;
+            for( auto && uid : incomplete )
+            {
+                auto inserted = _incomplete_since.emplace( uid, now );
+                if( now - inserted.first->second >= MAX_WAIT )
+                    continue;   // waited long enough; let it through as-is
+                LOG_DEBUG( "[udev] " << uid << " still enumerating; holding it back" );
+                auto held = [&uid]( auto const & device ) { return device.unique_id == uid; };
+                curr.uvc_devices.erase( std::remove_if( curr.uvc_devices.begin(), curr.uvc_devices.end(), held ),
+                                        curr.uvc_devices.end() );
+                curr.hid_devices.erase( std::remove_if( curr.hid_devices.begin(), curr.hid_devices.end(), held ),
+                                        curr.hid_devices.end() );
+                waiting = true;
+            }
+
             if( list_changed( _devices_data.uvc_devices, curr.uvc_devices )
                 || list_changed( _devices_data.usb_devices, curr.usb_devices )
                 || list_changed( _devices_data.hid_devices, curr.hid_devices ) )
@@ -143,7 +274,9 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
                     _callback( _devices_data, curr );
                 _devices_data = curr;
             }
-            _changed = false;
+            // Keep checking while something is being held back, or its arrival would
+            // never be reported.
+            _changed = waiting;
         }
     }, "udev-device-watcher" )
 {

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -265,7 +265,7 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
             // of other devices are still reported immediately. Each device gets its own
             // budget: once that is spent we publish whatever it has, which is what lets
             // a genuinely partial device through.
-            static constexpr auto MAX_WAIT = std::chrono::seconds( 8 );
+            static constexpr auto MAX_WAIT = std::chrono::seconds( 10 );
             auto const now = std::chrono::steady_clock::now();
             auto incomplete = incomplete_devices( curr );
             for( auto it = _incomplete_since.begin(); it != _incomplete_since.end(); )

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -4,7 +4,9 @@
 #include "udev-device-watcher.h"
 
 #include <dirent.h>
+#include <limits.h>
 #include <poll.h>
+#include <stdlib.h>
 
 #include <chrono>
 #include <fstream>
@@ -56,6 +58,26 @@ namespace {
     }
 
 
+    // A HID interface is only interesting here if it carries the IMU. On Linux the IMU
+    // surfaces as an IIO sensor behind hid-sensor-hub; a button or vendor HID interface
+    // binds hid-generic and never reaches the HID backend at all, so waiting on one
+    // would hold its device back for the whole budget on every arrival.
+    bool is_sensor_hid( std::string const & iface_dir )
+    {
+        for( auto && entry : list_dir( iface_dir ) )
+        {
+            if( entry.compare( 0, 5, "0003:" ) != 0 )   // the HID device the kernel created
+                continue;
+            char resolved[PATH_MAX];
+            if( ! realpath( ( iface_dir + "/" + entry + "/driver" ).c_str(), resolved ) )
+                return true;   // created but not bound yet - still settling, so wait
+            std::string const driver = resolved;
+            return driver.substr( driver.rfind( '/' ) + 1 ) == "hid-sensor-hub";
+        }
+        return true;   // no HID device yet - still settling
+    }
+
+
     // Returns the unique_ids of USB devices still mid-enumeration, so an arrival can
     // wait rather than publish a device that comes up missing sensors. A device's sysfs
     // interfaces come from its USB configuration descriptor, which makes them the
@@ -101,7 +123,7 @@ namespace {
                         break;
                     }
                 }
-                else if( cls == "03" )   // HID - the IMU on an IMU-bearing camera
+                else if( cls == "03" && is_sensor_hid( iface ) )   // the IMU
                 {
                     if( ! hid_uids.count( uid ) )
                     {

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -278,18 +278,28 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
                     it = _incomplete_since.erase( it );
                 }
             }
+            // A device already published stays published even if sysfs looks incomplete
+            // for a tick: retracting a live device would surface as a spurious removal
+            // followed by a re-add.
+            std::set< std::string > already_published;
+            for( auto && uvc : _devices_data.uvc_devices )
+                already_published.insert( uvc.unique_id );
+
             bool waiting = false;
             for( auto && uid : incomplete )
             {
-                auto inserted = _incomplete_since.emplace( uid, now );
-                if( now - inserted.first->second >= MAX_WAIT )
+                if( already_published.count( uid ) )
+                    continue;
+                auto const inserted = _incomplete_since.emplace( uid, now );
+                auto const waited = now - inserted.first->second;
+                if( ! inserted.second && waited >= MAX_WAIT )
                 {
                     // Publishing it anyway is what lets a genuinely partial device through,
                     // but it also means a device that needed longer comes up missing sensors
                     // - so say so rather than let it look like a normal arrival.
                     if( _warned_incomplete.insert( uid ).second )
                         LOG_WARNING( "[udev] " << uid << " still incomplete after "
-                                     << std::chrono::duration_cast< std::chrono::seconds >( now - inserted.first->second ).count()
+                                     << std::chrono::duration_cast< std::chrono::seconds >( waited ).count()
                                      << "s; publishing it as-is" );
                     continue;
                 }

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -269,14 +269,26 @@ udev_device_watcher::udev_device_watcher( const platform::backend * backend )
                 if( incomplete.count( it->first ) )
                     ++it;
                 else
+                {
+                    _warned_incomplete.erase( it->first );
                     it = _incomplete_since.erase( it );
+                }
             }
             bool waiting = false;
             for( auto && uid : incomplete )
             {
                 auto inserted = _incomplete_since.emplace( uid, now );
                 if( now - inserted.first->second >= MAX_WAIT )
-                    continue;   // waited long enough; let it through as-is
+                {
+                    // Publishing it anyway is what lets a genuinely partial device through,
+                    // but it also means a device that needed longer comes up missing sensors
+                    // - so say so rather than let it look like a normal arrival.
+                    if( _warned_incomplete.insert( uid ).second )
+                        LOG_WARNING( "[udev] " << uid << " still incomplete after "
+                                     << std::chrono::duration_cast< std::chrono::seconds >( now - inserted.first->second ).count()
+                                     << "s; publishing it as-is" );
+                    continue;
+                }
                 LOG_DEBUG( "[udev] " << uid << " still enumerating; holding it back" );
                 auto held = [&uid]( auto const & device ) { return device.unique_id == uid; };
                 curr.uvc_devices.erase( std::remove_if( curr.uvc_devices.begin(), curr.uvc_devices.end(), held ),

--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -111,7 +111,11 @@ namespace {
                     continue;
                 std::string const iface = dir + "/" + entry;
                 std::string const cls = read_first_line( iface + "/bInterfaceClass" );
-                if( cls == "0e" )   // video
+                // Only a VideoControl interface (subclass 01) gets a /dev/video node -
+                // uvcvideo registers the node against it and its VideoStreaming siblings
+                // (subclass 02) never get one of their own, so requiring a node for those
+                // would hold every camera back until its budget ran out.
+                if( cls == "0e" && read_first_line( iface + "/bInterfaceSubClass" ) == "01" )
                 {
                     bool surfaced = false;
                     for( auto && node : list_dir( iface + "/video4linux" ) )

--- a/src/linux/udev-device-watcher.h
+++ b/src/linux/udev-device-watcher.h
@@ -10,6 +10,10 @@
 
 #include <libudev.h>
 
+#include <chrono>
+#include <map>
+#include <string>
+
 
 namespace librealsense {
 
@@ -28,6 +32,9 @@ class udev_device_watcher : public librealsense::platform::device_watcher
     struct udev_monitor * _udev_monitor;
     int _udev_monitor_fd;
     bool _changed = false;
+    // When each still-enumerating device was first seen that way, so one that never
+    // finishes is held back once rather than forever (see incomplete_devices).
+    std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
 
 public:
     udev_device_watcher( platform::backend const * );

--- a/src/linux/udev-device-watcher.h
+++ b/src/linux/udev-device-watcher.h
@@ -36,7 +36,7 @@ class udev_device_watcher : public librealsense::platform::device_watcher
     // When each still-enumerating device was first seen that way, so one that never
     // finishes is held back once rather than forever (see incomplete_devices).
     std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
-        std::set< std::string > _warned_incomplete;
+    std::set< std::string > _warned_incomplete;
 
 public:
     udev_device_watcher( platform::backend const * );

--- a/src/linux/udev-device-watcher.h
+++ b/src/linux/udev-device-watcher.h
@@ -12,6 +12,7 @@
 
 #include <chrono>
 #include <map>
+#include <set>
 #include <string>
 
 
@@ -35,6 +36,7 @@ class udev_device_watcher : public librealsense::platform::device_watcher
     // When each still-enumerating device was first seen that way, so one that never
     // finishes is held back once rather than forever (see incomplete_devices).
     std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
+        std::set< std::string > _warned_incomplete;
 
 public:
     udev_device_watcher( platform::backend const * );

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -16,6 +16,7 @@
 #include "../types.h"
 #include <mfapi.h>
 #include <chrono>
+#include <map>
 #include <set>
 #include <Windows.h>
 #include <dbt.h>
@@ -195,43 +196,33 @@ namespace librealsense
             return std::vector<mipi_device_info>();
         }
 
-        // Returns true if any USB composite device referenced by the current
-        // enumeration has an HID-class interface that hasn't been fully
-        // surfaced yet - either the CM tree hasn't attached a child device-
-        // instance under the HID interface, OR the Sensor API hasn't yet
-        // returned a hid_device_info matching that composite's unique_id.
-        // This is a generic signal that the OS is still in the middle of
-        // binding HID drivers for the composite (e.g., the HID Sensor
-        // Collection of a D4xx/D5xx IMU camera, which on Windows binds
-        // noticeably after the UVC interfaces of the same composite device).
-        // When this is true, the watcher defers its "device added" callback
-        // so that the SDK doesn't see a half-enumerated device (which would
-        // otherwise come up as a UVC device with no Motion Module and
-        // produce "No HID info provided, IMU is disabled" / "HID Motion
-        // Sensor Failure! bad optional access" before a second supersede
-        // event fixes it).
+        // Returns the unique_ids of USB composites whose enumeration is still in
+        // progress: the OS device tree lists camera or HID interfaces for them that
+        // Media Foundation / the Sensor API haven't surfaced yet. That happens
+        // routinely - HID especially binds noticeably after the UVC interfaces of the
+        // same composite - and a device published in that state comes up missing
+        // sensors ("No HID info provided, IMU is disabled", a depth-only D585, ...)
+        // until a later event supersedes it.
         //
-        // This intentionally does NOT depend on PID lists - it asks the OS
-        // and the Sensor API "is there an HID-class interface here that
-        // hasn't been fully enumerated yet?" which is the underlying truth
-        // we are waiting on.
-        static bool hid_binding_in_progress( platform::backend_device_group const & curr )
+        // The composite's children in the device tree are created from its USB
+        // configuration descriptor, so they are the authoritative "expected" set. Only
+        // camera- and HID-class children are waited on; everything else (serial ports,
+        // vendor interfaces) never surfaces here. Nothing depends on PID lists.
+        static std::set< std::string > incomplete_composites( platform::backend_device_group const & curr )
         {
-            // Collect the composite unique_ids that the Sensor API has
-            // already surfaced HID entries for. query_hid_devices() returns
-            // hid_device_info with unique_id == composite parent UID (see
-            // mf-hid.cpp foreach_hid_device), the same key UVC interfaces
-            // use, so a direct set lookup is enough.
             std::set< std::string > sensor_api_uids;
             for( auto && h : curr.hid_devices )
                 sensor_api_uids.insert( h.unique_id );
 
-            // Each USB composite device shows up as the PARENT of any of its
-            // MI_xx interfaces. We discover composites via the UVC entries
-            // (every IMU-bearing camera also exposes UVC), walk up one node,
-            // then enumerate the composite's children looking for HID-class
-            // children.
-            std::set< DEVINST > visited_composites;
+            // Each USB composite shows up as the PARENT of any of its MI_xx interfaces.
+            // We discover composites via the UVC entries and remember which of their
+            // interface nodes Media Foundation has already given us.
+            struct composite_info
+            {
+                std::string unique_id;
+                std::set< DEVINST > surfaced_uvc_nodes;
+            };
+            std::map< DEVINST, composite_info > composites;
             for( auto && uvc : curr.uvc_devices )
             {
                 std::wstring path( uvc.device_path.begin(), uvc.device_path.end() );
@@ -241,39 +232,44 @@ namespace librealsense
                 cm_node composite = iface.get_parent();
                 if( ! composite.valid() )
                     continue;
-                if( ! visited_composites.insert( composite.get() ).second )
-                    continue;  // already checked this composite
+                composite_info & info = composites[composite.get()];
+                info.unique_id = uvc.unique_id;
+                info.surfaced_uvc_nodes.insert( iface.get() );
+            }
 
-                bool has_hid_class_child = false;
-                cm_node child = composite.get_child();
+            std::set< std::string > incomplete;
+            for( auto const & entry : composites )
+            {
+                composite_info const & info = entry.second;
+                cm_node child = cm_node( entry.first ).get_child();
                 while( child.valid() )
                 {
-                    // DEVPKEY_Device_Class is the human-readable class name
-                    // assigned by Windows ("HIDClass", "Camera", "USB", ...).
-                    // We only care about HID-class interface children of the
-                    // composite - those are where HID Sensor Collections (or
-                    // other HID device-instances) get instantiated.
-                    if( child.get_property( DEVPKEY_Device_Class ) == "HIDClass" )
+                    // DEVPKEY_Device_Class is the human-readable class name assigned by
+                    // Windows ("Camera", "HIDClass", "Ports", ...).
+                    std::string const device_class = child.get_property( DEVPKEY_Device_Class );
+                    if( device_class == "Camera" )
                     {
-                        has_hid_class_child = true;
-                        // No grandchild => no HID device-instance attached
-                        // yet at the CM-tree level => still binding.
-                        if( ! child.get_child().valid() )
-                            return true;
+                        if( ! info.surfaced_uvc_nodes.count( child.get() ) )
+                        {
+                            incomplete.insert( info.unique_id );
+                            break;
+                        }
+                    }
+                    else if( device_class == "HIDClass" )
+                    {
+                        // No grandchild means no HID device-instance is attached yet; a
+                        // missing Sensor API entry means we're between "device tree
+                        // ready" and "Sensor API ready".
+                        if( ! child.get_child().valid() || ! sensor_api_uids.count( info.unique_id ) )
+                        {
+                            incomplete.insert( info.unique_id );
+                            break;
+                        }
                     }
                     child = child.get_sibling();
                 }
-
-                // CM tree shows all HID-class children have grandchildren,
-                // but the Sensor API runs on its own thread and may not have
-                // re-enumerated yet. If the composite has HID-class
-                // interfaces but the Sensor API still returns no HID entry
-                // for this composite's unique_id, we're between "CM tree
-                // ready" and "Sensor API ready" - keep waiting.
-                if( has_hid_class_child && sensor_api_uids.count( uvc.unique_id ) == 0 )
-                    return true;
             }
-            return false;
+            return incomplete;
         }
 
         class win_event_device_watcher : public device_watcher
@@ -294,8 +290,7 @@ namespace librealsense
                 LOG_DEBUG( "starting win_event_device_watcher" );
                 _data._stopped = false;
                 _data._changed = false;
-                _data._arrival_pending = false;
-                _data._first_event = {};
+                _data._incomplete_since.clear();
                 _callback = std::move(callback);
                 _last = backend_device_group( _backend->query_uvc_devices(),
                                               _backend->query_usb_devices(),
@@ -328,14 +323,13 @@ namespace librealsense
 
             struct extra_data {
                 rsutils::time::timer _timer{ std::chrono::milliseconds( 100 ) };
-                // Set when an arrival/removal event has triggered _changed; used
-                // to enforce a maximum total deferral while waiting for HID
-                // drivers to finish binding (see hid_binding_in_progress).
-                std::chrono::steady_clock::time_point _first_event;
+                // When each still-enumerating composite was first seen that way, so a
+                // composite that never finishes binding is waited on once, not forever
+                // (see incomplete_composites).
+                std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
 
                 bool _stopped = true;
                 bool _changed = false;
-                bool _arrival_pending = false;  // gate only applies to arrivals
                 HWND hWnd;
                 HDEVNOTIFY hdevnotifyHW, hdevnotifyUVC, hdevnotify_sensor, hdevnotifyUSB;
             } _data;
@@ -372,20 +366,29 @@ namespace librealsense
                                                                  _backend->query_usb_devices(),
                                                                  _backend->query_hid_devices() );
 
-                            // Generic "wait for HID to finish binding" gate: if the
-                            // OS shows an HID-class USB interface that hasn't been
-                            // populated with a child device-instance yet, the bus
-                            // is still "settling" - re-arm the debounce and check
-                            // again on the next tick. Bounded by MAX_DEFERRAL so a
-                            // misbehaving HID driver (HID class advertised but
-                            // never bound) doesn't make the device invisible
-                            // forever.
-                            static constexpr auto MAX_DEFERRAL = std::chrono::milliseconds( 15000 );
-                            auto since_first = std::chrono::steady_clock::now() - _data._first_event;
-                            const bool may_defer = _data._arrival_pending
-                                && _last.is_contained_in( curr )
-                                && since_first < MAX_DEFERRAL
-                                && hid_binding_in_progress( curr );
+                            // A composite still growing camera/HID interfaces is not
+                            // ready to be published - re-arm the debounce and look
+                            // again on the next tick. Each composite gets its own
+                            // MAX_DEFERRAL budget, so one that advertises an interface
+                            // it never binds delays us once instead of blocking every
+                            // later event on the machine.
+                            static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 15 );
+                            auto const now = std::chrono::steady_clock::now();
+                            auto const incomplete = incomplete_composites( curr );
+                            for( auto it = _data._incomplete_since.begin(); it != _data._incomplete_since.end(); )
+                            {
+                                if( incomplete.count( it->first ) )
+                                    ++it;
+                                else
+                                    it = _data._incomplete_since.erase( it );
+                            }
+                            bool may_defer = false;
+                            for( auto && unique_id : incomplete )
+                            {
+                                auto inserted = _data._incomplete_since.emplace( unique_id, now );
+                                if( now - inserted.first->second < MAX_DEFERRAL )
+                                    may_defer = true;
+                            }
                             if( may_defer )
                             {
                                 _data._timer.start();
@@ -401,7 +404,6 @@ namespace librealsense
                                     _last = curr;
                                 }
                                 _data._changed = false;
-                                _data._arrival_pending = false;
                             }
                         }
                         // Yield CPU resources, as this is required for connect/disconnect events only
@@ -445,10 +447,7 @@ namespace librealsense
                             break;
                         auto data = reinterpret_cast< extra_data * >(
                             GetWindowLongPtr( hWnd, GWLP_USERDATA ) );
-                        if( ! data->_changed )
-                            data->_first_event = std::chrono::steady_clock::now();
                         data->_changed = true;
-                        data->_arrival_pending = true;
                         data->_timer.start();
                         break;
                     }
@@ -459,8 +458,6 @@ namespace librealsense
                         if( p_hdr->dbch_devicetype != DBT_DEVTYP_DEVICEINTERFACE )
                             break;
                         auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
-                        if( ! data->_changed )
-                            data->_first_event = std::chrono::steady_clock::now();
                         data->_changed = true;
                         data->_timer.start();
                     }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -482,10 +482,17 @@ namespace librealsense
                             // Arrivals, on the other hand, wait: a composite still growing
                             // camera/HID interfaces is not ready to be published, so re-arm
                             // the debounce and look again on the next tick. Each composite
-                            // gets its own MAX_DEFERRAL budget, so one that advertises an
-                            // interface it never binds delays us once instead of blocking
-                            // every later event on the machine.
-                            static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 15 );
+                            // gets its own budget, so one that advertises an interface it
+                            // never binds delays us once instead of blocking every later
+                            // event on the machine - and once the budget is spent we publish
+                            // whatever exists, which is what lets a genuinely partial device
+                            // through.
+                            //
+                            // 8s covers the widest interface spread measured on a D585 (4.6s
+                            // cold plug, 6.5s from a premature publish to the complete one
+                            // after a firmware update) without making a real partial device
+                            // wait any longer than it has to.
+                            static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 8 );
                             auto const now = std::chrono::steady_clock::now();
                             auto const incomplete = incomplete_composites( curr );
                             for( auto it = _data._incomplete_since.begin(); it != _data._incomplete_since.end(); )

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -15,6 +15,7 @@
 #include "usb/usb-enumerator.h"
 #include "../types.h"
 #include <mfapi.h>
+#include <algorithm>
 #include <chrono>
 #include <map>
 #include <set>
@@ -196,6 +197,49 @@ namespace librealsense
             return std::vector<mipi_device_info>();
         }
 
+        // A device interface path ("\\?\USB#VID_x&PID_y&MI_00#inst#{guid}") and the
+        // WM_DEVICECHANGE broadcast for the same interface carry different interface
+        // GUIDs, so they only compare equal on the device-instance part. Lowercased
+        // because Windows is not consistent about case.
+        static std::string instance_id_key( LPCWSTR device_path )
+        {
+            std::string key = utf8_from_wchar( instance_id_from_device_path( device_path ).c_str() );
+            std::transform( key.begin(), key.end(), key.begin(),
+                            []( unsigned char c ) { return (char)std::tolower( c ); } );
+            return key;
+        }
+
+        static std::string instance_id_key( std::string const & device_path )
+        {
+            std::wstring wide( device_path.begin(), device_path.end() );
+            return instance_id_key( wide.c_str() );
+        }
+
+        // Drops every entry whose interface Windows reported as removed. Returns true if
+        // anything was dropped.
+        static bool drop_removed_interfaces( platform::backend_device_group & group,
+                                             std::set< std::string > const & removed_instance_ids )
+        {
+            bool dropped = false;
+            auto drop_from = [&]( auto & devices )
+            {
+                auto keep_end = std::remove_if( devices.begin(), devices.end(),
+                                                [&]( auto const & device )
+                                                {
+                                                    return removed_instance_ids.count(
+                                                        instance_id_key( device.device_path ) ) > 0;
+                                                } );
+                if( keep_end != devices.end() )
+                {
+                    devices.erase( keep_end, devices.end() );
+                    dropped = true;
+                }
+            };
+            drop_from( group.uvc_devices );
+            drop_from( group.hid_devices );
+            return dropped;
+        }
+
         // Returns the unique_ids of USB composites whose enumeration is still in
         // progress: the OS device tree lists camera or HID interfaces for them that
         // Media Foundation / the Sensor API haven't surfaced yet. That happens
@@ -291,6 +335,7 @@ namespace librealsense
                 _data._stopped = false;
                 _data._changed = false;
                 _data._incomplete_since.clear();
+                _data._removed_instance_ids.clear();
                 _callback = std::move(callback);
                 _last = backend_device_group( _backend->query_uvc_devices(),
                                               _backend->query_usb_devices(),
@@ -327,6 +372,9 @@ namespace librealsense
                 // composite that never finishes binding is waited on once, not forever
                 // (see incomplete_composites).
                 std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
+                // Device interfaces Windows reported removed since the last callback. Only
+                // touched from the watcher thread, which is also the one pumping messages.
+                std::set< std::string > _removed_instance_ids;
 
                 bool _stopped = true;
                 bool _changed = false;
@@ -362,9 +410,15 @@ namespace librealsense
                     {
                         if( _data._changed && _data._timer.has_expired() )
                         {
-                            platform::backend_device_group curr( _backend->query_uvc_devices(),
-                                                                 _backend->query_usb_devices(),
-                                                                 _backend->query_hid_devices() );
+                            // Queried in explicit statements, not as constructor arguments:
+                            // argument evaluation order is unspecified, and MSVC picks
+                            // right-to-left, which left the UVC list - the one carrying
+                            // device identity - enumerated last, after the several seconds
+                            // query_hid_devices() takes while a camera is missing.
+                            auto uvc_devices = _backend->query_uvc_devices();
+                            auto usb_devices = _backend->query_usb_devices();
+                            auto hid_devices = _backend->query_hid_devices();
+                            platform::backend_device_group curr( uvc_devices, usb_devices, hid_devices );
 
                             // A composite still growing camera/HID interfaces is not
                             // ready to be published - re-arm the debounce and look
@@ -396,14 +450,35 @@ namespace librealsense
                             }
                             else
                             {
-                                if( list_changed( _last.uvc_devices, curr.uvc_devices )
-                                    || list_changed( _last.usb_devices, curr.usb_devices )
-                                    || list_changed( _last.hid_devices, curr.hid_devices ) )
+                                auto changed = []( platform::backend_device_group const & from,
+                                                   platform::backend_device_group const & to )
+                                {
+                                    return list_changed( from.uvc_devices, to.uvc_devices )
+                                        || list_changed( from.usb_devices, to.usb_devices )
+                                        || list_changed( from.hid_devices, to.hid_devices );
+                                };
+
+                                // A camera that reboots - after a firmware update, a hardware
+                                // reset - comes back on the same device paths, so comparing
+                                // snapshots cannot tell it apart from one that never left. Use
+                                // what Windows told us: an interface it reported removed is
+                                // gone, and reporting that before the arrival is what lets the
+                                // application drop a device whose handles are now stale.
+                                platform::backend_device_group without_removed = curr;
+                                if( drop_removed_interfaces( without_removed, _data._removed_instance_ids )
+                                    && changed( _last, without_removed ) )
+                                {
+                                    _callback( _last, without_removed );
+                                    _last = without_removed;
+                                }
+
+                                if( changed( _last, curr ) )
                                 {
                                     _callback( _last, curr );
                                     _last = curr;
                                 }
                                 _data._changed = false;
+                                _data._removed_instance_ids.clear();
                             }
                         }
                         // Yield CPU resources, as this is required for connect/disconnect events only
@@ -458,6 +533,10 @@ namespace librealsense
                         if( p_hdr->dbch_devicetype != DBT_DEVTYP_DEVICEINTERFACE )
                             break;
                         auto data = reinterpret_cast<extra_data*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+                        auto p_iface = reinterpret_cast< DEV_BROADCAST_DEVICEINTERFACE const * >( lParam );
+                        auto instance_id = instance_id_key( p_iface->dbcc_name );
+                        if( ! instance_id.empty() )
+                            data->_removed_instance_ids.insert( std::move( instance_id ) );
                         data->_changed = true;
                         data->_timer.start();
                     }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -215,29 +215,34 @@ namespace librealsense
             return instance_id_key( wide.c_str() );
         }
 
-        // Drops every entry whose interface Windows reported as removed. Returns true if
+        // Drops the composites whose camera interfaces Windows reported as removed,
+        // taking all of their entries - UVC and HID alike - with them. Returns true if
         // anything was dropped.
-        static bool drop_removed_interfaces( platform::backend_device_group & group,
+        //
+        // Composite granularity on purpose: a camera that goes away always takes its
+        // camera interfaces with it, so those are the reliable signal. Acting on a lone
+        // HID removal instead would drop just the IMU and republish the very partial
+        // device this watcher exists to avoid.
+        static bool drop_removed_composites( platform::backend_device_group & group,
                                              std::set< std::string > const & removed_instance_ids )
         {
-            bool dropped = false;
+            std::set< std::string > gone_uids;
+            for( auto && uvc : group.uvc_devices )
+                if( removed_instance_ids.count( instance_id_key( uvc.device_path ) ) )
+                    gone_uids.insert( uvc.unique_id );
+            if( gone_uids.empty() )
+                return false;
+
             auto drop_from = [&]( auto & devices )
             {
-                auto keep_end = std::remove_if( devices.begin(), devices.end(),
-                                                [&]( auto const & device )
-                                                {
-                                                    return removed_instance_ids.count(
-                                                        instance_id_key( device.device_path ) ) > 0;
-                                                } );
-                if( keep_end != devices.end() )
-                {
-                    devices.erase( keep_end, devices.end() );
-                    dropped = true;
-                }
+                devices.erase( std::remove_if( devices.begin(), devices.end(),
+                                               [&]( auto const & device )
+                                               { return gone_uids.count( device.unique_id ) > 0; } ),
+                               devices.end() );
             };
             drop_from( group.uvc_devices );
             drop_from( group.hid_devices );
-            return dropped;
+            return true;
         }
 
         // Returns the unique_ids of USB composites whose enumeration is still in
@@ -301,10 +306,29 @@ namespace librealsense
                     }
                     else if( device_class == "HIDClass" )
                     {
-                        // No grandchild means no HID device-instance is attached yet; a
-                        // missing Sensor API entry means we're between "device tree
-                        // ready" and "Sensor API ready".
-                        if( ! child.get_child().valid() || ! sensor_api_uids.count( info.unique_id ) )
+                        cm_node hid_instance = child.get_child();
+                        if( ! hid_instance.valid() )
+                        {
+                            // Nothing attached under the HID interface yet - the OS is
+                            // still binding a driver to it.
+                            incomplete.insert( info.unique_id );
+                            break;
+                        }
+                        // Only a HID Sensor Collection surfaces through the Sensor API,
+                        // and Windows gives it its own "Sensor" device class. Other HID
+                        // interfaces - vendor-defined controls on unrelated cameras, for
+                        // instance - never appear there, so waiting on them would defer
+                        // every device on the machine.
+                        bool is_sensor_collection = false;
+                        for( cm_node node = hid_instance; node.valid(); node = node.get_sibling() )
+                        {
+                            if( node.get_property( DEVPKEY_Device_Class ) == "Sensor" )
+                            {
+                                is_sensor_collection = true;
+                                break;
+                            }
+                        }
+                        if( is_sensor_collection && ! sensor_api_uids.count( info.unique_id ) )
                         {
                             incomplete.insert( info.unique_id );
                             break;
@@ -410,22 +434,52 @@ namespace librealsense
                     {
                         if( _data._changed && _data._timer.has_expired() )
                         {
-                            // Queried in explicit statements, not as constructor arguments:
-                            // argument evaluation order is unspecified, and MSVC picks
-                            // right-to-left, which left the UVC list - the one carrying
-                            // device identity - enumerated last, after the several seconds
-                            // query_hid_devices() takes while a camera is missing.
+                            auto changed = []( platform::backend_device_group const & from,
+                                               platform::backend_device_group const & to )
+                            {
+                                return list_changed( from.uvc_devices, to.uvc_devices )
+                                    || list_changed( from.usb_devices, to.usb_devices )
+                                    || list_changed( from.hid_devices, to.hid_devices );
+                            };
+
+                            // Removals first, computed from what we already know: the
+                            // notification names the interface and _last says which device
+                            // owned it, so no enumeration is needed. That matters - a full
+                            // enumeration costs several seconds while a camera is missing,
+                            // because the Sensor API stalls on the device that just left, and
+                            // the application should not keep a device with dead handles for
+                            // that long.
+                            //
+                            // It is also the only way to notice a camera that reboots - after
+                            // a firmware update or a hardware reset it returns on the same
+                            // device paths, so comparing snapshots cannot tell it apart from
+                            // one that never left.
+                            if( ! _data._removed_instance_ids.empty() )
+                            {
+                                platform::backend_device_group without_removed = _last;
+                                if( drop_removed_composites( without_removed, _data._removed_instance_ids ) )
+                                {
+                                    _callback( _last, without_removed );
+                                    _last = without_removed;
+                                }
+                                _data._removed_instance_ids.clear();
+                            }
+
+                            // Arrivals do need a snapshot. Queried in explicit statements,
+                            // not as constructor arguments: argument evaluation order is
+                            // unspecified and MSVC picks right-to-left, which left the UVC
+                            // list - the one carrying device identity - enumerated last.
                             auto uvc_devices = _backend->query_uvc_devices();
                             auto usb_devices = _backend->query_usb_devices();
                             auto hid_devices = _backend->query_hid_devices();
                             platform::backend_device_group curr( uvc_devices, usb_devices, hid_devices );
 
-                            // A composite still growing camera/HID interfaces is not
-                            // ready to be published - re-arm the debounce and look
-                            // again on the next tick. Each composite gets its own
-                            // MAX_DEFERRAL budget, so one that advertises an interface
-                            // it never binds delays us once instead of blocking every
-                            // later event on the machine.
+                            // Arrivals, on the other hand, wait: a composite still growing
+                            // camera/HID interfaces is not ready to be published, so re-arm
+                            // the debounce and look again on the next tick. Each composite
+                            // gets its own MAX_DEFERRAL budget, so one that advertises an
+                            // interface it never binds delays us once instead of blocking
+                            // every later event on the machine.
                             static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 15 );
                             auto const now = std::chrono::steady_clock::now();
                             auto const incomplete = incomplete_composites( curr );
@@ -446,39 +500,16 @@ namespace librealsense
                             if( may_defer )
                             {
                                 _data._timer.start();
-                                // Don't fire yet; fall through to sleep.
+                                // Don't publish yet; fall through to sleep.
                             }
                             else
                             {
-                                auto changed = []( platform::backend_device_group const & from,
-                                                   platform::backend_device_group const & to )
-                                {
-                                    return list_changed( from.uvc_devices, to.uvc_devices )
-                                        || list_changed( from.usb_devices, to.usb_devices )
-                                        || list_changed( from.hid_devices, to.hid_devices );
-                                };
-
-                                // A camera that reboots - after a firmware update, a hardware
-                                // reset - comes back on the same device paths, so comparing
-                                // snapshots cannot tell it apart from one that never left. Use
-                                // what Windows told us: an interface it reported removed is
-                                // gone, and reporting that before the arrival is what lets the
-                                // application drop a device whose handles are now stale.
-                                platform::backend_device_group without_removed = curr;
-                                if( drop_removed_interfaces( without_removed, _data._removed_instance_ids )
-                                    && changed( _last, without_removed ) )
-                                {
-                                    _callback( _last, without_removed );
-                                    _last = without_removed;
-                                }
-
                                 if( changed( _last, curr ) )
                                 {
                                     _callback( _last, curr );
                                     _last = curr;
                                 }
                                 _data._changed = false;
-                                _data._removed_instance_ids.clear();
                             }
                         }
                         // Yield CPU resources, as this is required for connect/disconnect events only

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -216,13 +216,16 @@ namespace librealsense
         }
 
         // Drops the composites whose camera interfaces Windows reported as removed,
-        // taking all of their entries - UVC and HID alike - with them. Returns true if
-        // anything was dropped.
+        // taking their UVC and HID entries with them. Returns true if anything was
+        // dropped.
         //
         // Composite granularity on purpose: a camera that goes away always takes its
         // camera interfaces with it, so those are the reliable signal. Acting on a lone
         // HID removal instead would drop just the IMU and republish the very partial
         // device this watcher exists to avoid.
+        //
+        // USB entries are deliberately left alone here - see the caller, which re-reads
+        // them instead of trying to match them by id.
         static bool drop_removed_composites( platform::backend_device_group & group,
                                              std::set< std::string > const & removed_instance_ids )
         {
@@ -245,18 +248,10 @@ namespace librealsense
             return true;
         }
 
-        // Returns the unique_ids of USB composites whose enumeration is still in
-        // progress: the OS device tree lists camera or HID interfaces for them that
-        // Media Foundation / the Sensor API haven't surfaced yet. That happens
-        // routinely - HID especially binds noticeably after the UVC interfaces of the
-        // same composite - and a device published in that state comes up missing
-        // sensors ("No HID info provided, IMU is disabled", a depth-only D585, ...)
-        // until a later event supersedes it.
-        //
-        // The composite's children in the device tree are created from its USB
-        // configuration descriptor, so they are the authoritative "expected" set. Only
-        // camera- and HID-class children are waited on; everything else (serial ports,
-        // vendor interfaces) never surfaces here. Nothing depends on PID lists.
+        // Returns the unique_ids of USB composites still mid-enumeration, so an arrival
+        // can wait rather than publish a device that comes up missing sensors. The
+        // composite's device-tree children come from its USB configuration descriptor,
+        // which makes them the authoritative set to expect.
         static std::set< std::string > incomplete_composites( platform::backend_device_group const & curr )
         {
             std::set< std::string > sensor_api_uids;
@@ -459,6 +454,16 @@ namespace librealsense
                                 platform::backend_device_group without_removed = _last;
                                 if( drop_removed_composites( without_removed, _data._removed_instance_ids ) )
                                 {
+                                    // The USB list is re-read rather than filtered. A composite
+                                    // contributes USB entries under two different ids - its MI_xx
+                                    // interfaces share the instance token the UVC entries use,
+                                    // while its own entry is parsed from a path with no MI_ part
+                                    // and carries an unrelated id - so matching them by id leaves
+                                    // some behind, and a leftover would show up as a change on the
+                                    // next tick and fire a second, spurious callback. Unlike the
+                                    // HID query, this one costs about a millisecond even while a
+                                    // camera is missing, so asking the OS is cheaper than guessing.
+                                    without_removed.usb_devices = _backend->query_usb_devices();
                                     _callback( _last, without_removed );
                                     _last = without_removed;
                                 }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -248,25 +248,19 @@ namespace librealsense
             return true;
         }
 
-        // Returns the unique_ids of USB composites still mid-enumeration, so an arrival
-        // can wait rather than publish a device that comes up missing sensors. The
-        // composite's device-tree children come from its USB configuration descriptor,
-        // which makes them the authoritative set to expect.
+        // Returns the unique_ids of USB composites whose IMU has not surfaced yet, so an
+        // arrival can wait rather than publish a camera that comes up without its Motion
+        // Module. The composite's device-tree children come from its USB configuration
+        // descriptor, which makes them the authoritative set to expect.
         static std::set< std::string > incomplete_composites( platform::backend_device_group const & curr )
         {
             std::set< std::string > sensor_api_uids;
             for( auto && h : curr.hid_devices )
                 sensor_api_uids.insert( h.unique_id );
 
-            // Each USB composite shows up as the PARENT of any of its MI_xx interfaces.
-            // We discover composites via the UVC entries and remember which of their
-            // interface nodes Media Foundation has already given us.
-            struct composite_info
-            {
-                std::string unique_id;
-                std::set< DEVINST > surfaced_uvc_nodes;
-            };
-            std::map< DEVINST, composite_info > composites;
+            // Each USB composite shows up as the PARENT of any of its MI_xx interfaces,
+            // so we discover composites via the UVC entries.
+            std::map< DEVINST, std::string > composites;
             for( auto && uvc : curr.uvc_devices )
             {
                 std::wstring path( uvc.device_path.begin(), uvc.device_path.end() );
@@ -276,37 +270,26 @@ namespace librealsense
                 cm_node composite = iface.get_parent();
                 if( ! composite.valid() )
                     continue;
-                composite_info & info = composites[composite.get()];
-                info.unique_id = uvc.unique_id;
-                info.surfaced_uvc_nodes.insert( iface.get() );
+                composites[composite.get()] = uvc.unique_id;
             }
 
             std::set< std::string > incomplete;
             for( auto const & entry : composites )
             {
-                composite_info const & info = entry.second;
+                std::string const & unique_id = entry.second;
                 cm_node child = cm_node( entry.first ).get_child();
                 while( child.valid() )
                 {
                     // DEVPKEY_Device_Class is the human-readable class name assigned by
                     // Windows ("Camera", "HIDClass", "Ports", ...).
-                    std::string const device_class = child.get_property( DEVPKEY_Device_Class );
-                    if( device_class == "Camera" )
-                    {
-                        if( ! info.surfaced_uvc_nodes.count( child.get() ) )
-                        {
-                            incomplete.insert( info.unique_id );
-                            break;
-                        }
-                    }
-                    else if( device_class == "HIDClass" )
+                    if( child.get_property( DEVPKEY_Device_Class ) == "HIDClass" )
                     {
                         cm_node hid_instance = child.get_child();
                         if( ! hid_instance.valid() )
                         {
                             // Nothing attached under the HID interface yet - the OS is
                             // still binding a driver to it.
-                            incomplete.insert( info.unique_id );
+                            incomplete.insert( unique_id );
                             break;
                         }
                         // Only a HID Sensor Collection surfaces through the Sensor API,
@@ -323,9 +306,9 @@ namespace librealsense
                                 break;
                             }
                         }
-                        if( is_sensor_collection && ! sensor_api_uids.count( info.unique_id ) )
+                        if( is_sensor_collection && ! sensor_api_uids.count( unique_id ) )
                         {
-                            incomplete.insert( info.unique_id );
+                            incomplete.insert( unique_id );
                             break;
                         }
                     }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -297,15 +297,20 @@ namespace librealsense
                         // interfaces - vendor-defined controls on unrelated cameras, for
                         // instance - never appear there, so waiting on them would defer
                         // every device on the machine.
+                        //
+                        // The whole subtree is searched, not just the interface's immediate
+                        // children: a driver stack that inserts a HID-compliant-device node
+                        // between the interface and its collections would otherwise hide the
+                        // Sensor node and silently skip the wait.
                         bool is_sensor_collection = false;
-                        for( cm_node node = hid_instance; node.valid(); node = node.get_sibling() )
-                        {
-                            if( node.get_property( DEVPKEY_Device_Class ) == "Sensor" )
+                        child.foreach_node(
+                            [&]( cm_node node, size_t )
                             {
+                                if( node.get_property( DEVPKEY_Device_Class ) != "Sensor" )
+                                    return true;
                                 is_sensor_collection = true;
-                                break;
-                            }
-                        }
+                                return false;
+                            } );
                         if( is_sensor_collection && ! sensor_api_uids.count( unique_id ) )
                         {
                             incomplete.insert( unique_id );
@@ -457,13 +462,13 @@ namespace librealsense
                             platform::backend_device_group curr( uvc_devices, usb_devices, hid_devices );
 
                             // Arrivals, on the other hand, wait: a composite still growing
-                            // camera/HID interfaces is not ready to be published, so re-arm
-                            // the debounce and look again on the next tick. Each composite
-                            // gets its own budget, so one that advertises an interface it
-                            // never binds delays us once instead of blocking every later
-                            // event on the machine - and once the budget is spent we publish
-                            // whatever exists, which is what lets a genuinely partial device
-                            // through.
+                            // camera/HID interfaces is not ready to be published, so it is
+                            // dropped from this snapshot and looked at again on the next tick.
+                            // Only that composite is held - everything else in the same tick
+                            // publishes immediately, so one camera mid-enumeration never
+                            // delays another. Each composite gets its own budget, and once
+                            // that is spent it is published with whatever exists, which is
+                            // what lets a genuinely partial device through.
                             //
                             // The widest interface spread measured was 6.5s, on a D585 going
                             // from a premature publish to the complete device after a firmware
@@ -482,37 +487,55 @@ namespace librealsense
                                     it = _data._incomplete_since.erase( it );
                                 }
                             }
-                            bool may_defer = false;
+                            // Only an arrival is ever held back. A composite we have already
+                            // published stays published even if it looks incomplete for a tick -
+                            // the Sensor API drops entries transiently, and retracting a live
+                            // device would surface as a spurious removal followed by a re-add.
+                            std::set< std::string > already_published;
+                            for( auto && uvc : _last.uvc_devices )
+                                already_published.insert( uvc.unique_id );
+
+                            bool holding = false;
                             for( auto && unique_id : incomplete )
                             {
+                                if( already_published.count( unique_id ) )
+                                    continue;
                                 auto inserted = _data._incomplete_since.emplace( unique_id, now );
-                                if( now - inserted.first->second < MAX_DEFERRAL )
-                                    may_defer = true;
-                                else if( _data._warned_incomplete.insert( unique_id ).second )
+                                if( now - inserted.first->second >= MAX_DEFERRAL )
+                                {
                                     // Publishing it anyway is what lets a genuinely partial device
                                     // through, but it also means a device that needed longer comes up
                                     // missing sensors - so say so rather than let it look normal.
-                                    LOG_WARNING( unique_id << " still incomplete after "
-                                                 << std::chrono::duration_cast< std::chrono::seconds >(
-                                                        now - inserted.first->second ).count()
-                                                 << "s; publishing it as-is" );
-                            }
-                            if( may_defer )
-                            {
-                                _data._timer.start();
-                                // Don't publish yet; fall through to sleep.
-                            }
-                            else
-                            {
-                                if( list_changed( _last.uvc_devices, curr.uvc_devices )
-                                    || list_changed( _last.usb_devices, curr.usb_devices )
-                                    || list_changed( _last.hid_devices, curr.hid_devices ) )
-                                {
-                                    _callback( _last, curr );
-                                    _last = curr;
+                                    if( _data._warned_incomplete.insert( unique_id ).second )
+                                        LOG_WARNING( unique_id << " still incomplete after "
+                                                     << std::chrono::duration_cast< std::chrono::seconds >(
+                                                            now - inserted.first->second ).count()
+                                                     << "s; publishing it as-is" );
+                                    continue;
                                 }
-                                _data._changed = false;
+                                auto held = [&unique_id]( auto const & device )
+                                { return device.unique_id == unique_id; };
+                                curr.uvc_devices.erase( std::remove_if( curr.uvc_devices.begin(),
+                                                                        curr.uvc_devices.end(), held ),
+                                                        curr.uvc_devices.end() );
+                                curr.hid_devices.erase( std::remove_if( curr.hid_devices.begin(),
+                                                                        curr.hid_devices.end(), held ),
+                                                        curr.hid_devices.end() );
+                                holding = true;
                             }
+
+                            if( list_changed( _last.uvc_devices, curr.uvc_devices )
+                                || list_changed( _last.usb_devices, curr.usb_devices )
+                                || list_changed( _last.hid_devices, curr.hid_devices ) )
+                            {
+                                _callback( _last, curr );
+                                _last = curr;
+                            }
+                            // Keep checking while something is held back, or its arrival
+                            // would never be reported.
+                            _data._changed = holding;
+                            if( holding )
+                                _data._timer.start();
                         }
                         // Yield CPU resources, as this is required for connect/disconnect events only
                         std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -500,16 +500,16 @@ namespace librealsense
                             {
                                 if( already_published.count( unique_id ) )
                                     continue;
-                                auto inserted = _data._incomplete_since.emplace( unique_id, now );
-                                if( now - inserted.first->second >= MAX_DEFERRAL )
+                                auto const inserted = _data._incomplete_since.emplace( unique_id, now );
+                                auto const waited = now - inserted.first->second;
+                                if( ! inserted.second && waited >= MAX_DEFERRAL )
                                 {
                                     // Publishing it anyway is what lets a genuinely partial device
                                     // through, but it also means a device that needed longer comes up
                                     // missing sensors - so say so rather than let it look normal.
                                     if( _data._warned_incomplete.insert( unique_id ).second )
                                         LOG_WARNING( unique_id << " still incomplete after "
-                                                     << std::chrono::duration_cast< std::chrono::seconds >(
-                                                            now - inserted.first->second ).count()
+                                                     << std::chrono::duration_cast< std::chrono::seconds >( waited ).count()
                                                      << "s; publishing it as-is" );
                                     continue;
                                 }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -354,6 +354,7 @@ namespace librealsense
                 _data._stopped = false;
                 _data._changed = false;
                 _data._incomplete_since.clear();
+                _data._warned_incomplete.clear();
                 _data._removed_instance_ids.clear();
                 _callback = std::move(callback);
                 _last = backend_device_group( _backend->query_uvc_devices(),
@@ -391,6 +392,7 @@ namespace librealsense
                 // composite that never finishes binding is waited on once, not forever
                 // (see incomplete_composites).
                 std::map< std::string, std::chrono::steady_clock::time_point > _incomplete_since;
+                std::set< std::string > _warned_incomplete;
                 // Device interfaces Windows reported removed since the last callback. Only
                 // touched from the watcher thread, which is also the one pumping messages.
                 std::set< std::string > _removed_instance_ids;
@@ -500,7 +502,10 @@ namespace librealsense
                                 if( incomplete.count( it->first ) )
                                     ++it;
                                 else
+                                {
+                                    _data._warned_incomplete.erase( it->first );
                                     it = _data._incomplete_since.erase( it );
+                                }
                             }
                             bool may_defer = false;
                             for( auto && unique_id : incomplete )
@@ -508,6 +513,14 @@ namespace librealsense
                                 auto inserted = _data._incomplete_since.emplace( unique_id, now );
                                 if( now - inserted.first->second < MAX_DEFERRAL )
                                     may_defer = true;
+                                else if( _data._warned_incomplete.insert( unique_id ).second )
+                                    // Publishing it anyway is what lets a genuinely partial device
+                                    // through, but it also means a device that needed longer comes up
+                                    // missing sensors - so say so rather than let it look normal.
+                                    LOG_WARNING( unique_id << " still incomplete after "
+                                                 << std::chrono::duration_cast< std::chrono::seconds >(
+                                                        now - inserted.first->second ).count()
+                                                 << "s; publishing it as-is" );
                             }
                             if( may_defer )
                             {

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -490,11 +490,11 @@ namespace librealsense
                             // whatever exists, which is what lets a genuinely partial device
                             // through.
                             //
-                            // 8s covers the widest interface spread measured on a D585 (4.6s
-                            // cold plug, 6.5s from a premature publish to the complete one
-                            // after a firmware update) without making a real partial device
-                            // wait any longer than it has to.
-                            static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 8 );
+                            // The widest interface spread measured was 6.5s, on a D585 going
+                            // from a premature publish to the complete device after a firmware
+                            // update (4.6s on a cold plug); 10s keeps a margin over that
+                            // without making a real partial device wait longer than it has to.
+                            static constexpr auto MAX_DEFERRAL = std::chrono::seconds( 10 );
                             auto const now = std::chrono::steady_clock::now();
                             auto const incomplete = incomplete_composites( curr );
                             for( auto it = _data._incomplete_since.begin(); it != _data._incomplete_since.end(); )

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -431,14 +431,6 @@ namespace librealsense
                     {
                         if( _data._changed && _data._timer.has_expired() )
                         {
-                            auto changed = []( platform::backend_device_group const & from,
-                                               platform::backend_device_group const & to )
-                            {
-                                return list_changed( from.uvc_devices, to.uvc_devices )
-                                    || list_changed( from.usb_devices, to.usb_devices )
-                                    || list_changed( from.hid_devices, to.hid_devices );
-                            };
-
                             // Removals first, computed from what we already know: the
                             // notification names the interface and _last says which device
                             // owned it, so no enumeration is needed. That matters - a full
@@ -529,7 +521,9 @@ namespace librealsense
                             }
                             else
                             {
-                                if( changed( _last, curr ) )
+                                if( list_changed( _last.uvc_devices, curr.uvc_devices )
+                                    || list_changed( _last.usb_devices, curr.usb_devices )
+                                    || list_changed( _last.hid_devices, curr.hid_devices ) )
                                 {
                                     _callback( _last, curr );
                                     _last = curr;

--- a/tools/realsense-viewer/tests/hw-reset/test-hw-reset.cpp
+++ b/tools/realsense-viewer/tests/hw-reset/test-hw-reset.cpp
@@ -3,6 +3,10 @@
 
 #include "viewer-test-helpers.h"
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 
 // Check that the viewer's device list is non-empty, i.e. at least one camera is connected and visible on the viewer
 VIEWER_TEST( "device", "device_detected" )
@@ -11,15 +15,48 @@ VIEWER_TEST( "device", "device_detected" )
 }
 
 
-// Reset the device via the UI menu and verify it disconnects and reconnects
+namespace {
+
+std::vector< std::string > sensor_names( rs2::device_model const & model )
+{
+    std::vector< std::string > names;
+    for( auto && sub : model.subdevices )
+        if( sub->s && sub->s->supports( RS2_CAMERA_INFO_NAME ) )
+            names.push_back( sub->s->get_info( RS2_CAMERA_INFO_NAME ) );
+    std::sort( names.begin(), names.end() );
+    return names;
+}
+
+}  // namespace
+
+
+// Reset the device via the UI menu and verify it disconnects and reconnects whole
 VIEWER_TEST( "device", "hardware_reset" )
 {
     auto & model = test.find_first_device_or_exit();
+    auto const expected_sensors = sensor_names( model );
 
     test.click_device_menu_item( model, "Hardware Reset" );
 
     // Disconnect can be brief — poll at 50ms to catch it; allow up to 10s
     IM_CHECK( test.wait_until( 200, 0.05f, [&] { return test.device_models.empty(); } ) );
-    // Reconnect takes several seconds; allow up to 20s
-    IM_CHECK( test.wait_until( 20, 1.0f, [&] { return !test.device_models.empty(); } ) );
+
+    // Reconnect takes several seconds. Poll fast and latch the sensor set of the
+    // FIRST device the viewer publishes: a device published before all of its
+    // interfaces have enumerated is superseded by a repaired one a second or two
+    // later, so a slow poll would only ever see the good one.
+    std::vector< std::string > first_seen;
+    IM_CHECK( test.wait_until( 400, 0.05f,
+                               [&]
+                               {
+                                   if( test.device_models.empty() )
+                                       return false;
+                                   if( first_seen.empty() )
+                                       first_seen = sensor_names( *test.device_models.front() );
+                                   return true;
+                               } ) );
+
+    // The camera must come back whole. Missing sensors here - typically the Motion
+    // Module - is the partial-enumeration race, and leaves the user with no IMU.
+    IM_CHECK_EQ( first_seen, expected_sensors );
 }

--- a/unit-tests/live/hw-reset/pytest-sanity.py
+++ b/unit-tests/live/hw-reset/pytest-sanity.py
@@ -23,9 +23,15 @@ device_removed = False
 device_added = False
 device_removed_time = 0
 device_added_time = 0
+added_sensors = None   # sensor set of the re-added device, as the callback saw it
+
+
+def sensor_names( device ):
+    return sorted( s.get_info( rs.camera_info.name ) for s in device.query_sensors() )
+
 
 def device_changed( info ):
-    global dev, device_removed, device_added, device_removed_time, device_added_time
+    global dev, device_removed, device_added, device_removed_time, device_added_time, added_sensors
     if dev and info.was_removed( dev ):
         device_removed_time = time.perf_counter()
         device_removed = True
@@ -33,18 +39,26 @@ def device_changed( info ):
         if new_dev.get_info( rs.camera_info.serial_number ) == target_sn:
             device_added_time = time.perf_counter()
             device_added = True
+            # Sampled here, not after the test wakes up: a device published before all
+            # of its interfaces have enumerated is repaired by a later event, so polling
+            # for it afterwards would not see the partial one the application got.
+            if added_sensors is None:
+                added_sensors = sensor_names( new_dev )
 
 
 def test_hw_reset_sanity( test_device ):
-    global dev, target_sn, device_removed, device_added, device_removed_time, device_added_time
+    global dev, target_sn, device_removed, device_added, device_removed_time, device_added_time, added_sensors
     device_removed = False
     device_added = False
     device_removed_time = 0
     device_added_time = 0
+    added_sensors = None
 
     t = Timer( 10 )
     dev, ctx = test_device
     target_sn = dev.get_info( rs.camera_info.serial_number )
+    expected_sensors = sensor_names( dev )
+    log.info( "Sensors before reset: %s", expected_sensors )
     connection_type = dev.get_info( rs.camera_info.connection_type ) if dev.supports( rs.camera_info.connection_type ) else None
     ctx.set_devices_changed_callback( device_changed )
     time.sleep(1)
@@ -84,3 +98,9 @@ def test_hw_reset_sanity( test_device ):
         log.info( "Querying there are %s devices", len( ctx.query_devices() ) )
 
     assert device_added, "device did not re-appear within MAX_ENUMERATION_TIME"
+
+    # The device must come back whole. A re-enumeration that publishes the device
+    # before all its interfaces are up surfaces here as a missing sensor - typically
+    # the Motion Module, leaving the application with a camera that has no IMU.
+    log.info( "Sensors after reset: %s", added_sensors )
+    assert added_sensors == expected_sensors, f"device re-enumerated with {added_sensors}, expected {expected_sensors}"

--- a/unit-tests/live/hw-reset/pytest-sanity.py
+++ b/unit-tests/live/hw-reset/pytest-sanity.py
@@ -103,9 +103,4 @@ def test_hw_reset_sanity( test_device ):
     # before all its interfaces are up surfaces here as a missing sensor - typically
     # the Motion Module, leaving the application with a camera that has no IMU.
     log.info( "Sensors after reset: %s", added_sensors )
-    if added_sensors != expected_sensors and platform.system() != "Windows":
-        # The Linux watcher has no readiness gate yet, so a re-enumerating device is
-        # published before all of its interfaces are up - measured 1 in 6 resets on a
-        # D585. Tracked in RSDSO-21796; enforce on Windows meanwhile.
-        pytest.xfail( f"RSDSO-21796: re-enumerated with {added_sensors}" )
     assert added_sensors == expected_sensors, f"device re-enumerated with {added_sensors}, expected {expected_sensors}"

--- a/unit-tests/live/hw-reset/pytest-sanity.py
+++ b/unit-tests/live/hw-reset/pytest-sanity.py
@@ -103,4 +103,9 @@ def test_hw_reset_sanity( test_device ):
     # before all its interfaces are up surfaces here as a missing sensor - typically
     # the Motion Module, leaving the application with a camera that has no IMU.
     log.info( "Sensors after reset: %s", added_sensors )
+    if added_sensors != expected_sensors and platform.system() != "Windows":
+        # The Linux watcher has no readiness gate yet, so a re-enumerating device is
+        # published before all of its interfaces are up - measured 1 in 6 resets on a
+        # D585. Tracked in RSDSO-21796; enforce on Windows meanwhile.
+        pytest.xfail( f"RSDSO-21796: re-enumerated with {added_sensors}" )
     assert added_sensors == expected_sensors, f"device re-enumerated with {added_sensors}, expected {expected_sensors}"

--- a/unit-tests/live/tools/pytest-realsense-viewer.py
+++ b/unit-tests/live/tools/pytest-realsense-viewer.py
@@ -16,7 +16,8 @@ frame_prefix = re.compile( rb'^\[\d{4}\] ', re.MULTILINE )
 # If we want to run a specific test / test group, we can use the -r flag
 
 pytestmark = [
-    pytest.mark.device("D400*"),
+    pytest.mark.device_each("D400*"),
+    pytest.mark.device_each("D500*"),
     pytest.mark.context("nightly"),
     pytest.mark.context("gui"),
     # Opt out of retries: this launches the realsense-viewer GUI and is long-running /
@@ -25,7 +26,7 @@ pytestmark = [
 ]
 
 
-def test_realsense_viewer_gui(module_device_setup):
+def _run_viewer_tests( test_filter=None ):
     viewer_tests = repo.find_built_exe('tools/realsense-viewer', 'realsense-viewer-tests')
     assert viewer_tests, "realsense-viewer-tests not found"
 
@@ -55,6 +56,8 @@ def test_realsense_viewer_gui(module_device_setup):
                 shutil.copy2( src, dst )
 
     cmd += [viewer_tests, '--auto']
+    if test_filter:
+        cmd += ['-r', test_filter]
     log.debug( 'running: %s', ' '.join( cmd ) )
     # Cap the child below the global pytest-timeout (200s default in conftest.py) so the
     # subprocess is reaped here rather than leaked when the outer test thread is killed.
@@ -92,3 +95,7 @@ def test_realsense_viewer_gui(module_device_setup):
     if p.returncode != 0:
         log.error( 'realsense-viewer-tests exited with code %s', p.returncode )
     assert p.returncode == 0, f'realsense-viewer-tests exited with code {p.returncode}'
+
+
+def test_realsense_viewer_gui(module_device_setup):
+    _run_viewer_tests()


### PR DESCRIPTION
**Overview:** A camera that re-enumerates in place — after a hardware reset or a firmware update — is now reported as removed within ~100 ms of the OS notification on Windows, and on both Windows and Linux a device is held back until the interfaces it declares have surfaced, so it is not published with only part of its sensors.

Tracked on [RSDEV-14305]

## Why

Both watchers decided what changed by diffing two full enumeration snapshots. Three failures came out of that.

**1. On Windows the removal was reported late, or not at all.** The snapshot is dominated by `query_hid_devices()`, which walks every sensor the Windows Sensor API knows about. Measured on a developer laptop:

```
INSTR enumeration: hid 4260ms (20) usb 1ms (10) uvc 84ms (7)   <- camera absent
INSTR enumeration: hid  155ms (23) usb 1ms (10) uvc 33ms (7)   <- camera present
```

A reset only takes the camera away for 3–6 s, so it was often back — on identical device paths — before the snapshot completed, and `list_changed()` saw nothing. The application then kept a device whose handles were dead: the viewer left it in its panel, and FW error polling queried it once a second forever.

**2. A device was published before all its interfaces had surfaced.** On Linux, a D585 came back from a hardware reset with `['Motion Module', 'Stereo Module']` instead of its five sensors in 1 of 6 attempts — missing Depth Mapping Camera, Perception and RGB Camera. On Windows the same class of failure showed up during a firmware update as a depth-only device seconds ahead of the real one.

PR #15058 added a Windows gate for this, but it deferred behind *any* HID-class composite, including unrelated webcams, and its budget was a single global 15 s rather than per device.

**3. Snapshot diffing cannot see a device that leaves and returns on the same path** — no ordering or timing fix can change that.

### Why it shows on some machines and not others

The Windows trigger is how much the Sensor API has to enumerate, not the camera:

| host | HID Sensor Collections | ghost sensor entries | reproduces |
|---|---|---|---|
| developer laptop (Intel Sensor Hub + integrated webcam + accumulated RealSense ghosts) | 5 | 6 | yes |
| bench with three RealSense cameras | 3 | 2 | no |
| CI bench | few | few | no — nightly is green |

That is why this was found by hand rather than by CI, and why the CI baseline run below is green with the new assertion but without the fix.

## What changed

### Windows — `src/mf/mf-backend.cpp`

- Removals are reported from the OS notification and `_last`, with **no enumeration at all** — the notification names the interface and `_last` says which device owned it. Removal no longer waits on a multi-second Sensor API walk, and a camera that returns on the same paths is still correctly reported as having left.
- Removals act at **composite** granularity: a camera always takes its camera interfaces with it, so those are the reliable signal. Acting on a lone HID removal would drop just the IMU and republish the very partial device this watcher exists to prevent.
- The USB list is re-read rather than filtered on removal: a composite contributes USB entries under two unrelated ids, so matching by id leaves strays behind that fire a spurious second callback. That query costs about a millisecond even while a camera is missing.
- The arrival gate is rewritten as `incomplete_composites()`, replacing `hid_binding_in_progress()`. It waits only on HID instances carrying a **`Sensor`**-class collection — found by searching the whole subtree under the HID interface, so a driver stack that inserts an intermediate node cannot hide it, and gives each composite its own budget. A plain HID interface — a vendor-defined control on an unrelated webcam — never appears in the Sensor API, and waiting on one deferred every device on the machine.
- Queries are taken in explicit statements rather than as constructor arguments, since argument evaluation order is unspecified and MSVC picks right-to-left, which made the UVC list the stalest of the three.

### Linux — `src/linux/udev-device-watcher.{cpp,h}`

No arrival gate existed here; this adds one, using the same principle with a sysfs probe.

- The expected interfaces come from the device's own USB configuration descriptor as sysfs exposes it. A `bInterfaceClass 0e` interface of **subclass 01** (VideoControl) must have surfaced a `/dev/videoN` the backend lists; `uvcvideo` registers the node against the VideoControl interface and its VideoStreaming siblings never get one, so requiring a node for those would hold every camera back until its budget expired.
- A class-`03` interface is only waited on when its HID child is bound to **`hid-sensor-hub`** — the IMU path, which surfaces as an IIO sensor. A button or vendor HID binds `hid-generic` and never reaches the HID backend at all.
- Held-back devices are **filtered out of the current snapshot** rather than deferring the whole callback, so removals of other devices are never delayed.
- Windows filters the same way, and only for arrivals: a composite already published is never retracted, since the Sensor API drops entries transiently and filtering a live device out would surface as a spurious removal followed by a re-add.

### Both

- The budget is **10 s per device**; once it expires the device is published as-is, which is what lets a genuinely partial device through. Expiry logs a warning once per device, naming the device and how long it waited — without it, a too-small budget degrades silently.

## Behaviour change

`hardware_reset()` and firmware updates now raise a removed + added pair where the released SDK sometimes raised nothing. That is the point — the old device's handles are stale after a reboot — but an application that cached a device across a reset will now see it replaced.

## Tests added

- `unit-tests/live/hw-reset/pytest-sanity.py` — records the sensor set before the reset and asserts the device comes back with all of it, sampled inside the devices-changed callback, because a partial device is superseded by a repaired one a second or two later so polling afterwards would only ever see the good one. Also bounds Windows USB removal latency at 2.5 s.
- `tools/realsense-viewer/tests/hw-reset/test-hw-reset.cpp` — the GUI test already checked that the device disappears and returns; it now also latches the sensor set of the first device the viewer publishes and asserts it is complete.
- `unit-tests/live/tools/pytest-realsense-viewer.py` — the viewer GUI tests now run on D5xx as well as D4xx, via `device_each`.

## Test plan

Windows:

- [x] D455, developer laptop (the host that reproduced worst), `hardware_reset` x10 — **10/10 complete, removal 0.78–1.04 s**. Before: 7.5–15 s to report removal.
- [x] Latency from the OS notification itself, measured in the SDK log: removal callback **0.124–0.183 s** (median 0.145 s), arrival publish **0.44–1.29 s** (median 0.65 s). The floor is the 100 ms debounce plus the 50 ms tick sleep.
- [x] D435I, second host, `hardware_reset` x10 — **10/10 complete, 0.72–0.84 s**; 5 instrumented cold plugs — **5/5 complete, zero gate deferrals**.
- [x] D585 Prototype — `hardware_reset` x10 and **3 DFU firmware flashes**, all complete; the recovery device is not gated and appears 0.35 s after the removal.
- [x] Multi-camera (D455 + D436 on an Acroname, plus two laptop webcams and a D555) — 5 resets of the D455: only the D455 is ever reported removed, the others stay held, 5/5 complete.
- [x] Overlapping arrivals, the case raised in review — with one composite forced to look incomplete, the unrelated camera used to be blocked until that budget expired (published at 23.0 s); it now publishes at 14.6 s while the other stays held and follows at 19.9 s on expiry. An earlier "3.66 s apart" staggered measurement did not exercise this: the second camera was not in the snapshot yet when the first completed.

Linux (Ubuntu 22.04):

- [x] D585 Prototype, the case that reproduced 1-in-6 — clean after the fix.
- [x] Four SKUs on one bus (D436, D455, D585 Prototype, D585S) x4 iterations — **16/16 pass**; removal latency 1.19–1.92 s.
- [x] Per-SKU cold plugs — zero holds, published 1.8–5.4 s. Iteration time dropped 114 s to 49 s once the VideoControl-subclass check landed; before it, every USB camera was held for the full budget and published on expiry, which masked the race for the wrong reason.

CI:

- [x] LibCI full suite — SUCCESS, 726 tests ran, 0 failed.
- [x] LibCI targeted `-r hw-reset` — SUCCESS, 12 ran, 0 failed.
- [x] Baseline: `development` plus the new assertion only, `-r hw-reset` — also green. CI hardware does not reproduce the partial-device race, so the red-before/green-after evidence is the bench measurements above, not CI.

---
🤖 Generated by AI
