### PR TITLE
Fix libcurl build with Ninja generator and system libidn2

### DIFF
--- a/CMake/external_libcurl.cmake
+++ b/CMake/external_libcurl.cmake
@@ -5,7 +5,7 @@ if(CHECK_FOR_UPDATES OR ENABLE_STATS)
     include(ExternalProject)
     message(STATUS "Building libcurl enabled")
     
-    set(CURL_FLAGS -DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DUSE_WIN32_LDAP=OFF -DHTTP_ONLY=ON -DCURL_ZLIB=OFF -DCURL_DISABLE_CRYPTO_AUTH=ON -DCURL_USE_LIBSSH2=OFF -DBUILD_TESTING=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_USE_LIBPSL=OFF )
+    set(CURL_FLAGS -DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DUSE_WIN32_LDAP=OFF -DHTTP_ONLY=ON -DCURL_ZLIB=OFF -DCURL_DISABLE_CRYPTO_AUTH=ON -DCURL_USE_LIBSSH2=OFF -DBUILD_TESTING=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_USE_LIBPSL=OFF -DUSE_LIBIDN2=OFF )
     if (WIN32)
         set(CURL_FLAGS ${CURL_FLAGS} -DCURL_STATIC_CRT=ON )
     endif()
@@ -17,6 +17,10 @@ if(CHECK_FOR_UPDATES OR ENABLE_STATS)
         set(CURL_FLAGS ${CURL_FLAGS} -DCURL_USE_OPENSSL=ON )
     endif()
     
+    set(CURL_DEBUG_TARGET_NAME "libcurl-d")
+    set(CURL_RELEASE_TARGET_NAME "libcurl")
+    set(CURL_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/libcurl/libcurl_install)
+
     ExternalProject_Add(
         libcurl
         PREFIX libcurl
@@ -32,7 +36,7 @@ if(CHECK_FOR_UPDATES OR ENABLE_STATS)
                     -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                     -DCMAKE_C_FLAGS_RELWITHDEBINFO=${CMAKE_C_FLAGS_RELWITHDEBINFO}
                     -DCMAKE_CXX_STANDARD_LIBRARIES=${CMAKE_CXX_STANDARD_LIBRARIES}
-                    -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcurl/libcurl_install
+                    -DCMAKE_INSTALL_PREFIX=${CURL_INSTALL_DIR}
                     -DCMAKE_INSTALL_LIBDIR=lib
                     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                     -DANDROID_ABI=${ANDROID_ABI}
@@ -40,17 +44,18 @@ if(CHECK_FOR_UPDATES OR ENABLE_STATS)
         UPDATE_COMMAND ""
         PATCH_COMMAND ""
         TEST_COMMAND ""
+        # Ninja needs to know these are generated; we link them by path, below
+        BUILD_BYPRODUCTS ${CURL_INSTALL_DIR}/lib/${CURL_DEBUG_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                         ${CURL_INSTALL_DIR}/lib/${CURL_RELEASE_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
     )
 
-    set(CURL_DEBUG_TARGET_NAME "libcurl-d")
-    set(CURL_RELEASE_TARGET_NAME "libcurl")
     add_library(curl INTERFACE)
     add_definitions(-DCURL_STATICLIB) # Mandatory for building libcurl as static lib
 
-    target_include_directories(curl INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libcurl/libcurl_install/include>)
+    target_include_directories(curl INTERFACE $<BUILD_INTERFACE:${CURL_INSTALL_DIR}/include>)
         
-    target_link_libraries(curl INTERFACE debug ${CMAKE_CURRENT_BINARY_DIR}/libcurl/libcurl_install/lib/${CURL_DEBUG_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    target_link_libraries(curl INTERFACE optimized ${CMAKE_CURRENT_BINARY_DIR}/libcurl/libcurl_install/lib/${CURL_RELEASE_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    target_link_libraries(curl INTERFACE debug ${CURL_INSTALL_DIR}/lib/${CURL_DEBUG_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    target_link_libraries(curl INTERFACE optimized ${CURL_INSTALL_DIR}/lib/${CURL_RELEASE_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
     
    # libcurl required libs per OS 
    # (Linux require that the link dependency will be added after the libcurl link target that use it)


### PR DESCRIPTION
**Overview:** Fixes two build failures that prevent the viewer and depth-quality tools from linking on Linux — one when using the Ninja generator, one on distributions that ship libidn2 development headers.

## Why

`external_libcurl.cmake` links the libcurl static library by absolute path, but the `ExternalProject_Add` declares no `BUILD_BYPRODUCTS`. The Makefiles generator tolerates this because `add_dependencies(${_target} libcurl)` in `tools/tools_common.cmake` is enough to order the build. Ninja does not: it requires a rule that produces the exact path, so it aborts before the external project ever runs:

```
ninja: error: 'libcurl/libcurl_install/lib/libcurl.a', needed by
'Release/realsense-viewer', missing and no known rule to make it
```

Separately, curl's CMake defaults `USE_LIBIDN2` to `ON` and auto-detects the host's libidn2. On distributions shipping those headers the resulting static library references `idn2_*`, but nothing links `-lidn2`, so the link fails:

```
libcurl.a(idn.c.o): undefined reference to `idn2_lookup_ul'
```

Both reproduce on a stock Ubuntu 24.04/26.04 host with `libidn2-dev` present.

## Summary

- Add `BUILD_BYPRODUCTS` for the debug and release static libraries so Ninja knows they are generated. Both names are declared because the debug/release selection happens per-config at build time.
- Add `-DUSE_LIBIDN2=OFF` to `CURL_FLAGS`, alongside the existing feature-disabling flags. IDN is not needed — the update-check and stats URLs are plain ASCII.
- Hoist `CURL_DEBUG_TARGET_NAME` / `CURL_RELEASE_TARGET_NAME` above the `ExternalProject_Add` (they are needed by `BUILD_BYPRODUCTS`) and introduce `CURL_INSTALL_DIR` to replace five copies of the same install path.

No behavior change for existing working configurations.

## Test plan

- [x] Clean Ninja build on Ubuntu, `-DBUILD_EXAMPLES=true -DCMAKE_BUILD_TYPE=Release`: 671/671 targets, `realsense-viewer` and `rs-depth-quality` link successfully. Fails on `development` without this change.
- [x] Clean Unix Makefiles build with the same flags — confirms no regression to the previously working generator.
- [x] `ninja -t query .../libcurl.a` reports `input: CUSTOM_COMMAND` and lists `Release/realsense-viewer` among its outputs; before the change the path had no producing rule.
- [x] `nm -uC Release/realsense-viewer | grep idn2` returns no unresolved symbols; 16 `curl_easy` symbols are statically linked.
- [x] Incremental rebuild triggers no recompilation or relinking; the byproducts cause no spurious rebuilds (the libcurl ExternalProject stamp steps re-run, as they do without this change).
- [x] `rs-enumerate-devices` runs and enumerates cleanly.
- [x] Clean Ninja build with `-DBUILD_WITH_DDS=ON` (adds FastDDS, built from source): 1035/1035 targets, no failures. `realsense-viewer`, `rs-depth-quality` and the DDS tools (`rs-dds-config`, `rs-dds-adapter`, `rs-dds-sniffer`) all link. This is the configuration needed for Ethernet/PoE cameras such as the D555.
- [x] With DDS enabled, `ninja -t query .../libcurl.a` again reports `input: CUSTOM_COMMAND`, listing `Release/realsense-viewer` and `Release/rs-depth-quality` as outputs; `nm -uC` shows no unresolved `idn2` symbols and 16 statically-linked `curl_easy` symbols.
- [x] DDS runtime sanity with the resulting binaries: `rs-enumerate-devices` brings up a DDS participant on domain 0 and subscribes to the `realsense/device-info` topic.
- [ ] CI: Windows and macOS unaffected (`USE_LIBIDN2` is a no-op where libidn2 is absent; byproducts are generator-agnostic).

---
🤖 Generated by AI
