### PR TITLE
Viewer - fix colormap ruler for DDS

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -194,13 +194,6 @@ namespace rs2
 
         try
         {
-            if (s->supports(RS2_OPTION_DEPTH_UNITS))
-                depth_units = s->get_option(RS2_OPTION_DEPTH_UNITS);
-        }
-        catch (...) {}
-
-        try
-        {
             if (s->supports(RS2_OPTION_STEREO_BASELINE))
                 stereo_baseline = s->get_option(RS2_OPTION_STEREO_BASELINE);
         }
@@ -2335,11 +2328,6 @@ namespace rs2
                             auto_exposure_enabled = false;
                         }
                     }
-                }
-
-                if (next == RS2_OPTION_DEPTH_UNITS)
-                {
-                    opt_md.dev->depth_units = opt_md.value_as_float();
                 }
 
                 if (next == RS2_OPTION_STEREO_BASELINE)

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -204,7 +204,6 @@ namespace rs2
         rect normalized_zoom{ 0, 0, 1, 1 };
         rect roi_rect;
         bool auto_exposure_enabled = false;
-        float depth_units = 1.f;
         float stereo_baseline = -1.f;
 
         bool roi_checked = false;

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2321,6 +2321,9 @@ namespace rs2
                     auto depth_height = depth_vid_profile.height();
                     auto depth_data = static_cast<const uint16_t*>(frame.get_data());
                     auto textured_depth_data = static_cast<const uint8_t*>(textured_frame.get_data());
+                    // Take the scale off the frame, like the colorizer does: sensors that don't
+                    // expose RS2_OPTION_DEPTH_UNITS (DDS) leave the cached value at its 1.0 default.
+                    const float depth_scale = frame.as<depth_frame>().get_units();
                     static const auto skip_pixels_factor = 30;
                     std::vector<rgb_per_distance> rgb_per_distance_vec;
                     std::vector<float> distances;
@@ -2329,7 +2332,7 @@ namespace rs2
                         for (uint64_t j = 0; j < depth_width; j+= skip_pixels_factor)
                         {
                             auto depth_index = i*depth_width + j;
-                            auto length = depth_data[depth_index] * stream_mv.dev->depth_units;
+                            auto length = depth_data[depth_index] * depth_scale;
                             if (length > 0.f)
                             {
                                 auto textured_depth_index = depth_index * 3;


### PR DESCRIPTION
Overview: The viewer's colormap ruler showed depth distances in the thousands of metres on Ethernet (DDS) cameras. It now reports correct metres.

Why
The ruler scaled raw Z16 by subdevice_model::depth_units, cached from RS2_OPTION_DEPTH_UNITS when the sensor model is built. A D555 over DDS does not publish that option, so the member kept its 1.f default and raw millimetres were labelled as metres — a 9.7 m scene read 9728 m. USB devices do publish the option and were unaffected.

The depth image itself looked right, which hid the cause: the colorizer already takes the scale from the frame, so only the ruler's axis was wrong.

Summary
Scale the ruler by depth_frame::get_units(), the same source the colorizer uses. DDS stamps the correct units onto every frame even when the option is absent.
Remove subdevice_model::depth_units and its two writers. The ruler was its only reader, and a member that is silently 1.0 on DDS invites the same bug again.
