### PR TITLE
Add Ubuntu 26.04 to issue template OS dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,6 +61,7 @@ body:
         - Ubuntu 20.04
         - Ubuntu 22.04
         - Ubuntu 24.04
+        - Ubuntu 26.04
         - Nvidia Jetson JP5
         - Nvidia Jetson JP6
         - Nvidia Jetson JP7

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -96,6 +96,7 @@ body:
         - Ubuntu 20.04
         - Ubuntu 22.04
         - Ubuntu 24.04
+        - Ubuntu 26.04
         - Nvidia Jetson JP5
         - Nvidia Jetson JP6
         - Nvidia Jetson JP7


### PR DESCRIPTION
**Overview:** Adds Ubuntu 26.04 as an option in the Operating System dropdowns of the bug report and question issue forms.

## Why
Ubuntu 26.04 LTS is out, but the issue forms stop at 24.04, so reporters on it have to pick "Other Linux" and describe the OS in free text.

## Summary
- Added `Ubuntu 26.04` to the Operating System dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml` and `.github/ISSUE_TEMPLATE/question.yml`.

Matches the same change made to the ROS wrapper forms in realsenseai/realsense-ros#3557.

## Test plan
- [x] Both YAML files parse with `yaml.safe_load`.
- [ ] Verify the new option renders in the GitHub "New issue" page after merge.

---
🤖 Generated by AI
