### PR TITLE
Raise the FW tool timeout above the real GMSL/MIPI flash time

### DIFF
--- a/unit-tests/pytest-fw-update.py
+++ b/unit-tests/pytest-fw-update.py
@@ -26,14 +26,14 @@ pytestmark = [
     pytest.mark.device_each("D585"),
     pytest.mark.device_exclude("D585S"),
     pytest.mark.priority(1),
-    pytest.mark.timeout(750),
+    pytest.mark.timeout(1600),
     pytest.mark.skipif(bool(os.environ.get('GITHUB_ACTIONS')), reason="not runnable on GHA"),
 ]
 
 
 # A FW tool that never returns blocks the whole pytest session, and if pytest is then killed the
 # tool survives as an orphan whose CWD pins the workspace directory (undeletable on Windows).
-FW_TOOL_TIMEOUT = 150  # seconds; a real flash + device reboot is well under 100s
+FW_TOOL_TIMEOUT = 600  # seconds; a USB flash takes ~50s, a GMSL/MIPI one ~385s
 
 
 def abs_fw_path( path ):
@@ -231,7 +231,7 @@ def recover_dds_device_on_golden_domain( serial, context, fw_updater_exe ):
         # its DDS domain to the rig's configured value.
         cmd = [dds_config_exe, '--serial-number', serial,
                '--transient-sdk-domain-id', '0', '--domain-id', str( config_domain )]
-        result = run_fw_tool( cmd )
+        result = run_fw_tool( cmd, timeout = 30 )  # a domain write plus reboot, not a flash
         if result.returncode != 0:
             log.warning( f"rs-dds-config returned rc={result.returncode}; camera may not be on DDS domain {config_domain}" )
         wait_for_reboot( same_version=False )


### PR DESCRIPTION
**Overview:** The nightly firmware-update test no longer fails on MIPI cameras — the FW tool timeout added in #15628 was below the time a GMSL flash actually takes.

## Why

`test_fw_update` has failed on every GMSL/MIPI camera since #15628 merged, on both Jetson agents:

```
rs-fw-update did not exit within 150 seconds; killed it
Failed: rs-fw-update should return exit code 0 (got -1)
```

`FW_TOOL_TIMEOUT` was set to 150s on the assumption that "a real flash plus reboot is well under 100s". That holds over USB, not over GMSL. Measured `rs-fw-update` wall time from the last green builds and the first red ones:

| Build | Device | Link | Tool runtime | Result |
|---|---|---|---|---|
| jetson 19041 | D401 | GMSL | 383.0s | pass (pre-#15628) |
| jetson 19043 | D401 | GMSL | 382.3s | pass (pre-#15628) |
| jetson 19042 | D457 | GMSL | 381.4s | pass (pre-#15628) |
| jetson 19048 | D436 | USB3.2 | 49.7s | pass |
| jetson 19047 / 19048 / 19049 | D401, D457 | GMSL | killed at 150s | **fail** |

A MIPI flash is ~7.7x a USB one and takes ~385s, so the bound fired on every healthy MIPI run. The camera was mid-flash when killed, and the retry hit the same wall.

## Summary

- `FW_TOOL_TIMEOUT` 150s -> 600s, above the measured ~385s GMSL flash with margin. It stays a hang bound, not a performance budget.
- The `rs-dds-config` call takes an explicit 30s instead: it resolves the device with a single `query_devices()`, writes a domain, issues `hardware_reset()` and returns without waiting for the device to come back — it never flashes, so it does not need the flash budget.
- The module's `pytest.mark.timeout` 750s -> 1600s so the bounded steps still fit inside it. Worst case is the DDS recovery path — gold flash, `rs-dds-config`, then the main flash, each followed by a 60s reboot wait: `600 + 30 + 600 + 180 = 1410s`, leaving the same room as before for the gold-FW download and device discovery, which are not bounded here. The GMSL path that regressed is lighter: gold flash plus main flash, `600 + 600 + 120 = 1320s`.

The `pytest.mark.timeout` covers setup and teardown as well as the call (no `func_only`), and `conftest.py` re-arms it per retry attempt, so each attempt gets the full budget.

## Test plan

- [ ] LibCI nightly: `pytest-fw-update.py` passes on D457 and D401 over GMSL (both Jetson agents), which is the regression
- [ ] LibCI Windows + Linux: still passes on D400 / D555 over USB — timing there is unchanged, only the unused headroom grows
- [ ] Recovery paths unaffected: D400 USB DFU gold-flash, D555 domain-0 recovery + `rs-dds-config` domain restore

---
🤖 Generated by AI
