### PR TITLE
Read and write advanced-mode control groups by name from python

### DIFF
--- a/unit-tests/live/options/pytest-advanced-mode.py
+++ b/unit-tests/live/options/pytest-advanced-mode.py
@@ -303,24 +303,6 @@ def test_set_amp_factor(test_device_wrapped):
     assert new_af.a_factor == pytest.approx(0.12, abs=0.005)
 
 
-# (attribute on advanced_controls, the getter that reads the same group by itself)
-_ALL_CONTROLS_GROUPS = [
-    ('depth_control', 'get_depth_control'),
-    ('rsm', 'get_rsm'),
-    ('rsvc', 'get_rau_support_vector_control'),
-    ('color_control', 'get_color_control'),
-    ('rctc', 'get_rau_thresholds_control'),
-    ('sctc', 'get_slo_color_thresholds_control'),
-    ('spc', 'get_slo_penalty_control'),
-    ('hdad', 'get_hdad'),
-    ('cc', 'get_color_correction'),
-    ('depth_table', 'get_depth_table'),
-    ('ae', 'get_ae_control'),
-    ('census', 'get_census'),
-    ('amp_factor', 'get_amp_factor'),
-]
-
-
 def test_get_all_controls_matches_individual_getters(test_device_wrapped):
     """get_all_controls reads every group and mode in one bulk operation - the values must be the ones
     the per-group getters return. A group whose min/max FW does not report gives its value instead."""
@@ -329,15 +311,16 @@ def test_get_all_controls_matches_individual_getters(test_device_wrapped):
     dev, ctx = test_device_wrapped
     am_dev = get_am_dev(dev)
     all_controls = am_dev.get_all_controls()
-    for attr, getter in _ALL_CONTROLS_GROUPS:
-        per_mode = getattr(all_controls, attr)
-        assert len(per_mode) == 3, f"{attr}: expected a value, a minimum and a maximum"
+    # Every group is reported under the name it is read by on its own
+    for group in all_controls.keys():
+        per_mode = all_controls[group]
+        assert len(per_mode) == 3, f"{group}: expected a value, a minimum and a maximum"
         for mode in (0, 1, 2):
             try:
-                expected = getattr(am_dev, getter)(mode)
+                expected = am_dev[group, mode]
             except RuntimeError:  # FW has no min/max for this group, so the value is expected
-                expected = getattr(am_dev, getter)(0)
-            assert repr(per_mode[mode]) == repr(expected), f"{getter} mode {mode}"
+                expected = am_dev[group]
+            assert repr(per_mode[mode]) == repr(expected), f"{group} mode {mode}"
 
 
 def test_return_to_default_visual_preset(test_device_wrapped):

--- a/wrappers/python/pyrs_advanced_mode.cpp
+++ b/wrappers/python/pyrs_advanced_mode.cpp
@@ -4,12 +4,40 @@ Copyright(c) 2017 RealSense, Inc. All Rights Reserved. */
 #include "pyrealsense2.h"
 #include <librealsense2/rs_advanced_mode.hpp>
 #include <librealsense2/hpp/rs_serializable_device.hpp>
+#include <cmath>
 
 // Each control group in STAdvancedModeControls is an array, which python sees as a list
 template< typename T, size_t N >
 static std::vector< T > to_list( T const ( & a )[N] )
 {
     return std::vector< T >( a, a + N );
+}
+
+static void bind_as_mapping( py::object cls, bool writable = true )
+{
+    cls.attr( "keys" ) = py::cpp_function(
+        []( py::object self ) {
+            auto property_type = py::module_::import( "builtins" ).attr( "property" );
+            py::list names;
+            for( auto item : self.attr( "__class__" ).attr( "__dict__" ).cast< py::dict >() )
+                if( py::isinstance( item.second, property_type ) )
+                    names.append( item.first );
+            return names;
+        },
+        py::is_method( cls ) );
+    cls.attr( "__getitem__" ) = py::cpp_function(
+        []( py::object self, std::string const & key ) { return self.attr( key.c_str() ); },
+        py::is_method( cls ) );
+    if( ! writable )
+        return;
+    // An int field will not take a float, so round rather than fail.
+    cls.attr( "__setitem__" ) = py::cpp_function(
+        []( py::object self, std::string const & key, py::object value ) {
+            if( py::isinstance< py::int_ >( self.attr( key.c_str() ) ) )
+                value = py::int_( long( std::lround( value.cast< double >() ) ) );
+            self.attr( key.c_str() ) = value;
+        },
+        py::is_method( cls ) );
 }
 
 void init_advanced_mode(py::module &m) {
@@ -232,17 +260,27 @@ void init_advanced_mode(py::module &m) {
     py::class_< STAdvancedModeControls > advanced_controls( m, "STAdvancedModeControls" );
     advanced_controls.def_property_readonly( "depth_control", []( STAdvancedModeControls const & self ) { return to_list( self.depth_control ); } );
     advanced_controls.def_property_readonly( "rsm", []( STAdvancedModeControls const & self ) { return to_list( self.rsm ); } );
-    advanced_controls.def_property_readonly( "rsvc", []( STAdvancedModeControls const & self ) { return to_list( self.rsvc ); } );
+    advanced_controls.def_property_readonly( "rau_support_vector_control", []( STAdvancedModeControls const & self ) { return to_list( self.rsvc ); } );
     advanced_controls.def_property_readonly( "color_control", []( STAdvancedModeControls const & self ) { return to_list( self.color_control ); } );
-    advanced_controls.def_property_readonly( "rctc", []( STAdvancedModeControls const & self ) { return to_list( self.rctc ); } );
-    advanced_controls.def_property_readonly( "sctc", []( STAdvancedModeControls const & self ) { return to_list( self.sctc ); } );
-    advanced_controls.def_property_readonly( "spc", []( STAdvancedModeControls const & self ) { return to_list( self.spc ); } );
+    advanced_controls.def_property_readonly( "rau_thresholds_control", []( STAdvancedModeControls const & self ) { return to_list( self.rctc ); } );
+    advanced_controls.def_property_readonly( "slo_color_thresholds_control", []( STAdvancedModeControls const & self ) { return to_list( self.sctc ); } );
+    advanced_controls.def_property_readonly( "slo_penalty_control", []( STAdvancedModeControls const & self ) { return to_list( self.spc ); } );
     advanced_controls.def_property_readonly( "hdad", []( STAdvancedModeControls const & self ) { return to_list( self.hdad ); } );
-    advanced_controls.def_property_readonly( "cc", []( STAdvancedModeControls const & self ) { return to_list( self.cc ); } );
+    advanced_controls.def_property_readonly( "color_correction", []( STAdvancedModeControls const & self ) { return to_list( self.cc ); } );
     advanced_controls.def_property_readonly( "depth_table", []( STAdvancedModeControls const & self ) { return to_list( self.depth_table ); } );
-    advanced_controls.def_property_readonly( "ae", []( STAdvancedModeControls const & self ) { return to_list( self.ae ); } );
+    advanced_controls.def_property_readonly( "ae_control", []( STAdvancedModeControls const & self ) { return to_list( self.ae ); } );
     advanced_controls.def_property_readonly( "census", []( STAdvancedModeControls const & self ) { return to_list( self.census ); } );
     advanced_controls.def_property_readonly( "amp_factor", []( STAdvancedModeControls const & self ) { return to_list( self.amp_factor ); } );
+
+    for( auto cls : { py::object( _STDepthControlGroup ), py::object( _STRsm ),
+                      py::object( _STRauSupportVectorControl ), py::object( _STColorControl ),
+                      py::object( _STRauColorThresholdsControl ), py::object( _STSloColorThresholdsControl ),
+                      py::object( _STSloPenaltyControl ), py::object( _STHdad ), py::object( _STColorCorrection ),
+                      py::object( _STDepthTableControl ), py::object( _STAEControl ), py::object( _STCensusRadius ),
+                      py::object( _STAFactor ) } )
+        bind_as_mapping( cls );
+
+    bind_as_mapping( advanced_controls, false );
 
     py::class_<rs400::advanced_mode> rs400_advanced_mode(m, "rs400_advanced_mode");
     rs400_advanced_mode.def(py::init<rs2::device>(), "device"_a)
@@ -278,6 +316,37 @@ void init_advanced_mode(py::module &m) {
              "Read every control group and mode at once, in a single bulk operation")
         .def("serialize_json", &rs400::advanced_mode::serialize_json)
         .def("load_json", &rs400::advanced_mode::load_json, "json_content"_a);
+
+    // Groups are named after the get_/set_ pairs above: am[group] reads and writes the
+    // current values, am[group, 1] the minimums and am[group, 2] the maximums.
+    rs400_advanced_mode.attr( "keys" ) = py::cpp_function(
+        []( py::object self ) {
+            py::list names;
+            for( auto item : self.attr( "__class__" ).attr( "__dict__" ).cast< py::dict >() )
+            {
+                auto name = item.first.cast< std::string >();
+                if( name.rfind( "get_", 0 ) == 0 && py::hasattr( self, ( "set_" + name.substr( 4 ) ).c_str() ) )
+                    names.append( name.substr( 4 ) );
+            }
+            return names;
+        },
+        py::is_method( rs400_advanced_mode ) );
+    rs400_advanced_mode.attr( "__getitem__" ) = py::cpp_function(
+        []( py::object self, py::object key ) {
+            if( py::isinstance< py::tuple >( key ) )
+            {
+                auto group_and_mode = key.cast< py::tuple >();
+                auto group = group_and_mode[0].cast< std::string >();
+                return self.attr( ( "get_" + group ).c_str() )( group_and_mode[1] );
+            }
+            return self.attr( ( "get_" + key.cast< std::string >() ).c_str() )( 0 );
+        },
+        py::is_method( rs400_advanced_mode ) );
+    rs400_advanced_mode.attr( "__setitem__" ) = py::cpp_function(
+        []( py::object self, std::string const & group, py::object values ) {
+            self.attr( ( "set_" + group ).c_str() )( values );
+        },
+        py::is_method( rs400_advanced_mode ) );
 }
 
 void init_serializable_device(py::module& m) {


### PR DESCRIPTION
Advanced-mode controls are C structs, so in python their fields are attributes rather than the enumerable keys the options API has: nothing can ask a group what it holds. Anything wanting to walk the controls generically - the REST API, a script, a test - has to hardcode the 13 group names and their 63 field names. `unit-tests/live/options/pytest-advanced-mode.py` did exactly that, with a 17-line pairing table.

This gives the control structs and `rs400_advanced_mode` a mapping view - `keys()`, `group[field]`, `group[field] = value`, `am[group]`, `am[group] = values` - derived from the properties the bindings already declare, so no name is spelled out twice and fields keep their declaration order (`dir()` would sort them, which is not the order firmware or the viewer uses). Assignment rounds to the field's own type, so a caller can hand over a number without knowing whether the struct holds an int or a float.

The test now walks the groups generically instead of the table. Note the six short property names on `STAdvancedModeControls` (`rsvc`, `rctc`, `sctc`, `spc`, `cc`, `ae`) are renamed to match their existing `get_`/`set_` accessors - that is what makes a group name resolvable to its getter and setter.