### PR TITLE
viewer: draw detection overlay on color streams only

### DIFF
--- a/common/objects-in-frame.h
+++ b/common/objects-in-frame.h
@@ -20,7 +20,7 @@ std::string object_type_to_string( object_type type );
 
 struct object_in_frame
 {
-    rs2::rect normalized_color_bbox, normalized_depth_bbox;
+    rs2::rect normalized_color_bbox;
     std::string name;
     float mean_depth;
     float metadata_depth;         // distance reported by the detection model (meters); 0 if unavailable
@@ -28,11 +28,10 @@ struct object_in_frame
     size_t id;
     object_type type = object_type::other;
 
-    object_in_frame( size_t _id, std::string const & _name, rs2::rect _bbox_color, rs2::rect _bbox_depth, float _depth,
+    object_in_frame( size_t _id, std::string const & _name, rs2::rect _bbox_color, float _depth,
                      float _metadata_depth, int _score,
                      object_type _type = object_type::other )
         : normalized_color_bbox( _bbox_color )
-        , normalized_depth_bbox( _bbox_depth )
         , name( _name )
         , mean_depth( _depth )
         , metadata_depth( _metadata_depth )

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -4093,20 +4093,6 @@ namespace rs2
                                       float( det.bottom_right_y - det.top_left_y ) };
                 rs2::rect normalized_color_bbox = color_bbox.normalize( color_frame_rect );
 
-                // depth_bbox_full: simple resolution scaling of the color bbox.
-                // COM runs within this region for a stable, deterministic depth measurement.
-                // The depth-view dot position is corrected for sensor parallax separately
-                // by projecting the single COM pixel through rs2_project_color_pixel_to_depth_pixel.
-                float const depth_scale_x = float( depth_intrin.width  ) / float( color_intrin.width  );
-                float const depth_scale_y = float( depth_intrin.height ) / float( color_intrin.height );
-                // depth_bbox_full: unclipped scaled bbox, kept for the ROI intersection below.
-                // Clipping only affects the actual ROI sampled.
-                rs2::rect depth_bbox_full{
-                    color_bbox.x * depth_scale_x, color_bbox.y * depth_scale_y,
-                    color_bbox.w * depth_scale_x, color_bbox.h * depth_scale_y };
-                rs2::rect depth_bbox = depth_bbox_full.intersection( depth_frame_rect );
-                rs2::rect normalized_depth_bbox = depth_bbox.normalize( depth_frame_rect );
-
                 float const hkr_depth_m = det.depth;
                 float viewer_depth_m = 0.f;
 
@@ -4122,6 +4108,12 @@ namespace rs2
                         com::center_of_mass_calculator::create_depth_8u( com_raw, com_depth8u );
                         depth8u_ready = true;
                     }
+                    // COM ROI: scale the color bbox to depth resolution, clipped to the frame.
+                    float const depth_scale_x = float( depth_intrin.width  ) / float( color_intrin.width  );
+                    float const depth_scale_y = float( depth_intrin.height ) / float( color_intrin.height );
+                    rs2::rect depth_bbox = rs2::rect{
+                        color_bbox.x * depth_scale_x, color_bbox.y * depth_scale_y,
+                        color_bbox.w * depth_scale_x, color_bbox.h * depth_scale_y }.intersection( depth_frame_rect );
                     int const com_x = (int)depth_bbox.x;
                     int const com_y = (int)depth_bbox.y;
                     com::rect  com_bbox{ com_x, com_y,
@@ -4161,7 +4153,7 @@ namespace rs2
                 float const mean_depth = hkr_depth_m > 0.f ? hkr_depth_m : viewer_depth_m;
 
                 std::string name = object_type_to_string( static_cast< object_type >( det.class_id ) );
-                new_objects.emplace_back( obj_id++, name, normalized_color_bbox, normalized_depth_bbox, mean_depth,
+                new_objects.emplace_back( obj_id++, name, normalized_color_bbox, mean_depth,
                                           hkr_depth_m, det.score,
                                           static_cast< object_type >( det.class_id ) );
             }

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2163,7 +2163,8 @@ namespace rs2
                 }
             }
 
-            //switch( stream_mv.profile.stream_type() )
+            // Detection overlays only make sense on the color stream; bbox coords are in color-frame space.
+            if( stream_mv.profile.stream_type() == RS2_STREAM_COLOR )
             {
                 static std::vector< std::pair< ImColor, bool > > colors =
                 {
@@ -2237,10 +2238,7 @@ namespace rs2
 
                 for( object_in_frame & object : *p_objects )
                 {
-                    rect const & normalized_bbox = stream_mv.profile.stream_type() == RS2_STREAM_DEPTH
-                        ? object.normalized_depth_bbox
-                        : object.normalized_color_bbox;
-                    rect const unbbox = normalized_bbox.unnormalize( stream_rect );
+                    rect const unbbox = object.normalized_color_bbox.unnormalize( stream_rect );
                     rect bbox = unbbox.grow( 10, 5 );  // Allow more text, and easier identification of the face
 
                     float a = 0.75f;

--- a/tools/realsense-viewer/openvino-face-detection.cpp
+++ b/tools/realsense-viewer/openvino-face-detection.cpp
@@ -278,18 +278,10 @@ private:
                 cv::Rect const & loc = face->get_location();
                 rs2::rect bbox { float( loc.x ), float( loc.y ), float( loc.width ), float( loc.height ) };
                 rs2::rect normalized_color_bbox = bbox.normalize( rs2::rect { 0, 0, float(color_intrin.width), float(color_intrin.height) } );
-                rs2::rect normalized_depth_bbox = normalized_color_bbox;
-                if( df )
-                {
-                    cv::Rect const & depth_loc = face->get_depth_location();
-                    rs2::rect depth_bbox { float( depth_loc.x ), float( depth_loc.y ), float( depth_loc.width ), float( depth_loc.height ) };
-                    normalized_depth_bbox = depth_bbox.normalize( rs2::rect { 0, 0, float( df.get_width() ), float( df.get_height() ) } );
-                }
                 objects.emplace_back(
                     face->get_id(),
                     object_type_to_string( object_type::face ),
                     normalized_color_bbox,
-                    normalized_depth_bbox,
                     face->get_depth(),
                     0.f,           // metadata_depth — not provided by face detection
                     0,             // score — not provided by face detection


### PR DESCRIPTION
Tracked by: RSDEV-14425

**Overview:** Restrict the object/person detection bounding-box overlay to the color stream, so it no longer appears on depth or IR tiles.

## Why
On D585 dual-RGB the person-detection boxes were rendered on top of every visible stream, including depth and IR. The per-tile render loop had lost its stream-type guard (the `switch(stream_type)` at `common/viewer.cpp` was commented out), and `atomic_objects_in_frame` is device-level and shared across all sub-devices — so any stream inherited the color-space bboxes, which do not align with depth/IR pixels.

## Summary
- Wrap the detection overlay block in `if (stream_type == RS2_STREAM_COLOR)`.
- Drop the now-dead `stream_type == RS2_STREAM_DEPTH ? depth_bbox : color_bbox` ternary inside the loop.

## Test plan
- [x] realsense-viewer with D585 dual-RGB: enable person detection, confirm boxes appear only on the color tile — not on depth or IR.

---
🤖 Generated by AI