### PR TITLE
realsense-viewer: adapt depth color-map ruler to visible range (RSDEV-14227)

### DIFF
--- a/common/device-model.h
+++ b/common/device-model.h
@@ -139,6 +139,9 @@ namespace rs2
             static const char* log_severity{ "viewer_model.log_severity" };
             static const char* post_processing{ "viewer_model.post_processing" };
             static const char* show_map_ruler{ "viewer_model.show_map_ruler" };
+            static const char* ruler_range_mode{ "viewer_model.ruler_range_mode" };
+            static const char* ruler_fixed_min{ "viewer_model.ruler_fixed_min" };
+            static const char* ruler_fixed_max{ "viewer_model.ruler_fixed_max" };
             static const char* show_stream_details{ "viewer_model.show_stream_details" };
             static const char* metric_system{ "viewer_model.metric_system" };
             static const char* shading_mode{ "viewer_model.shading_mode" };

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -678,12 +678,12 @@ namespace rs2
 
             // Range popover (right-click the ruler button). ImGui associates the
             // popup with the most-recently-submitted item, so it targets the button.
-            const std::string popup_id = "##ColorMapRulerPopup";
+            static const char* const popup_id = "##ColorMapRulerPopup";
             if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
             {
-                ImGui::OpenPopup(popup_id.c_str());
+                ImGui::OpenPopup(popup_id);
             }
-            if (ImGui::BeginPopup(popup_id.c_str()))
+            if (ImGui::BeginPopup(popup_id))
             {
                 ImGui::TextUnformatted("Depth ruler range");
                 ImGui::Separator();

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -30,13 +30,18 @@ namespace rs2
             int mode_val = config_file::instance().get_or_default(
                 configurations::viewer::ruler_range_mode,
                 static_cast<int>(ruler_range_mode::auto_dynamic));
-            if (mode_val < 0 || mode_val > 2) mode_val = 0;
+            if (mode_val < static_cast<int>(ruler_range_mode::auto_dynamic) ||
+                mode_val > static_cast<int>(ruler_range_mode::fixed_user))
+            {
+                mode_val = static_cast<int>(ruler_range_mode::auto_dynamic);
+            }
             ruler_mode = static_cast<ruler_range_mode>(mode_val);
             ruler_fixed_min = config_file::instance().get_or_default(
                 configurations::viewer::ruler_fixed_min, 0.f);
             ruler_fixed_max = config_file::instance().get_or_default(
                 configurations::viewer::ruler_fixed_max, 4.f);
-            if (ruler_fixed_max <= ruler_fixed_min) ruler_fixed_max = ruler_fixed_min + 0.1f;
+            if (ruler_fixed_max <= ruler_fixed_min + k_min_ruler_gap)
+                ruler_fixed_max = ruler_fixed_min + k_min_ruler_gap;
         }
         show_stream_details = config_file::instance().get_or_default(
             configurations::viewer::show_stream_details, false);
@@ -643,7 +648,6 @@ namespace rs2
         if (RS2_STREAM_DEPTH == profile.stream_type())
         {
             label = rsutils::string::from() << textual_icons::bar_chart << "##Color map";
-            const bool ruler_was_shown = show_map_ruler;
             if (show_map_ruler)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
@@ -675,7 +679,6 @@ namespace rs2
             // Range popover (right-click the ruler button). ImGui associates the
             // popup with the most-recently-submitted item, so it targets the button.
             const std::string popup_id = "##ColorMapRulerPopup";
-            (void)ruler_was_shown;
             if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
             {
                 ImGui::OpenPopup(popup_id.c_str());
@@ -713,8 +716,8 @@ namespace rs2
                 if (range_changed)
                 {
                     if (ruler_fixed_min < 0.f) ruler_fixed_min = 0.f;
-                    if (ruler_fixed_max <= ruler_fixed_min)
-                        ruler_fixed_max = ruler_fixed_min + 0.1f;
+                    if (ruler_fixed_max <= ruler_fixed_min + k_min_ruler_gap)
+                        ruler_fixed_max = ruler_fixed_min + k_min_ruler_gap;
                     config_file::instance().set(configurations::viewer::ruler_fixed_min, ruler_fixed_min);
                     config_file::instance().set(configurations::viewer::ruler_fixed_max, ruler_fixed_max);
                     ruler_state.initialized = false;

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -26,6 +26,18 @@ namespace rs2
     {
         show_map_ruler = config_file::instance().get_or_default(
             configurations::viewer::show_map_ruler, true);
+        {
+            int mode_val = config_file::instance().get_or_default(
+                configurations::viewer::ruler_range_mode,
+                static_cast<int>(ruler_range_mode::auto_dynamic));
+            if (mode_val < 0 || mode_val > 2) mode_val = 0;
+            ruler_mode = static_cast<ruler_range_mode>(mode_val);
+            ruler_fixed_min = config_file::instance().get_or_default(
+                configurations::viewer::ruler_fixed_min, 0.f);
+            ruler_fixed_max = config_file::instance().get_or_default(
+                configurations::viewer::ruler_fixed_max, 4.f);
+            if (ruler_fixed_max <= ruler_fixed_min) ruler_fixed_max = ruler_fixed_min + 0.1f;
+        }
         show_stream_details = config_file::instance().get_or_default(
             configurations::viewer::show_stream_details, false);
         show_safety_zones_2d = config_file::instance().get_or_default(
@@ -631,6 +643,7 @@ namespace rs2
         if (RS2_STREAM_DEPTH == profile.stream_type())
         {
             label = rsutils::string::from() << textual_icons::bar_chart << "##Color map";
+            const bool ruler_was_shown = show_map_ruler;
             if (show_map_ruler)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
@@ -642,7 +655,7 @@ namespace rs2
                 }
                 if (ImGui::IsItemHovered())
                 {
-                    RsImGui::CustomTooltip("Hide color map ruler");
+                    RsImGui::CustomTooltip("Hide color map ruler (right-click for range options)");
                 }
                 ImGui::PopStyleColor(2);
             }
@@ -655,9 +668,60 @@ namespace rs2
                 }
                 if (ImGui::IsItemHovered())
                 {
-                    RsImGui::CustomTooltip("Show color map ruler");
+                    RsImGui::CustomTooltip("Show color map ruler (right-click for range options)");
                 }
             }
+
+            // Range popover (right-click the ruler button). ImGui associates the
+            // popup with the most-recently-submitted item, so it targets the button.
+            const std::string popup_id = "##ColorMapRulerPopup";
+            (void)ruler_was_shown;
+            if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
+            {
+                ImGui::OpenPopup(popup_id.c_str());
+            }
+            if (ImGui::BeginPopup(popup_id.c_str()))
+            {
+                ImGui::TextUnformatted("Depth ruler range");
+                ImGui::Separator();
+                int mode_i = static_cast<int>(ruler_mode);
+                bool mode_changed = false;
+                mode_changed |= ImGui::RadioButton("Auto (adaptive)##rulerAuto",  &mode_i, 0);
+                if (ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip("Percentile-driven, smoothed across frames");
+                mode_changed |= ImGui::RadioButton("Fixed 0-4 m (legacy)##rulerLegacy", &mode_i, 1);
+                mode_changed |= ImGui::RadioButton("Fixed custom range##rulerCustom", &mode_i, 2);
+
+                if (mode_changed)
+                {
+                    ruler_mode = static_cast<ruler_range_mode>(mode_i);
+                    config_file::instance().set(configurations::viewer::ruler_range_mode, mode_i);
+                    ruler_state.initialized = false; // re-seed on next frame
+                }
+
+                const bool custom_enabled = (ruler_mode == ruler_range_mode::fixed_user);
+                if (!custom_enabled) ImGui::BeginDisabled();
+                ImGui::PushItemWidth(90);
+                bool range_changed = false;
+                range_changed |= ImGui::DragFloat("min (m)##rulerFixedMin",
+                                                  &ruler_fixed_min, 0.05f, 0.f, 100.f, "%.2f");
+                range_changed |= ImGui::DragFloat("max (m)##rulerFixedMax",
+                                                  &ruler_fixed_max, 0.05f, 0.f, 100.f, "%.2f");
+                ImGui::PopItemWidth();
+                if (!custom_enabled) ImGui::EndDisabled();
+
+                if (range_changed)
+                {
+                    if (ruler_fixed_min < 0.f) ruler_fixed_min = 0.f;
+                    if (ruler_fixed_max <= ruler_fixed_min)
+                        ruler_fixed_max = ruler_fixed_min + 0.1f;
+                    config_file::instance().set(configurations::viewer::ruler_fixed_min, ruler_fixed_min);
+                    config_file::instance().set(configurations::viewer::ruler_fixed_max, ruler_fixed_max);
+                    ruler_state.initialized = false;
+                }
+                ImGui::EndPopup();
+            }
+
             ImGui::SameLine();
         }
 

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -38,6 +38,10 @@ namespace rs2
         fixed_user   = 2,   // user-typed min/max
     };
 
+    // Minimum span (m) between user-typed min and max in fixed_user mode.
+    // Enforced by both the load path, the popover, and calculate_ruler_bounds.
+    static constexpr float k_min_ruler_gap = 0.1f;
+
     struct depth_ruler_state
     {
         // EMA-smoothed data-driven bounds (raw percentile values feed this).

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -31,6 +31,26 @@ namespace rs2
 
     bool draw_combo_box(const std::string& id, const std::vector<std::string>& device_names, int& new_index);
 
+    enum class ruler_range_mode : int
+    {
+        auto_dynamic = 0,   // percentile-driven, hysteresis-smoothed
+        fixed_4m     = 1,   // legacy 0..4 m behavior
+        fixed_user   = 2,   // user-typed min/max
+    };
+
+    struct depth_ruler_state
+    {
+        // EMA-smoothed data-driven bounds (raw percentile values feed this).
+        float smoothed_min = 0.f;
+        float smoothed_max = 4.f;
+        // Currently-displayed nice-step-snapped bounds. Only refreshed when
+        // the smoothed value moves past a symmetric deadband away from these,
+        // so the ruler doesn't oscillate at a step boundary.
+        float snapped_min = 0.f;
+        float snapped_max = 4.f;
+        bool  initialized = false;
+    };
+
     class stream_model
     {
     public:
@@ -103,6 +123,10 @@ namespace rs2
         rect curr_info_rect{};
         temporal_event _stream_not_alive;
         bool show_map_ruler = true;
+        ruler_range_mode ruler_mode = ruler_range_mode::auto_dynamic;
+        float ruler_fixed_min = 0.f;
+        float ruler_fixed_max = 4.f;
+        depth_ruler_state ruler_state;
         bool show_metadata = false;
         bool show_safety_zones_2d = true;
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1829,17 +1829,23 @@ namespace rs2
     }
 
     namespace {
-        // Nice-step ladder: pick the tick spacing for a given displayed range so
-        // labels come out round (0.05/0.10/0.25/... instead of 0.37, 0.74, ...).
+        // The one nice-step ladder. Both the snap grid (nice_step_for_range,
+        // used by the bounds smoothing) and the tick-label picker in
+        // draw_color_ruler iterate this same array — extending it changes both.
+        static constexpr float k_step_ladder[] = {
+            0.05f, 0.10f, 0.25f, 0.5f, 1.f, 2.f, 5.f, 10.f, 20.f, 50.f, 100.f
+        };
+
+        // Snap grid: coarsest step that keeps ~≤10 grid cells across the range.
+        // Verified to match the previous hardcoded thresholds through 20 m; beyond
+        // that, extrapolates sensibly (100 m → 10 m step instead of the old 5 m).
         float nice_step_for_range(float range)
         {
-            if (range <= 0.5f) return 0.05f;
-            if (range <= 1.0f) return 0.10f;
-            if (range <= 2.0f) return 0.25f;
-            if (range <= 5.0f) return 0.50f;
-            if (range <= 10.f) return 1.0f;
-            if (range <= 20.f) return 2.0f;
-            return 5.0f;
+            for (float s : k_step_ladder)
+            {
+                if (range <= s * 10.f) return s;
+            }
+            return k_step_ladder[sizeof(k_step_ladder)/sizeof(k_step_ladder[0]) - 1];
         }
 
         // p in [0,1]. Modifies the vector via nth_element — cheap and avoids a full sort.
@@ -1939,16 +1945,13 @@ namespace rs2
         const float x_ruler_val = right_x_colored_ruler + 4.0f;
         const auto  font_size   = ImGui::GetFontSize();
 
-        static constexpr float step_ladder[] = {
-            0.05f, 0.10f, 0.25f, 0.5f, 1.f, 2.f, 5.f, 10.f, 20.f, 50.f, 100.f
-        };
         auto tick_count = [ruler_min, ruler_max](float s) {
             const float first = std::ceil(ruler_min / s - 1e-4f) * s;
             if (first > ruler_max + 1e-4f) return 0;
             return static_cast<int>(std::floor((ruler_max + 1e-4f - first) / s)) + 1;
         };
-        float draw_step = step_ladder[sizeof(step_ladder)/sizeof(step_ladder[0]) - 1];
-        for (float s : step_ladder)
+        float draw_step = k_step_ladder[sizeof(k_step_ladder)/sizeof(k_step_ladder[0]) - 1];
+        for (float s : k_step_ladder)
         {
             if (tick_count(s) <= 5) { draw_step = s; break; }
         }
@@ -2034,7 +2037,7 @@ namespace rs2
     }
 
     viewer_model::ruler_bounds viewer_model::calculate_ruler_bounds(
-        const std::vector<float>& distances, stream_model& s_model) const
+        std::vector<float> distances, stream_model& s_model)
     {
         assert(!distances.empty());
 
@@ -2051,7 +2054,7 @@ namespace rs2
         if (s_model.ruler_mode == ruler_range_mode::fixed_user)
         {
             float lo = std::max(0.f, s_model.ruler_fixed_min);
-            float hi = std::max(lo + 0.05f, s_model.ruler_fixed_max);
+            float hi = std::max(lo + k_min_ruler_gap, s_model.ruler_fixed_max);
             s_model.ruler_state.snapped_min = lo;
             s_model.ruler_state.snapped_max = hi;
             s_model.ruler_state.smoothed_min = lo;
@@ -2060,13 +2063,14 @@ namespace rs2
             return { lo, hi };
         }
 
-        // 2) Auto: percentile-driven raw bounds with a bit of headroom, robust to
-        //    a few far outliers (a single stray pixel at 8 m shouldn't pin the ruler).
-        auto copy = distances;
-        float raw_lo = percentile(copy, 0.05f);
-        float raw_hi = percentile(copy, 0.95f);
-        raw_lo = std::max(0.f, raw_lo - 0.05f * std::max(raw_hi - raw_lo, 0.05f));
-        raw_hi = raw_hi + 0.05f * std::max(raw_hi - raw_lo, 0.05f);
+        // 2) Auto: percentile-driven raw bounds with symmetric 5% headroom on
+        //    each side. Cache the span before mutating either endpoint — else
+        //    the second line's headroom would ride the already-shrunk raw_lo.
+        float raw_lo = percentile(distances, 0.05f);
+        float raw_hi = percentile(distances, 0.95f);
+        const float span = std::max(raw_hi - raw_lo, 0.05f);
+        raw_lo = std::max(0.f, raw_lo - 0.05f * span);
+        raw_hi = raw_hi + 0.05f * span;
         if (raw_hi <= raw_lo) raw_hi = raw_lo + 0.05f;
 
         // 3) Asymmetric EMA hysteresis. "Expand" (max moves up, min moves down)
@@ -2470,7 +2474,8 @@ namespace rs2
 
                     if (!distances.empty())
                     {
-                        auto bounds = calculate_ruler_bounds(distances, streams[stream]);
+                        auto bounds = calculate_ruler_bounds(std::move(distances),
+                                                             streams[stream]);
                         draw_color_ruler(active_mouse, streams[stream], stream_rect,
                                          rgb_per_distance_vec, bounds, depth_units);
                     }

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1828,17 +1828,45 @@ namespace rs2
         }
     }
 
+    namespace {
+        // Nice-step ladder: pick the tick spacing for a given displayed range so
+        // labels come out round (0.05/0.10/0.25/... instead of 0.37, 0.74, ...).
+        float nice_step_for_range(float range)
+        {
+            if (range <= 0.5f) return 0.05f;
+            if (range <= 1.0f) return 0.10f;
+            if (range <= 2.0f) return 0.25f;
+            if (range <= 5.0f) return 0.50f;
+            if (range <= 10.f) return 1.0f;
+            if (range <= 20.f) return 2.0f;
+            return 5.0f;
+        }
+
+        // p in [0,1]. Modifies the vector via nth_element — cheap and avoids a full sort.
+        float percentile(std::vector<float>& v, float p)
+        {
+            if (v.empty()) return 0.f;
+            if (p < 0.f) p = 0.f;
+            if (p > 1.f) p = 1.f;
+            size_t idx = static_cast<size_t>(p * (v.size() - 1));
+            std::nth_element(v.begin(), v.begin() + idx, v.end());
+            return v[idx];
+        }
+    }
+
     void viewer_model::draw_color_ruler(const mouse_info& mouse,
                                         const stream_model& s_model,
                                         const rect& stream_rect,
                                         std::vector<rgb_per_distance> rgb_per_distance_vec,
-                                        float ruler_length,
+                                        const ruler_bounds& bounds,
                                         const std::string& ruler_units)
     {
-        if (rgb_per_distance_vec.empty() || (ruler_length <= 0.f))
+        const float ruler_min = bounds.min;
+        const float ruler_max = bounds.max;
+        const float ruler_range = ruler_max - ruler_min;
+        if (rgb_per_distance_vec.empty() || (ruler_range <= 0.f))
             return;
 
-        ruler_length = std::ceil(ruler_length);
         std::sort(rgb_per_distance_vec.begin(), rgb_per_distance_vec.end(), [](const rgb_per_distance& a,
             const rgb_per_distance& b) {
             return a.depth_val < b.depth_val;
@@ -1866,12 +1894,10 @@ namespace rs2
         const auto left_x_colored_ruler = stream_width - left_x_colored_ruler_offset;
         const auto right_x_colored_ruler = stream_width - (left_x_colored_ruler_offset - colored_ruler_width);
         assert((bottom_y_ruler - top_y_ruler) != 0.f);
-        const auto ratio = (bottom_y_ruler - top_y_ruler) / ruler_length;
+        // px per meter for depth->y mapping (independent of ruler start offset).
+        const auto ratio = (bottom_y_ruler - top_y_ruler) / ruler_range;
 
-        // Draw numbered ruler
-        float y_ruler_val = top_y_ruler;
         static const auto numbered_ruler_width = 20.f;
-
         const auto right_x_numbered_ruler = right_x_colored_ruler + numbered_ruler_width;
         static const auto hovered_numbered_ruler_opac = 0.8f;
         static const auto unhovered_numbered_ruler_opac = 0.6f;
@@ -1889,7 +1915,7 @@ namespace rs2
             std::stringstream ss;
             auto relative_mouse_y = ImGui::GetMousePos().y - top_y_ruler;
             auto y = (bottom_y_ruler - top_y_ruler) - relative_mouse_y;
-            ss << std::fixed << std::setprecision(2) << (y / ratio) << ruler_units;
+            ss << std::fixed << std::setprecision(2) << (ruler_min + y / ratio) << ruler_units;
             RsImGui::CustomTooltip("%s", ss.str().c_str());
             colored_ruler_opac = 1.f;
             numbered_ruler_background_opac = hovered_numbered_ruler_opac;
@@ -1906,26 +1932,49 @@ namespace rs2
         glVertex2f(right_x_colored_ruler, bottom_y_ruler);
         glEnd();
 
-
+        // Numbered ruler: labels sit only on nice-step multiples that fall inside
+        // the bar. No forced min/max — a range whose ends aren't on the step grid
+        // (e.g. min=0.15, max=2.5 with step=1) shows "1" and "2" and nothing else,
+        // never duplicating a tick label as a rounded-off endpoint. Cap at 5 ticks.
         const float x_ruler_val = right_x_colored_ruler + 4.0f;
-        ImGui::SetCursorScreenPos({ x_ruler_val, y_ruler_val });
-        const auto font_size = ImGui::GetFontSize();
-        ImGui::TextUnformatted(std::to_string(static_cast<int>(ruler_length)).c_str());
-        const auto skip_numbers = ((ruler_length / 10.f) - 1.f);
-        auto to_skip = (skip_numbers < 0.f)?0.f: skip_numbers;
-        for (int i = static_cast<int>(ruler_length - 1); i > 0; --i)
-        {
-            y_ruler_val += ((bottom_y_ruler - top_y_ruler) / ruler_length);
-            ImGui::SetCursorScreenPos({ x_ruler_val, y_ruler_val - font_size / 2 });
-            if (((to_skip--) > 0))
-                continue;
+        const auto  font_size   = ImGui::GetFontSize();
 
-            ImGui::TextUnformatted(std::to_string(i).c_str());
-            to_skip = skip_numbers;
+        static constexpr float step_ladder[] = {
+            0.05f, 0.10f, 0.25f, 0.5f, 1.f, 2.f, 5.f, 10.f, 20.f, 50.f, 100.f
+        };
+        auto tick_count = [ruler_min, ruler_max](float s) {
+            const float first = std::ceil(ruler_min / s - 1e-4f) * s;
+            if (first > ruler_max + 1e-4f) return 0;
+            return static_cast<int>(std::floor((ruler_max + 1e-4f - first) / s)) + 1;
+        };
+        float draw_step = step_ladder[sizeof(step_ladder)/sizeof(step_ladder[0]) - 1];
+        for (float s : step_ladder)
+        {
+            if (tick_count(s) <= 5) { draw_step = s; break; }
         }
-        y_ruler_val += ((bottom_y_ruler - top_y_ruler) / ruler_length);
-        ImGui::SetCursorScreenPos({ x_ruler_val, y_ruler_val - font_size });
-        ImGui::Text("0");
+
+        // Decimals: minimum that still faithfully represents every step multiple.
+        const int decimals = (draw_step >= 1.f  - 1e-4f) ? 0
+                           : (draw_step >= 0.1f - 1e-4f) ? 1
+                                                        : 2;
+        auto fmt_label = [decimals](float v) {
+            std::stringstream ss;
+            ss << std::fixed << std::setprecision(decimals) << v;
+            return ss.str();
+        };
+
+        const float first_tick = std::ceil(ruler_min / draw_step - 1e-4f) * draw_step;
+        for (float v = first_tick; v <= ruler_max + 1e-4f; v += draw_step)
+        {
+            const float y = bottom_y_ruler - (v - ruler_min) * ratio;
+            if (y < top_y_ruler || y > bottom_y_ruler) continue;
+            // Keep the label glyph inside the bar even for ticks flush at either edge.
+            float ly = y - font_size / 2.f;
+            if (ly < top_y_ruler)                ly = top_y_ruler;
+            if (ly > bottom_y_ruler - font_size) ly = bottom_y_ruler - font_size;
+            ImGui::SetCursorScreenPos({ x_ruler_val, ly });
+            ImGui::TextUnformatted(fmt_label(v).c_str());
+        }
 
         auto total_depth_scale = rgb_per_distance_vec.back().depth_val - rgb_per_distance_vec.front().depth_val;
         static const auto sensitivity_factor = 0.01f;
@@ -1954,9 +2003,12 @@ namespace rs2
             last_depth_value = curr_depth;
             last_index = i;
 
-            auto y = bottom_y_ruler - ((rgb_per_distance_vec[i].depth_val) * ratio);
-            if ((i == (rgb_per_distance_vec.size() - 1)) || (std::ceil(curr_depth) > ruler_length))
-                y = top_y_ruler;
+            // Map depth into the [top_y_ruler, bottom_y_ruler] strip, clipping any
+            // pixels that fall outside the current [ruler_min, ruler_max] window.
+            float y = bottom_y_ruler - (curr_depth - ruler_min) * ratio;
+            if (y < top_y_ruler)    y = top_y_ruler;
+            if (y > bottom_y_ruler) y = bottom_y_ruler;
+            if (i == (rgb_per_distance_vec.size() - 1)) y = top_y_ruler;
 
             glColor4f(rgb_per_distance_vec[i].rgb_val.r / 255.f,
                       rgb_per_distance_vec[i].rgb_val.g / 255.f,
@@ -1981,23 +2033,96 @@ namespace rs2
         glEnd();
     }
 
-    float viewer_model::calculate_ruler_max_distance(const std::vector<float>& distances) const
+    viewer_model::ruler_bounds viewer_model::calculate_ruler_bounds(
+        const std::vector<float>& distances, stream_model& s_model) const
     {
         assert(!distances.empty());
 
-        float mean = std::accumulate(distances.begin(),
-            distances.end(), 0.0f) / distances.size();
-
-        float e = 0;
-        float inverse = 1.f / distances.size();
-        for (auto elem : distances)
+        // 1) User override / legacy modes short-circuit the data-driven path.
+        if (s_model.ruler_mode == ruler_range_mode::fixed_4m)
         {
-            e += static_cast<float>(pow(elem - mean, 2));
+            s_model.ruler_state.snapped_min = 0.f;
+            s_model.ruler_state.snapped_max = 4.f;
+            s_model.ruler_state.smoothed_min = 0.f;
+            s_model.ruler_state.smoothed_max = 4.f;
+            s_model.ruler_state.initialized = true;
+            return { 0.f, 4.f };
+        }
+        if (s_model.ruler_mode == ruler_range_mode::fixed_user)
+        {
+            float lo = std::max(0.f, s_model.ruler_fixed_min);
+            float hi = std::max(lo + 0.05f, s_model.ruler_fixed_max);
+            s_model.ruler_state.snapped_min = lo;
+            s_model.ruler_state.snapped_max = hi;
+            s_model.ruler_state.smoothed_min = lo;
+            s_model.ruler_state.smoothed_max = hi;
+            s_model.ruler_state.initialized = true;
+            return { lo, hi };
         }
 
-        auto standard_deviation = sqrt(inverse * e);
-        static const auto length_jump = 4.f;
-        return std::ceil((mean + 1.5f * standard_deviation) / length_jump) * length_jump;
+        // 2) Auto: percentile-driven raw bounds with a bit of headroom, robust to
+        //    a few far outliers (a single stray pixel at 8 m shouldn't pin the ruler).
+        auto copy = distances;
+        float raw_lo = percentile(copy, 0.05f);
+        float raw_hi = percentile(copy, 0.95f);
+        raw_lo = std::max(0.f, raw_lo - 0.05f * std::max(raw_hi - raw_lo, 0.05f));
+        raw_hi = raw_hi + 0.05f * std::max(raw_hi - raw_lo, 0.05f);
+        if (raw_hi <= raw_lo) raw_hi = raw_lo + 0.05f;
+
+        // 3) Asymmetric EMA hysteresis. "Expand" (max moves up, min moves down)
+        //    tracks fast so the ruler grows immediately when a farther object
+        //    appears; "contract" tracks slowly so a brief close-up doesn't
+        //    collapse the ruler. Attack/release, the same trick a compressor uses.
+        auto& st = s_model.ruler_state;
+        constexpr float alpha_fast = 0.25f;   // ~4-frame attack
+        constexpr float alpha_slow = 0.03f;   // ~30-frame release (~1 s @ 30 fps)
+
+        auto ema = [](float& state, float target, float alpha_expand, float alpha_contract, bool max_edge)
+        {
+            const bool expanding = max_edge ? (target > state) : (target < state);
+            const float a = expanding ? alpha_expand : alpha_contract;
+            state = (1.f - a) * state + a * target;
+        };
+
+        if (!st.initialized)
+        {
+            st.smoothed_min = raw_lo;
+            st.smoothed_max = raw_hi;
+            float step0 = nice_step_for_range(std::max(0.05f, st.smoothed_max - st.smoothed_min));
+            st.snapped_min = std::max(0.f, std::floor(st.smoothed_min / step0) * step0);
+            st.snapped_max = std::ceil(st.smoothed_max / step0) * step0;
+            if (st.snapped_max <= st.snapped_min) st.snapped_max = st.snapped_min + step0;
+            st.initialized = true;
+            return { st.snapped_min, st.snapped_max };
+        }
+        ema(st.smoothed_max, raw_hi, alpha_fast, alpha_slow, /*max_edge=*/true);
+        ema(st.smoothed_min, raw_lo, alpha_fast, alpha_slow, /*max_edge=*/false);
+
+        // 4) Asymmetric deadband: expand at ½·step (snap up quickly when needed),
+        //    contract only at 1½·step (three times harder to shrink than grow),
+        //    so a bound sitting near a tick edge doesn't ping-pong.
+        const float cur_range = std::max(0.05f, st.snapped_max - st.snapped_min);
+        const float cur_step  = nice_step_for_range(cur_range);
+
+        auto needs_resnap = [cur_step](float snapped, float smoothed, bool max_edge)
+        {
+            const float diff = smoothed - snapped;
+            const bool expanding = max_edge ? (diff > 0.f) : (diff < 0.f);
+            const float threshold = expanding ? 0.5f * cur_step : 1.5f * cur_step;
+            return std::fabs(diff) > threshold;
+        };
+        const bool re_snap = needs_resnap(st.snapped_max, st.smoothed_max, true)
+                          || needs_resnap(st.snapped_min, st.smoothed_min, false);
+
+        if (re_snap)
+        {
+            const float new_range = std::max(0.05f, st.smoothed_max - st.smoothed_min);
+            const float step      = nice_step_for_range(new_range);
+            st.snapped_min = std::max(0.f, std::floor(st.smoothed_min / step) * step);
+            st.snapped_max = std::ceil(st.smoothed_max / step) * step;
+            if (st.snapped_max <= st.snapped_min) st.snapped_max = st.snapped_min + step;
+        }
+        return { st.snapped_min, st.snapped_max };
     }
 
     void viewer_model::render_2d_view(const rect& view_rect,
@@ -2317,7 +2442,6 @@ namespace rs2
                 if(RS2_FORMAT_RGB8 == textured_frame.get_profile().format())
                 {
                     static const std::string depth_units = "m";
-                    float ruler_length = 0.f;
                     auto depth_vid_profile = stream_mv.profile.as<video_stream_profile>();
                     auto depth_width = depth_vid_profile.width();
                     auto depth_height = depth_vid_profile.height();
@@ -2346,8 +2470,9 @@ namespace rs2
 
                     if (!distances.empty())
                     {
-                        ruler_length = calculate_ruler_max_distance(distances);
-                        draw_color_ruler(active_mouse, streams[stream], stream_rect, rgb_per_distance_vec, ruler_length, depth_units);
+                        auto bounds = calculate_ruler_bounds(distances, streams[stream]);
+                        draw_color_ruler(active_mouse, streams[stream], stream_rect,
+                                         rgb_per_distance_vec, bounds, depth_units);
                     }
                 }
             }

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -275,8 +275,11 @@ namespace rs2
                               std::vector<rgb_per_distance> rgb_per_distance_vec,
                               const ruler_bounds& bounds,
                               const std::string& ruler_units);
-        ruler_bounds calculate_ruler_bounds(const std::vector<float>& distances,
-                                            stream_model& s_model) const;
+        // Takes distances by value so the caller can std::move — nth_element
+        // partitions in place, avoiding a per-frame copy. Not const: updates
+        // the ruler smoothing state that lives on s_model.
+        ruler_bounds calculate_ruler_bounds(std::vector<float> distances,
+                                            stream_model& s_model);
 
         void set_export_popup(ImFont* large_font, ImFont* font, rect stream_rect, std::string& error_message, config_file& temp_cfg);
         void init_depth_uid(int& selected_depth_source, std::vector<std::string>& depth_sources_str, std::vector<int>& depth_sources);

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -268,13 +268,15 @@ namespace rs2
         std::map<int, rect> get_interpolated_layout(const std::map<int, rect>& l);
         void show_icon(ImFont* font_18, const char* label_str, const char* text, int x, int y,
                        int id, const ImVec4& color, const std::string& tooltip = "");
+        struct ruler_bounds { float min; float max; };
         void draw_color_ruler(const mouse_info& mouse,
                               const stream_model& s_model,
                               const rect& stream_rect,
                               std::vector<rgb_per_distance> rgb_per_distance_vec,
-                              float ruler_length,
+                              const ruler_bounds& bounds,
                               const std::string& ruler_units);
-        float calculate_ruler_max_distance(const std::vector<float>& distances) const;
+        ruler_bounds calculate_ruler_bounds(const std::vector<float>& distances,
+                                            stream_model& s_model) const;
 
         void set_export_popup(ImFont* large_font, ImFont* font, rect stream_rect, std::string& error_message, config_file& temp_cfg);
         void init_depth_uid(int& selected_depth_source, std::vector<std::string>& depth_sources_str, std::vector<int>& depth_sources);


### PR DESCRIPTION
Tracked by: RSDEV-14227

## Overview
On close-range D401 scenes the color-map ruler kept labelling `0-4 m` even when everything visible was at 30-50 cm. The old `calculate_ruler_max_distance` was data-driven in principle (mean + 1.5·σ of visible depths), but then snapped up to the next 4 m grid multiple, so any scene with mean+1.5·σ ≤ 4 m always displayed exactly `0..4 m`. The bottom of the ruler was a hardcoded `"0"` regardless of the actual minimum depth.

This change makes the ruler read the actual measured range, on a fine step ladder, without introducing SKU-specific behavior. The colored strip already sampled a subset of pixels (`skip_pixels_factor = 30`) to color the bar — the new bounds computation reuses that same `distances` vector, so per-frame cost stays effectively unchanged.

## What changed
- **Dynamic bounds** (`common/viewer.cpp`, new `calculate_ruler_bounds`): p05 / p95 of visible-depth samples with 5% headroom, snapped to a "nice" step from `{0.05, 0.10, 0.25, 0.5, 1, 2, 5, 10, 20, 50, 100} m`. Replaces `calculate_ruler_max_distance` and its hardcoded 4 m grid.
- **Attack/release hysteresis**: asymmetric EMA (α_expand = 0.25, α_contract = 0.03) plus asymmetric deadband (½·step to expand, 1½·step to contract). A new farther object grows the ruler quickly; a brief close-up doesn't collapse it. Bounds near a tick edge don't oscillate.
- **Ruler labels rewrite** (`draw_color_ruler`): the ruler now takes `{min, max}` instead of a single length. Labels come only from nice-step multiples inside the range — no forced min/max, no rounded-off duplicate at the top. Capped at 5 total ticks. Decimals derived from the step (`≥1 → 0`, `≥0.1 → 1`, else `2`), consistent across all labels. Depth-to-y clips pixels that fall outside the current window.
- **Right-click popover on the ruler button** (`common/stream-model.cpp`): mode selector with three options, persisted through `config_file`:
  - **Auto** (default): the new adaptive behavior.
  - **Fixed 0-4 m (legacy)**: bit-for-bit old behavior for anyone who needs it.
  - **Fixed custom**: user-typed min/max.
- **Ruler mode state** (`common/stream-model.h`): new `ruler_range_mode` enum and `depth_ruler_state` (EMA + snapped bounds) live on `stream_model`, so each depth stream keeps its own smoothing.
- **Config keys** (`common/device-model.h`): `viewer_model.ruler_range_mode`, `viewer_model.ruler_fixed_min`, `viewer_model.ruler_fixed_max`.

## Not in scope
- No SKU/PID branching — the decision is purely data-driven from the pixel percentiles.
- No changes to the depth colorizer itself; the hues on the strip were already scene-adaptive (histogram equalization). This PR only makes the numeric labels match.
- No changes to the FW or the librealsense pipeline; viewer-only.

## Test plan
- [x] D401 close-range scene (all pixels ~0.15-0.40 m): ruler settles to a `0..0.5 m` or `0..0.25 m` window; labels are `0.25` and `0.5` (or similar) rather than `0-4`.
- [x] D455 room scene (mixed depths ~0.5-4 m): ruler shows a `0..5 m` window with labels `1, 2, 3, 4, 5`.
- [x] Wave a hand into a close scene and back out: ruler expands within ~4 frames, contracts over ~1 s, no visible ping-pong at boundaries.
- [x] Right-click the ruler button → popover appears; Auto / Fixed 0-4 m / Fixed custom all switch behavior; min/max inputs enabled only in Fixed custom; settings persist across viewer restarts.
- [x] Fixed 0-4 m mode reproduces the pre-PR ruler pixel-for-pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)