### PR TITLE
Enable Depth and RGB on Intel IPU6/IPU7 Upstream

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1288,7 +1288,7 @@ namespace librealsense
 
                 _variable_frame_size = false;
                 // IPU6/IPU7 upstream video node reports no formats; it is validated via the subdev instead
-                if (_sub_fd <= 0)
+                if (_sub_fd < 0)
                 while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
                 {
                     v4l2_frmsizeenum frame_size = {};
@@ -1348,6 +1348,8 @@ namespace librealsense
                 {
                     v4l2_subdev_frame_interval frame_interval = {};
                     frame_interval.pad = 0;
+                    if (_sub_fd < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_G_PARM) failed and no subdev to query frame interval");
                     if(xioctl(_sub_fd, VIDIOC_SUBDEV_G_FRAME_INTERVAL, &frame_interval) < 0)
                         throw linux_backend_exception("xioctl(VIDIOC_G_PARM) and xioctl(VIDIOC_SUBDEV_G_FRAME_INTERVAL) failed");
 
@@ -1645,6 +1647,8 @@ namespace librealsense
                                 }
 
                                 // Drop partial and overflow frames (assumes D4XX metadata only)
+                                // IPU6/IPU7 upstream pads the queued buffer for ISYS/DMA alignment, so bytesused is one
+                                // stride short of the full length; relax the partial check by a stride to avoid false 99% drops.
                                 bool partial_frame = (!skip_partial_frame_check && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE - buffer->get_stride()));
                                 bool overflow_frame = (buf.bytesused ==  buffer->get_length_frame_only() + MAX_META_DATA_SIZE);
                                 if (_dev.buf_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
@@ -2125,7 +2129,7 @@ namespace librealsense
                 case MEDIA_BUS_FMT_RGB888_1X24:   return V4L2_PIX_FMT_RGB24;
                 case MEDIA_BUS_FMT_BGR888_1X24:   return V4L2_PIX_FMT_BGR24;
                 case MEDIA_BUS_FMT_YUYV8_2X8:
-                case MEDIA_BUS_FMT_YUYV8_1X16:    return 0x59555956; // 'YUYV' as consumed by librealsense
+                case MEDIA_BUS_FMT_YUYV8_1X16:    return V4L2_PIX_FMT_YUYV;
                 case MEDIA_BUS_FMT_UYVY8_2X8:
                 case MEDIA_BUS_FMT_UYVY8_1X16:    return V4L2_PIX_FMT_UYVY;
                 case MEDIA_BUS_FMT_VYUY8_1X16:    return V4L2_PIX_FMT_VYUY;
@@ -2140,7 +2144,7 @@ namespace librealsense
                 case MEDIA_BUS_FMT_Y8_1X8:        return V4L2_PIX_FMT_GREY;
                 case MEDIA_BUS_FMT_Y10_1X10:      return V4L2_PIX_FMT_Y10;
                 case MEDIA_BUS_FMT_Y12_1X12:      return V4L2_PIX_FMT_Y12;
-                case MEDIA_BUS_FMT_FIXED:         return 0x5A313620; // 'Z16 '
+                case MEDIA_BUS_FMT_FIXED:         return V4L2_PIX_FMT_Z16;
                 default:                          return 0;
             }
         }
@@ -2150,14 +2154,16 @@ namespace librealsense
             std::vector<stream_profile> results;
 
             // On IPU6/IPU7 upstream the video node exposes no formats; enumerate them from the subdev instead
-            if (_sub_fd > 0)
+            if (_sub_fd >= 0)
             {
                 v4l2_subdev_mbus_code_enum pixel_format_subdev = {};
                 pixel_format_subdev.pad = 0;
                 pixel_format_subdev.index = 0;
                 while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
                 {
-                    uint32_t fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+                    // subdev returns an mbus code in little-endian; convert to fourcc then to big_endian as results expect
+                    uint32_t temp_fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+                    uint32_t fourcc = (const big_endian<int> &)temp_fourcc;
 
                     v4l2_subdev_frame_size_enum frame_size = {};
                     frame_size.pad = 0;
@@ -2400,7 +2406,8 @@ namespace librealsense
             {
                 _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
                 if (_sub_fd < 0)
-                    LOG_WARNING(__FUNCTION__ << ": Failed to open subdev " << _subdev_name);
+                    LOG_WARNING(__FUNCTION__ << ": Failed to open subdev '" << _subdev_name
+                                << "' (non-fatal, subdev controls will be unavailable)");
             }
 
             if (pipe(_stop_pipe_fd) < 0)
@@ -2841,8 +2848,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_G_EXT_CTRLS) failed and no subdev to get ext_ctrls from");
                 rc = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+            }
 
             if (rc < 0)
             {
@@ -2872,8 +2882,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_S_EXT_CTRLS) failed and no subdev to set ext_ctrls");
                 rc = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+            }
 
             if (rc < 0)
             {
@@ -2910,6 +2923,8 @@ namespace librealsense
             int retVal = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             if (retVal < 0)
             {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_S_EXT_CTRLS) failed and no subdev to set ext_ctrls");
                 // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
                 retVal = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
                 if (retVal < 0)
@@ -2940,6 +2955,10 @@ namespace librealsense
                 int ret = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ext);
                 if (ret < 0)
                 {
+                    if (_sub_fd < 0) {
+                        LOG_WARNING("xioctl(VIDIOC_G_EXT_CTRLS) failed and no subdev to get ext_ctrls from");
+                        continue;
+                    }
                     // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
                     ret = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ext);
                     if (ret < 0)
@@ -2972,6 +2991,9 @@ namespace librealsense
             xctrl_query.id = v4l_mipi_logic::xu_to_cid(xu,control);
 
             if(0 > ioctl(_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query)){
+                if (_sub_fd < 0)
+                    throw linux_backend_exception(rsutils::string::from() <<
+                        "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno << " and no subdev to query ext_ctrls from");
                 // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
                 if(0 > ioctl(_sub_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query))
                     throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
@@ -3008,8 +3030,11 @@ namespace librealsense
             int rc = xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query);
             // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
             // not the capture (video) node. Fall back to the subdev when available.
-            if (rc < 0 && _sub_fd > 0)
+            if (rc < 0) {
+                if (_sub_fd < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_QUERY_EXT_CTRL) failed and no subdev to query ext_ctrls from");
                 rc = xioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            }
             if (rc < 0)
             {
                 // Some controls (exposure, auto exposure, auto hue) do not seem to work on V4L2

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2838,7 +2838,13 @@ namespace librealsense
             // Extract the control group from the underlying control query
             v4l2_ext_controls ctrls_block { control.id&0xffff0000, 1, 0, 0, 0, &control};
 
-            if (xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block) < 0)
+            int rc = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ctrls_block);
+
+            if (rc < 0)
             {
                 if (errno == EIO || errno == EAGAIN) // TODO: Log?
                     return false;
@@ -2863,7 +2869,13 @@ namespace librealsense
 
             // Extract the control group from the underlying control query
             v4l2_ext_controls ctrls_block{ control.id & 0xffff0000, 1, 0, 0, 0, &control };
-            if (xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block) < 0)
+            int rc = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+
+            if (rc < 0)
             {
                 if (errno == EIO || errno == EAGAIN) // TODO: Log?
                     return false;
@@ -2993,7 +3005,12 @@ namespace librealsense
 
             struct v4l2_query_ext_ctrl query = {};
             query.id = v4l_mipi_logic::option_to_cid(option);
-            if (xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query) < 0)
+            int rc = xioctl(_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            // On Intel IPU6/IPU7 upstream pipelines V4L2 controls live on the subdev,
+            // not the capture (video) node. Fall back to the subdev when available.
+            if (rc < 0 && _sub_fd > 0)
+                rc = xioctl(_sub_fd, VIDIOC_QUERY_EXT_CTRL, &query);
+            if (rc < 0)
             {
                 // Some controls (exposure, auto exposure, auto hue) do not seem to work on V4L2
                 // Instead of throwing an error, return an empty range. This will cause this control to be omitted on our UI sample.

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -57,6 +57,7 @@
 #include <linux/media.h>
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
+#include <linux/v4l2-subdev.h>
 #include <regex>
 #include <list>
 
@@ -312,6 +313,13 @@ namespace librealsense
         buffer::buffer(int fd, v4l2_buf_type type, bool use_memory_map, uint32_t index)
             : _type(type), _use_memory_map(use_memory_map), _index(index)
         {
+            // Store the negotiated stride so partial-frame checks can account for the extra metadata line
+            v4l2_format g_fmt = {};
+            g_fmt.type = _type;
+            if (xioctl(fd, VIDIOC_G_FMT, &g_fmt) < 0)
+                throw linux_backend_exception("xioctl(VIDIOC_G_FMT) failed");
+            _stride = g_fmt.fmt.pix.bytesperline;
+
             v4l2_buffer buf = {};
             struct v4l2_plane planes[VIDEO_MAX_PLANES] = {};
             buf.type = _type;
@@ -1060,6 +1068,15 @@ namespace librealsense
                         info.dfu_device_path = dfu_device_path;
                     }
 
+                    // Get subdev node (IPU6/IPU7 upstream) - controls and formats are issued on it
+                    std::string subdev_path = "/dev/" + v4l_mipi_logic::rs_enum_subdev_node_name(vs, i);
+                    vfd = open(subdev_path.c_str(), O_RDONLY | O_NONBLOCK);
+                    if (vfd >= 0)
+                    {
+                        ::close(vfd);
+                        info.subdev_name = subdev_path;
+                    }
+
                     info.mi = vs.compare("imu") ? 0 : 4;
                     info.unique_id += "-" + std::to_string(i);
                     info.uvc_capabilities &= ~(V4L2_CAP_META_CAPTURE); // clean caps
@@ -1233,6 +1250,7 @@ namespace librealsense
 
         v4l_uvc_device::v4l_uvc_device(const uvc_device_info& info, bool use_memory_map)
             : _name(info.id), 
+              _subdev_name(info.subdev_name),
               _device_path(info.device_path),
               _device_usb_spec(info.usb_conn_spec),
               _info(info),
@@ -1269,6 +1287,8 @@ namespace librealsense
                 pixel_format.type = _dev.buf_type;
 
                 _variable_frame_size = false;
+                // IPU6/IPU7 upstream video node reports no formats; it is validated via the subdev instead
+                if (_sub_fd <= 0)
                 while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
                 {
                     v4l2_frmsizeenum frame_size = {};
@@ -1322,13 +1342,27 @@ namespace librealsense
 
                 v4l2_streamparm parm = {};
                 parm.type = _dev.buf_type;
-                if(xioctl(_fd, VIDIOC_G_PARM, &parm) < 0)
-                    throw linux_backend_exception("xioctl(VIDIOC_G_PARM) failed");
 
-                parm.parm.capture.timeperframe.numerator = 1;
-                parm.parm.capture.timeperframe.denominator = profile.fps;
-                if(xioctl(_fd, VIDIOC_S_PARM, &parm) < 0)
-                    throw linux_backend_exception("xioctl(VIDIOC_S_PARM) failed");
+                // On IPU6/IPU7 upstream the frame rate is set on the subdev when the video node has no PARM support
+                if(xioctl(_fd, VIDIOC_G_PARM, &parm) < 0)
+                {
+                    v4l2_subdev_frame_interval frame_interval = {};
+                    frame_interval.pad = 0;
+                    if(xioctl(_sub_fd, VIDIOC_SUBDEV_G_FRAME_INTERVAL, &frame_interval) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_G_PARM) and xioctl(VIDIOC_SUBDEV_G_FRAME_INTERVAL) failed");
+
+                    frame_interval.interval.numerator = 1;
+                    frame_interval.interval.denominator = profile.fps;
+                    if(xioctl(_sub_fd, VIDIOC_SUBDEV_S_FRAME_INTERVAL, &frame_interval) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_SUBDEV_S_FRAME_INTERVAL) failed");
+                }
+                else
+                {
+                    parm.parm.capture.timeperframe.numerator = 1;
+                    parm.parm.capture.timeperframe.denominator = profile.fps;
+                    if(xioctl(_fd, VIDIOC_S_PARM, &parm) < 0)
+                        throw linux_backend_exception("xioctl(VIDIOC_S_PARM) failed");
+                }
 
                 // Init memory mapped IO
                 negotiate_kernel_buffers(static_cast<size_t>(buffers));
@@ -1611,7 +1645,7 @@ namespace librealsense
                                 }
 
                                 // Drop partial and overflow frames (assumes D4XX metadata only)
-                                bool partial_frame = (!skip_partial_frame_check && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE));
+                                bool partial_frame = (!skip_partial_frame_check && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE - buffer->get_stride()));
                                 bool overflow_frame = (buf.bytesused ==  buffer->get_length_frame_only() + MAX_META_DATA_SIZE);
                                 if (_dev.buf_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
                                     /* metadata size is one line of profile, temporary disable validation */
@@ -2085,9 +2119,77 @@ namespace librealsense
             return range;
         }
 
+        uint32_t v4l_uvc_device::mbus_code_to_fourcc(uint32_t mbus_code) const
+        {
+            switch (mbus_code) {
+                case MEDIA_BUS_FMT_RGB888_1X24:   return V4L2_PIX_FMT_RGB24;
+                case MEDIA_BUS_FMT_BGR888_1X24:   return V4L2_PIX_FMT_BGR24;
+                case MEDIA_BUS_FMT_YUYV8_2X8:
+                case MEDIA_BUS_FMT_YUYV8_1X16:    return 0x59555956; // 'YUYV' as consumed by librealsense
+                case MEDIA_BUS_FMT_UYVY8_2X8:
+                case MEDIA_BUS_FMT_UYVY8_1X16:    return V4L2_PIX_FMT_UYVY;
+                case MEDIA_BUS_FMT_VYUY8_1X16:    return V4L2_PIX_FMT_VYUY;
+                case MEDIA_BUS_FMT_SBGGR8_1X8:    return V4L2_PIX_FMT_SBGGR8;
+                case MEDIA_BUS_FMT_SGBRG8_1X8:    return V4L2_PIX_FMT_SGBRG8;
+                case MEDIA_BUS_FMT_SGRBG8_1X8:    return V4L2_PIX_FMT_SGRBG8;
+                case MEDIA_BUS_FMT_SRGGB8_1X8:    return V4L2_PIX_FMT_SRGGB8;
+                case MEDIA_BUS_FMT_SBGGR10_1X10:  return V4L2_PIX_FMT_SBGGR10;
+                case MEDIA_BUS_FMT_SGBRG10_1X10:  return V4L2_PIX_FMT_SGBRG10;
+                case MEDIA_BUS_FMT_SGRBG10_1X10:  return V4L2_PIX_FMT_SGRBG10;
+                case MEDIA_BUS_FMT_SRGGB10_1X10:  return V4L2_PIX_FMT_SRGGB10;
+                case MEDIA_BUS_FMT_Y8_1X8:        return V4L2_PIX_FMT_GREY;
+                case MEDIA_BUS_FMT_Y10_1X10:      return V4L2_PIX_FMT_Y10;
+                case MEDIA_BUS_FMT_Y12_1X12:      return V4L2_PIX_FMT_Y12;
+                case MEDIA_BUS_FMT_FIXED:         return 0x5A313620; // 'Z16 '
+                default:                          return 0;
+            }
+        }
+
         std::vector<stream_profile> v4l_uvc_device::get_profiles() const
         {
             std::vector<stream_profile> results;
+
+            // On IPU6/IPU7 upstream the video node exposes no formats; enumerate them from the subdev instead
+            if (_sub_fd > 0)
+            {
+                v4l2_subdev_mbus_code_enum pixel_format_subdev = {};
+                pixel_format_subdev.pad = 0;
+                pixel_format_subdev.index = 0;
+                while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_MBUS_CODE, &pixel_format_subdev) == 0)
+                {
+                    uint32_t fourcc = mbus_code_to_fourcc(pixel_format_subdev.code);
+
+                    v4l2_subdev_frame_size_enum frame_size = {};
+                    frame_size.pad = 0;
+                    frame_size.code = pixel_format_subdev.code;
+                    frame_size.index = 0;
+                    while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_FRAME_SIZE, &frame_size) == 0)
+                    {
+                        v4l2_subdev_frame_interval_enum frame_interval = {};
+                        frame_interval.pad = 0;
+                        frame_interval.code = pixel_format_subdev.code;
+                        frame_interval.width = frame_size.max_width;
+                        frame_interval.height = frame_size.max_height;
+                        frame_interval.index = 0;
+                        while (ioctl(_sub_fd, VIDIOC_SUBDEV_ENUM_FRAME_INTERVAL, &frame_interval) == 0)
+                        {
+                            auto fps = static_cast<float>(frame_interval.interval.denominator) /
+                                       static_cast<float>(frame_interval.interval.numerator);
+
+                            stream_profile p{};
+                            p.format = fourcc;
+                            p.width = frame_size.max_width;
+                            p.height = frame_size.max_height;
+                            p.fps = fps;
+                            results.push_back(p);
+                            ++frame_interval.index;
+                        }
+                        ++frame_size.index;
+                    }
+                    ++pixel_format_subdev.index;
+                }
+                return results;
+            }
 
             // Retrieve the caps one by one, first get pixel format, then sizes, then
             // frame rates. See http://linuxtv.org/downloads/v4l-dvb-apis for reference.
@@ -2292,6 +2394,14 @@ namespace librealsense
             _fd = open_v4l_node(_name);
             if(_fd < 0)
                 throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot open '" << _name);
+
+            // IPU6/IPU7 upstream expose a subdev alongside the video node; controls and formats are issued on it
+            if (!_subdev_name.empty())
+            {
+                _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
+                if (_sub_fd < 0)
+                    LOG_WARNING(__FUNCTION__ << ": Failed to open subdev " << _subdev_name);
+            }
 
             if (pipe(_stop_pipe_fd) < 0)
                 throw linux_backend_exception(rsutils::string::from() <<__FUNCTION__ << " Cannot create pipe!");
@@ -2788,12 +2898,17 @@ namespace librealsense
             int retVal = xioctl(_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
             if (retVal < 0)
             {
-                if (errno == EIO || errno == EAGAIN) // TODO: Log?
-                    return false;
+                // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
+                retVal = xioctl(_sub_fd, VIDIOC_S_EXT_CTRLS, &ctrls_block);
+                if (retVal < 0)
+                {
+                    if (errno == EIO || errno == EAGAIN) // TODO: Log?
+                        return false;
 
-                throw linux_backend_exception(rsutils::string::from()
-                                              << "xioctl(VIDIOC_S_EXT_CTRLS) failed on control "
-                                              << static_cast< int >( control ) << ", errno=" << errno );
+                    throw linux_backend_exception(rsutils::string::from()
+                                                  << "xioctl(VIDIOC_S_EXT_CTRLS) failed on control "
+                                                  << static_cast< int >( control ) << ", errno=" << errno );
+                }
             }
             return true;
         }
@@ -2813,8 +2928,13 @@ namespace librealsense
                 int ret = xioctl(_fd, VIDIOC_G_EXT_CTRLS, &ext);
                 if (ret < 0)
                 {
-                    // exception is thrown if the ioctl fails twice
-                    continue;
+                    // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
+                    ret = xioctl(_sub_fd, VIDIOC_G_EXT_CTRLS, &ext);
+                    if (ret < 0)
+                    {
+                        // exception is thrown if the ioctl fails twice
+                        continue;
+                    }
                 }
 
                 if (v4l_mipi_logic::is_auto_exposure_control(control))
@@ -2840,7 +2960,9 @@ namespace librealsense
             xctrl_query.id = v4l_mipi_logic::xu_to_cid(xu,control);
 
             if(0 > ioctl(_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query)){
-                throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
+                // IPU6/IPU7 upstream: controls are not propagated to the video node, retry on the subdev
+                if(0 > ioctl(_sub_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query))
+                    throw linux_backend_exception(rsutils::string::from() << "xioctl(VIDIOC_QUERY_EXT_CTRL) failed, errno=" << errno);
             }
 
             if ((xctrl_query.elems !=1 ) ||

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2406,7 +2406,7 @@ namespace librealsense
             {
                 _sub_fd = open(_subdev_name.c_str(), O_RDWR | O_NONBLOCK, 0);
                 if (_sub_fd < 0)
-                    LOG_WARNING(__FUNCTION__ << ": Failed to open subdev '" << _subdev_name
+                    LOG_DEBUG(__FUNCTION__ << ": Failed to open subdev '" << _subdev_name
                                 << "' (non-fatal, subdev controls will be unavailable)");
             }
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2477,6 +2477,14 @@ namespace librealsense
             if(::close(_fd) < 0)
                 throw linux_backend_exception("v4l_uvc_device: close(_fd) failed");
 
+            // _sub_fd is opened in map_device_descriptor(); close it here too, otherwise it
+            // leaks and keeps the sensor sub-device busy, blocking the mutually-exclusive DFU node.
+            if (_sub_fd >= 0)
+            {
+                ::close(_sub_fd);
+                _sub_fd = -1;
+            }
+
             if(::close(_stop_pipe_fd[0]) < 0)
                throw linux_backend_exception("v4l_uvc_device: close(_stop_pipe_fd[0]) failed");
             if(::close(_stop_pipe_fd[1]) < 0)

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1647,9 +1647,14 @@ namespace librealsense
                                 }
 
                                 // Drop partial and overflow frames (assumes D4XX metadata only)
-                                // IPU6/IPU7 upstream pads the queued buffer for ISYS/DMA alignment, so bytesused is one
-                                // stride short of the full length; relax the partial check by a stride to avoid false 99% drops.
-                                bool partial_frame = (!skip_partial_frame_check && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE - buffer->get_stride()));
+                                // The V4L2 buffer length reflects sizeimage, which on IPU7 ISYS includes a fixed DMA
+                                // over-allocation (IPU_ISYS_OVERALLOC_MIN, 1024 bytes) unrelated to the payload. For tiny
+                                // frames (e.g. the D457 IMU node, 38x1 -> 64 bytes) it dominates and made every complete
+                                // frame look partial. Base the check on the real payload (stride * height), keeping one
+                                // stride of slack for the IPU line-padding workaround.
+                                uint32_t expected_frame_size = buffer->get_stride() * _profile.height;
+                                bool partial_frame = (!skip_partial_frame_check && expected_frame_size > buffer->get_stride() &&
+                                                      (buf.bytesused < expected_frame_size - buffer->get_stride()));
                                 bool overflow_frame = (buf.bytesused ==  buffer->get_length_frame_only() + MAX_META_DATA_SIZE);
                                 if (_dev.buf_type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
                                     /* metadata size is one line of profile, temporary disable validation */

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -135,6 +135,7 @@ namespace librealsense
 
             uint32_t get_full_length() const { return _length; }
             uint32_t get_length_frame_only() const { return _original_length; }
+            uint32_t get_stride() const { return _stride; }
 
             uint8_t* get_frame_start() const { return _start; }
 
@@ -145,6 +146,7 @@ namespace librealsense
             uint8_t* _start;
             uint32_t _length;
             uint32_t _original_length;
+            uint32_t _stride;
             uint32_t _offset;
             bool _use_memory_map;
             uint32_t _index;
@@ -364,6 +366,7 @@ namespace librealsense
 
             control_range get_pu_range(rs2_option option) const override;
 
+            uint32_t mbus_code_to_fourcc(uint32_t mbus_code) const;
             std::vector<stream_profile> get_profiles() const override;
 
             void lock() const override;
@@ -442,6 +445,7 @@ namespace librealsense
 
             power_state _state = D3;
             std::string _name = "";
+            std::string _subdev_name = "";
             std::string _device_path = "";
             usb_spec _device_usb_spec = usb_undefined;
             uvc_device_info _info;
@@ -466,6 +470,7 @@ namespace librealsense
             std::vector<int>  _fds;             // list the file descriptors to be monitored during frames polling
             buffers_mgr     _buf_dispatch;      // Holder for partial (MD only) frames that shall be preserved between 'select' calls when polling v4l buffers
             int _fd = 0;
+            int _sub_fd = -1;                   // subdev node (IPU6/IPU7 upstream), -1 when unavailable
             frame_drop_monitor _frame_drop_monitor;           // used to check the frames drops kpi
             v4l2_video_md_syncer _video_md_syncer;
             bool _are_device_capabilities_assigned;

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -91,11 +91,24 @@ namespace librealsense
                 if( *fd < 0 )
                     throw linux_backend_exception( "Mipi device GVD could not be read" );
 
+                // IPU6/IPU7 upstream expose the GVD control on the subdev rather than the video node.
+                // Derive the subdev path from the depth node ("/dev/video-rs-depth-0" -> "/dev/video-rs-depth-sd-0").
+                std::string sub_path = dev_name;
+                auto dash = sub_path.rfind( '-' );
+                if( dash != std::string::npos )
+                    sub_path.insert( dash, "-sd" );
+                std::unique_ptr< int, std::function< void( int * ) > > sub_fd(
+                    new int( sub_path != dev_name ? open( sub_path.c_str(), O_RDWR ) : -1 ),
+                    []( int * d ) { if( d && *d >= 0 ) ::close( *d ); delete d; } );
+
                 // GVD payload has different size depending on product line. Query the control's size so the full struct is read.
                 struct v4l2_query_ext_ctrl qctrl = {};
                 qctrl.id = RS_CAMERA_CID_GVD;
                 if( xioctl( *fd, VIDIOC_QUERY_EXT_CTRL, &qctrl ) != 0 || qctrl.elems == 0 )
-                    throw linux_backend_exception( "Mipi device GVD size could not be queried" );
+                {
+                    if( *sub_fd < 0 || xioctl( *sub_fd, VIDIOC_QUERY_EXT_CTRL, &qctrl ) != 0 || qctrl.elems == 0 )
+                        throw linux_backend_exception( "Mipi device GVD size could not be queried" );
+                }
 
                 std::vector< uint8_t > gvd( qctrl.elems * qctrl.elem_size, 0 );
                 struct v4l2_ext_control ctrl;
@@ -114,7 +127,10 @@ namespace librealsense
                 bool opcode_ok = false;
                 while( ! opcode_ok && retries-- )
                 {
-                    if( xioctl( *fd, VIDIOC_G_EXT_CTRLS, &ext ) == 0 )
+                    int rc = xioctl( *fd, VIDIOC_G_EXT_CTRLS, &ext );
+                    if( rc != 0 && *sub_fd >= 0 )
+                        rc = xioctl( *sub_fd, VIDIOC_G_EXT_CTRLS, &ext );
+                    if( rc == 0 )
                     {
                         auto opcode = gvd[0];
                         if( opcode != GVD_VALID_OPCODE )
@@ -263,6 +279,11 @@ namespace librealsense
             std::string rs_enum_video_node_name( const std::string & sensor, int cam_idx, bool metadata )
             {
                 return "video-rs-" + sensor + ( metadata ? "-md-" : "-" ) + std::to_string( cam_idx );
+            }
+
+            std::string rs_enum_subdev_node_name( const std::string & sensor, int cam_idx )
+            {
+                return "video-rs-" + sensor + "-sd-" + std::to_string( cam_idx );
             }
 
             std::string rs_enum_dfu_node_path( int cam_idx )

--- a/src/linux/v4l-mipi-logic.cpp
+++ b/src/linux/v4l-mipi-logic.cpp
@@ -97,6 +97,8 @@ namespace librealsense
                 auto dash = sub_path.rfind( '-' );
                 if( dash != std::string::npos )
                     sub_path.insert( dash, "-sd" );
+                else
+                    LOG_WARNING( "Could not derive subdev path from " << dev_name );
                 std::unique_ptr< int, std::function< void( int * ) > > sub_fd(
                     new int( sub_path != dev_name ? open( sub_path.c_str(), O_RDWR ) : -1 ),
                     []( int * d ) { if( d && *d >= 0 ) ::close( *d ); delete d; } );

--- a/src/linux/v4l-mipi-logic.h
+++ b/src/linux/v4l-mipi-logic.h
@@ -44,6 +44,7 @@ namespace librealsense
 
             // rs-enum link naming conventions
             std::string rs_enum_video_node_name( const std::string & sensor, int cam_idx, bool metadata );
+            std::string rs_enum_subdev_node_name( const std::string & sensor, int cam_idx );
             std::string rs_enum_dfu_node_path( int cam_idx );
         }  // namespace v4l_mipi_logic
     }  // namespace platform

--- a/src/platform/uvc-device-info.h
+++ b/src/platform/uvc-device-info.h
@@ -20,6 +20,7 @@ struct uvc_device_info
     uint16_t mi = 0;
     std::string unique_id;
     std::string device_path;
+    std::string subdev_name; // subdev node for MIPI/GMSL on IPU6/IPU7 upstream
     std::string dfu_device_path; // for mipi multiple cameras
     std::string serial;
     usb_spec usb_conn_spec = usb_undefined;


### PR DESCRIPTION
Get control from actual subdev instead of propagate from capture node. Include stride in frame calculation.