### PR TITLE
viewer: show Calibration Data on all D500 devices, not only D555

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -3981,17 +3981,16 @@ namespace rs2
                         RsImGui::CustomTooltip( "Tare calibration is used to adjust camera absolute distance to flat target.\n"
                                            "User needs either to enter the known ground truth or use the get button\n"
                                            "with specific target to get the ground truth." );
+                }
 
-                    if (_calib_model.supports())
+                if (_calib_model.supports())
+                {
+                    if (ImGui::Selectable("Calibration Data"))
                     {
-                        if (ImGui::Selectable("Calibration Data"))
-                        {
-                            _calib_model.open();
-                        }
-                        if (ImGui::IsItemHovered())
-                            RsImGui::CustomTooltip("Access low level camera calibration parameters");
+                        _calib_model.open();
                     }
-
+                    if (ImGui::IsItemHovered())
+                        RsImGui::CustomTooltip("Access low level camera calibration parameters");
                 }
 
                 has_autocalib = true;


### PR DESCRIPTION
Tracked by: RSDEV-14058

**Overview:** Show the "Calibration Data" / "Restore Factory" menu entry on every D500 device (D585F, D535F, D555F, etc.), not only on D555.

## Why
On D585F GMSL/USB the "More → Calibration Data" entry was missing, so users had no viewer-side path to `reset_to_factory_calibration()` — the "Restore Factory" button lives inside that popup. The block was inadvertently nested inside the D555-only branch of `draw_device_panel_auto_calib_d500` (the `else` of `if (!is_d555)`), so no other D5x5 SKU could reach it. The D400 path already has this entry at the top level.

## Summary
- Hoist the `if (_calib_model.supports()) { "Calibration Data" ... }` block out of the D555-only `else` branch in `common/device-model.cpp::draw_device_panel_auto_calib_d500()`. No new PID gates; the gate is unchanged (`dev.is<rs2::auto_calibrated_device>()`, which every `d500_device` satisfies unconditionally).

## Test plan
- [x] realsense-viewer with D585F (GMSL and USB): confirm "More → Calibration Data" appears and the "Restore Factory" button round-trips through `CAL_RESTORE_DFLT`.
- [ ] realsense-viewer with D555: confirm the item still appears alongside Focal Length / Tare (D555 behavior unchanged).
- [ ] realsense-viewer with D455: confirm no regression on the D400 path.

---
🤖 Generated by AI