### PR TITLE
viewer: expose DPP temporal alpha as float

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2909,10 +2909,7 @@ namespace rs2
                                 rs2_temporal_filter_dpp_config cfg{};
                                 memcpy(&cfg, bytes.data(), sizeof(cfg));
                                 sub->temporal_filter_dpp_enabled = cfg.enabled;
-                                // Wire value is normalized [0,1] scaled into [0,1000] (every DPP
-                                // param slot is an int32 - see rs_temporal_filter_dpp.h) -
-                                // converted back to a plain [0,1] float for the slider below.
-                                sub->temporal_filter_dpp_smooth_alpha = cfg.smooth_alpha / 1000.0f;
+                                sub->temporal_filter_dpp_smooth_alpha = cfg.smooth_alpha;
                                 sub->temporal_filter_dpp_smooth_delta = cfg.smooth_delta;
                                 sub->temporal_filter_dpp_persistency_index = cfg.persistency_index;
                                 sub->temporal_filter_dpp_populated = true;
@@ -2937,9 +2934,7 @@ namespace rs2
                             {
                                 rs2_temporal_filter_dpp_config cfg{};
                                 cfg.enabled = sub->temporal_filter_dpp_enabled;
-                                // [0,1] float slider back to the wire's [0,1000] scaled int32 -
-                                // see the matching conversion on read, above.
-                                cfg.smooth_alpha = static_cast<int32_t>( std::lround( sub->temporal_filter_dpp_smooth_alpha * 1000.0f ) );
+                                cfg.smooth_alpha = sub->temporal_filter_dpp_smooth_alpha;
                                 cfg.smooth_delta = sub->temporal_filter_dpp_smooth_delta;
                                 cfg.persistency_index = sub->temporal_filter_dpp_persistency_index;
                                 sub->s->set_composite_option(RS2_COMPOSITE_OPTION_TEMPORAL_FILTER_DPP, &cfg, sizeof(cfg));

--- a/common/embedded-filter-model.cpp
+++ b/common/embedded-filter-model.cpp
@@ -546,11 +546,19 @@ namespace rs2
     // field is meaningful all the time.
     bool embedded_filter_model::draw_temporal_filter_dpp_fields()
     {
-        bool any_field_active = draw_temporal_filter_dpp_manual_editable_field( "Smooth Alpha:", "temporal_filter_dpp_smooth_alpha",
-            _temporal_filter_dpp_editor.value.smooth_alpha, 0, 1000,
-            _temporal_filter_dpp_smooth_alpha_edit_mode, _temporal_filter_dpp_smooth_alpha_edit_buf );
-        if( ImGui::IsItemHovered() )
-            ImGui::SetTooltip( "Normalized [0,1] scaled into [0,1000] - e.g. 400 = 0.4." );
+        ImGui::Text("Smooth Alpha:");
+        ImGui::SameLine();
+        const bool alpha_changed = ImGui::SliderFloat("##temporal_filter_dpp_smooth_alpha",
+            &_temporal_filter_dpp_editor.value.smooth_alpha, 0.0F, 1.0F, "%.2f");
+        if (alpha_changed || ImGui::IsItemActive())
+            _temporal_filter_dpp_editor.touch();
+        if (ImGui::IsItemDeactivatedAfterEdit())
+            _temporal_filter_dpp_editor.finalize(
+                _temporal_filter_dpp_editor.numeric_commit_delay);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Normalized alpha in the range [0.0, 1.0].");
+
+        bool any_field_active = ImGui::IsItemActive();
 
         any_field_active |= draw_temporal_filter_dpp_manual_editable_field( "Smooth Delta:", "temporal_filter_dpp_smooth_delta",
             _temporal_filter_dpp_editor.value.smooth_delta, 1, 100,

--- a/examples/C/composite-ctl/rs-composite-ctl.c
+++ b/examples/C/composite-ctl/rs-composite-ctl.c
@@ -83,7 +83,7 @@ static void print_decimation_filter_dpp_range( const rs2_decimation_filter_dpp_r
 }
 
 /* C99 equivalent of print_struct(temporal_filter_dpp_fields(), ...) - see
-   print_decimation_filter_dpp_struct() above. smooth_alpha is [0,1] scaled into [0,1000] (every
+   print_decimation_filter_dpp_struct() above. smooth_alpha is a normalized float in [0,1] (every
    DPP param slot is an int32), so it prints as a plain %d like every other field, not a float. */
 static void print_temporal_filter_dpp_struct( const rs2_temporal_filter_dpp_config * v )
 {
@@ -93,7 +93,7 @@ static void print_temporal_filter_dpp_struct( const rs2_temporal_filter_dpp_conf
     printf( "        %-16s = %d\n", "param_count", (int)v->header.param_count );
     printf( "        %-16s = %d\n", "param_type", (int)v->header.param_type );
     printf( "        %-16s = %d\n", "enabled", v->enabled );
-    printf( "        %-16s = %d\n", "smooth_alpha", v->smooth_alpha );
+    printf( "        %-16s = %.3f\n", "smooth_alpha", v->smooth_alpha );
     printf( "        %-16s = %d\n", "smooth_delta", v->smooth_delta );
     printf( "        %-16s = %d\n", "persistency_index", v->persistency_index );
 }
@@ -376,12 +376,12 @@ static int exercise_temporal_filter_dpp( const rs2_options * opts, rs2_composite
        every step below, same discipline as exercise_hdrd_control() below. */
     cfg = current;
     cfg.enabled = 1;
-    cfg.smooth_alpha = 550;  /* normalized [0,1] scaled into [0,1000] - i.e. 0.55 */
+    cfg.smooth_alpha = 0.55F;
     cfg.smooth_delta = 35;
     cfg.persistency_index = 5;
     if( ! temporal_filter_dpp_set_and_readback( opts, id, &cfg, &after ) )
         return 0;  /* helper already printed and freed its own error */
-    printf( "      Set (enabled=1 smooth_alpha=550 smooth_delta=35 persistency_index=5): %s\n",
+    printf( "      Set (enabled=1 smooth_alpha=0.55 smooth_delta=35 persistency_index=5): %s\n",
             ( after.enabled == cfg.enabled && after.smooth_alpha == cfg.smooth_alpha
               && after.smooth_delta == cfg.smooth_delta && after.persistency_index == cfg.persistency_index )
                 ? "matches what was sent" : "differs - FW may quantize/clamp on write" );

--- a/examples/composite-option-mock/rs-composite-option-mock.cpp
+++ b/examples/composite-option-mock/rs-composite-option-mock.cpp
@@ -226,7 +226,7 @@ bool test_temporal_filter_dpp()
 {
     rs2_temporal_filter_dpp_config initial{};
     initial.enabled = 1;
-    initial.smooth_alpha = 400;  // normalized [0,1] scaled into [0,1000] - see rs_temporal_filter_dpp.h
+    initial.smooth_alpha = 0.4F;  // normalized float in [0,1] - see rs_temporal_filter_dpp.h
     initial.smooth_delta = 20;
     initial.persistency_index = 3;
     rs2_temporal_filter_dpp_config modified = initial;

--- a/examples/composite-option/rs-composite-option.cpp
+++ b/examples/composite-option/rs-composite-option.cpp
@@ -280,11 +280,11 @@ namespace
 
         rs2_temporal_filter_dpp_config cfg_to_send = current;
         cfg_to_send.enabled = 1;
-        cfg_to_send.smooth_alpha = 550;  // normalized [0,1] scaled into [0,1000] - i.e. 0.55
+        cfg_to_send.smooth_alpha = 0.55F;
         cfg_to_send.smooth_delta = 35;
         cfg_to_send.persistency_index = 5;
         opts.set_composite_option_from( id, cfg_to_send );
-        std::cout << "      Set (read-modify-write): enabled=1 smooth_alpha=550 smooth_delta=35 persistency_index=5\n";
+        std::cout << "      Set (read-modify-write): enabled=1 smooth_alpha=0.55 smooth_delta=35 persistency_index=5\n";
 
         print_bytes( "Get (after)", opts.get_composite_option( id ) );
         auto cfg = opts.get_composite_option_as< rs2_temporal_filter_dpp_config >( id );

--- a/examples/sensor-control/api_how_to.h
+++ b/examples/sensor-control/api_how_to.h
@@ -557,7 +557,7 @@ public:
             std::cout << "  persistency_index : [" << range.min.persistency_index << ", " << range.max.persistency_index << "]" << std::endl;
 
             std::cout << "\nWhich field would you like to change?\n" << std::endl;
-            std::cout << "  0 : enabled\n  1 : smooth_alpha (normalized [0,1] scaled into [0,1000])\n"
+            std::cout << "  0 : enabled\n  1 : smooth_alpha (normalized float in [0,1])\n"
                           "  2 : smooth_delta\n  3 : persistency_index" << std::endl;
             uint32_t field_index = get_user_selection("Select a field by index: ");
 

--- a/include/librealsense2/h/rs_dpp_header.h
+++ b/include/librealsense2/h/rs_dpp_header.h
@@ -4,7 +4,7 @@
 /** \file rs_dpp_header.h
 * \brief
 * Wire header shared by every control in the HKR Depth Post-Processing (DPP) composite-option
-* family: this header + a fixed 8-slot int32 param block; param_count says how many are active,
+* family: this header + a fixed 8-slot 32-bit param block; param_count says how many are active,
 * the rest MUST be zero on SET. See rs_hdrd_control.h for a control that uses it.
 */
 
@@ -30,7 +30,7 @@ typedef struct dpp_header
     uint8_t  flags;         /**< Bitwise control-status mask (active/read-only) */
     uint16_t ctl_id;        /**< dpp_ctrl_list entry identifying this control */
     uint8_t  param_count;   /**< Active param slots out of the fixed 8 that follow */
-    uint8_t  param_type;    /**< Per-param int/float bitmap. 0x00 = all-integer */
+    uint8_t  param_type;    /**< Per-param int/float bitmap. 0x00 = all-integer; a float slot is IEEE-754 float32 */
 } dpp_header;
 
 #pragma pack(pop)

--- a/include/librealsense2/h/rs_temporal_filter_dpp.h
+++ b/include/librealsense2/h/rs_temporal_filter_dpp.h
@@ -4,7 +4,7 @@
 /** \file rs_temporal_filter_dpp.h
 * \brief
 * Cast-target struct for RS2_COMPOSITE_OPTION_TEMPORAL_FILTER_DPP (see rs_composite_option.h).
-* Same shared HKR DPP wire layout (see rs_hdrd_control.h): dpp_header + 8 int32 param slots,
+* Same shared HKR DPP wire layout (see rs_hdrd_control.h): dpp_header + 8 32-bit param slots,
 * 4 used (38 bytes, little-endian, pack(1)); ctl_id = 0x0002.
 */
 
@@ -26,8 +26,7 @@ typedef struct rs2_temporal_filter_dpp_config
     dpp_header header;
 
     int32_t enabled;             /**< 0 = Off, 1 = On. Default 0 */
-    int32_t smooth_alpha;        /**< Normalized [0,1] scaled into [0,1000] (every param slot is
-                                  * an int32, not a float). Default 400 (0.4) */
+    float smooth_alpha;          /**< IEEE-754 float32, normalized [0,1]. Default 0.4 */
     int32_t smooth_delta;        /**< Range [1,100], step 1. Default 20 */
     int32_t persistency_index;   /**< Range [0,8], step 1. Default 3 */
 


### PR DESCRIPTION
## Summary
- expose USB DPP Temporal Smooth Alpha as normalized IEEE-754 float32
- render the Viewer control as 0.000–1.000 rather than x1000
- retain the fixed 38-byte DPP control payload and protocol version 1

## Compatibility
This is an intentional paired Host/FW ABI semantic change. It requires the matching firmware change in https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/609. GMSL behavior is unchanged.

## Validation
- `cmake --build build --target realsense-viewer --parallel 20`
- manually flashed matching D585 temporary FW image and confirmed device enumeration

## Manual check
Open Embedded-Filters > Temporal. `Smooth Alpha` should show values in `[0.000, 1.000]` (e.g. `0.400`, `1.000`).