### PR TITLE
pytest-advanced-occ-calibrations: gate post>modified fill-rate check on perturbation actually degrading

### DIFF
--- a/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
+++ b/unit-tests/live/calib/pytest-advanced-occ-calibrations.py
@@ -173,15 +173,23 @@ def run_advanced_occ_calibration_test(host_assistance, config, pipeline, calib_d
             log.error("Fill rate after OCC unavailable")
             pytest.fail()
 
-        # Fill rate assertions: post-OCC must be better than both base and modified
+        # Fill rate assertions.
+        # The "post > modified" invariant only holds when the perturbation actually degraded the
+        # scene. When the factory ppy is off-optimum, the shift can accidentally land closer to
+        # the true value and *raise* fill rate; OCC then correctly converges near that better
+        # optimum and post ≈ modified. Only enforce the improvement check when the perturbation
+        # degraded fill rate; always require post to stay within tolerance of base.
         if base_fill_rate is not None and modified_fill_rate is not None and post_fill_rate is not None:
             log.info(f"Fill rates: base={base_fill_rate*100:.1f}% modified={modified_fill_rate*100:.1f}% post={post_fill_rate*100:.1f}%")
-            if post_fill_rate <= modified_fill_rate:
+            perturbation_degraded = modified_fill_rate < base_fill_rate - FILL_RATE_TOLERANCE
+            if perturbation_degraded and post_fill_rate <= modified_fill_rate:
                 log.error("Post-OCC fill rate did not improve over perturbed fill rate")
                 pytest.fail()
             elif post_fill_rate < base_fill_rate - FILL_RATE_TOLERANCE:
                 log.error(f"Post-OCC fill rate ({post_fill_rate*100:.1f}%) is below base ({base_fill_rate*100:.1f}%) by more than tolerance ({FILL_RATE_TOLERANCE*100:.0f}%)")
                 pytest.fail()
+            elif not perturbation_degraded:
+                log.info(f"Perturbation did not degrade fill rate (modified={modified_fill_rate*100:.1f}% vs base={base_fill_rate*100:.1f}%); skipping post>modified check, post={post_fill_rate*100:.1f}% is within tolerance of base")
             else:
                 log.info(f"Fill rate improved after OCC vs modified (+{(post_fill_rate - modified_fill_rate)*100:.1f}%) and vs base (+{(post_fill_rate - base_fill_rate)*100:.1f}%)")
 


### PR DESCRIPTION
## Overview

`test_advanced_occ_calibration` perturbs right `ppy` by `-2 px` and asserts that post-OCC fill rate strictly exceeds the perturbed fill rate. That invariant assumes the perturbation always degrades the scene, which is not the case: when the factory `ppy` is off-optimum, a `-2 px` shift can land closer to the true value and *raise* fill rate. OCC then correctly converges near that better optimum, so `post ~= modified` and the test fails even though calibration behaved correctly.

## Observed failure (D455 S/N 013322250065, FW 5.17.3.10)

| Metric | Run 1 | Run 2 |
|---|---|---|
| base fill rate | 68.9% | 68.6% |
| modified (ppy shifted -2 px) | 77.3% | 77.8% |
| post-OCC | 77.2% | 77.7% |
| ppy: base → modified → final | 405.44 → 403.44 → 403.91 | 405.44 → 403.44 → 403.81 |

Health factor ~ -0.17, well within threshold. OCC converged near the perturbed value because that value was closer to the true principal point than the factory value was. The direction / reversion check below (`(final - modified) * (base - modified) > 0`) would have passed; the fill-rate gate fired first.

## Fix

Only enforce the `post > modified` assertion when the perturbation actually degraded fill rate beyond `FILL_RATE_TOLERANCE`. The `post >= base - tolerance` sanity check still applies unconditionally, and the ppy direction / reversion check downstream is unchanged and remains the primary semantic assertion.

## Test plan

- [ ] Rerun `pytest-advanced-occ-calibrations.py::test_advanced_occ_calibration` on the D455 that produced the failure above — expect pass with `Perturbation did not degrade fill rate ...` log line.
- [ ] Rerun the same test on a D455 where the factory `ppy` is well-centered (perturbation should degrade fill rate) — expect the existing `post > modified` path to still enforce improvement.
- [ ] Nightly run across the D400 family (excluding D401, D555) to confirm no regressions.