### PR TITLE
Dual RGB block unsupported stream combinations

### DIFF
--- a/common/embedded-filter-model.h
+++ b/common/embedded-filter-model.h
@@ -77,6 +77,19 @@ namespace rs2
             return _decimation_filter_dpp_editor.initialized && _decimation_filter_dpp_editor.value.enabled != 0;
         }
 
+        // Seeds the cache above straight from the device, so is_decimation_filter_dpp_enabled() is
+        // right from the first frame instead of only once the editor has been drawn. Idempotent -
+        // ensure_initialized() no-ops after a successful read, and a failure leaves it unread.
+        void sync_decimation_filter_dpp_state( std::string & error_message )
+        {
+            if( ! _embedded_filter
+                || _embedded_filter->get_type() != RS2_EMBEDDED_FILTER_TYPE_DECIMATION
+                || ! _embedded_filter->supports_composite_option( RS2_COMPOSITE_OPTION_DECIMATION_FILTER_DPP ) )
+                return;
+            _decimation_filter_dpp_editor.ensure_initialized(
+                _embedded_filter, RS2_COMPOSITE_OPTION_DECIMATION_FILTER_DPP, error_message );
+        }
+
         bool _is_visible = true;
 
         // Optional predicate; null means always available. When false the enable toggle is

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -355,6 +355,10 @@ namespace rs2
                 model->unavailable_tooltip = "Improved Close Range Depth cannot be activated while color streams are active";
             }
 
+            // is_multiple_resolutions_supported() reads the composite enabled state on the draw
+            // path, so seed it here rather than waiting for the editor's first draw.
+            model->sync_decimation_filter_dpp_state( error_message );
+
             embedded_filters.push_back(model);
         }
 
@@ -605,8 +609,13 @@ namespace rs2
                         auto res_it = resolutions_for_current_stream.end() - 1;
                         ui.selected_stream_to_res[cur_stream] = *res_it;
 
-                        while (res_it->first && !is_selected_combination_supported())
+                        // Walk this stream down to a resolution the combination resolves at. The
+                        // selection must be updated each step - it is what the check above reads.
+                        while (res_it != resolutions_for_current_stream.begin() && !is_selected_combination_supported())
+                        {
                             --res_it;
+                            ui.selected_stream_to_res[cur_stream] = *res_it;
+                        }
                     }
                 }
             }
@@ -1818,9 +1827,10 @@ namespace rs2
             auto filter = ef->get_filter();
             if( ! filter || filter->get_type() != RS2_EMBEDDED_FILTER_TYPE_DECIMATION )
                 continue;
-            // Filter present without the ENABLED option => permanently on in FW.
+            // Decimation is registered as a composite option, which intentionally does not carry
+            // EMBEDDED_FILTER_ENABLED - the composite's own enabled field is the real state.
             if( ! filter->supports( RS2_OPTION_EMBEDDED_FILTER_ENABLED ) )
-                return true;
+                return ef->is_decimation_filter_dpp_enabled();
             return ef->is_enabled();
         }
         return false;
@@ -1882,8 +1892,10 @@ namespace rs2
         // filter (FW-side) only accepts depth at 640x360 and pairs it with IR at 1280x720.
         // Landing the combo boxes on these values here avoids the streaming-time error
         // in avoid_streaming_on_embedded_filters_not_matching_configuration().
+        // Dual-color carries color on this same sensor, so pin it alongside IR
         static const std::pair< int, int > DEPTH_RES{ 640, 360 };
         static const std::pair< int, int > IR_RES{ 1280, 720 };
+        static const std::pair< int, int > COLOR_RES{ 1280, 720 };
 
         auto force = [&]( rs2_stream stream, const std::pair< int, int > & res ) {
             auto it = resolutions_per_stream.find( stream );
@@ -1894,6 +1906,7 @@ namespace rs2
         };
         force( RS2_STREAM_DEPTH, DEPTH_RES );
         force( RS2_STREAM_INFRARED, IR_RES );
+        force( RS2_STREAM_COLOR, COLOR_RES );
     }
 
     std::pair<int, int> subdevice_model::get_max_resolution(rs2_stream stream) const

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -152,26 +152,10 @@ namespace librealsense
             uvc->set_frame_metadata_modifier(callback);
     }
 
-    void d500_depth_sensor::color_stream_allowed_or_throw( const stream_profiles & requests ) const
-    {
-        bool color_requested = false;
-        for( auto & p : requests )
-            if( p && p->get_stream_type() == RS2_STREAM_COLOR )
-                color_requested = true;
-        if( ! color_requested )
-            return;  // color only lives on this sensor for dual-color devices
-
-        for( auto & f : _embedded_filters )
-            if( f && f->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE
-                && f->supports_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED )
-                && f->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ).query() != 0.f )
-                throw wrong_api_call_sequence_exception(
-                    "Color streams cannot be activated while Improved Close Range Depth is enabled" );
-    }
-
     void d500_depth_sensor::open( const stream_profiles & requests )
     {
-        color_stream_allowed_or_throw( requests );
+        if( _owner )
+            _owner->stream_combination_allowed_or_throw( requests );
 
         group_multiple_fw_calls(*this, [&]() {
             _depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -154,8 +154,9 @@ namespace librealsense
 
     void d500_depth_sensor::open( const stream_profiles & requests )
     {
-        if( _owner )
-            _owner->stream_combination_allowed_or_throw( requests );
+        if( ! _owner )
+            throw std::runtime_error( "d500_depth_sensor has no owner device" );
+        _owner->stream_combination_allowed_or_throw( requests );
 
         group_multiple_fw_calls(*this, [&]() {
             _depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+#include <functional>
 #include "hw_monitor_extended_buffers.h"
 
 #include "core/debug.h"
@@ -53,10 +54,6 @@ namespace librealsense
         embedded_filters get_supported_embedded_filters() const override { return _embedded_filters; }
         void add_embedded_filter( std::shared_ptr< embedded_filter_interface > filter ) { _embedded_filters.push_back( filter ); }
 
-        // Throws if a color stream in 'requests' cannot start now. Dual-color: color shares this sensor
-        // and close-range works on depth only, so color is blocked while close-range is enabled.
-        void color_stream_allowed_or_throw( const stream_profiles & requests ) const;
-
         // Streams contributed by feature mixins (e.g. dual-color) that this sensor physically carries. They are
         // assigned to matching profiles (by stream type + index) during init_stream_profiles.
         void add_stream( std::shared_ptr< stream_interface > stream ) { _extra_streams.push_back( stream ); }
@@ -91,6 +88,20 @@ namespace librealsense
     public:
         std::shared_ptr<synthetic_sensor> create_depth_device(std::shared_ptr<context> ctx,
             const std::vector<platform::uvc_device_info>& all_device_infos);
+
+        // Adds a rule that vetoes stream combinations this device cannot run: feature mixins register
+        // their hardware's restrictions at construction, and each throws when a request violates it.
+        void add_stream_combination_validator( std::function< void( const stream_profiles & ) > validator )
+        {
+            _stream_combination_validators.push_back( std::move( validator ) );
+        }
+
+        // Throws if the profiles cannot stream together. A device with no registered rule allows everything.
+        void stream_combination_allowed_or_throw( const stream_profiles & requests ) const
+        {
+            for( auto & validator : _stream_combination_validators )
+                validator( requests );
+        }
 
         synthetic_sensor& get_depth_sensor()
         {
@@ -179,6 +190,7 @@ namespace librealsense
         bool _is_symmetrization_enabled = true;
         bool _is_mipi_device = false;
 
+        std::vector< std::function< void( const stream_profiles & ) > > _stream_combination_validators;
         // Populated in init() only when _is_mipi_device is true.
         std::unique_ptr< d500_mipi_device > _mipi_device;
     };

--- a/src/ds/d500/d500-dual-color.cpp
+++ b/src/ds/d500/d500-dual-color.cpp
@@ -16,6 +16,7 @@
 #include <rsutils/type/fourcc.h>
 using rs_fourcc = rsutils::type::fourcc;
 
+#include <algorithm>
 #include <set>
 
 
@@ -69,10 +70,84 @@ namespace librealsense
         d500_depth.add_stream( _color_stream_1 );
         d500_depth.add_stream( _color_stream_2 );
 
+        add_stream_combination_validator( [this]( const stream_profiles & requests ) { close_range_allowed_or_throw( requests ); } );
+        add_stream_combination_validator( [this]( const stream_profiles & requests ) { frame_rates_allowed_or_throw( requests ); } );
+
         register_color_extrinsics();
         register_color_metadata();
         register_ae_policy_option();
     }
+
+    // Both rules below only bite once a color stream shares the depth sensor's imagers.
+    static bool color_requested( const stream_profiles & requests )
+    {
+        return std::any_of( requests.begin(), requests.end(), []( auto & p )
+                            { return p && p->get_stream_type() == RS2_STREAM_COLOR; } );
+    }
+
+    static bool depth_or_ir_requested( const stream_profiles & requests )
+    {
+        return std::any_of( requests.begin(), requests.end(), []( auto & p )
+                            { return p && ( p->get_stream_type() == RS2_STREAM_DEPTH || p->get_stream_type() == RS2_STREAM_INFRARED ); } );
+    }
+
+    // Close range works on depth only, so it cannot be enabled while a color stream starts.
+    void d500_dual_color::close_range_allowed_or_throw( const stream_profiles & requests ) const
+    {
+        if( ! color_requested( requests ) )
+            return;
+
+        // get_depth_sensor() has no const overload, and this rule only reads the filter's state.
+        auto & depth_sensor = dynamic_cast< const d500_depth_sensor & >( const_cast< d500_dual_color * >( this )->get_depth_sensor() );
+        for( auto & f : depth_sensor.get_supported_embedded_filters() )
+            if( f && f->get_type() == RS2_EMBEDDED_FILTER_TYPE_CLOSE_RANGE
+                && f->supports_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED )
+                && f->get_option( RS2_OPTION_EMBEDDED_FILTER_ENABLED ).query() != 0.f )
+                throw wrong_api_call_sequence_exception(
+                    "Color streams cannot be activated while Improved Close Range Depth is enabled" );
+    }
+
+    // Produce a friendly stream name to the user, e.g. "Depth" / "Color 1"
+    static std::string stream_name( const stream_profile_interface & profile )
+    {
+        std::string name = get_string( profile.get_stream_type() );
+        if( profile.get_stream_index() )
+            name += " " + std::to_string( profile.get_stream_index() );
+        return name;
+    }
+
+    // Resolutions may differ freely, but a frame-rate mismatch silently starves the streams - both
+    // between the two color pins and between color and depth/IR.
+    void d500_dual_color::frame_rates_allowed_or_throw( const stream_profiles & requests ) const
+    {
+        if( ! color_requested( requests ) )
+            return;
+
+        // Depth/IR and color run off the same imagers, so together they cap at 45 FPS - the enumerated
+        // 60 and 90 FPS profiles stream only when each runs without the other.
+        static const uint32_t MAX_COMBINED_FPS = 45;
+
+        bool const with_depth_or_ir = depth_or_ir_requested( requests );
+
+        stream_profile_interface * first = nullptr;
+        for( auto & p : requests )
+        {
+            if( ! p )
+                continue;
+            if( with_depth_or_ir && p->get_framerate() > MAX_COMBINED_FPS )
+                throw wrong_api_call_sequence_exception( rsutils::string::from()
+                    << "Depth/Infrared and Color cannot stream together at 60 or 90 FPS ("
+                    << stream_name( *p ) << " requested " << p->get_framerate() << " FPS)" );
+            if( ! first )
+                first = p.get();
+            else if( p->get_framerate() != first->get_framerate() )
+                throw wrong_api_call_sequence_exception( rsutils::string::from()
+                    << "All streams must share one frame rate while color is streaming ("
+                    << stream_name( *first ) << " requested " << first->get_framerate() << " FPS, "
+                    << stream_name( *p ) << " requested " << p->get_framerate() << " FPS)" );
+        }
+    }
+
     void d500_dual_color::register_ae_policy_option()
     {
         if( _fw_version < firmware_version( "7.58.45946.14332" ) )

--- a/src/ds/d500/d500-dual-color.h
+++ b/src/ds/d500/d500-dual-color.h
@@ -19,11 +19,16 @@ namespace librealsense
     public:
         d500_dual_color( std::shared_ptr< const d500_info > const & dev_info );
 
+
     protected:
         std::shared_ptr< stream_interface > _color_stream_1;
         std::shared_ptr< stream_interface > _color_stream_2;
 
     private:
+        // Stream-combination rules for the shared imagers, registered as validators at construction.
+        void close_range_allowed_or_throw( const stream_profiles & requests ) const;
+        void frame_rates_allowed_or_throw( const stream_profiles & requests ) const;
+
         void register_color_extrinsics();
         void register_color_metadata();
         void register_ae_policy_option();

--- a/unit-tests/live/d500/pytest-dual-color-fps-limits.py
+++ b/unit-tests/live/d500/pytest-dual-color-fps-limits.py
@@ -157,5 +157,8 @@ def test_color_only_high_fps_accepted(depth_sensor, fps):
     if color1 is None:
         pytest.skip( f"Device publishes no color profile at {fps} FPS" )
     color2 = pick( depth_sensor, rs.stream.color, 2, fps, (color1.width(), color1.height()) )
+    if color2 is None:
+        # A lone color stream cannot trip the same-rate rule, so it would prove nothing here.
+        pytest.skip( f"Device publishes no second color profile at {fps} FPS on Color 1's resolution" )
 
-    open_and_close( depth_sensor, [color1, color2] if color2 else [color1] )
+    open_and_close( depth_sensor, [color1, color2] )

--- a/unit-tests/live/d500/pytest-dual-color-fps-limits.py
+++ b/unit-tests/live/d500/pytest-dual-color-fps-limits.py
@@ -158,4 +158,4 @@ def test_color_only_high_fps_accepted(depth_sensor, fps):
         pytest.skip( f"Device publishes no color profile at {fps} FPS" )
     color2 = pick( depth_sensor, rs.stream.color, 2, fps, (color1.width(), color1.height()) )
 
-    open_and_close( depth_sensor, [color1, color2] if color2 else color1 )
+    open_and_close( depth_sensor, [color1, color2] if color2 else [color1] )

--- a/unit-tests/live/d500/pytest-dual-color-fps-limits.py
+++ b/unit-tests/live/d500/pytest-dual-color-fps-limits.py
@@ -1,0 +1,161 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+# Frame-rate limits when depth/IR and color stream together on a dual-color (2C) device.
+#
+# Both run off the same imagers, so together they cap at 45 FPS and must share one frame rate:
+# the enumerated 60/90 FPS profiles, and any rate mismatch, stream no frames at all. The SDK
+# rejects those combinations at sensor open with a user-friendly error, surfaced as a
+# RuntimeError in Python. Resolutions may differ freely and are not restricted.
+#
+# The test adapts to the device: each case skips when the device does not publish the profiles
+# it needs, rather than gating on firmware versions.
+
+import pytest
+import pyrealsense2 as rs
+import logging
+log = logging.getLogger(__name__)
+
+
+pytestmark = [
+    # "Dual RGB" matches the 2C SKUs only (D535/D585 Dual RGB, incl. the prototype).
+    pytest.mark.device_each( "Dual RGB" ),
+    pytest.mark.context( "nightly" ),
+]
+
+COLOR_INDEX = 1
+IR_INDEX = 1
+
+
+@pytest.fixture
+def depth_sensor(test_device):
+    # On a dual-color device depth, IR and both color streams all live on the depth sensor.
+    dev, _ = test_device
+    sensor = dev.first_depth_sensor()
+    yield sensor
+    try:
+        sensor.close()   # the sensor outlives the test - never hand it to the next one still open
+    except RuntimeError:
+        pass             # not open, which is the normal path
+
+
+def video_profiles(sensor, stream_type, index):
+    out = []
+    for p in sensor.get_stream_profiles():
+        vp = p.as_video_stream_profile()
+        if vp and p.stream_type() == stream_type and p.stream_index() == index:
+            out.append( vp )
+    return out
+
+
+def pick(sensor, stream_type, index, fps, res=None):
+    """First profile of the given stream at `fps`, optionally at resolution `res` = (w, h)."""
+    for vp in video_profiles( sensor, stream_type, index ):
+        if vp.fps() == fps and (res is None or (vp.width(), vp.height()) == res):
+            return vp
+    return None
+
+
+def stereo_and_color(sensor, stream_type, stereo_fps, color_fps=None, shared_res=True):
+    """A (depth-or-IR, color) profile pair at the requested rates, sharing a resolution when asked.
+    Returns None when the device does not publish such a pair."""
+    color_fps = stereo_fps if color_fps is None else color_fps
+    stereo_index = 0 if stream_type == rs.stream.depth else IR_INDEX
+    colors = [c for c in video_profiles( sensor, rs.stream.color, COLOR_INDEX ) if c.fps() == color_fps]
+    for stereo in video_profiles( sensor, stream_type, stereo_index ):
+        if stereo.fps() != stereo_fps:
+            continue
+        for color in colors:
+            if ((color.width(), color.height()) == (stereo.width(), stereo.height())) == shared_res:
+                return stereo, color
+    return None
+
+
+def get_or_skip(pair, what):
+    if pair is None:
+        pytest.skip( f"Device publishes no {what}" )
+    return pair
+
+
+def open_and_close(sensor, profiles):
+    sensor.open( profiles )
+    sensor.close()
+
+
+def expect_rejected(sensor, profiles):
+    """Assert the combination is refused at open. A refusal carrying 'already opened' means an
+    earlier test leaked the sensor, which would otherwise look like a pass here."""
+    try:
+        sensor.open( profiles )
+    except RuntimeError as e:
+        assert "already opened" not in str( e ), f"sensor was left open by an earlier test: {e}"
+        log.debug( "rejected as expected: %s", e )
+        return
+    sensor.close()   # accepted - undo it before failing so the next test starts clean
+    pytest.fail( "open() accepted an unsupported stream combination" )
+
+
+@pytest.mark.parametrize( "stream_type", [rs.stream.depth, rs.stream.infrared] )
+@pytest.mark.parametrize( "fps", [60, 90] )
+def test_60_and_90_fps_rejected(depth_sensor, stream_type, fps):
+    """60/90 FPS is enumerated on each stream but unusable once depth/IR and color run together."""
+    stereo, color = get_or_skip( stereo_and_color( depth_sensor, stream_type, fps ),
+                                 f"{stream_type} + color pair at {fps} FPS" )
+
+    # The rejection only means something if each stream opens standalone at this rate.
+    for profile in (stereo, color):
+        try:
+            open_and_close( depth_sensor, profile )
+        except RuntimeError as e:
+            pytest.skip( f"{profile.stream_type()} not openable standalone at {fps} FPS: {e}" )
+
+    expect_rejected( depth_sensor, [stereo, color] )
+
+
+@pytest.mark.parametrize( "stream_type", [rs.stream.depth, rs.stream.infrared] )
+def test_mismatched_fps_rejected(depth_sensor, stream_type):
+    """Both rates are within the combined limit, but they must be equal."""
+    stereo, color = get_or_skip( stereo_and_color( depth_sensor, stream_type, 45, color_fps=30 ),
+                                 f"{stream_type} at 45 FPS with color at 30 FPS" )
+
+    expect_rejected( depth_sensor, [stereo, color] )
+
+
+@pytest.mark.parametrize( "stream_type", [rs.stream.depth, rs.stream.infrared] )
+def test_matched_fps_accepted(depth_sensor, stream_type):
+    stereo, color = get_or_skip( stereo_and_color( depth_sensor, stream_type, 30 ),
+                                 f"{stream_type} + color pair at 30 FPS" )
+
+    open_and_close( depth_sensor, [stereo, color] )
+
+
+@pytest.mark.parametrize( "stream_type", [rs.stream.depth, rs.stream.infrared] )
+def test_different_resolutions_accepted(depth_sensor, stream_type):
+    """Only the frame rate is constrained - depth/IR and color may run at different resolutions."""
+    stereo, color = get_or_skip( stereo_and_color( depth_sensor, stream_type, 30, shared_res=False ),
+                                 f"{stream_type} + color pair at 30 FPS on different resolutions" )
+
+    open_and_close( depth_sensor, [stereo, color] )
+
+
+def test_color_streams_mismatched_fps_rejected(depth_sensor):
+    """The two color pins must share a rate too - this one holds without depth/IR in the request."""
+    color1 = pick( depth_sensor, rs.stream.color, 1, 30 )
+    if color1 is None:
+        pytest.skip( "Device publishes no Color 1 profile at 30 FPS" )
+    color2 = pick( depth_sensor, rs.stream.color, 2, 60, (color1.width(), color1.height()) )
+    if color2 is None:
+        pytest.skip( "Device publishes no Color 2 profile at 60 FPS on Color 1's resolution" )
+
+    expect_rejected( depth_sensor, [color1, color2] )
+
+
+@pytest.mark.parametrize( "fps", [60, 90] )
+def test_color_only_high_fps_accepted(depth_sensor, fps):
+    """Without depth/IR the color streams reach 60/90 FPS, so the guard must not fire."""
+    color1 = pick( depth_sensor, rs.stream.color, 1, fps )
+    if color1 is None:
+        pytest.skip( f"Device publishes no color profile at {fps} FPS" )
+    color2 = pick( depth_sensor, rs.stream.color, 2, fps, (color1.width(), color1.height()) )
+
+    open_and_close( depth_sensor, [color1, color2] if color2 else color1 )


### PR DESCRIPTION
**Overview:** On D585/D535 dual-RGB (2C), streaming depth or infrared together with color now fails at open with a readable message instead of silently delivering no frames.

Tracked on [RSDEV-13131]

## Why

The 2C firmware drives depth/IR and both color streams from the same imagers. Asking for them together above 45 FPS, or at mismatched frame rates, yields zero frames and no error — the user just sees a black stream. Firmware rejects these combinations on its side already; this is the matching SDK-side block.

Measured on a D585 Proto Dual RGB (FW 7.58.46212.14758):

| Combination | Firmware |
|---|---|
| Depth/IR + color at 60 or 90 FPS | no frames |
| Depth/IR + color at different frame rates | no frames |
| Color 1 + Color 2 at different frame rates | no frames |
| Depth/IR + color, matched rate at or below 45 FPS | streams |
| Depth/IR + color at **different resolutions**, matched rate | streams |
| Color only at 60/90 FPS, or depth+IR at 60 FPS | streams |

Two of these differ from the HAS matrix in RSDEV-12716: resolutions do **not** have to match, and the frame-rate match requirement is not in that table at all.

## Summary

- `d500_device` gains a validator registry (`add_stream_combination_validator`). `d500_depth_sensor::open` runs the registered rules before the device is touched.
- `d500_dual_color` registers two rules: color versus Improved Close Range Depth (moved off `d500_depth_sensor`), and the frame-rate rules. A registry rather than a virtual, because `rs5x5_device` mixes in five classes that all virtually inherit `d500_device` — two overrides of one virtual would leave no unique final overrider.
- Rejections throw `wrong_api_call_sequence_exception`, naming the offending stream and rate. Surfaces as `RuntimeError` in Python and in the Viewer's error popup.
- Side effect: a rejected combination no longer reaches the firmware, which previously left the color pin needing a hardware reset.
- Viewer, separate pre-existing bug found while verifying: the split-resolution UI treated "filter has no `RS2_OPTION_EMBEDDED_FILTER_ENABLED`" as "decimation is always on in firmware". Since the composite-option refactor that holds for every D500, so the split UI turned on unconditionally on 2C, 3C and D555. It now reads the composite's own enabled field, seeded once at construction so the first frame is correct.

## Test plan

- [ ] New `unit-tests/live/d500/pytest-dual-color-fps-limits.py` — 13 cases, `device_each("Dual RGB")`, `context("nightly")`. 13/13 on D585 Proto Dual RGB, FW 7.58.46212.14758.
- [ ] Bench script over 14 combinations: every rejection confirmed to carry a guard message rather than a backend error; every allowed combination opens.
- [ ] Bench: 15 rejected opens back to back, then all 6 allowed combinations deliver frames, with no hardware reset in between.
- [ ] Builds clean: Windows Release + Debug; Linux GCC 13.3 / Ubuntu 24.04 with `BUILD_GRAPHICAL_EXAMPLES=ON` so `common/` is included.
- [ ] **No CI coverage** — no CI agent has a 2C unit, so this test never runs in CI.
- [ ] **Not verified on hardware** — the close-range rule's throw path. No embedded filter exposes `RS2_OPTION_EMBEDDED_FILTER_ENABLED` on this firmware, so it cannot fire; the relocation is verified by inspection (the new call site reads the same filter list).

---
🤖 Generated by AI