### PR TITLE
Fix stale IMU samples after reset (RSDEV-14102)

### DIFF
--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -492,7 +492,7 @@ namespace librealsense
             if (_is_capturing)
                 return;
 
-            // Drop reports retained in the IIO kfifo during HID enumeration.
+            // Drop reports retained by the IIO kfifo during HID enumeration, even if it is now disabled.
             clear_buffer();
             set_power(true);
             std::ostringstream iio_read_device_path;

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -492,6 +492,8 @@ namespace librealsense
             if (_is_capturing)
                 return;
 
+            // Drop reports retained in the IIO kfifo during HID enumeration.
+            clear_buffer();
             set_power(true);
             std::ostringstream iio_read_device_path;
             iio_read_device_path << "/dev/" << IIO_DEVICE_PREFIX << _iio_device_number;


### PR DESCRIPTION
## Summary
- Clear retained Linux IIO reports before enabling IMU capture.
- Prevent an apparent hardware-timestamp jump at the start of the accelerometer stream after a hardware reset.

## Root cause
The Linux IIO kfifo retained 128 accelerometer reports during HID enumeration. The next stream start consumed those stale reports before live data, producing a multi-second timestamp discontinuity at frame 129 even though the total frame count was correct.

## Verification
- Clean Release build of the realsense2 target: PASS.
- D585 Prototype 333622320156, FW 7.58.46132.14758, USB3.
- Baseline after hardware reset: 5/5 runs reproduced the jump at accelerometer frame 129 (4.53-4.74 s).
- After fix: 0/5 hardware-reset runs reproduced the jump.
- Stop/start regression: 3/3 cycles passed without a large timestamp jump.

## JIRA
https://rsjira.realsenseai.com/browse/RSDEV-14102