### PR TITLE
Fix recorder crash on frames whose stride is smaller than their format requires

### DIFF
--- a/src/media/ros2/ros2_image_codec.cpp
+++ b/src/media/ros2/ros2_image_codec.cpp
@@ -102,6 +102,14 @@ namespace librealsense
             if (width > 0x7FFFFFFFu || height > 0x7FFFFFFFu)
                 throw invalid_value_exception("image dimensions exceed the PNG limit");
 
+            // The scanline pass reads width * bpp bytes per row, with rows stride apart: a frame
+            // whose stride is narrower than its own format demands would be read out of bounds
+            const size_t bpp = layout.bytes_per_channel * layout.num_channels;
+            if (stride < width * bpp)
+                throw invalid_value_exception( rsutils::string::from()
+                                               << "frame stride (" << stride << ") is too small for "
+                                               << width << " pixels of " << bpp << " bytes" );
+
             // allocation retried on failure rather than caching a permanently-null compressor
             static thread_local std::unique_ptr<libdeflate_compressor, void(*)(libdeflate_compressor*)>
                 compressor(nullptr, libdeflate_free_compressor);

--- a/unit-tests/syncer/sw_syncer.py
+++ b/unit-tests/syncer/sw_syncer.py
@@ -18,12 +18,14 @@ domain = rs.timestamp_domain.hardware_clock       # For either depth/color
 fps_c = fps_d = 60
 w = 640
 h = 480
-bpp = 2  # bytes
+bpp_d = 2  # bytes, Z16
+bpp_c = 4  # bytes, RGBA8
 #
 # Set by init() or playback() -- don't set these unless you know what you're doing!
 #
 gap_c = gap_d = 0
-pixels = None
+pixels_d = None
+pixels_c = None
 device = None
 depth_sensor = None
 color_sensor = None
@@ -52,8 +54,9 @@ def init( syncer_matcher = rs.matchers.default ):
     gap_d = 1000 / fps_d
     gap_c = 1000 / fps_c
     #
-    global pixels, w, h
-    pixels = bytearray( b'\x00' * ( w * h * 2 ))  # Dummy data
+    global pixels_d, pixels_c, w, h
+    pixels_d = bytearray( b'\x00' * ( w * h * bpp_d ))  # Dummy data
+    pixels_c = bytearray( b'\x00' * ( w * h * bpp_c ))
     #
     global device
     device = rs.software_device()
@@ -69,7 +72,7 @@ def init( syncer_matcher = rs.matchers.default ):
     depth_stream.uid = 0
     depth_stream.width = 640
     depth_stream.height = 480
-    depth_stream.bpp = 2
+    depth_stream.bpp = bpp_d
     depth_stream.fmt = rs.format.z16
     depth_stream.fps = fps_d
     #
@@ -81,7 +84,7 @@ def init( syncer_matcher = rs.matchers.default ):
     color_stream.uid = 1
     color_stream.width = 640
     color_stream.height = 480
-    color_stream.bpp = 2
+    color_stream.bpp = bpp_c
     color_stream.fmt = rs.format.rgba8
     color_stream.fps = fps_c
     #
@@ -191,11 +194,11 @@ def generate_depth_frame( frame_number, timestamp, next_expected=None ):
     if playback_status is not None:
         raise RuntimeError( "cannot generate frames when playing back" )
     #
-    global depth_profile, domain, pixels, depth_sensor, w, bpp
+    global depth_profile, domain, pixels_d, depth_sensor, w, bpp_d
     depth_frame = rs.software_video_frame()
-    depth_frame.pixels = pixels
-    depth_frame.stride = w * bpp
-    depth_frame.bpp = bpp
+    depth_frame.pixels = pixels_d
+    depth_frame.stride = w * bpp_d
+    depth_frame.bpp = bpp_d
     depth_frame.frame_number = frame_number
     depth_frame.timestamp = timestamp
     depth_frame.domain = domain
@@ -217,11 +220,11 @@ def generate_color_frame( frame_number, timestamp, next_expected=None ):
     if playback_status is not None:
         raise RuntimeError( "cannot generate frames when playing back" )
     #
-    global color_profile, domain, pixels, color_sensor, w, bpp
+    global color_profile, domain, pixels_c, color_sensor, w, bpp_c
     color_frame = rs.software_video_frame()
-    color_frame.pixels = pixels
-    color_frame.stride = w * bpp
-    color_frame.bpp = bpp
+    color_frame.pixels = pixels_c
+    color_frame.stride = w * bpp_c
+    color_frame.bpp = bpp_c
     color_frame.frame_number = frame_number
     color_frame.timestamp = timestamp
     color_frame.domain = domain


### PR DESCRIPTION
**Overview:** Recording a video frame whose stride is smaller than its stream format requires no longer reads past the end of the frame buffer and crashes the process.

Tracked on [RSDSO-21934]

## Why

`Win_ST_Py_CI` on GHA fails intermittently with exit code 139 — a segfault inside `unit-tests/syncer/pytest-ts-eof.py` at `recorder.pause()`. The main thread is only blocked in `flush()`; the fault is on the recorder's write thread:

```
ACCESS VIOLATION (read)
 #00 ros2_image_codec::build_scanlines   [src/media/ros2/ros2_image_codec.cpp:80]
 #01 ros2_image_codec::encode_png        [src/media/ros2/ros2_image_codec.cpp:118]
 #02 ros2_writer::write_compressed_video_frame [src/media/ros2/ros2_writer.cpp:162]
 #03 ros2_writer::write_frame            [src/media/ros2/ros2_writer.cpp:231]
 #04 record_device write lambda          [src/media/record/record_device.cpp:180]
 #05 dispatcher thread                   [third-party/rsutils/src/dispatcher.cpp:33]
```

`build_scanlines` computes `row = width * bpp` with `bpp` taken from the stream *format*, then reads `row` bytes per line at `pixels + y * stride` using the *frame's* stride. When the frame's stride is narrower than the format demands, the encoder reads past the buffer. Recording is compressed by default, so the PNG path is always taken.

The test helper triggers it: `sw_syncer.py` declares Color as RGBA8 (4 bytes/pixel) but pushes frames with `bpp=2`, `stride=w*2` and a `w*h*2` buffer, so the encoder reads twice the buffer size. Whether that faults depends on the pages past the allocation — hence the flakiness (2 of 4 runs crashed on the same commit).

## Summary

- `encode_png` rejects a frame whose stride is too small for its format instead of reading out of bounds; recording stops with a clear error.
- `sw_syncer.py` pushes RGBA8 color frames with 4 bytes/pixel and its own buffer; depth keeps Z16 at 2 bytes/pixel.

## Test plan

- [x] `unit-tests/syncer/` pytest run (Release, Windows): 19 passed, `pytest-ts-eof.py` included — it is the only syncer test that records.
- [x] Standalone recording stress, 300 iterations x 4 runs with a deliberately mismatched stride: 4/4 runs segfaulted before the fix, 0/4 after (the frame is rejected and recording reports the error).
- [ ] GHA Build_CI green, `Win_ST_Py_CI` in particular.

---
🤖 Generated by AI
