### PR TITLE
Support thermal compensation control on D457

### DIFF
--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -290,7 +290,7 @@ namespace librealsense
             _ds_color_common->register_standard_options();
 
             // Register for tracking of thermal compensation changes
-            if (val_in_range(_pid, { ds::RS455_PID }))
+            if (val_in_range(_pid, { ds::RS455_PID, ds::RS457_PID }))
             {
                 if (_thermal_monitor)
                     _thermal_monitor->add_observer([&](float) {

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -845,10 +845,14 @@ namespace librealsense
                 }
             }
 
-            if ((val_in_range(_pid, { RS455_PID })) && (_fw_version >= firmware_version("5.12.11.0")))
+            if ((val_in_range(_pid, { RS455_PID, RS457_PID })) && (_fw_version >= firmware_version("5.12.11.0")))
             {
-                auto thermal_compensation_toggle = std::make_shared<protected_xu_option<uint8_t>>( raw_depth_sensor, depth_xu,
-                    ds::DS5_THERMAL_COMPENSATION, "Toggle Thermal Compensation Mechanism");
+                std::shared_ptr< option > thermal_compensation_toggle;
+                if( _is_mipi_device )
+                    thermal_compensation_toggle = std::make_shared< thermal_compensation_option_mipi >( _hw_monitor );
+                else
+                    thermal_compensation_toggle = std::make_shared<protected_xu_option<uint8_t>>( raw_depth_sensor, depth_xu,
+                        ds::DS5_THERMAL_COMPENSATION, "Toggle Thermal Compensation Mechanism");
 
                 auto temperature_sensor = depth_sensor.get_option_handler(RS2_OPTION_ASIC_TEMPERATURE);
 

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -845,7 +845,12 @@ namespace librealsense
                 }
             }
 
-            if ((val_in_range(_pid, { RS455_PID, RS457_PID })) && (_fw_version >= firmware_version("5.12.11.0")))
+            // D455 drives the thermal loop over its depth XU control, D457 over the HWM TC_CMD
+            // opcode - gated on the last major release rather than the D455 XU baseline.
+            const bool thermal_compensation_supported
+                = ( _pid == RS455_PID && _fw_version >= firmware_version( "5.12.11.0" ) )
+               || ( _pid == RS457_PID && _fw_version >= firmware_version( "5.17.0.10" ) );
+            if( thermal_compensation_supported )
             {
                 std::shared_ptr< option > thermal_compensation_toggle;
                 if( _is_mipi_device )

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -735,7 +735,8 @@ namespace librealsense
                          public d400_color,
                          public d400_motion_uvc,
                          public d400_mipi_device,
-                         public firmware_logger_device
+                         public firmware_logger_device,
+                         public ds_thermal_tracking
     {
     public:
         rs457_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
@@ -747,6 +748,7 @@ namespace librealsense
             , d400_motion_uvc( dev_info )
             , d400_mipi_device()
             , firmware_logger_device( dev_info, d400_device::_hw_monitor, get_firmware_logs_command(), get_flash_logs_command() )
+            , ds_thermal_tracking( d400_device::_thermal_monitor )
         {
         }
 

--- a/src/ds/d400/d400-options.cpp
+++ b/src/ds/d400/d400-options.cpp
@@ -45,9 +45,6 @@ namespace librealsense
 
     void thermal_compensation_option_mipi::set( float value )
     {
-        if( ! is_valid( value ) )
-            throw invalid_value_exception( "Invalid input for thermal compensation toggle: " + std::to_string( value ) );
-
         auto hwm = _hw_monitor.lock();
         if( ! hwm )
             throw wrong_api_call_sequence_exception( "hw monitor is not available for thermal compensation" );

--- a/src/ds/d400/d400-options.cpp
+++ b/src/ds/d400/d400-options.cpp
@@ -52,10 +52,9 @@ namespace librealsense
         if( ! hwm )
             throw wrong_api_call_sequence_exception( "hw monitor is not available for thermal compensation" );
 
-        const int tc_switch = 5;  // TC_CMD sub-command selecting the thermal loop on/off switch
         try
         {
-            command cmd( ds::TC_CMD, tc_switch, value > 0 ? 1 : 0 );
+            command cmd( ds::TC_CMD, ds::TC_CMD_SWITCH, value > 0 ? 1 : 0 );
             hwm->send( cmd );
         }
         catch( const std::exception & e )

--- a/src/ds/d400/d400-options.cpp
+++ b/src/ds/d400/d400-options.cpp
@@ -38,6 +38,34 @@ namespace librealsense
         return option_range{ -40, 125, 0, 0 };
     }
 
+    thermal_compensation_option_mipi::thermal_compensation_option_mipi( std::shared_ptr< hw_monitor > hwm )
+        : _hw_monitor( hwm )
+    {}
+
+    void thermal_compensation_option_mipi::set( float value )
+    {
+        if( value < 0 )
+            throw invalid_value_exception( "Invalid input for thermal compensation toggle: " + std::to_string( value ) );
+
+        auto hwm = _hw_monitor.lock();
+        if( ! hwm )
+            throw wrong_api_call_sequence_exception( "hw monitor is not available for thermal compensation" );
+
+        const int tc_switch = 5;  // TC_CMD sub-command selecting the thermal loop on/off switch
+        try
+        {
+            command cmd( ds::TC_CMD, tc_switch, value > 0 ? 1 : 0 );
+            hwm->send( cmd );
+        }
+        catch( ... )
+        {
+            throw wrong_api_call_sequence_exception( "hw monitor command for setting thermal compensation failed" );
+        }
+
+        _value = value > 0 ? 1.f : 0.f;
+        _recording_function( *this );
+    }
+
     projector_temperature_option_mipi::projector_temperature_option_mipi(std::shared_ptr<hw_monitor> hwm, rs2_option opt)
         : _hw_monitor(hwm), _option(opt)
     {}

--- a/src/ds/d400/d400-options.cpp
+++ b/src/ds/d400/d400-options.cpp
@@ -39,12 +39,13 @@ namespace librealsense
     }
 
     thermal_compensation_option_mipi::thermal_compensation_option_mipi( std::shared_ptr< hw_monitor > hwm )
-        : _hw_monitor( hwm )
+        : bool_option( true )
+        , _hw_monitor( hwm )
     {}
 
     void thermal_compensation_option_mipi::set( float value )
     {
-        if( value < 0 )
+        if( ! is_valid( value ) )
             throw invalid_value_exception( "Invalid input for thermal compensation toggle: " + std::to_string( value ) );
 
         auto hwm = _hw_monitor.lock();
@@ -57,12 +58,13 @@ namespace librealsense
             command cmd( ds::TC_CMD, tc_switch, value > 0 ? 1 : 0 );
             hwm->send( cmd );
         }
-        catch( ... )
+        catch( const std::exception & e )
         {
-            throw wrong_api_call_sequence_exception( "hw monitor command for setting thermal compensation failed" );
+            throw wrong_api_call_sequence_exception(
+                std::string( "hw monitor command for setting thermal compensation failed: " ) + e.what() );
         }
 
-        _value = value > 0 ? 1.f : 0.f;
+        bool_option::set( value );
         _recording_function( *this );
     }
 

--- a/src/ds/d400/d400-options.h
+++ b/src/ds/d400/d400-options.h
@@ -35,29 +35,19 @@ namespace librealsense
     };
 
     // MIPI has no XU transport for the thermal loop toggle, so it is driven by the TC_CMD HWM
-    // opcode. The command is write-only, hence the last set value is cached for query.
-    class thermal_compensation_option_mipi : public option
+    // opcode. The command is write-only, hence query() returns the last value set - defaulting to
+    // on, as FW enables the loop by default on D45x.
+    class thermal_compensation_option_mipi : public bool_option
     {
     public:
         explicit thermal_compensation_option_mipi( std::shared_ptr< hw_monitor > hwm );
 
         void set( float value ) override;
-        float query() const override { return _value; }
-
-        option_range get_range() const override { return { 0.f, 1.f, 1.f, 1.f }; }
-        bool is_enabled() const override { return true; }
 
         const char * get_description() const override { return "Toggle Thermal Compensation Mechanism"; }
 
-        void enable_recording( std::function< void( const option & ) > record_action ) override
-        {
-            _recording_function = record_action;
-        }
-
     private:
         std::weak_ptr< hw_monitor > _hw_monitor;
-        float _value = 1.f;  // FW enables the loop by default on D45x
-        std::function< void( const option & ) > _recording_function = []( const option & ) {};
     };
 
     class projector_temperature_option_mipi : public readonly_option

--- a/src/ds/d400/d400-options.h
+++ b/src/ds/d400/d400-options.h
@@ -34,6 +34,32 @@ namespace librealsense
         std::shared_ptr<hw_monitor>  _hw_monitor;
     };
 
+    // MIPI has no XU transport for the thermal loop toggle, so it is driven by the TC_CMD HWM
+    // opcode. The command is write-only, hence the last set value is cached for query.
+    class thermal_compensation_option_mipi : public option
+    {
+    public:
+        explicit thermal_compensation_option_mipi( std::shared_ptr< hw_monitor > hwm );
+
+        void set( float value ) override;
+        float query() const override { return _value; }
+
+        option_range get_range() const override { return { 0.f, 1.f, 1.f, 1.f }; }
+        bool is_enabled() const override { return true; }
+
+        const char * get_description() const override { return "Toggle Thermal Compensation Mechanism"; }
+
+        void enable_recording( std::function< void( const option & ) > record_action ) override
+        {
+            _recording_function = record_action;
+        }
+
+    private:
+        std::weak_ptr< hw_monitor > _hw_monitor;
+        float _value = 1.f;  // FW enables the loop by default on D45x
+        std::function< void( const option & ) > _recording_function = []( const option & ) {};
+    };
+
     class projector_temperature_option_mipi : public readonly_option
     {
     public:

--- a/src/ds/d400/d400-private.h
+++ b/src/ds/d400/d400-private.h
@@ -171,6 +171,10 @@ namespace librealsense
             AE_ACCEL_PARAMS    = 0x95, // Get/Set Accelerated AE tuning parameters, FW >= 5.17.3.20
         };
 
+        // TC_CMD param1 selecting the thermal loop on/off switch. The other sub-commands write the
+        // calibration T0 values and flash the table, so the selector must be explicit.
+        const uint8_t TC_CMD_SWITCH = 5;
+
         inline std::string d400_fw_cmd2str(const d400_fw_cmd state)
         {
             switch (state)

--- a/src/ds/d400/d400-private.h
+++ b/src/ds/d400/d400-private.h
@@ -165,6 +165,7 @@ namespace librealsense
             CALIBRECALC        = 0x51, // Calibration recalc and update on the fly
             SETINTCALNEW       = 0x62, // Set Internal sub calibration table (new format)
             ASIC_TEMP_MIPI     = 0x7A, // get ASIC temperature - with mipi device
+            TC_CMD             = 0x84, // Thermal compensation command, param1 selects the sub-command
             GETAELIMITS        = 0x89, // Auto Exp/Gain Limit command FW version >= 5.13.0.200
             SETAELIMITS        = 0x8A, // Auto Exp/Gain Limit command FW version >= 5.13.0.200
             AE_ACCEL_PARAMS    = 0x95, // Get/Set Accelerated AE tuning parameters, FW >= 5.17.3.20

--- a/src/ds/ds-options.cpp
+++ b/src/ds/ds-options.cpp
@@ -760,7 +760,7 @@ namespace librealsense
 
     void thermal_compensation::set(float value)
     {
-        if (value < 0)
+        if (value != 0 && value != 1)
             throw invalid_value_exception("Invalid input for thermal compensation toggle: " + std::to_string(value));
 
         _thermal_toggle->set(value);


### PR DESCRIPTION
**Overview:** D457 now exposes the Thermal Compensation control, so the FW thermal loop is visible to the user and the RGB intrinsics are refreshed when it adjusts the calibration.

Tracked on [RSDEV-14430]

## Why

FW enables the thermal loop by default on D45x and adjusts the RGB calibration as the camera heats. On D457 the SDK had no control for it and never invalidated the cached color calibration, so a running application kept serving stale RGB intrinsics after FW had re-calibrated - breaking UV-mapping. Reading the intrinsics from a fresh process returned different values than the live session.

The existing toggle is a depth XU control, which has no transport on MIPI: `xu_to_cid()` has no mapping for selector `0x0F`, so simply adding the PID to the gate produces a control that throws on every query. FW exposes the same underlying switch through the `TC_CMD` (0x84) HWM opcode, which the MIPI stack already carries.

## Summary

- Add the `TC_CMD` opcode and a `thermal_compensation_option_mipi` that drives the thermal loop over the HW monitor. The command is write-only, so the option caches the value it set.
- Register the option for D457, picking the HWM-backed option on MIPI and keeping the XU option on USB.
- Split the FW gate per PID: D457 requires 5.17.0.10 (the last major release), D455 keeps its 5.12.11.0 XU baseline.
- Reset the color calibration table on a thermal change for D457, as already done for D455.
- Let `rs457_device` inherit `ds_thermal_tracking` so applications receive the calibration-change callback.

No firmware or kernel-driver change is required.

## Test plan

- [ ] Manual, D457 SN 203522251262, FW 5.17.3.10, Jetson d4xx driver 1.0.5.10: `TC_CMD` accepted over GMSL (opcode echoed); an invalid param1 returns a FW error, confirming the command is parsed rather than blindly acked.
- [ ] `rs-enumerate-devices -o` lists Thermal Compensation; range is `[0,1]` step 1, `set(0)` and `set(1)` reach FW and round-trip through the cached value, `set(0.5)` and `set(2)` are rejected.
- [ ] 180 s stream from a cooled camera (ASIC 29 -> 33 C), reading the color intrinsics at each callback. 5 callbacks fired; on the third the color intrinsics changed within the live session:

  ```
  START Color 640x480  fx=386.463257 fy=386.014465
    CALIBRATION-CHANGE CALLBACK #1   post-callback fx=386.463257  (unchanged)
    CALIBRATION-CHANGE CALLBACK #2   post-callback fx=386.463257  (unchanged)
    CALIBRATION-CHANGE CALLBACK #3   post-callback fx=386.673767  <== CHANGED (was 386.463257)
    CALIBRATION-CHANGE CALLBACK #4   post-callback fx=386.673767  (unchanged)
    CALIBRATION-CHANGE CALLBACK #5   post-callback fx=386.673767  (unchanged)
  END   Depth 640x480  fx=390.076324                              (depth unchanged)
  ```

  The callback signals "re-read the calibration", not "it changed" - the monitor notifies on each 2 C ASIC step while FW decides independently when to rewrite the RGB table. Depth intrinsics are unaffected, as expected: only the RGB table is adjusted.
- [ ] Toggle verified to gate the FW loop. Same cool-down, same 180 s stream, ASIC 29 -> 33 C in both runs:

  | thermal_compensation | result |
  |---|---|
  | 1 | intrinsics changed - 7 Fx entries, fx 213.3308 -> 213.5924 |
  | 0 | intrinsics identical - no calibration change while heating |

  The disabled run is measured *after* the toggle settles: a disable moves FW to `etDscThermalStateResetting`, which itself unwinds the compensation to baseline, so a baseline captured before the toggle would show that reset rather than the loop's behaviour.
- [ ] D455 (USB) unchanged - still uses the XU path.

## Note for consumers

An application must register the calibration-change callback on the device returned by `pipeline_profile::get_device()`. A device obtained from `context::query_devices()` is a different instance from the one the pipeline creates, and its callback never fires.

---
🤖 Generated by AI
