### PR TITLE
Fix 64 byte alignment on GMSL

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -285,17 +285,19 @@ void log_callback_end( uint32_t fps,
     }
 
     // TODO - make this method more efficient, using parralel computation, with SSE or CUDA, when available
-    std::vector<uint8_t> sensor_base::align_width_to_64(int width, int height, int bpp, uint8_t * pix) const
+    std::vector<uint8_t> sensor_base::align_width_to_64(int width, int height, int bpp, rs2_format format, uint8_t * pix) const
     {
-        int factor = bpp >> 3;
-        int bytes_in_width = width * factor;
-        int actual_input_bytes_in_width = (((bytes_in_width / 64 ) + 1) * 64);
+        // Semi-planar 4:2:0 rows are `width` bytes and the image holds height*3/2 of them (Y plane
+        // plus the interleaved chroma plane), unlike packed formats' single plane of width*bpp/8.
+        bool const semi_planar_420 = ( format == RS2_FORMAT_NV12 || format == RS2_FORMAT_M420 );
+        int const bytes_in_width = semi_planar_420 ? width : width * bpp >> 3;
+        int const rows = semi_planar_420 ? height * 3 / 2 : height;
+        int const padded_bytes_in_width = ( bytes_in_width + 63 ) & ~63;
         std::vector<uint8_t> pixels;
-        for (int j = 0; j < height; ++j)
+        for (int j = 0; j < rows; ++j)
         {
-            int start_index = j * actual_input_bytes_in_width;
-            int end_index = (width * factor) + (j * actual_input_bytes_in_width);
-            pixels.insert(pixels.end(), pix + start_index, pix + end_index);
+            int start_index = j * padded_bytes_in_width;
+            pixels.insert(pixels.end(), pix + start_index, pix + start_index + bytes_in_width);
         }
         return pixels;
     }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -294,6 +294,7 @@ void log_callback_end( uint32_t fps,
         int const rows = semi_planar_420 ? height * 3 / 2 : height;
         int const padded_bytes_in_width = ( bytes_in_width + 63 ) & ~63;
         std::vector<uint8_t> pixels;
+        pixels.reserve( size_t( rows ) * bytes_in_width );  // one allocation instead of the insert loop's growth
         for (int j = 0; j < rows; ++j)
         {
             int start_index = j * padded_bytes_in_width;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -149,7 +149,7 @@ namespace librealsense
             return width * height * bpp >> 3;
         }
 
-        std::vector<uint8_t> align_width_to_64(int width, int height, int bpp, uint8_t * pix) const;
+        std::vector<uint8_t> align_width_to_64(int width, int height, int bpp, rs2_format format, uint8_t * pix) const;
 
         std::atomic<bool> _is_streaming;
         std::atomic<bool> _is_opened;

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -13,6 +13,7 @@
 #include <src/metadata-parser.h>
 #include <src/core/time-service.h>
 #include <src/core/frame-continuation.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -322,9 +323,12 @@ void uvc_sensor::open( const stream_profiles & requests )
                         // when the resolution's width is not aligned to 64
                         else if( align64 )
                         {
-                            std::vector< uint8_t > pixels = align_width_to_64( width, height, bpp, (uint8_t *)f.pixels );
-                            assert( expected_size == sizeof( uint8_t ) * pixels.size() );
-                            memcpy( (void *)fh->get_frame_data(), pixels.data(), expected_size );
+                            std::vector< uint8_t > pixels = align_width_to_64(
+                                width, height, bpp, req_profile_base->get_format(), (uint8_t *)f.pixels );
+                            // Clamp rather than trust the layout: a short repack would otherwise read past the buffer
+                            if( pixels.size() < expected_size )
+                                LOG_ERROR( "Realigned frame is " << pixels.size() << " bytes, expected " << expected_size );
+                            memcpy( (void *)fh->get_frame_data(), pixels.data(), std::min( expected_size, pixels.size() ) );
                         }
                         else
                         {


### PR DESCRIPTION
**Overview:** Fixes a crash and silently corrupted colors when streaming color on GMSL/MIPI at resolutions whose width is not a multiple of 64.

Tracked on [RSDEV-14377/RSDEV-14377]

## Why

The MIPI driver pads each row of the capture buffer to a 64-byte boundary, and `align_width_to_64()` repacks it tightly. That repack assumed a single packed plane: it derived bytes-per-row as `width * bpp/8` and copied exactly `height` rows.

NV12 breaks both assumptions. It is semi-planar 4:2:0 — rows are `width` bytes, and there are `height * 3/2` of them (Y plane plus the interleaved chroma plane). With `bpp = 12`, `bpp >> 3` truncated to 1, so the repack produced a buffer holding only the Y plane. `uvc-sensor.cpp` then copied the full expected frame size out of it, reading past the end. The `assert` guarding this is compiled out in Release.

For Color 848x480 on D585 GMSL:

| | bytes |
|---|---|
| Driver buffer | 645,120 (896 stride x 720 rows) |
| Expected frame | 610,560 (848 x 480 x 1.5) |
| Repack produced | 407,040 (848 x 480, Y plane only) |
| Over-read | 203,520 |

Whether it crashes depends only on how far past the buffer the copy reaches, so the same defect had two faces:

| Resolution | Y stride | Over-read | Before |
|---|---|---|---|
| 848x480 | 896 | 203,520 B | SIGSEGV |
| 424x240 | 448 | 50,880 B | SIGSEGV |
| 480x270 | 512 | 64,800 B | Silent corruption - chroma plane was heap garbage |
| 1280x*, 640x* | unpadded | - | Unaffected (repack not taken) |

The defect predates PR #15510. That PR exposed it by merging the `rs_5x5_mipi` variant into the shared `rs_5x5` class: MIPI had passed `RS2_FORMAT_YUYV` as the native color format, and the shared class passes `RS2_FORMAT_NV12`, routing NV12 frames into the repack path for the first time.

## Summary

- `align_width_to_64()` is now format-aware: NV12 and M420 use `width` bytes per row over `height * 3/2` rows; packed formats keep `width * bpp/8` over `height` rows. Y411 is also 12 bpp but genuinely packed, so it stays on the packed path.
- Round the padded row length up correctly (`(x + 63) & ~63`). The old `((x / 64) + 1) * 64` added a spurious 64 whenever the row was already aligned - unreachable today, but a trap once the row length is no longer `width * bpp/8`.
- Replace the Release-inert `assert` with a `LOG_ERROR` and a clamped `memcpy`, so a short repack can never read past the buffer.

## Test plan

- [x] D585 Prototype on GMSL (Jetson, FW 7.58.46212.14758): color-only matrix, 7 resolutions x {RGB8, YUYV, NV12}, 3 s each - 21/21 pass. 4 of them segfaulted before the fix (848x480 and 424x240, RGB8 and NV12).
- [x] Image content verified against an independent YUYV capture at each padded resolution: luma correlation 0.998-0.999, uniform per-row. Chroma saturation at 480x270 goes from mean 220.2 (garbage) to 6.4, matching the unpadded 640x480 control at 6.6.
- [x] 60 s three-stream soak - IR1 1280x960 Y8 + Depth 1280x960 Z16 + Color 848x480 RGB8 @60: 3790 frames per stream, 62.3 fps each, clean stop.
- [x] Windows MSVC (VS2022) builds clean; the repack path is MIPI-only and unreachable on USB, which is unchanged.
- [ ] CI regression run on the GMSL hosts.

---
🤖 Generated by AI