### PR TITLE
D585 2C dual-color RGB controls (Windows + Linux)

### DIFF
--- a/src/ds/d500/d500-dual-color.cpp
+++ b/src/ds/d500/d500-dual-color.cpp
@@ -11,7 +11,12 @@
 #include <src/platform/uvc-option.h>
 #include <src/metadata-parser.h>
 #include <src/ds/ds-color-common.h>
+#include <src/ds/ds-timestamp.h>
 #include <src/firmware-version.h>
+#include <src/backend.h>
+#include <src/platform/platform-utils.h>
+
+#include <cstring>
 
 #include <rsutils/type/fourcc.h>
 using rs_fourcc = rsutils::type::fourcc;
@@ -76,9 +81,7 @@ namespace librealsense
         register_color_extrinsics();
         register_color_metadata();
         register_ae_policy_option();
-#if defined(_WIN32)
-        register_color_options();
-#endif
+        register_color_options( dev_info );
     }
 
     // Both rules below only bite once a color stream shares the depth sensor's imagers.
@@ -170,15 +173,21 @@ namespace librealsense
                                                                                           false ) ); // Not settable while streaming
     }
 
-#if defined(_WIN32)
-    void d500_dual_color::register_color_options()
+    // D585 2C dual-color topology: on the depth-function UVC interface, the RGB streams' PU chain
+    // is UVC entity 0x07 and, on Windows, KS topology node 6.
+    constexpr uint8_t D585_2C_RGB_PU_UNIT_ID  = 0x07;
+    constexpr int     D585_2C_RGB_PU_KS_NODE = 6;
+
+    void d500_dual_color::register_color_options( std::shared_ptr< const d500_info > const & dev_info )
     {
-        // The dual-color UVC function contains Depth and RGB processing units. Windows' aggregate
-        // IAMVideoProcAmp binds to the first (Depth) PU, so RGB controls must address its topology node directly.
-        static const platform::processing_unit rgb_pu = { 0, 0x07, 6 };
+        // Route RGB controls via the RGB PU: node-based routing on WMF, a dedicated raw sensor on V4L2.
+        static const platform::processing_unit rgb_pu = { 0, D585_2C_RGB_PU_UNIT_ID, D585_2C_RGB_PU_KS_NODE };
+
+        auto raw_ep = pick_rgb_pu_raw_endpoint( dev_info, rgb_pu );
+        if( ! raw_ep )
+            return;  // discovery failed on this backend; leave the options unregistered rather than expose broken ones
 
         auto & color_ep = get_depth_sensor();
-        auto raw_ep = get_raw_depth_sensor();
         auto make_rgb_option = [raw_ep](rs2_option option)
         {
             return std::make_shared<uvc_pu_option>(raw_ep, option, rgb_pu);
@@ -212,7 +221,66 @@ namespace librealsense
             RS2_OPTION_WHITE_BALANCE,
             std::make_shared<auto_disabling_control>(white_balance, auto_white_balance));
     }
+
+    std::shared_ptr< uvc_sensor > d500_dual_color::pick_rgb_pu_raw_endpoint(
+        std::shared_ptr< const d500_info > const & dev_info,
+        const platform::processing_unit & rgb_pu )
+    {
+#if defined(_WIN32)
+        // WMF: any depth-function pin resolves to the same IMFMediaSource and node routing picks the PU.
+        return get_raw_depth_sensor();
+#else
+        // V4L2: each /dev/videoN's fd only exposes its own PU chain's CIDs; probe MI-0 siblings to find
+        // the one whose fd hosts the RGB PU. Skip the depth pin - the multi_pins depth sensor already
+        // holds it and opening a second fd there just adds startup latency.
+        std::string depth_path;
+        try { depth_path = get_depth_sensor().get_info( RS2_CAMERA_INFO_PHYSICAL_PORT ); }
+        catch( ... ) {}
+
+        for( auto & info : filter_by_mi( dev_info->get_group().uvc_devices, 0 ) )
+        {
+            if( ! depth_path.empty() && info.device_path == depth_path )
+                continue;
+
+            std::shared_ptr< platform::uvc_device > uvc_dev;
+            try { uvc_dev = get_backend()->create_uvc_device( info ); }
+            catch( ... ) { continue; }
+            if( ! uvc_dev )
+                continue;
+
+            auto candidate = std::make_shared< uvc_sensor >(
+                "Raw RGB PU Sensor", uvc_dev,
+                std::make_unique< ds_timestamp_reader >(), this );
+            try
+            {
+                auto r = candidate->invoke_powered( [ & rgb_pu ]( platform::uvc_device & dev )
+                {
+                    return dev.get_pu_range( rgb_pu, RS2_OPTION_BRIGHTNESS );
+                } );
+                // v4l_uvc_device::get_pu_range returns an all-zero range for unknown CIDs instead of
+                // throwing - reject that fallback shape. Read via memcpy to stay strict-aliasing clean.
+                if( r.max.size() >= sizeof( int32_t ) && r.min.size() >= sizeof( int32_t ) )
+                {
+                    int32_t r_min = 0, r_max = 0;
+                    std::memcpy( &r_min, r.min.data(), sizeof( int32_t ) );
+                    std::memcpy( &r_max, r.max.data(), sizeof( int32_t ) );
+                    if( r_min != 0 || r_max != 0 )
+                    {
+                        _raw_rgb_ep = candidate;
+                        return _raw_rgb_ep;
+                    }
+                }
+            }
+            catch( ... )
+            {
+                // this pin doesn't recognize the CID - try the next
+            }
+        }
+
+        LOG_WARNING( "Dual-color RGB PU pin not found on MI 0; RGB controls will not be registered" );
+        return nullptr;
 #endif
+    }
 
     void d500_dual_color::register_color_metadata()
     {

--- a/src/ds/d500/d500-dual-color.cpp
+++ b/src/ds/d500/d500-dual-color.cpp
@@ -76,6 +76,9 @@ namespace librealsense
         register_color_extrinsics();
         register_color_metadata();
         register_ae_policy_option();
+#if defined(_WIN32)
+        register_color_options();
+#endif
     }
 
     // Both rules below only bite once a color stream shares the depth sensor's imagers.
@@ -165,8 +168,51 @@ namespace librealsense
                                                                                           "Auto exposure policy for sensor with both color and depth streams",
                                                                                           options_map,
                                                                                           false ) ); // Not settable while streaming
-                                                
     }
+
+#if defined(_WIN32)
+    void d500_dual_color::register_color_options()
+    {
+        // The dual-color UVC function contains Depth and RGB processing units. Windows' aggregate
+        // IAMVideoProcAmp binds to the first (Depth) PU, so RGB controls must address its topology node directly.
+        static const platform::processing_unit rgb_pu = { 0, 0x07, 6 };
+
+        auto & color_ep = get_depth_sensor();
+        auto raw_ep = get_raw_depth_sensor();
+        auto make_rgb_option = [raw_ep](rs2_option option)
+        {
+            return std::make_shared<uvc_pu_option>(raw_ep, option, rgb_pu);
+        };
+
+        color_ep.register_option(RS2_OPTION_BACKLIGHT_COMPENSATION,
+                                 make_rgb_option(RS2_OPTION_BACKLIGHT_COMPENSATION));
+        color_ep.register_option(RS2_OPTION_BRIGHTNESS, make_rgb_option(RS2_OPTION_BRIGHTNESS));
+        color_ep.register_option(RS2_OPTION_CONTRAST, make_rgb_option(RS2_OPTION_CONTRAST));
+        color_ep.register_option(RS2_OPTION_SATURATION, make_rgb_option(RS2_OPTION_SATURATION));
+        color_ep.register_option(RS2_OPTION_GAMMA, make_rgb_option(RS2_OPTION_GAMMA));
+        color_ep.register_option(RS2_OPTION_SHARPNESS, make_rgb_option(RS2_OPTION_SHARPNESS));
+        color_ep.register_option(RS2_OPTION_HUE, make_rgb_option(RS2_OPTION_HUE));
+
+        std::map<float, std::string> power_line_descriptions = {
+            { 0.f, "Disabled" },
+            { 1.f, "50Hz" },
+            { 2.f, "60Hz" }
+        };
+        color_ep.register_option(
+            RS2_OPTION_POWER_LINE_FREQUENCY,
+            std::make_shared<uvc_pu_option>(raw_ep,
+                                            RS2_OPTION_POWER_LINE_FREQUENCY,
+                                            rgb_pu,
+                                            power_line_descriptions));
+
+        auto white_balance = make_rgb_option(RS2_OPTION_WHITE_BALANCE);
+        auto auto_white_balance = make_rgb_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
+        color_ep.register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, auto_white_balance);
+        color_ep.register_option(
+            RS2_OPTION_WHITE_BALANCE,
+            std::make_shared<auto_disabling_control>(white_balance, auto_white_balance));
+    }
+#endif
 
     void d500_dual_color::register_color_metadata()
     {

--- a/src/ds/d500/d500-dual-color.cpp
+++ b/src/ds/d500/d500-dual-color.cpp
@@ -257,8 +257,7 @@ namespace librealsense
                 {
                     return dev.get_pu_range( rgb_pu, RS2_OPTION_BRIGHTNESS );
                 } );
-                // v4l_uvc_device::get_pu_range returns an all-zero range for unknown CIDs instead of
-                // throwing - reject that fallback shape. Read via memcpy to stay strict-aliasing clean.
+                // v4l_uvc_device::get_pu_range returns an all-zero range for unknown CIDs instead of throwing - reject that fallback shape.
                 if( r.max.size() >= sizeof( int32_t ) && r.min.size() >= sizeof( int32_t ) )
                 {
                     int32_t r_min = 0, r_max = 0;

--- a/src/ds/d500/d500-dual-color.h
+++ b/src/ds/d500/d500-dual-color.h
@@ -23,11 +23,8 @@ namespace librealsense
     protected:
         std::shared_ptr< stream_interface > _color_stream_1;
         std::shared_ptr< stream_interface > _color_stream_2;
-        // Raw endpoint tied specifically to the pin whose fd hosts the RGB Processing Unit.
-        // Only populated when discovery finds a distinct RGB pin (e.g. Linux V4L2, where each
-        // /dev/videoN's fd exposes only its own PU chain's CIDs). Left null on backends where
-        // any pin resolves to the same source (e.g. WMF), in which case the RGB controls
-        // register against the aggregate depth raw endpoint and rely on node-based routing.
+        // Endpoint bound to the pin that hosts the RGB PU. Null when the backend routes by
+        // topology node instead (WMF) - RGB options then use the depth raw endpoint.
         std::shared_ptr< uvc_sensor > _raw_rgb_ep;
 
     private:

--- a/src/ds/d500/d500-dual-color.h
+++ b/src/ds/d500/d500-dual-color.h
@@ -23,6 +23,12 @@ namespace librealsense
     protected:
         std::shared_ptr< stream_interface > _color_stream_1;
         std::shared_ptr< stream_interface > _color_stream_2;
+        // Raw endpoint tied specifically to the pin whose fd hosts the RGB Processing Unit.
+        // Only populated when discovery finds a distinct RGB pin (e.g. Linux V4L2, where each
+        // /dev/videoN's fd exposes only its own PU chain's CIDs). Left null on backends where
+        // any pin resolves to the same source (e.g. WMF), in which case the RGB controls
+        // register against the aggregate depth raw endpoint and rely on node-based routing.
+        std::shared_ptr< uvc_sensor > _raw_rgb_ep;
 
     private:
         // Stream-combination rules for the shared imagers, registered as validators at construction.
@@ -32,9 +38,10 @@ namespace librealsense
         void register_color_extrinsics();
         void register_color_metadata();
         void register_ae_policy_option();
-#if defined(_WIN32)
-        void register_color_options();
-#endif
+        void register_color_options( std::shared_ptr< const d500_info > const & dev_info );
+        std::shared_ptr< uvc_sensor > pick_rgb_pu_raw_endpoint(
+            std::shared_ptr< const d500_info > const & dev_info,
+            const platform::processing_unit & rgb_pu );
 
         // Stream-id resolver: route color pins (NV12/M420/YUY2) to Color 1 / Color 2 streams
         static void resolve_color_stream( const std::vector< platform::stream_profile > & all,

--- a/src/ds/d500/d500-dual-color.h
+++ b/src/ds/d500/d500-dual-color.h
@@ -32,6 +32,9 @@ namespace librealsense
         void register_color_extrinsics();
         void register_color_metadata();
         void register_ae_policy_option();
+#if defined(_WIN32)
+        void register_color_options();
+#endif
 
         // Stream-id resolver: route color pins (NV12/M420/YUY2) to Color 1 / Color 2 streams
         static void resolve_color_stream( const std::vector< platform::stream_profile > & all,

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -563,6 +563,25 @@ namespace librealsense
             throw std::runtime_error( rsutils::string::from() << "Unsupported control - " << opt );
         }
 
+        bool wmf_uvc_device::get_pu(const processing_unit& unit, rs2_option opt, int32_t& value) const
+        {
+            long val = 0, flags = 0;
+            for (auto & pu : pu_controls)
+            {
+                if (opt == pu.option)
+                {
+                    auto hr = get_video_proc(unit.node)->Get(pu.property, &val, &flags);
+                    if (hr == DEVICE_NOT_READY_ERROR)
+                        return false;
+
+                    value = pu.enable_auto ? (flags == VideoProcAmp_Flags_Auto) : val;
+                    CHECK_HR(hr);
+                    return true;
+                }
+            }
+            return get_pu(opt, value);
+        }
+
         bool wmf_uvc_device::set_pu(rs2_option opt, int value)
         {
             if (opt == RS2_OPTION_EXPOSURE)
@@ -684,6 +703,54 @@ namespace librealsense
             throw std::runtime_error( rsutils::string::from() << "Unsupported control - " << opt );
         }
 
+        bool wmf_uvc_device::set_pu(const processing_unit& unit, rs2_option opt, int value)
+        {
+            for (auto & pu : pu_controls)
+            {
+                if (opt != pu.option)
+                    continue;
+
+                auto video_proc = get_video_proc(unit.node);
+                if (pu.enable_auto)
+                {
+                    if (value)
+                    {
+                        auto hr = video_proc->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
+                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
+                            return false;
+                        CHECK_HR(hr);
+                    }
+                    else
+                    {
+                        long min, max, step, def, caps;
+                        auto hr = video_proc->GetRange(pu.property, &min, &max, &step, &def, &caps);
+                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
+                            return false;
+                        CHECK_HR(hr);
+
+                        hr = video_proc->Set(pu.property, def, VideoProcAmp_Flags_Manual);
+                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
+                            return false;
+                        CHECK_HR(hr);
+                    }
+                }
+                else
+                {
+                    auto hr = video_proc->Set(pu.property, value, VideoProcAmp_Flags_Manual);
+                    if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
+                    {
+                        if( hr == SEMAPHORE_TIMEOUT_ERROR )
+                            LOG_DEBUG( "set_pu returned error code: "
+                                       << rsutils::hresult::hr_to_string( hr ) );
+                        return false;
+                    }
+                    CHECK_HR(hr);
+                }
+                return true;
+            }
+            return set_pu(opt, value);
+        }
+
         control_range wmf_uvc_device::get_pu_range(rs2_option opt) const
         {
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE ||
@@ -721,6 +788,25 @@ namespace librealsense
                 }
             }
             throw std::runtime_error("unsupported control");
+        }
+
+        control_range wmf_uvc_device::get_pu_range(const processing_unit& unit, rs2_option opt) const
+        {
+            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE ||
+                opt == RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE)
+                return control_range(0, 1, 1, 1);
+
+            long min = 0, max = 0, step = 0, def = 0, caps = 0;
+            for (auto & pu : pu_controls)
+            {
+                if (opt == pu.option)
+                {
+                    CHECK_HR(get_video_proc(unit.node)->GetRange(
+                        pu.property, &min, &max, &step, &def, &caps));
+                    return control_range(min, max, step, def);
+                }
+            }
+            return get_pu_range(opt);
         }
 
         void wmf_uvc_device::foreach_uvc_device(enumeration_callback action)
@@ -926,6 +1012,10 @@ namespace librealsense
             // Release any stale COM pointers from a previously failed set_d0() or set_d3()
             safe_release(_camera_control);
             safe_release(_video_proc);
+            {
+                std::lock_guard< std::mutex > lk( _video_procs_mtx );
+                _video_procs.clear();
+            }
             safe_release(_reader);
             if (_source)
             {
@@ -953,6 +1043,10 @@ namespace librealsense
         {
             safe_release(_camera_control);
             safe_release(_video_proc);
+            {
+                std::lock_guard< std::mutex > lk( _video_procs_mtx );
+                _video_procs.clear();
+            }
             safe_release(_reader);
             if (_source)
             {
@@ -1205,6 +1299,42 @@ namespace librealsense
             if (!_video_proc.p)
                 throw std::runtime_error("The device does not support adjusting the qualities of an incoming video signal, such as brightness, contrast, hue, saturation, gamma, and sharpness.");
             return _video_proc.p;
+        }
+
+        CComPtr< IAMVideoProcAmp > wmf_uvc_device::get_video_proc( int node ) const
+        {
+            if (get_power_state() != D0)
+                throw std::runtime_error("Device must be powered to query a processing-unit node!");
+
+            // Guard both the cache read and the lazy insert. Callers receive a CComPtr copy that keeps
+            // the interface alive even if a concurrent set_d3() clears the cache mid-use.
+            std::lock_guard< std::mutex > lk( _video_procs_mtx );
+            auto const found = _video_procs.find(node);
+            if (found != _video_procs.end())
+                return found->second;
+
+            CComPtr<IKsTopologyInfo> topology = nullptr;
+            CHECK_HR(_source->QueryInterface(__uuidof(IKsTopologyInfo),
+                reinterpret_cast<void **>(&topology)));
+
+            DWORD node_count = 0;
+            CHECK_HR(topology->get_NumNodes(&node_count));
+            if (node < 0 || static_cast<DWORD>(node) >= node_count)
+                throw std::runtime_error(rsutils::string::from()
+                    << "Processing-unit node " << node << " is outside topology node count " << node_count);
+
+            GUID node_type = {};
+            CHECK_HR(topology->get_NodeType(static_cast<DWORD>(node), &node_type));
+            if (!IsEqualGUID(node_type, KSNODETYPE_VIDEO_PROCESSING))
+                throw std::runtime_error(rsutils::string::from()
+                    << "Topology node " << node << " is not a video processing node");
+
+            CComPtr<IAMVideoProcAmp> video_proc = nullptr;
+            CHECK_HR(topology->CreateNodeInstance(static_cast<DWORD>(node),
+                __uuidof(IAMVideoProcAmp), reinterpret_cast<LPVOID *>(&video_proc)));
+
+            auto const inserted = _video_procs.emplace(node, video_proc);
+            return inserted.first->second;
         }
 
         IAMCameraControl* wmf_uvc_device::get_camera_control() const

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -518,6 +518,11 @@ namespace librealsense
 
         bool wmf_uvc_device::get_pu(rs2_option opt, int32_t& value) const
         {
+            return get_pu( processing_unit{ 0, 0, DEFAULT_PU_NODE }, opt, value );
+        }
+
+        bool wmf_uvc_device::get_pu(const processing_unit& unit, rs2_option opt, int32_t& value) const
+        {
             long val = 0, flags = 0;
             if ((opt == RS2_OPTION_EXPOSURE) || (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE))
             {
@@ -534,7 +539,7 @@ namespace librealsense
             {
                 if (opt == pu.option)
                 {
-                    auto hr = get_video_proc()->Get(pu.property, &val, &flags);
+                    auto hr = get_video_proc(unit.node)->Get(pu.property, &val, &flags);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
@@ -563,26 +568,12 @@ namespace librealsense
             throw std::runtime_error( rsutils::string::from() << "Unsupported control - " << opt );
         }
 
-        bool wmf_uvc_device::get_pu(const processing_unit& unit, rs2_option opt, int32_t& value) const
+        bool wmf_uvc_device::set_pu(rs2_option opt, int value)
         {
-            long val = 0, flags = 0;
-            for (auto & pu : pu_controls)
-            {
-                if (opt == pu.option)
-                {
-                    auto hr = get_video_proc(unit.node)->Get(pu.property, &val, &flags);
-                    if (hr == DEVICE_NOT_READY_ERROR)
-                        return false;
-
-                    value = pu.enable_auto ? (flags == VideoProcAmp_Flags_Auto) : val;
-                    CHECK_HR(hr);
-                    return true;
-                }
-            }
-            return get_pu(opt, value);
+            return set_pu( processing_unit{ 0, 0, DEFAULT_PU_NODE }, opt, value );
         }
 
-        bool wmf_uvc_device::set_pu(rs2_option opt, int value)
+        bool wmf_uvc_device::set_pu(const processing_unit& unit, rs2_option opt, int value)
         {
             if (opt == RS2_OPTION_EXPOSURE)
             {
@@ -612,11 +603,12 @@ namespace librealsense
             {
                 if (opt == pu.option)
                 {
+                    auto video_proc = get_video_proc(unit.node);
                     if (pu.enable_auto)
                     {
                         if (value)
                         {
-                            auto hr = get_video_proc()->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
+                            auto hr = video_proc->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -625,13 +617,13 @@ namespace librealsense
                         else
                         {
                             long min, max, step, def, caps;
-                            auto hr = get_video_proc()->GetRange(pu.property, &min, &max, &step, &def, &caps);
+                            auto hr = video_proc->GetRange(pu.property, &min, &max, &step, &def, &caps);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
                             CHECK_HR(hr);
 
-                            hr = get_video_proc()->Set(pu.property, def, VideoProcAmp_Flags_Manual);
+                            hr = video_proc->Set(pu.property, def, VideoProcAmp_Flags_Manual);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -640,7 +632,7 @@ namespace librealsense
                     }
                     else
                     {
-                        auto hr = get_video_proc()->Set(pu.property, value, VideoProcAmp_Flags_Manual);
+                        auto hr = video_proc->Set(pu.property, value, VideoProcAmp_Flags_Manual);
 
                         // We found 2 cases when we want to return false and let the backend retry mechanism call another set command.
                         // DEVICE_NOT_READY_ERROR: Can be return if the device is busy, not a real error.
@@ -703,55 +695,12 @@ namespace librealsense
             throw std::runtime_error( rsutils::string::from() << "Unsupported control - " << opt );
         }
 
-        bool wmf_uvc_device::set_pu(const processing_unit& unit, rs2_option opt, int value)
+        control_range wmf_uvc_device::get_pu_range(rs2_option opt) const
         {
-            for (auto & pu : pu_controls)
-            {
-                if (opt != pu.option)
-                    continue;
-
-                auto video_proc = get_video_proc(unit.node);
-                if (pu.enable_auto)
-                {
-                    if (value)
-                    {
-                        auto hr = video_proc->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
-                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
-                            return false;
-                        CHECK_HR(hr);
-                    }
-                    else
-                    {
-                        long min, max, step, def, caps;
-                        auto hr = video_proc->GetRange(pu.property, &min, &max, &step, &def, &caps);
-                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
-                            return false;
-                        CHECK_HR(hr);
-
-                        hr = video_proc->Set(pu.property, def, VideoProcAmp_Flags_Manual);
-                        if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
-                            return false;
-                        CHECK_HR(hr);
-                    }
-                }
-                else
-                {
-                    auto hr = video_proc->Set(pu.property, value, VideoProcAmp_Flags_Manual);
-                    if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
-                    {
-                        if( hr == SEMAPHORE_TIMEOUT_ERROR )
-                            LOG_DEBUG( "set_pu returned error code: "
-                                       << rsutils::hresult::hr_to_string( hr ) );
-                        return false;
-                    }
-                    CHECK_HR(hr);
-                }
-                return true;
-            }
-            return set_pu(opt, value);
+            return get_pu_range( processing_unit{ 0, 0, DEFAULT_PU_NODE }, opt );
         }
 
-        control_range wmf_uvc_device::get_pu_range(rs2_option opt) const
+        control_range wmf_uvc_device::get_pu_range(const processing_unit& unit, rs2_option opt) const
         {
             if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE ||
                 opt == RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE)
@@ -773,7 +722,7 @@ namespace librealsense
             {
                 if (opt == pu.option)
                 {
-                    CHECK_HR(get_video_proc()->GetRange(pu.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
+                    CHECK_HR(get_video_proc(unit.node)->GetRange(pu.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
                     control_range result(minVal, maxVal, steppingDelta, defVal);
                     return result;
                 }
@@ -788,25 +737,6 @@ namespace librealsense
                 }
             }
             throw std::runtime_error("unsupported control");
-        }
-
-        control_range wmf_uvc_device::get_pu_range(const processing_unit& unit, rs2_option opt) const
-        {
-            if (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE ||
-                opt == RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE)
-                return control_range(0, 1, 1, 1);
-
-            long min = 0, max = 0, step = 0, def = 0, caps = 0;
-            for (auto & pu : pu_controls)
-            {
-                if (opt == pu.option)
-                {
-                    CHECK_HR(get_video_proc(unit.node)->GetRange(
-                        pu.property, &min, &max, &step, &def, &caps));
-                    return control_range(min, max, step, def);
-                }
-            }
-            return get_pu_range(opt);
         }
 
         void wmf_uvc_device::foreach_uvc_device(enumeration_callback action)
@@ -1011,7 +941,6 @@ namespace librealsense
 
             // Release any stale COM pointers from a previously failed set_d0() or set_d3()
             safe_release(_camera_control);
-            safe_release(_video_proc);
             {
                 std::lock_guard< std::mutex > lk( _video_procs_mtx );
                 _video_procs.clear();
@@ -1027,11 +956,20 @@ namespace librealsense
             CHECK_HR(MFCreateDeviceSource(_device_attrs, &_source));
             LOG_HR(_source->QueryInterface(__uuidof(IAMCameraControl), reinterpret_cast<void **>(&_camera_control)));
             // The IAMVideoProcAmp interface adjusts the qualities of an incoming video signal, such as brightness,
-            // contrast, hue, saturation, gamma, and sharpness.
-            auto hr = _source->QueryInterface( __uuidof( IAMVideoProcAmp ), reinterpret_cast< void ** >( &_video_proc ) );
-            // E_NOINTERFACE is expected... especially when no video camera
-            if( hr != E_NOINTERFACE )
-                LOG_HR_STR( "QueryInterface(IAMVideoProcAmp)", hr );
+            // contrast, hue, saturation, gamma, and sharpness. Cache it under DEFAULT_PU_NODE so the aggregate and
+            // any per-topology-node instances share one map (and one clear site in set_d3).
+            {
+                CComPtr< IAMVideoProcAmp > video_proc;
+                auto hr = _source->QueryInterface( __uuidof( IAMVideoProcAmp ), reinterpret_cast< void ** >( &video_proc ) );
+                // E_NOINTERFACE is expected... especially when no video camera
+                if( hr != E_NOINTERFACE )
+                    LOG_HR_STR( "QueryInterface(IAMVideoProcAmp)", hr );
+                if( video_proc.p )
+                {
+                    std::lock_guard< std::mutex > lk( _video_procs_mtx );
+                    _video_procs.emplace( DEFAULT_PU_NODE, video_proc );
+                }
+            }
 
             //enable reader
             CHECK_HR(MFCreateSourceReaderFromMediaSource(_source, _reader_attrs, &_reader));
@@ -1042,7 +980,6 @@ namespace librealsense
         void wmf_uvc_device::set_d3()
         {
             safe_release(_camera_control);
-            safe_release(_video_proc);
             {
                 std::lock_guard< std::mutex > lk( _video_procs_mtx );
                 _video_procs.clear();
@@ -1292,19 +1229,10 @@ namespace librealsense
             _frame_callbacks.push_back(callback);
         }
 
-        IAMVideoProcAmp* wmf_uvc_device::get_video_proc() const
-        {
-            if (get_power_state() != D0)
-                throw std::runtime_error("Device must be powered to query video_proc!");
-            if (!_video_proc.p)
-                throw std::runtime_error("The device does not support adjusting the qualities of an incoming video signal, such as brightness, contrast, hue, saturation, gamma, and sharpness.");
-            return _video_proc.p;
-        }
-
         CComPtr< IAMVideoProcAmp > wmf_uvc_device::get_video_proc( int node ) const
         {
             if (get_power_state() != D0)
-                throw std::runtime_error("Device must be powered to query a processing-unit node!");
+                throw std::runtime_error("Device must be powered to query video_proc!");
 
             // Guard both the cache read and the lazy insert. Callers receive a CComPtr copy that keeps
             // the interface alive even if a concurrent set_d3() clears the cache mid-use.
@@ -1312,6 +1240,11 @@ namespace librealsense
             auto const found = _video_procs.find(node);
             if (found != _video_procs.end())
                 return found->second;
+
+            // DEFAULT_PU_NODE is the aggregate IAMVideoProcAmp; set_d0 populates it eagerly. Absence here
+            // means the device did not expose the interface at all.
+            if (node == DEFAULT_PU_NODE)
+                throw std::runtime_error("The device does not support adjusting the qualities of an incoming video signal, such as brightness, contrast, hue, saturation, gamma, and sharpness.");
 
             CComPtr<IKsTopologyInfo> topology = nullptr;
             CHECK_HR(_source->QueryInterface(__uuidof(IKsTopologyInfo),

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -88,6 +88,9 @@ namespace librealsense
             bool get_pu(rs2_option opt, int32_t& value) const override;
             bool set_pu(rs2_option opt, int value) override;
             control_range get_pu_range(rs2_option opt) const override;
+            bool get_pu(const processing_unit& pu, rs2_option opt, int32_t& value) const override;
+            bool set_pu(const processing_unit& pu, rs2_option opt, int value) override;
+            control_range get_pu_range(const processing_unit& pu, rs2_option opt) const override;
 
             void lock() const override { _systemwide_lock.lock(); }
             void unlock() const override { _systemwide_lock.unlock(); }
@@ -97,6 +100,7 @@ namespace librealsense
             std::string get_device_location() const override { return _location; }
             usb_spec get_usb_specification() const override { return _device_usb_spec; }
             IAMVideoProcAmp* get_video_proc() const;
+            CComPtr< IAMVideoProcAmp > get_video_proc( int node ) const;
             IAMCameraControl* get_camera_control() const;
 
         private:
@@ -128,6 +132,8 @@ namespace librealsense
 
             CComPtr<IAMCameraControl>               _camera_control = nullptr;
             CComPtr<IAMVideoProcAmp>                _video_proc = nullptr;
+            mutable std::mutex _video_procs_mtx;
+            mutable std::unordered_map<int, CComPtr<IAMVideoProcAmp>> _video_procs;
             std::unordered_map<int, CComPtr<IKsControl>>      _ks_controls;
 
             auto_reset_event                        _is_flushed;

--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -99,8 +99,7 @@ namespace librealsense
 
             std::string get_device_location() const override { return _location; }
             usb_spec get_usb_specification() const override { return _device_usb_spec; }
-            IAMVideoProcAmp* get_video_proc() const;
-            CComPtr< IAMVideoProcAmp > get_video_proc( int node ) const;
+            CComPtr< IAMVideoProcAmp > get_video_proc( int node = platform::DEFAULT_PU_NODE ) const;
             IAMCameraControl* get_camera_control() const;
 
         private:
@@ -131,8 +130,9 @@ namespace librealsense
             CComPtr<IMFAttributes>                  _reader_attrs = nullptr;
 
             CComPtr<IAMCameraControl>               _camera_control = nullptr;
-            CComPtr<IAMVideoProcAmp>                _video_proc = nullptr;
             mutable std::mutex _video_procs_mtx;
+            // Keyed by KS topology node; the sentinel DEFAULT_PU_NODE holds the aggregate
+            // IAMVideoProcAmp obtained from IMFMediaSource for backends with a single PU.
             mutable std::unordered_map<int, CComPtr<IAMVideoProcAmp>> _video_procs;
             std::unordered_map<int, CComPtr<IKsControl>>      _ks_controls;
 

--- a/src/platform/uvc-device.h
+++ b/src/platform/uvc-device.h
@@ -52,6 +52,14 @@ struct extension_unit
     guid id;
 };
 
+// subdevice and node are assigned by the host driver; unit is the UVC firmware entity ID
+struct processing_unit
+{
+    int subdevice;
+    uint8_t unit;
+    int node;
+};
+
 enum power_state
 {
     D0,
@@ -136,6 +144,21 @@ public:
     virtual bool get_pu( rs2_option opt, int32_t & value ) const = 0;
     virtual bool set_pu( rs2_option opt, int32_t value ) = 0;
     virtual control_range get_pu_range( rs2_option opt ) const = 0;
+
+    // Most devices expose one PU per UVC function, so backends may use the default PU transport. Composite UVC
+    // functions can override these methods to address a specific host topology node.
+    virtual bool get_pu( const processing_unit &, rs2_option opt, int32_t & value ) const
+    {
+        return get_pu( opt, value );
+    }
+    virtual bool set_pu( const processing_unit &, rs2_option opt, int32_t value )
+    {
+        return set_pu( opt, value );
+    }
+    virtual control_range get_pu_range( const processing_unit &, rs2_option opt ) const
+    {
+        return get_pu_range( opt );
+    }
 
     virtual std::vector< stream_profile > get_profiles() const = 0;
 
@@ -240,6 +263,35 @@ public:
 
     control_range get_pu_range( rs2_option opt ) const override { return _dev->get_pu_range( opt ); }
 
+    bool get_pu( const processing_unit & pu, rs2_option opt, int32_t & value ) const override
+    {
+        for( auto i = 0; i < MAX_RETRIES; ++i )
+        {
+            if( _dev->get_pu( pu, opt, value ) )
+                return true;
+
+            std::this_thread::sleep_for( std::chrono::milliseconds( DELAY_FOR_RETRIES ) );
+        }
+        return false;
+    }
+
+    bool set_pu( const processing_unit & pu, rs2_option opt, int32_t value ) override
+    {
+        for( auto i = 0; i < MAX_RETRIES; ++i )
+        {
+            if( _dev->set_pu( pu, opt, value ) )
+                return true;
+
+            std::this_thread::sleep_for( std::chrono::milliseconds( DELAY_FOR_RETRIES ) );
+        }
+        return false;
+    }
+
+    control_range get_pu_range( const processing_unit & pu, rs2_option opt ) const override
+    {
+        return _dev->get_pu_range( pu, opt );
+    }
+
     std::vector< stream_profile > get_profiles() const override { return _dev->get_profiles(); }
 
     std::string get_device_location() const override { return _dev->get_device_location(); }
@@ -337,6 +389,21 @@ public:
     bool set_pu( rs2_option opt, int32_t value ) override { return _dev.front()->set_pu( opt, value ); }
 
     control_range get_pu_range( rs2_option opt ) const override { return _dev.front()->get_pu_range( opt ); }
+
+    bool get_pu( const processing_unit & pu, rs2_option opt, int32_t & value ) const override
+    {
+        return _dev.front()->get_pu( pu, opt, value );
+    }
+
+    bool set_pu( const processing_unit & pu, rs2_option opt, int32_t value ) override
+    {
+        return _dev.front()->set_pu( pu, opt, value );
+    }
+
+    control_range get_pu_range( const processing_unit & pu, rs2_option opt ) const override
+    {
+        return _dev.front()->get_pu_range( pu, opt );
+    }
 
     std::vector< stream_profile > get_profiles() const override
     {

--- a/src/platform/uvc-device.h
+++ b/src/platform/uvc-device.h
@@ -52,6 +52,12 @@ struct extension_unit
     guid id;
 };
 
+// Sentinel node value meaning "use the backend's default/aggregate processing unit"
+// (WMF: the aggregate IAMVideoProcAmp on the media source; V4L2: forwards to the non-PU
+// transport). KS topology node ids start at 0, so 0 is a legal PU node and cannot be the
+// sentinel; -1 is unambiguous.
+constexpr int DEFAULT_PU_NODE = -1;
+
 // subdevice and node are assigned by the host driver; unit is the UVC firmware entity ID
 struct processing_unit
 {

--- a/src/platform/uvc-option.cpp
+++ b/src/platform/uvc-option.cpp
@@ -18,6 +18,34 @@ uvc_pu_option::uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep, rs2_option
                               const std::map< float, std::string > & description_per_value )
     : _ep(ep), _id(id), _description_per_value(description_per_value)
 {
+    initialize_range();
+}
+
+
+uvc_pu_option::uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep,
+                              rs2_option id,
+                              platform::processing_unit pu )
+    : uvc_pu_option( ep, id, pu, std::map< float, std::string >() )
+{
+}
+
+
+uvc_pu_option::uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep,
+                              rs2_option id,
+                              platform::processing_unit pu,
+                              const std::map< float, std::string > & description_per_value )
+    : _ep( ep )
+    , _id( id )
+    , _description_per_value( description_per_value )
+    , _pu( pu )
+    , _use_processing_unit( true )
+{
+    initialize_range();
+}
+
+
+void uvc_pu_option::initialize_range()
+{
     _range = [this]()
     {
         auto ep = _ep.lock();
@@ -26,7 +54,9 @@ uvc_pu_option::uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep, rs2_option
 
         auto uvc_range = ep->invoke_powered( [this]( platform::uvc_device & dev )
             {
-                return dev.get_pu_range(_id);
+                if( _use_processing_unit )
+                    return dev.get_pu_range( _pu, _id );
+                return dev.get_pu_range( _id );
             });
 
         if (uvc_range.min.size() < sizeof(int32_t)) return option_range{ 0,0,1,0 };
@@ -51,7 +81,10 @@ void uvc_pu_option::set(float value)
     ep->invoke_powered(
         [this, value](platform::uvc_device& dev)
         {
-            if (!dev.set_pu(_id, static_cast<int32_t>(value)))
+            auto const success = _use_processing_unit
+                ? dev.set_pu( _pu, _id, static_cast< int32_t >( value ) )
+                : dev.set_pu( _id, static_cast< int32_t >( value ) );
+            if( ! success )
             throw invalid_value_exception( rsutils::string::from()
                                            << "set_pu(id=" << std::to_string( _id ) << ") failed!"
                                            << " Last Error: " << strerror( errno ) );
@@ -69,7 +102,10 @@ float uvc_pu_option::query() const
         [this](platform::uvc_device& dev)
         {
             int32_t value = 0;
-            if (!dev.get_pu(_id, value))
+            auto const success = _use_processing_unit
+                ? dev.get_pu( _pu, _id, value )
+                : dev.get_pu( _id, value );
+            if( ! success )
                 throw invalid_value_exception( rsutils::string::from()
                                                << "get_pu(id=" << std::to_string( _id ) << ") failed!"
                                                << " Last Error: " << strerror( errno ) );

--- a/src/platform/uvc-option.cpp
+++ b/src/platform/uvc-option.cpp
@@ -38,7 +38,6 @@ uvc_pu_option::uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep,
     , _id( id )
     , _description_per_value( description_per_value )
     , _pu( pu )
-    , _use_processing_unit( true )
 {
     initialize_range();
 }
@@ -54,9 +53,7 @@ void uvc_pu_option::initialize_range()
 
         auto uvc_range = ep->invoke_powered( [this]( platform::uvc_device & dev )
             {
-                if( _use_processing_unit )
-                    return dev.get_pu_range( _pu, _id );
-                return dev.get_pu_range( _id );
+                return dev.get_pu_range( _pu, _id );
             });
 
         if (uvc_range.min.size() < sizeof(int32_t)) return option_range{ 0,0,1,0 };
@@ -81,13 +78,10 @@ void uvc_pu_option::set(float value)
     ep->invoke_powered(
         [this, value](platform::uvc_device& dev)
         {
-            auto const success = _use_processing_unit
-                ? dev.set_pu( _pu, _id, static_cast< int32_t >( value ) )
-                : dev.set_pu( _id, static_cast< int32_t >( value ) );
-            if( ! success )
-            throw invalid_value_exception( rsutils::string::from()
-                                           << "set_pu(id=" << std::to_string( _id ) << ") failed!"
-                                           << " Last Error: " << strerror( errno ) );
+            if( ! dev.set_pu( _pu, _id, static_cast< int32_t >( value ) ) )
+                throw invalid_value_exception( rsutils::string::from()
+                                               << "set_pu(id=" << std::to_string( _id ) << ") failed!"
+                                               << " Last Error: " << strerror( errno ) );
             _record(*this);
         });
 }
@@ -102,10 +96,7 @@ float uvc_pu_option::query() const
         [this](platform::uvc_device& dev)
         {
             int32_t value = 0;
-            auto const success = _use_processing_unit
-                ? dev.get_pu( _pu, _id, value )
-                : dev.get_pu( _id, value );
-            if( ! success )
+            if( ! dev.get_pu( _pu, _id, value ) )
                 throw invalid_value_exception( rsutils::string::from()
                                                << "get_pu(id=" << std::to_string( _id ) << ") failed!"
                                                << " Last Error: " << strerror( errno ) );

--- a/src/platform/uvc-option.h
+++ b/src/platform/uvc-option.h
@@ -20,6 +20,10 @@ class uvc_pu_option : public option
     const std::map< float, std::string > _description_per_value;
     std::function< void( const option & ) > _record = []( const option & ) {};
     rsutils::lazy< option_range > _range;
+    platform::processing_unit _pu = { 0, 0, 0 };
+    bool _use_processing_unit = false;
+
+    void initialize_range();
 
 public:
     void set( float value ) override;
@@ -33,6 +37,15 @@ public:
     uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep, rs2_option id );
 
     uvc_pu_option( const std::weak_ptr < uvc_sensor > & ep, rs2_option id,
+                   const std::map< float, std::string > & description_per_value );
+
+    uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep,
+                   rs2_option id,
+                   platform::processing_unit pu );
+
+    uvc_pu_option( const std::weak_ptr< uvc_sensor > & ep,
+                   rs2_option id,
+                   platform::processing_unit pu,
                    const std::map< float, std::string > & description_per_value );
 
     const char * get_description() const override;

--- a/src/platform/uvc-option.h
+++ b/src/platform/uvc-option.h
@@ -20,8 +20,7 @@ class uvc_pu_option : public option
     const std::map< float, std::string > _description_per_value;
     std::function< void( const option & ) > _record = []( const option & ) {};
     rsutils::lazy< option_range > _range;
-    platform::processing_unit _pu = { 0, 0, 0 };
-    bool _use_processing_unit = false;
+    platform::processing_unit _pu = { 0, 0, platform::DEFAULT_PU_NODE };
 
     void initialize_range();
 


### PR DESCRIPTION
Tracked by: RSDEV-13003, RSDEV-12717

## Overview

Enables the ten RGB Processing-Unit controls on D585 2C (dual-color) for both Windows (WMF) and Linux (V4L2). Builds on and rebases @ghu3's #15567 (Windows path) and extends it to Linux by binding a raw sensor to the specific `/dev/videoN` that hosts the RGB PU.

## Background

The D585 2C unified UVC function exposes two Processing Units in one video streaming interface: Depth PU `0x02` and RGB PU `0x07` (KS topology node 6 on Windows; a distinct `/dev/videoN` per PU chain on Linux). The aggregate `IAMVideoProcAmp` binds to the first PU (Depth), so RGB controls fail with `HRESULT 0x80070490`. On Linux, `multi_pins_uvc_device` forwards to `_dev.front()` = the depth pin, whose fd doesn't advertise `V4L2_CID_BRIGHTNESS`/etc., so range queries silently return 0/0/0/0.

## Changes

**Platform abstraction** (`src/platform/`, from #15567): new `struct processing_unit { subdevice, unit, node }` + three PU-aware virtuals on `uvc_device` with default forwarding; two new `uvc_pu_option` constructors that carry the triple.

**Windows** (`src/mf/`, from #15567): `wmf_uvc_device::get_video_proc(int node)` opens a node-specific `IAMVideoProcAmp` via `IKsTopologyInfo::CreateNodeInstance`, cached in `_video_procs`.

**Linux** (`src/ds/d500/d500-dual-color.cpp`, new in this PR): `pick_rgb_pu_raw_endpoint()` probes MI-0 sibling video nodes at device construction and binds `_raw_rgb_ep` to the pin whose fd actually hosts the RGB PU CIDs. Skips the depth pin (avoids opening a redundant second fd on `video0`), stops on first success, and cleanly skips option registration if no pin qualifies. RGB options register against that endpoint, so every subsequent get/set goes straight to the right fd with no runtime iteration.

**Device registration** (`src/ds/d500/d500-dual-color.{cpp,h}`): `register_color_options()` is no longer `_WIN32`-only; it takes `dev_info` (needed by the Linux probe) and short-circuits cleanly if the probe returns null.

## Validation

- **Windows** (D585 2C 0x0C07 proto, FW 7.58.46213.14832): `rs-enumerate-devices -o` and `realsense-viewer` show all ten RGB controls with the expected ranges (Brightness -64..64, Contrast 0..100, Saturation 0..100, Hue -180..180, Gamma 40..260, Sharpness 0..100, WB 2800..6500 step 10, PLF 0..2, Auto WB 0..1, Backlight 0..0).
- **Linux** (Ubuntu 24.04, D585 2C 0x0C07 proto, same FW): fresh build → `rs-enumerate-devices -o` shows the same ten controls on the Stereo Module, with ranges identical to `v4l2-ctl --list-ctrls-menus /dev/video4`.

## Inherited findings from #15567

Rs-agentic bot on #15567 already flagged, and my self-review on this branch re-confirmed the following in the WMF-side code (unchanged in this branch):

- `wmf_uvc_device::_video_procs` is populated inside a `const` method with no locking, and `get_video_proc(int)` returns a raw `IAMVideoProcAmp*` aliased inside the map's `CComPtr` — data-race + UAF risk if a concurrent `set_d3()` clears the cache between emplace and use.
- `wmf_uvc_device::set_pu(unit, ...)` — the `enable_auto` branch is missing the `SEMAPHORE_TIMEOUT_ERROR` handling that the non-auto branch has.
- `wmf_uvc_device::get_pu(unit, ...)` / `set_pu(unit, ...)` duplicate the `pu_controls` loop from their non-node siblings, and `get_pu_range(unit, ...)` drops the `AUTO_EXPOSURE` clamp that the non-node version applies.
- The RGB PU triple `{0, 0x07, 6}` is magic-numbered; naming the two constants would document the topology assumption.

Happy to address these in this PR if preferred over a follow-up.